### PR TITLE
Add support for commitment coverage in CCM

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Toolset Name: `cloudcostmanagement`
 - `list_ccm_cost_categories`:  List all cost categories names for a specified account.
 - `list_ccm_cost_categories_detail`:  List all cost categories details for a specified account.
 - `get_ccm_cost_category`:  Retrieve a cost category detail by Id  for a specified account.
-- `get_commitment_coverage`: Get commitment coverage information for an account in Harness Cloud Cost Management
+- `get_ccm_commitment_coverage`: Get commitment coverage information for an account in Harness Cloud Cost Management
 
 #### Chaos Engineering Toolset
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Toolset Name: `cloudcostmanagement`
 - `list_ccm_cost_categories`:  List all cost categories names for a specified account.
 - `list_ccm_cost_categories_detail`:  List all cost categories details for a specified account.
 - `get_ccm_cost_category`:  Retrieve a cost category detail by Id  for a specified account.
+- `get_commitment_coverage`: Get commitment coverage information for an account in Harness Cloud Cost Management
 
 #### Chaos Engineering Toolset
 

--- a/client/dto/cloudcostmanagement.go
+++ b/client/dto/cloudcostmanagement.go
@@ -78,6 +78,14 @@ type CCMListCostCategoriesOptions struct {
 	SearchTerm        string `json:"search,omitempty"`
 }
 
