### PR TITLE
Add pagination for list_fme_workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Toolset Name: `audit`
 
 Toolset Name: `fme`
 
-- `list_fme_workspaces`: List all FME workspaces
+- `list_fme_workspaces`: List all FME workspaces (supports pagination via `offset` and `count`; default count: 20, max count: 1000)
 - `list_fme_environments`: List environments for a specific workspace
 - `list_fme_feature_flags`: List feature flags for a specific workspace
 - `get_fme_feature_flag_definition`: Get the definition of a specific feature flag in an environment

--- a/common/client/fme.go
+++ b/common/client/fme.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/harness/mcp-server/common/client/dto"
 )
@@ -12,12 +13,18 @@ type FMEService struct {
 	Client *Client
 }
 
-// ListWorkspaces retrieves all FME workspaces
+// ListWorkspaces retrieves FME workspaces with pagination support.
 // GET https://api.split.io/internal/api/v2/workspaces
-func (f *FMEService) ListWorkspaces(ctx context.Context) (*dto.FMEWorkspacesResponse, error) {
+// offset specifies the number of items to skip; limit controls how many items to return (max 100).
+func (f *FMEService) ListWorkspaces(ctx context.Context, offset, limit int) (*dto.FMEWorkspacesResponse, error) {
 	var response dto.FMEWorkspacesResponse
 
-	err := f.Client.Get(ctx, "internal/api/v2/workspaces", nil, nil, &response)
+	params := map[string]string{
+		"offset": strconv.Itoa(offset),
+		"limit":  strconv.Itoa(limit),
+	}
+
+	err := f.Client.Get(ctx, "internal/api/v2/workspaces", params, nil, &response)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list workspaces: %w", err)
 	}

--- a/common/pkg/tools/fme.go
+++ b/common/pkg/tools/fme.go
@@ -11,13 +11,37 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
+const (
+	fmeWorkspacesDefaultCount = 20
+	fmeWorkspacesMaxCount     = 1000
+)
+
 // ListFMEWorkspacesTool creates a tool for listing FME workspaces
 func ListFMEWorkspacesTool(config *config.McpServerConfig, fmeService *client.FMEService) (mcp.Tool, server.ToolHandlerFunc) {
 	return mcp.NewTool("list_fme_workspaces",
 			mcp.WithDescription("List Feature Management & Experimentation (FME) workspaces."),
+			mcp.WithNumber("offset",
+				mcp.Description("The number of workspaces to skip for pagination (default: 0)"),
+			),
+			mcp.WithNumber("count",
+				mcp.Description(fmt.Sprintf("The number of workspaces to return (default: %d, max: %d)", fmeWorkspacesDefaultCount, fmeWorkspacesMaxCount)),
+			),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			workspaces, err := fmeService.ListWorkspaces(ctx)
+			offset, err := OptionalIntParam(request, "offset")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			count, err := OptionalIntParamWithDefault(request, "count", fmeWorkspacesDefaultCount)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			if count > fmeWorkspacesMaxCount {
+				count = fmeWorkspacesMaxCount
+			}
+
+			workspaces, err := fmeService.ListWorkspaces(ctx, offset, count)
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("failed to list FME workspaces: %v", err)), nil
 			}


### PR DESCRIPTION
  - Added pagination support to list_fme_workspaces tool by exposing the offset and limit query parameters supported by the underlying Split.io API (GET /internal/api/v2/workspaces)
  - Updated FMEService.ListWorkspaces client method to accept offset and limit int parameters and pass them as query params
  - Added optional offset and count number parameters to the list_fme_workspaces MCP tool definition; defaults to count=20 if not provided, capped at a maximum of 1000 per the Split.io API documentation
  - Updated README to document the new pagination parameters for list_fme_workspaces