### PR TITLE
fix: sanitize HTML/JS redirect pages from 401/403 error messages

### DIFF
--- a/src/client/harness-client.ts
+++ b/src/client/harness-client.ts
@@ -9,26 +9,50 @@ const log = createLogger("harness-client");
 const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
 const BASE_BACKOFF_MS = 1000;
 
-/** Strip HTML tags and collapse whitespace — used for non-JSON error bodies. */
+/** Strip HTML tags, script/style contents, and collapse whitespace. */
 function stripHtml(html: string): string {
-  return html.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
+  return html
+    .replace(/<script[\s>][\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s>][\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** True when body is an HTML page (redirect, WAF block, proxy error). */
+function isHtmlBody(body: string): boolean {
+  return /^\s*</.test(body) || /<!doctype/i.test(body.slice(0, 100));
 }
 
 /** Produce a clean, actionable error message for non-JSON HTTP error responses. */
 function humanizeHttpError(status: number, rawBody: string): string {
-  const isHtml = /^\s*</.test(rawBody);
-  const hint = isHtml ? stripHtml(rawBody).slice(0, 120) : rawBody.slice(0, 200);
+  const html = isHtmlBody(rawBody);
 
   switch (status) {
     case 401:
-      return `HTTP 401 Unauthorized — API key is invalid or expired. Verify HARNESS_API_KEY is a valid PAT or Service Account token.${hint ? ` (${hint})` : ""}`;
+      return "HTTP 401 Unauthorized — API key is invalid or expired. Verify HARNESS_API_KEY is a valid PAT or Service Account token.";
     case 403:
-      return `HTTP 403 Forbidden — access denied. Possible causes: wrong HARNESS_ACCOUNT_ID, IP restrictions, missing RBAC permissions, or corporate proxy/WAF blocking the request.${hint ? ` (${hint})` : ""}`;
+      return "HTTP 403 Forbidden — access denied. Possible causes: wrong HARNESS_ACCOUNT_ID, IP restrictions, missing RBAC permissions, or corporate proxy/WAF blocking the request.";
     case 404:
-      return `HTTP 404 Not Found — the API endpoint or resource does not exist. Verify the base URL and resource identifiers.${hint ? ` (${hint})` : ""}`;
-    default:
+      return `HTTP 404 Not Found — the API endpoint or resource does not exist. Verify the base URL and resource identifiers.`;
+    default: {
+      if (html) return `HTTP ${status}: Harness returned an HTML error page (possible proxy, WAF, or redirect). Check HARNESS_BASE_URL and network connectivity.`;
+      const hint = rawBody.slice(0, 200);
       return `HTTP ${status}: ${hint || "empty response"}`;
+    }
   }
+}
+
+/**
+ * Detect when parsed.message contains HTML/JS from a redirect page
+ * rather than a real Harness API error message.
+ */
+function isGarbageMessage(message: string | undefined): boolean {
+  if (!message) return true;
+  if (isHtmlBody(message)) return true;
+  if (/function\s+\w+\s*\(/.test(message)) return true;
+  if (/redirectPage|signInPath|encodeURIComponent/.test(message)) return true;
+  return false;
 }
 
 /**
@@ -155,7 +179,9 @@ export class HarnessClient {
             // Provide actionable messages instead of leaking raw HTML to the LLM
           }
 
-          const message = parsed.message ?? humanizeHttpError(response.status, body);
+          const message = isGarbageMessage(parsed.message)
+            ? humanizeHttpError(response.status, body)
+            : parsed.message!;
           log.debug(`HTTP ${response.status} error`, { body: body.slice(0, 1000) });
           const error = new HarnessApiError(
             message,
@@ -295,7 +321,9 @@ export class HarnessClient {
           let parsed: { message?: string; code?: string; correlationId?: string } = {};
           try { parsed = JSON.parse(body); } catch { /* non-JSON */ }
 
-          const message = parsed.message ?? humanizeHttpError(response.status, body);
+          const message = isGarbageMessage(parsed.message)
+            ? humanizeHttpError(response.status, body)
+            : parsed.message!;
           const error = new HarnessApiError(message, response.status, parsed.code, parsed.correlationId);
 
           if (RETRYABLE_STATUS_CODES.has(response.status) && attempt < this.maxRetries) {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -52,6 +52,20 @@ export function isUserFixableApiError(err: unknown): err is HarnessApiError {
 }
 
 /**
+ * Strip HTML/JS noise from error messages that may have leaked from
+ * proxy redirect pages or WAF responses.
+ */
+function sanitizeErrorMessage(message: string): string {
+  if (/^\s*</.test(message) || /<!doctype/i.test(message.slice(0, 100))) {
+    return "Harness returned an HTML error page instead of JSON. Check your API key, account ID, and base URL.";
+  }
+  if (/function\s+\w+\s*\(/.test(message) || /redirectPage|signInPath/.test(message)) {
+    return "Harness returned a login redirect. The API key may be invalid or expired.";
+  }
+  return message;
+}
+
+/**
  * Map a HarnessApiError (or generic Error) to an MCP-friendly McpError.
  */
 export function toMcpError(err: unknown): McpError {
@@ -60,7 +74,8 @@ export function toMcpError(err: unknown): McpError {
   if (err instanceof HarnessApiError) {
     const code = mapHttpStatusToMcpCode(err.statusCode);
     const detail = err.correlationId ? ` (correlationId: ${err.correlationId})` : "";
-    const mcpErr = new McpError(code, `${err.message}${detail}`);
+    const cleanMessage = sanitizeErrorMessage(err.message);
+    const mcpErr = new McpError(code, `${cleanMessage}${detail}`);
     mcpErr.cause = err;
     return mcpErr;
   }

--- a/tests/client/harness-client.test.ts
+++ b/tests/client/harness-client.test.ts
@@ -239,6 +239,53 @@ describe("HarnessClient", () => {
       }
     });
 
+    it("strips JS redirect page from 401 error message", async () => {
+      const redirectHtml = `<html><head><script>
+        function redirectPage() {
+          const signInPath = "auth/#/signin";
+          const returnUrl = encodeURIComponent(window.location.href);
+          window.location.href = signInPath + "?returnUrl=" + returnUrl;
+        }
+        redirectPage();
+      </script></head><body></body></html>`;
+      fetchSpy.mockResolvedValue(new Response(redirectHtml, { status: 401 }));
+      const client = new HarnessClient(makeConfig({ HARNESS_MAX_RETRIES: 0 }));
+
+      try {
+        await client.request({ path: "/test" });
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HarnessApiError);
+        const e = err as HarnessApiError;
+        expect(e.statusCode).toBe(401);
+        expect(e.message).toContain("HARNESS_API_KEY");
+        expect(e.message).not.toContain("redirectPage");
+        expect(e.message).not.toContain("signInPath");
+        expect(e.message).not.toContain("function");
+        expect(e.message).not.toContain("<script");
+      }
+    });
+
+    it("strips garbage JSON message containing redirect JS", async () => {
+      const body = JSON.stringify({
+        message: 'Harness Redirect function redirectPage() { const signInPath = "auth/#/signin"; const returnUrl = encodeURIComponent(window.location.href) }',
+      });
+      fetchSpy.mockResolvedValue(new Response(body, { status: 401 }));
+      const client = new HarnessClient(makeConfig({ HARNESS_MAX_RETRIES: 0 }));
+
+      try {
+        await client.request({ path: "/test" });
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HarnessApiError);
+        const e = err as HarnessApiError;
+        expect(e.statusCode).toBe(401);
+        expect(e.message).toContain("HARNESS_API_KEY");
+        expect(e.message).not.toContain("redirectPage");
+        expect(e.message).not.toContain("signInPath");
+      }
+    });
+
     it("does not retry on 400", async () => {
       fetchSpy.mockResolvedValue(new Response(JSON.stringify({ message: "bad" }), { status: 400 }));
       const client = new HarnessClient(makeConfig({ HARNESS_MAX_RETRIES: 2 }));

--- a/tests/utils/errors.test.ts
+++ b/tests/utils/errors.test.ts
@@ -137,4 +137,24 @@ describe("toMcpError", () => {
     expect(result).toBeInstanceOf(McpError);
     expect(result.message).toContain("raw string");
   });
+
+  it("sanitizes HTML error messages from redirect pages", () => {
+    const htmlMsg = '<html><body>Please sign in</body></html>';
+    const result = toMcpError(new HarnessApiError(htmlMsg, 401));
+    expect(result.message).not.toContain("<html>");
+    expect(result.message).toContain("HTML error page");
+  });
+
+  it("sanitizes JS redirect content in error messages", () => {
+    const jsMsg = 'Harness Redirect function redirectPage() { const signInPath = "auth/#/signin"; }';
+    const result = toMcpError(new HarnessApiError(jsMsg, 401));
+    expect(result.message).not.toContain("redirectPage");
+    expect(result.message).toContain("login redirect");
+  });
+
+  it("passes through normal error messages unchanged", () => {
+    const normalMsg = "Pipeline not found in project default";
+    const result = toMcpError(new HarnessApiError(normalMsg, 404));
+    expect(result.message).toContain(normalMsg);
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

When Harness returns a 401 Unauthorized with an HTML redirect page (containing JavaScript like `function redirectPage() { const signInPath = "auth/#/signin"; const returnUrl = encodeURIComponent(...) }`), the raw script content was leaking into MCP error messages shown to users in Claude Code.

The error message looked like:
```
MCP error -32600: HTTP 401 Unauthorized — API key is invalid or expired. Verify HARNESS_API_KEY is a valid PAT or Service Account token.
(Harness Redirect function redirectPage() { const signInPath = "auth/#/signin"; const returnUrl = encodeURIComponent(wind...)
```

**Root causes fixed:**

1. **`stripHtml()` only removed HTML tags, not script contents** — `<script>function redirectPage()...</script>` had tags stripped but the JS body text remained. Now removes `<script>` and `<style>` element contents entirely before stripping tags.

2. **`humanizeHttpError()` appended HTML "hints" for 401/403** — For auth errors, the HTML body is always redirect/proxy noise. Removed the hint entirely for 401/403 since the actionable message ("verify HARNESS_API_KEY") is sufficient.

3. **No detection of garbage in `parsed.message`** — When the response was valid JSON but the `message` field contained HTML/JS redirect content, it was used as-is. New `isGarbageMessage()` function detects redirect-page patterns and falls back to the clean humanized message.

4. **No sanitization in `toMcpError()`** — Added `sanitizeErrorMessage()` as defense-in-depth, so even if garbage leaks through the HTTP client layer, the MCP error shown to the user is always clean.

**After this fix**, the error message is simply:
```
MCP error -32600: HTTP 401 Unauthorized — API key is invalid or expired. Verify HARNESS_API_KEY is a valid PAT or Service Account token.
```

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] Tests pass (769 tests, 5 new tests added for this fix)
- [x] Typecheck passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aedb5975-6403-4a75-aa83-58a6b82d6538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aedb5975-6403-4a75-aa83-58a6b82d6538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