+type CCMCommitmentOptions struct {
+	AccountIdentifier *string  `json:"accountIdentifier,omitempty"`
+	CloudAccountIDs   []string `json:"cloudAccountId,omitempty"`
+	Service           *string  `json:"service,omitempty"`
+	StartDate         *string  `json:"startDate,omitempty"`
+	EndDate           *string  `json:"endDate,omitempty"`
+}
+
 // CcmCostCategoryList represents a list of cost categories in CCM
 type CCMCostCategoryList struct {
 	CCMBaseResponse
@@ -205,4 +213,16 @@ type CCMCostCategory struct {
 type CCMGetCostCategoryOptions struct {
 	AccountIdentifier string `json:"accountIdentifier,omitempty"`
 	CostCategoryId    string `json:"id,omitempty"`
+}
+
+type CCMCommitmentBaseResponse struct {
+	Ts       int64    `json:"ts"`
+	Success  bool     `json:"success"`
+	Errors   []string `json:"errors"`
+	Response any      `json:"response"`
+}
+
+type CCMCommitmentAPIFilter struct {
+	CloudAccounts []string `json:"cloud_account_ids,omitempty"`
+	Service       string   `json:"service,omitempty"`
 }

--- a/pkg/harness/cloudcostmanagement.go
+++ b/pkg/harness/cloudcostmanagement.go
@@ -286,7 +286,7 @@ func getAccountID(config *config.Config, request mcp.CallToolRequest) (string, e
 }
 
 func FetchCommitmentCoverageTool(config *config.Config, client *client.CloudCostManagementService) (tool mcp.Tool, handler server.ToolHandlerFunc) {
-	return mcp.NewTool("get_commitment_coverage",
+	return mcp.NewTool("get_ccm_commitment_coverage",
 			mcp.WithDescription("Get commitment coverage information for an account in Harness Cloud Cost Management"),
 			mcp.WithString("start_date",
 				mcp.Required(),

--- a/pkg/harness/cloudcostmanagement.go
+++ b/pkg/harness/cloudcostmanagement.go
@@ -284,3 +284,89 @@ func getAccountID(config *config.Config, request mcp.CallToolRequest) (string, e
 	}
 	return "", fmt.Errorf("Account ID is required")
 }
+
+func FetchCommitmentCoverageTool(config *config.Config, client *client.CloudCostManagementService) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool("get_commitment_coverage",
+			mcp.WithDescription("Get commitment coverage information for an account in Harness Cloud Cost Management"),
+			mcp.WithString("start_date",
+				mcp.Required(),
+				mcp.Description("Start date to filter commitment coverage"),
+			),
+			mcp.WithString("end_date",
+				mcp.Required(),
+				mcp.Description("End date to filter commitment coverage"),
+			),
+			mcp.WithString("service",
+				mcp.Description("Optional service to filter commitment coverage"),
+			),
+			mcp.WithArray("cloud_account_ids",
+				mcp.Description("Optional cloud account IDs to filter commitment coverage"),
+				mcp.Items(map[string]any{
+					"type": "string",
+				}),
+			),
+			WithScope(config, false),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			accountId, err := getAccountID(config, request)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			params := &dto.CCMCommitmentOptions{}
+			params.AccountIdentifier = &accountId
+
+			// Handle service parameter
+			service, ok, err := OptionalParamOK[string](request, "service")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			if ok && service != "" {
+				params.Service = &service
+			}
+
+			// Handle cloud account IDs parameter
+			cloudAccountIDs, ok, err := OptionalParamOK[[]string](request, "cloud_account_ids")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			if ok && len(cloudAccountIDs) > 0 {
+				params.CloudAccountIDs = cloudAccountIDs
+			}
+
+			// Handle start date parameter
+			startDate, ok, err := OptionalParamOK[string](request, "start_date")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			if ok && startDate != "" {
+				params.StartDate = &startDate
+			}
+
+			// Handle end date parameter
+			endDate, ok, err := OptionalParamOK[string](request, "end_date")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			if ok && endDate != "" {
+				params.EndDate = &endDate
+			}
+
+			scope, err := fetchScope(config, request, false)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			data, err := client.GetComputeCoverage(ctx, scope, params)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get commitment coverage: %w", err)
+			}
+
+			r, err := json.Marshal(data)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal commitment coverage: %w", err)
+			}
+
+			return mcp.NewToolResultText(string(r)), nil
+		}
+}

--- a/pkg/harness/tools.go
+++ b/pkg/harness/tools.go
@@ -479,6 +479,7 @@ func registerCloudCostManagement(config *config.Config, tsg *toolsets.ToolsetGro
 			toolsets.NewServerTool(ListCcmCostCategoriesTool(config, ccmClient)),
 			toolsets.NewServerTool(ListCcmCostCategoriesDetailTool(config, ccmClient)),
 			toolsets.NewServerTool(GetCcmCostCategoryTool(config, ccmClient)),
+			toolsets.NewServerTool(FetchCommitmentCoverageTool(config, ccmClient)),
 		)
 
 	// Add toolset to the group


### PR DESCRIPTION

<img width="1193" alt="Screenshot 2025-07-08 at 10 58 31 PM" src="https://github.com/user-attachments/assets/9d56f824-051e-4b85-bc73-5df118870ba9" />




This pull request introduces a new feature for fetching commitment coverage information in the Harness Cloud Cost Management (CCM) toolset. The changes include updates to the API, data structures, and tool registration to support this functionality.

### New Feature: Commitment Coverage Retrieval

* **Added API Endpoint and Constants**:
  - Introduced `ccmCommitmentBasePath` and `ccmCommitmentCoverageDetailsPath` constants for the new API endpoint to fetch commitment coverage details. (`client/cloudcostmanagement.go`)
  
* **New Method in `CloudCostManagementService`**:
  - Implemented `GetComputeCoverage` method to handle API requests for commitment coverage, including default date handling and optional parameters like service and cloud account IDs. (`client/cloudcostmanagement.go`)

### Data Structure Enhancements

* **Added DTOs for Commitment Coverage**:
  - Introduced `CCMCommitmentOptions`, `CCMCommitmentBaseResponse`, and `CCMCommitmentAPIFilter` structs to represent request and response data for the new feature. (`client/dto/cloudcostmanagement.go`) [[1]](diffhunk://#diff-6171a0d6144db512fc3741336da15355803755ba736608ff4d91d23f703c2f17R81-R88) [[2]](diffhunk://#diff-6171a0d6144db512fc3741336da15355803755ba736608ff4d91d23f703c2f17R217-R228)

### Tool Registration and Documentation

* **New Tool for Commitment Coverage**:
  - Added `FetchCommitmentCoverageTool` to define and handle the new CLI tool for fetching commitment coverage, including parameter validation and response formatting. (`pkg/harness/cloudcostmanagement.go`)
  
* **Registered the Tool**:
  - Registered `FetchCommitmentCoverageTool` in the `registerCloudCostManagement` function to make it available in the toolset. (`pkg/harness/tools.go`)

* **Documentation Update**:
  - Updated the `README.md` to include the new `get_commitment_coverage` command in the list of available tools. (`README.md`)