### PR TITLE
feat: [AIDEVOPS-XXXX]: Add create pipeline and service tools

### DIFF
--- a/client/dto/pipeline.go
+++ b/client/dto/pipeline.go
@@ -417,3 +417,18 @@ type TriggerListItem struct {
 	TargetIdentifier   string `json:"targetIdentifier,omitempty"`
 	PipelineIdentifier string `json:"pipelineIdentifier,omitempty"`
 }
+
+// CreatePipelineRequest defines the structure for creating a pipeline
+type CreatePipelineRequest struct {
+	Name        string            `json:"name"`
+	Identifier  string            `json:"identifier"`
+	Description string            `json:"description,omitempty"`
+	Tags        map[string]string `json:"tags,omitempty"`
+	YAML        string            `json:"yaml,omitempty"`
+}
+
+// CreatePipelineResponse defines the response from pipeline creation
+type CreatePipelineResponse struct {
+	Status string       `json:"status,omitempty"`
+	Data   PipelineData `json:"data,omitempty"`
+}

--- a/client/dto/service.go
+++ b/client/dto/service.go
@@ -39,3 +39,18 @@ type ServiceOptions struct {
 	Order string `json:"order,omitempty"`
 	// Additional filtering options can be added as needed
 }
+
+// CreateServiceRequest defines the structure for creating a service
+type CreateServiceRequest struct {
+	Name        string            `json:"name"`
+	Identifier  string            `json:"identifier"`
+	Description string            `json:"description,omitempty"`
+	Tags        map[string]string `json:"tags,omitempty"`
+	YAML        string            `json:"yaml,omitempty"`
+}
+
+// CreateServiceResponse defines the response from service creation
+type CreateServiceResponse struct {
+	Status string  `json:"status,omitempty"`
+	Data   Service `json:"data,omitempty"`
+}

--- a/client/pipelines.go
+++ b/client/pipelines.go
@@ -13,6 +13,7 @@ import (
 const (
 	pipelinePath                 = "/api/pipelines/%s"
 	pipelineListPath             = "/api/pipelines/list"
+	pipelineCreatePath           = "/api/pipelines"
 	pipelineExecutionPath        = "/api/pipelines/execution/url"
 	pipelineExecutionGetPath     = "/api/pipelines/execution/v2/%s"
 	pipelineExecutionSummaryPath = "/api/pipelines/execution/summary"
@@ -43,6 +44,25 @@ func (p *PipelineService) Get(ctx context.Context, scope dto.Scope, pipelineID s
 	err := p.Client.Get(ctx, path, params, map[string]string{}, response)
 	if err != nil {
 		return nil, err
+	}
+
+	return response, nil
+}
+
+// Create creates a new pipeline
+func (p *PipelineService) Create(ctx context.Context, scope dto.Scope, createReq *dto.CreatePipelineRequest) (*dto.CreatePipelineResponse, error) {
+	path := pipelineCreatePath
+	params := make(map[string]string)
+	addScope(ctx, scope, params)
+
+	if createReq == nil {
+		return nil, fmt.Errorf("create request cannot be nil")
+	}
+
+	response := &dto.CreatePipelineResponse{}
+	err := p.Client.Post(ctx, path, params, createReq, map[string]string{}, response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pipeline: %w", err)
 	}
 
 	return response, nil

--- a/client/service.go
+++ b/client/service.go
@@ -8,8 +8,9 @@ import (
 )
 
 const (
-	serviceListPath = "/services"
-	serviceGetPath  = "/services/%s"
+	serviceListPath   = "/services"
+	serviceGetPath    = "/services/%s"
+	serviceCreatePath = "/services"
 )
 
 type ServiceClient struct {
@@ -34,6 +35,31 @@ func (s *ServiceClient) Get(ctx context.Context, scope dto.Scope, serviceIdentif
 	}
 
 	return &response.Data, nil
+}
+
+// Create creates a new service
+// https://apidocs.harness.io/tag/Services#operation/createServicesV2
+func (s *ServiceClient) Create(ctx context.Context, scope dto.Scope, createReq *dto.CreateServiceRequest) (*dto.CreateServiceResponse, error) {
+	path := serviceCreatePath
+	params := make(map[string]string)
+
+	// Ensure accountIdentifier is always set
+	if scope.AccountID == "" {
+		return nil, fmt.Errorf("accountIdentifier cannot be null")
+	}
+	addScope(ctx, scope, params)
+
+	if createReq == nil {
+		return nil, fmt.Errorf("create request cannot be nil")
+	}
+
+	response := &dto.CreateServiceResponse{}
+	err := s.Client.Post(ctx, path, params, createReq, map[string]string{}, response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create service: %w", err)
+	}
+
+	return response, nil
 }
 
 // setDefaultPaginationForService sets default pagination values for ServiceOptions

--- a/pkg/modules/cd.go
+++ b/pkg/modules/cd.go
@@ -124,6 +124,9 @@ func RegisterServices(config *config.Config, tsg *toolsets.ToolsetGroup) error {
 		AddReadTools(
 			toolsets.NewServerTool(tools.GetServiceTool(config, serviceClient)),
 			toolsets.NewServerTool(tools.ListServicesTool(config, serviceClient)),
+		).
+		AddWriteTools(
+			toolsets.NewServerTool(tools.CreateServiceTool(config, serviceClient)),
 		)
 
 	// Add toolset to the group

--- a/pkg/modules/core.go
+++ b/pkg/modules/core.go
@@ -199,6 +199,9 @@ func RegisterPipelines(config *config.Config, tsg *toolsets.ToolsetGroup) error 
 			toolsets.NewServerTool(tools.GetPipelineSummaryTool(config, pipelineClient)),
 			toolsets.NewServerTool(tools.ListTriggersTool(config, pipelineClient)),
 			toolsets.NewServerTool(tools.CreateFollowUpPromptTool(config, pipelineClient)),
+		).
+		AddWriteTools(
+			toolsets.NewServerTool(tools.CreatePipelineTool(config, pipelineClient)),
 		)
 
 	// Add toolset to the group


### PR DESCRIPTION
This commit adds new tools to create pipelines and services in Harness:

- Added CreatePipelineRequest and CreatePipelineResponse DTOs
- Added CreateServiceRequest and CreateServiceResponse DTOs
- Implemented Create method in PipelineService client
- Implemented Create method in ServiceClient
- Created CreatePipelineTool for creating pipelines
- Created CreateServiceTool for creating services
- Registered tools as write operations in their respective modules

The new tools allow users to create pipelines and services by providing:
- Name and identifier (required)
- Description (optional)
- YAML definition of the pipeline/service (required)