### PR TITLE
Add get_fme_feature_flag tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ Toolset Name: `fme`
 - `list_fme_workspaces`: List all FME workspaces
 - `list_fme_environments`: List environments for a specific workspace
 - `list_fme_feature_flags`: List feature flags for a specific workspace
+- `get_fme_feature_flag`: Get a specific feature flag (name, description, traffic type, tags, rollout status)
 - `get_fme_feature_flag_definition`: Get the definition of a specific feature flag in an environment
 
 #### SEI Toolset

--- a/common/client/fme.go
+++ b/common/client/fme.go
@@ -53,6 +53,20 @@ func (f *FMEService) ListFeatureFlags(ctx context.Context, wsID string) (*dto.FM
 	return &response, nil
 }
 
+// GetFeatureFlag retrieves a specific feature flag's metadata (without environment)
+// GET https://api.split.io/internal/api/v2/splits/ws/{wsId}/{feature_flag_name}
+func (f *FMEService) GetFeatureFlag(ctx context.Context, wsID, flagName string) (*dto.FMEFeatureFlag, error) {
+	var response dto.FMEFeatureFlag
+
+	path := fmt.Sprintf("internal/api/v2/splits/ws/%s/%s", wsID, flagName)
+	err := f.Client.Get(ctx, path, nil, nil, &response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get feature flag: %w", err)
+	}
+
+	return &response, nil
+}
+
 // GetFeatureFlagDefinition retrieves a specific feature flag definition
 // GET https://api.split.io/internal/api/v2/splits/ws/{wsId}/{feature_flag_name}/environments/{environment_id_or_name}
 func (f *FMEService) GetFeatureFlagDefinition(ctx context.Context, wsID, flagName, environmentIDOrName string) (*dto.FMEFeatureFlagDefinitionResponse, error) {

--- a/common/pkg/modules/fme.go
+++ b/common/pkg/modules/fme.go
@@ -89,6 +89,7 @@ func RegisterFeatureManagementAndExperimentation(config *config.McpServerConfig,
 			toolsets.NewServerTool(tools.ListFMEWorkspacesTool(config, fmeService)),
 			toolsets.NewServerTool(tools.ListFMEEnvironmentsTool(config, fmeService)),
 			toolsets.NewServerTool(tools.ListFMEFeatureFlagsTool(config, fmeService)),
+			toolsets.NewServerTool(tools.GetFMEFeatureFlagTool(config, fmeService)),
 			toolsets.NewServerTool(tools.GetFMEFeatureFlagDefinitionTool(config, fmeService)),
 		)
 

--- a/common/pkg/tools/fme.go
+++ b/common/pkg/tools/fme.go
@@ -89,6 +89,44 @@ func ListFMEFeatureFlagsTool(config *config.McpServerConfig, fmeService *client.
 		}
 }
 
+// GetFMEFeatureFlagTool creates a tool for getting a specific FME feature flag
+func GetFMEFeatureFlagTool(config *config.McpServerConfig, fmeService *client.FMEService) (mcp.Tool, server.ToolHandlerFunc) {
+	return mcp.NewTool("get_fme_feature_flag",
+			mcp.WithDescription("Get a specific Feature Management & Experimentation (FME) feature flag."),
+			mcp.WithString("ws_id",
+				mcp.Required(),
+				mcp.Description("The workspace ID"),
+			),
+			mcp.WithString("feature_flag_name",
+				mcp.Required(),
+				mcp.Description("The name of the feature flag"),
+			),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			wsID, err := RequiredParam[string](request, "ws_id")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			flagName, err := RequiredParam[string](request, "feature_flag_name")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			featureFlag, err := fmeService.GetFeatureFlag(ctx, wsID, flagName)
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("failed to get FME feature flag: %v", err)), nil
+			}
+
+			responseBytes, err := json.Marshal(featureFlag)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal feature flag: %w", err)
+			}
+
+			return mcp.NewToolResultText(string(responseBytes)), nil
+		}
+}
+
 // GetFMEFeatureFlagDefinitionTool creates a tool for getting a specific FME feature flag definition
 func GetFMEFeatureFlagDefinitionTool(config *config.McpServerConfig, fmeService *client.FMEService) (mcp.Tool, server.ToolHandlerFunc) {
 	return mcp.NewTool("get_fme_feature_flag_definition",


### PR DESCRIPTION
**Summary**

 Exposes the Split.io "Get feature flag" API endpoint (GET /internal/api/v2/splits/ws/{wsId}/{feature_flag_name}) as a new MCP tool.

The new get_fme_feature_flag tool retrieves basic metadata for a single feature flag — without requiring an environment. This complements the existing get_fme_feature_flag_definition tool, which returns environment-specific data (treatments, rules, traffic allocation) and requires an environment parameter.

**Changes**

  - common/client/fme.go: Added GetFeatureFlag() service method on FMEService
  - common/pkg/tools/fme.go: Added GetFMEFeatureFlagTool() handler with ws_id and feature_flag_name as required parameters
  - common/pkg/modules/fme.go: Registered the new tool in the fme toolset
  - README.md: Documented the new tool in the FME toolset section