### PR TITLE
feat: [SSCA-6128]: Langfuse observability + LLM-as-Judge evaluation framework for SCS smoke tests

### DIFF
--- a/src/registry/toolsets/scs.ts
+++ b/src/registry/toolsets/scs.ts
@@ -1,4 +1,4 @@
-import type { ToolsetDefinition, PathBuilderConfig } from "../types.js";
+import type { ToolsetDefinition } from "../types.js";
 import { scsCleanExtract, scsListExtract } from "../extractors.js";
 
 // ── P2-2: Per-resource field lists for list extractors ─────────────────────
@@ -674,7 +674,7 @@ export const scsToolset: ToolsetDefinition = {
         get: {
           method: "GET",
           path: `${SCS}/v1/components/details`,
-          pathBuilder: (input: Record<string, unknown>, config: PathBuilderConfig) => {
+          pathBuilder: (input, config) => {
             const artifactId = input.artifact_id as string | undefined;
             if (artifactId) {
               // Project-scoped: richer response with SBOM context

--- a/src/registry/toolsets/scs.ts
+++ b/src/registry/toolsets/scs.ts
@@ -1,4 +1,4 @@
-import type { ToolsetDefinition } from "../types.js";
+import type { ToolsetDefinition, PathBuilderConfig } from "../types.js";
 import { scsCleanExtract, scsListExtract } from "../extractors.js";
 
 // ── P2-2: Per-resource field lists for list extractors ─────────────────────
@@ -674,7 +674,7 @@ export const scsToolset: ToolsetDefinition = {
         get: {
           method: "GET",
           path: `${SCS}/v1/components/details`,
-          pathBuilder: (input, config) => {
+          pathBuilder: (input: Record<string, unknown>, config: PathBuilderConfig) => {
             const artifactId = input.artifact_id as string | undefined;
             if (artifactId) {
               // Project-scoped: richer response with SBOM context

--- a/tests/e2e/LANGFUSE_README.md
+++ b/tests/e2e/LANGFUSE_README.md
@@ -1,0 +1,239 @@
+# Langfuse + LLM-as-Judge Integration
+
+Automated evaluation framework for SCS MCP smoke tests using [Langfuse](https://langfuse.com) observability, LLM-as-Judge scoring, and optional [DeepEval](https://github.com/confident-ai/deepeval) G-Eval metrics.
+
+Inspired by the [AI Remediation Evaluation Framework](https://harness.atlassian.net/wiki/spaces/STOH/pages/23442620461) and its Remediation Quality Index (RQI) methodology.
+
+## Quick Start
+
+```bash
+# 1. Source Langfuse credentials
+source langfuse.env  # or export LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, LANGFUSE_HOST
+
+# 2. Run smoke tests with Langfuse tracing only (no judge)
+python scs_llm_smoke_test.py --langfuse
+
+# 3. Run with LLM-as-Judge scoring (uses OpenAI by default)
+python scs_llm_smoke_test.py --langfuse --langfuse-judge
+
+# 4. Run with Harness ai-evals judge (multi-criteria rubric)
+python scs_llm_smoke_test.py --langfuse --langfuse-judge --harness-judge
+
+# 5. Run with DeepEval G-Eval metrics (independent of Langfuse)
+pip install deepeval
+python scs_llm_smoke_test.py --deepeval
+
+# 6. Run with everything
+python scs_llm_smoke_test.py --langfuse --langfuse-judge --harness-judge --deepeval
+
+# 7. Sync datasets only (no test execution)
+python scs_llm_smoke_test.py --langfuse --langfuse-sync-only
+```
+
+## CLI Flags
+
+| Flag | Description |
+|------|-------------|
+| `--langfuse` | Enable Langfuse tracing and post-run scoring |
+| `--langfuse-judge` | Enable LLM-as-Judge answer quality evaluation (requires `--langfuse`) |
+| `--harness-judge` | Use Harness ai-evals service for rubric-based multi-criteria scoring (requires `--langfuse-judge`) |
+| `--deepeval` | Enable DeepEval G-Eval metrics (requires `pip install deepeval` + `OPENAI_API_KEY`) |
+| `--langfuse-sync-only` | Sync dataset definitions to Langfuse and exit (no test execution) |
+
+## Environment Variables
+
+### Required (for `--langfuse`)
+
+| Variable | Description |
+|----------|-------------|
+| `LANGFUSE_PUBLIC_KEY` | Langfuse project public key |
+| `LANGFUSE_SECRET_KEY` | Langfuse project secret key |
+| `LANGFUSE_HOST` | Langfuse host URL (default: `https://langfuse-prod.harness.io`) |
+
+### Judge Configuration (for `--langfuse-judge`)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `EVAL_JUDGE_PROVIDER` | `openai` | Judge provider: `openai`, `anthropic`, or `harness` |
+| `EVAL_JUDGE_MODEL` | `gpt-4.1-mini` | Model for LLM-as-Judge calls |
+| `OPENAI_API_KEY` | — | Required if `EVAL_JUDGE_PROVIDER=openai` |
+| `ANTHROPIC_API_KEY` | — | Required if `EVAL_JUDGE_PROVIDER=anthropic` |
+
+### Harness ai-evals (for `--harness-judge`)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `HARNESS_EVAL_API_URL` | — | Harness ai-evals REST API URL |
+| `HARNESS_EVAL_API_TOKEN` | — | API token for authentication |
+| `HARNESS_EVAL_AUTH_TYPE` | `api-key` | Auth type: `api-key` (x-api-key header) or `bearer` |
+| `HARNESS_EVAL_ORG` | — | Harness org identifier (optional) |
+| `HARNESS_EVAL_PROJECT` | — | Harness project identifier (optional) |
+
+### DeepEval (for `--deepeval`)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DEEPEVAL_MODEL` | `gpt-4.1-mini` | Model for G-Eval judge calls |
+| `OPENAI_API_KEY` | — | Required (DeepEval uses OpenAI by default) |
+
+### Quality Thresholds
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `QUALITY_COVERAGE_THRESHOLD` | `0.7` | Minimum judge score to count as "quality pass" for coverage metric |
+
+## Evaluators
+
+### Per-Query Evaluators (deterministic, no LLM calls)
+
+| Name | Score | Description |
+|------|-------|-------------|
+| `trajectory` | 0.0–1.0 | Tool selection accuracy — proportion of expected tools called |
+| `trajectory_order` | 0.0–1.0 | Whether tools were called in the expected subsequence order |
+| `parameters` | 0.0–1.0 | Validates tool parameters against `PARAM_VALIDATION_RULES` |
+| `latency` | 0.0–1.0 | Flags slow queries (>60s warn, >120s fail) |
+| `error_free` | 0.0/1.0 | Whether execution had any errors |
+| `answer_presence` | 0.0/1.0 | Whether a non-trivial answer was generated |
+
+### LLM-as-Judge Evaluators (with `--langfuse-judge`)
+
+| Name | Score | Description |
+|------|-------|-------------|
+| `answer_quality` | 0.0–1.0 | Single-criterion quality score (used when `--harness-judge` is NOT active) |
+
+### Harness Rubric Judge (with `--harness-judge`)
+
+Uses a **Chain-of-Thought (CoT)** prompt following the [G-Eval](https://arxiv.org/abs/2303.16634) methodology — the judge reasons step-by-step before producing scores, yielding more reliable evaluations.
+
+When using OpenAI as the judge provider, **token probability calibration** is applied: instead of taking the model's raw score, the expected value is computed from the probability distribution across possible score tokens.
+
+| Name | Weight | Description |
+|------|--------|-------------|
+| `task_completion` | 35% | Does the response fully address the user's request? |
+| `tool_usage` | 25% | Correct tools with correct parameters, no hallucinated calls |
+| `factual_accuracy` | 20% | Claims supported by actual tool results, no hallucinations |
+| `response_quality` | 20% | Well-structured, actionable, professional formatting |
+| `harness_judge_score` | — | Weighted average of above criteria (with optional logprobs calibration) |
+
+### DeepEval G-Eval Metrics (with `--deepeval`)
+
+Uses the [DeepEval](https://docs.confident-ai.com/docs/metrics-llm-evals) framework's battle-tested G-Eval implementation with chain-of-thought + token probability calibration built-in.
+
+| Name | Description |
+|------|-------------|
+| `deepeval_tool_correctness` | G-Eval metric for MCP tool selection quality |
+| `deepeval_answer_quality` | G-Eval metric for response completeness and accuracy |
+| `deepeval_faithfulness` | Anti-hallucination check — claims vs actual tool results |
+
+### Run-Level Aggregates
+
+| Name | Description |
+|------|-------------|
+| `avg_trajectory_accuracy` | Average trajectory score across all items |
+| `pass_rate` | Percentage of items with trajectory score = 1.0 |
+| `token_cost` | Total tokens (prompt + completion) with USD cost estimate |
+| `quality_coverage` | Percentage of items with judge score >= threshold (default 0.7). Inspired by RQI coverage metric. |
+| `category_breakdown` | Per-category pass rate (artifact, repo, compliance, remediation, dependency, sbom, cross_toolset, oss_risk). Structured `categories` field enables per-category regression detection. |
+| `mqi` | **MCP Quality Index** — confidence-weighted composite of trajectory (30%), parameters (15%), judge score (35%), latency (10%), error_free (5%), answer_presence (5%). Items are weighted by confidence level: Supported/High=1.0, Medium=0.7, Low=0.4, N/A=0.2. Inspired by RQI. |
+
+## Features
+
+### Experiment Tracking
+Each run creates a unique experiment name (`scs-smoke-YYYYMMDD-HHMMSS`). Traces are linked to Langfuse dataset items, enabling A/B comparison in the Experiments UI.
+
+### Regression Detection
+After scoring, the runner compares key metrics against the previous run's summary file:
+- **correct_rate**: 5% drop threshold
+- **avg_trajectory_accuracy**: 5% drop threshold
+- **pass_rate**: 5% drop threshold
+- **quality_coverage**: 5% drop threshold
+- **mqi**: 5% drop threshold
+- **avg_duration_s**: 20% increase threshold
+- **total_tokens**: 15% increase threshold
+- **category:\<name\>**: 5% drop threshold per category (artifact, repo, compliance, etc.)
+
+Per-category regression detection compares each category's pass rate independently, so a drop in e.g. `category:compliance` is flagged even if overall MQI is stable. Regressions are flagged with ⚠️ in console output and stored in the JSON results.
+
+**CI gating**: The script exits with code 1 when any regression is detected, enabling CI pipelines to gate merges on quality.
+
+### Flaky Query Detection
+After regression detection, the runner scans the last 5 result files in `benchmark_results/` and builds a per-query history of `tool_selection` outcomes. Queries with 2+ distinct outcomes (e.g. CORRECT → PARTIAL → CORRECT) are flagged as flaky with their flip count and outcome history. Results are stored in `summary["flaky_queries"]`.
+
+### Score Stability (σ)
+Aggregate metrics (trajectory accuracy, MQI) include population standard deviation (σ) in their comments. A high mean with high σ indicates inconsistent results across queries — useful for spotting fragile prompt configurations even when the average looks good.
+
+### Prompt Version Tracking
+Judge prompts are hashed (SHA-256, 12-char prefix) and stored in trace metadata as `prompt_version`. This allows correlating scores with the exact prompt that produced them across different experiment runs.
+
+### Multi-Turn Conversation Support
+- Parent trace per conversation with per-turn child traces
+- Session tracking via shared `session_id`
+- Per-turn judge scoring with conversation-level aggregation
+
+### Chain-of-Thought Judge (G-Eval)
+The Harness Rubric Judge uses a structured CoT evaluation:
+1. The judge reasons step-by-step through each criterion before scoring
+2. JSON scores are extracted from the CoT output (handles markdown fences, mixed text)
+3. When using OpenAI, logprobs-based calibration adjusts the final score using the probability distribution
+
+### A/B Comparison (Prompt Validation)
+
+When making changes to the judge prompt (e.g., adding CoT reasoning), validate the impact by running both versions as separate experiments and comparing in Langfuse:
+
+```bash
+# 1. Run baseline (before prompt change) — save results first
+python scs_llm_smoke_test.py --langfuse --langfuse-judge --harness-judge
+
+# 2. Apply prompt changes, then run again
+#    Each run auto-generates a unique experiment name (scs-smoke-YYYYMMDD-HHMMSS)
+python scs_llm_smoke_test.py --langfuse --langfuse-judge --harness-judge
+
+# 3. Compare in Langfuse UI:
+#    - Go to Experiments tab → select both experiment runs
+#    - Compare harness_judge_score distributions
+#    - Check per-query score differences
+#    - Verify category-level regression detection (console output)
+```
+
+Key metrics to compare:
+- **MQI**: Composite quality index should not drop (includes confidence weighting)
+- **harness_judge_score**: Mean and distribution across queries
+- **Per-category pass rates**: Ensure no category regresses
+- **Prompt version hash**: Recorded in trace metadata — confirms which prompt produced which scores
+
+The regression detection runs automatically and flags any metric drops exceeding thresholds.
+
+### Harness ai-evals Resilience
+- Automatic retry on 5xx/429 errors (exponential backoff, up to 2 retries)
+- Connection validation at startup
+- Graceful fallback to direct OpenAI/Anthropic calls if service is unavailable; logprobs calibration applied on fallback path
+
+## Output
+
+Scores appear in:
+1. **Console** — summary table with per-query scores
+2. **JSON** — `benchmark_results/smoke_test_summary.json` includes `langfuse_scores`, `deepeval_scores`, `run_aggregates`, and `deepeval_aggregates`
+3. **JSON (timestamped)** — `benchmark_results/smoke_test_results_YYYYMMDD_HHMMSS.json` — historical copies used by flaky detection and trend analysis
+4. **Langfuse UI** — traces with attached scores, filterable by experiment run, session, and tags
+
+### CLI Flags
+
+| Flag | Description |
+|------|-------------|
+| `--langfuse` | Enable Langfuse trace + score push |
+| `--langfuse-judge` | Enable LLM-as-Judge scoring |
+| `--harness-judge` | Use Harness ai-evals rubric judge (fallback to OpenAI) |
+| `--deepeval` | Enable DeepEval G-Eval metrics |
+| `--no-fail-on-regression` | Don't exit(1) on regression (useful for local dev) |
+| `--skip-na` | Skip queries with N/A confidence |
+| `--query-ids Q01,M03` | Run specific query/conversation IDs only |
+| `--concurrency 5` | Parallel query execution |
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `langfuse_evaluators.py` | Evaluator functions, `LangfuseIntegration` class, regression detection, CoT judge, logprobs calibration |
+| `deepeval_evaluators.py` | Optional DeepEval G-Eval metric definitions and scoring (requires `pip install deepeval`) |
+| `scs_llm_smoke_test.py` | Main test runner with `--langfuse*` and `--deepeval` flag handling |
+| `langfuse.env` | Credentials file (DO NOT commit) |

--- a/tests/e2e/deepeval_evaluators.py
+++ b/tests/e2e/deepeval_evaluators.py
@@ -1,0 +1,272 @@
+"""
+Optional DeepEval G-Eval integration for SCS MCP smoke tests.
+
+Provides battle-tested G-Eval metrics (chain-of-thought + token probability
+calibration) as drop-in replacements for the hand-rolled LLM-as-Judge in
+langfuse_evaluators.py.
+
+Usage:
+  pip install deepeval
+  python scs_llm_smoke_test.py --langfuse --deepeval
+
+Metrics provided:
+  - tool_correctness: G-Eval metric for tool selection quality
+  - answer_quality:   G-Eval metric for response completeness and accuracy
+  - faithfulness:     Checks claims against actual tool results (anti-hallucination)
+
+These metrics use the G-Eval paper's methodology:
+  1. Chain-of-thought reasoning before scoring
+  2. Token probability calibration for reliable continuous scores
+  3. Custom evaluation criteria per metric
+
+Environment variables:
+  DEEPEVAL_MODEL       - Model for G-Eval judge (default: gpt-4.1-mini)
+  OPENAI_API_KEY       - Required for DeepEval's default OpenAI backend
+
+References:
+  - G-Eval paper: https://arxiv.org/abs/2303.16634
+  - DeepEval docs: https://docs.confident-ai.com/docs/metrics-llm-evals
+  - Inspired by Sumeet Rai's AI Remediation Evaluation Framework
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Optional
+
+
+# ---------------------------------------------------------------------------
+# Lazy import — DeepEval is an optional dependency
+# ---------------------------------------------------------------------------
+def _check_deepeval() -> bool:
+    """Check if deepeval is installed."""
+    try:
+        import deepeval  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def _get_deepeval_model() -> str:
+    """Return the model string for DeepEval metrics."""
+    return os.getenv("DEEPEVAL_MODEL", "gpt-4.1-mini")
+
+
+# ---------------------------------------------------------------------------
+# G-Eval Metric Definitions
+# ---------------------------------------------------------------------------
+
+# Tool selection quality — evaluates whether the agent chose the right tools
+TOOL_CORRECTNESS_CRITERIA = """\
+Evaluate whether the AI agent selected the correct MCP tools (harness_list, \
+harness_get, harness_execute, harness_describe) with the correct resource_type \
+parameters to fulfill the user's request about software supply chain security.
+
+Consider:
+1. Were the essential tools called? Missing a critical tool in the chain is a major flaw.
+2. Were the resource_types correct? Using scs_artifact_source vs code_repo_security \
+   vs artifact_security matters — each serves a different purpose.
+3. Was the tool chain ordered logically? (e.g., list sources before getting details)
+4. Were extra unnecessary tools called? Minor penalty for noise, but not a failure.
+5. Were parameters correct? (e.g., correct artifact_id, purl, enforcement_id extracted \
+   from previous tool results)
+"""
+
+# Answer quality — evaluates the final response
+ANSWER_QUALITY_CRITERIA = """\
+Evaluate the quality of the AI agent's final response to the user's software \
+supply chain security query.
+
+Consider:
+1. Task completion: Does the response fully address what the user asked?
+2. Accuracy: Are all claims directly supported by the tool results? No hallucinated data.
+3. Actionability: Can the user take concrete action based on this response?
+4. Clarity: Is the response well-structured and easy to understand?
+5. Appropriate detail level: Not too verbose, not too terse.
+"""
+
+# Faithfulness — anti-hallucination check against tool results
+FAITHFULNESS_CRITERIA = """\
+Evaluate whether every factual claim in the agent's response is directly \
+supported by the actual tool results (API responses) provided.
+
+A claim is unfaithful if:
+- It states specific numbers, names, or values not present in the tool results
+- It fabricates security findings, vulnerability counts, or component details
+- It references entities (artifacts, repos, components) not returned by any tool
+- It makes definitive statements about security status without supporting data
+
+Minor rephrasing or summarization of tool results is acceptable. \
+Extrapolation or inference beyond the data is not.
+"""
+
+
+def create_geval_metrics() -> list:
+    """Create DeepEval G-Eval metric instances.
+
+    Returns a list of (name, metric) tuples. Each metric can be evaluated
+    via metric.measure(test_case).
+    """
+    try:
+        from deepeval.metrics import GEval
+        from deepeval.test_case import LLMTestCaseParams
+    except ImportError:
+        raise ImportError(
+            "deepeval package not installed. Run: pip install deepeval"
+        )
+
+    model = _get_deepeval_model()
+
+    tool_correctness = GEval(
+        name="deepeval_tool_correctness",
+        criteria=TOOL_CORRECTNESS_CRITERIA,
+        evaluation_params=[
+            LLMTestCaseParams.INPUT,
+            LLMTestCaseParams.ACTUAL_OUTPUT,
+            LLMTestCaseParams.EXPECTED_OUTPUT,
+        ],
+        model=model,
+        threshold=0.7,
+    )
+
+    answer_quality = GEval(
+        name="deepeval_answer_quality",
+        criteria=ANSWER_QUALITY_CRITERIA,
+        evaluation_params=[
+            LLMTestCaseParams.INPUT,
+            LLMTestCaseParams.ACTUAL_OUTPUT,
+            LLMTestCaseParams.EXPECTED_OUTPUT,
+        ],
+        model=model,
+        threshold=0.7,
+    )
+
+    faithfulness = GEval(
+        name="deepeval_faithfulness",
+        criteria=FAITHFULNESS_CRITERIA,
+        evaluation_params=[
+            LLMTestCaseParams.INPUT,
+            LLMTestCaseParams.ACTUAL_OUTPUT,
+            LLMTestCaseParams.RETRIEVAL_CONTEXT,
+        ],
+        model=model,
+        threshold=0.7,
+    )
+
+    return [
+        ("deepeval_tool_correctness", tool_correctness),
+        ("deepeval_answer_quality", answer_quality),
+        ("deepeval_faithfulness", faithfulness),
+    ]
+
+
+def _fmt_tool(spec: Any) -> str:
+    if isinstance(spec, (list, tuple)) and len(spec) == 2:
+        return f"{spec[0]}({spec[1]})"
+    return str(spec)
+
+
+def build_test_case(query_def: dict, extracted: dict) -> Any:
+    """Build a DeepEval LLMTestCase from smoke test data.
+
+    Maps our internal data format to DeepEval's expected structure:
+    - input: user query
+    - actual_output: agent's final answer + tool call summary
+    - expected_output: expected behavior description
+    - retrieval_context: actual tool results (for faithfulness check)
+    """
+    from deepeval.test_case import LLMTestCase
+
+    # Build actual_output: answer + tool summary
+    answer = extracted.get("final_answer", "")
+    tools = extracted.get("tools_called", [])
+    tools_str = ", ".join(_fmt_tool(t) for t in tools) if tools else "(none)"
+    actual_output = f"Tools called: {tools_str}\n\nResponse:\n{answer}"
+
+    # Build expected_output from query definition
+    expected_parts = []
+    expected_tools = query_def.get("expected_tools", [])
+    if expected_tools:
+        expected_parts.append(
+            f"Expected tools: {', '.join(_fmt_tool(t) for t in expected_tools)}"
+        )
+    observe = query_def.get("observe", "")
+    if observe:
+        expected_parts.append(f"Expected behavior: {observe}")
+    expected_output = "\n".join(expected_parts) or "Respond correctly to the query."
+
+    # Build retrieval_context from tool results (for faithfulness)
+    retrieval_context = []
+    raw_results = extracted.get("tool_results", [])
+    if isinstance(raw_results, list):
+        for r in raw_results:
+            preview = r.get("content_preview", "")
+            if preview:
+                name = r.get("name", "tool")
+                retrieval_context.append(f"[{name}]: {preview[:2000]}")
+    elif isinstance(raw_results, dict):
+        for key, val in raw_results.items():
+            retrieval_context.append(f"[{key}]: {str(val)[:2000]}")
+
+    return LLMTestCase(
+        input=query_def["query"],
+        actual_output=actual_output,
+        expected_output=expected_output,
+        retrieval_context=retrieval_context if retrieval_context else ["(no tool results)"],
+    )
+
+
+def run_deepeval_scoring(
+    query_def: dict,
+    extracted: dict,
+    metrics: Optional[list] = None,
+) -> dict[str, Any]:
+    """Run DeepEval G-Eval metrics on a single query result.
+
+    Returns dict of {metric_name: {"value": float, "comment": str, "reason": str}}.
+    """
+    if metrics is None:
+        metrics = create_geval_metrics()
+
+    test_case = build_test_case(query_def, extracted)
+    scores: dict[str, Any] = {}
+
+    for name, metric in metrics:
+        try:
+            metric.measure(test_case)
+            scores[name] = {
+                "value": round(metric.score, 3),
+                "comment": (metric.reason or "")[:500],
+                "passed": metric.score >= metric.threshold,
+            }
+        except Exception as e:
+            scores[name] = {
+                "value": None,
+                "comment": f"DeepEval error: {e}",
+                "passed": False,
+            }
+
+    return scores
+
+
+def run_deepeval_aggregate(item_scores: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compute aggregate DeepEval scores across all items.
+
+    Returns dict of {metric_name: {"value": avg_score, "comment": summary}}.
+    """
+    metric_scores: dict[str, list[float]] = {}
+    for scores in item_scores:
+        for name, data in scores.items():
+            if data.get("value") is not None:
+                metric_scores.setdefault(name, []).append(data["value"])
+
+    aggregates = {}
+    for name, values in metric_scores.items():
+        avg = sum(values) / len(values)
+        passed = sum(1 for v in values if v >= 0.7)
+        aggregates[f"avg_{name}"] = {
+            "value": round(avg, 3),
+            "comment": f"Avg: {avg:.1%}, passed: {passed}/{len(values)} (>= 0.7)",
+        }
+
+    return aggregates

--- a/tests/e2e/langfuse_evaluators.py
+++ b/tests/e2e/langfuse_evaluators.py
@@ -1,0 +1,1997 @@
+"""
+Langfuse evaluators and integration layer for SCS MCP smoke tests.
+
+Provides:
+  - Trajectory evaluator (tool selection matching with ordering awareness)
+  - Parameter validation evaluator (checks tool args against expected patterns)
+  - Answer quality evaluator (LLM-as-Judge via configurable model)
+  - Latency evaluator (flags slow queries)
+  - Chain completeness evaluator (all expected tools present)
+  - Run-level aggregate evaluators
+  - Langfuse Experiments (A/B run comparison via dataset_item.link())
+  - Session tracking (per-turn traces with session_id for multi-turn)
+  - Span-level tracing (child spans for tool calls and LLM generations)
+  - Harness ai-evals LLM-as-Judge integration (rubric-based scoring via REST API)
+
+Usage:
+  Called from scs_llm_smoke_test.py when --langfuse flag is passed.
+  Requires: pip install langfuse openai (or anthropic)
+
+Environment variables:
+  LANGFUSE_PUBLIC_KEY       - Langfuse project public key
+  LANGFUSE_SECRET_KEY       - Langfuse project secret key
+  LANGFUSE_HOST             - Langfuse host (default: https://langfuse-prod.harness.io)
+  EVAL_JUDGE_MODEL          - LLM judge model (default: gpt-4.1-mini)
+  EVAL_JUDGE_PROVIDER       - Judge provider: openai, anthropic, or harness (default: openai)
+  HARNESS_EVAL_API_URL      - Harness ai-evals API URL (for --harness-judge)
+  HARNESS_EVAL_API_TOKEN    - Harness ai-evals API token (Bearer auth)
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import time
+import urllib.request
+import urllib.error
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+LANGFUSE_HOST = os.getenv("LANGFUSE_HOST", "https://langfuse-prod.harness.io")
+DATASET_NAME_SINGLE = "scs-mcp-smoke-single-turn"
+DATASET_NAME_MULTI = "scs-mcp-smoke-multi-turn"
+LATENCY_WARN_THRESHOLD_S = 60.0
+LATENCY_FAIL_THRESHOLD_S = 120.0
+
+# Quality coverage: fraction of items scoring above this threshold on the judge score
+QUALITY_COVERAGE_THRESHOLD = float(os.getenv("QUALITY_COVERAGE_THRESHOLD", "0.7"))
+
+# MCP Quality Index (MQI) weights — composite score across all evaluator dimensions
+MQI_WEIGHTS = {
+    "trajectory": 0.30,
+    "parameters": 0.15,
+    "harness_judge_score": 0.35,
+    "latency": 0.10,
+    "error_free": 0.05,
+    "answer_presence": 0.05,
+}
+
+# Query categories for per-category aggregate breakdown
+QUERY_CATEGORIES: dict[str, str] = {
+    # Artifact queries
+    "Q01": "artifact", "Q02": "artifact", "Q03": "artifact", "Q07": "artifact",
+    "Q11": "artifact", "Q12": "artifact", "Q15": "artifact", "Q31": "artifact",
+    # Repo queries
+    "Q04": "repo", "Q05": "repo", "Q06": "repo", "Q16": "repo", "Q17": "repo",
+    # Compliance
+    "Q08": "compliance", "Q30": "compliance", "Q32": "compliance", "Q33": "compliance",
+    "Q34": "compliance", "Q35": "compliance", "Q36": "compliance", "Q37": "compliance",
+    # Remediation
+    "Q13": "remediation", "Q20": "remediation", "Q23": "remediation", "Q27": "remediation",
+    # Dependencies
+    "Q21": "dependency", "Q22": "dependency", "Q28": "dependency",
+    # SBOM & provenance
+    "Q09": "sbom", "Q10": "sbom", "Q40": "sbom",
+    # Cross-toolset
+    "Q19": "cross_toolset", "Q26": "cross_toolset", "Q29": "cross_toolset",
+    # OSS risk
+    "Q38": "oss_risk", "Q39": "oss_risk", "Q41": "oss_risk", "Q42": "oss_risk",
+    # N/A
+    "Q14": "unsupported",
+    # Multi-turn conversations
+    "M01": "artifact",          # Artifact deep-dive
+    "M02": "repo",              # Repo security overview → compliance
+    "M03": "remediation",       # Remediation journey
+    "M04": "artifact",          # Artifact refinement & correction
+    "M05": "cross_toolset",     # Repo → artifacts → cross-entity
+    "M06": "dependency",        # Dependency investigation + remediation
+    "M07": "artifact",          # Invalid artifact ID error recovery
+    "M08": "remediation",       # Remediation scope limitation recovery
+    "M09": "cross_toolset",     # OPA policy management (governance ↔ SCS)
+    "M10": "cross_toolset",     # Pipeline SBOM step inspection (SCS ↔ pipeline)
+    "M11": "cross_toolset",     # Security → policy → pipeline (3 toolsets)
+    "M12": "compliance",        # BOM enforcement violation investigation
+    "M13": "compliance",        # BOM violation → remediation chain
+    "M14": "oss_risk",          # Component OSS risk assessment
+    "M15": "sbom",              # SBOM drift between versions
+    "M16": "oss_risk",          # Project OSS risk → drill-down
+}
+
+# Truncation limits
+MAX_ANSWER_IN_PROMPT = 3000
+MAX_TRACE_OUTPUT = 5000
+MAX_COMMENT_LEN = 500
+MAX_TOOL_RESULT_OUTPUT = 2000
+
+# Harness ai-evals LLM-as-Judge service
+HARNESS_EVAL_API_URL = os.getenv("HARNESS_EVAL_API_URL", "")
+HARNESS_EVAL_API_TOKEN = os.getenv("HARNESS_EVAL_API_TOKEN", "")
+HARNESS_EVAL_ORG = os.getenv("HARNESS_ORG_ID", "SSCA")
+HARNESS_EVAL_PROJECT = os.getenv("HARNESS_PROJECT_ID", "SSCA_Sanity_Automation")
+
+
+def _get_judge_config() -> tuple[str, str]:
+    """Return (provider, model) for the LLM judge from env vars."""
+    provider = os.getenv("EVAL_JUDGE_PROVIDER", "openai")
+    default_model = "claude-sonnet-4-20250514" if provider == "anthropic" else "gpt-4.1-mini"
+    model = os.getenv("EVAL_JUDGE_MODEL", default_model)
+    return provider, model
+
+
+# Parameter patterns to validate per query (query_id -> list of checks)
+# Each check: {"tool": (name, resource_type), "param": "key", "pattern": regex_or_value}
+PARAM_VALIDATION_RULES: dict[str, list[dict[str, Any]]] = {
+    # Compliance: standards array must include CIS
+    "Q08": [{"tool": ("harness_list", "scs_compliance_result"), "param": "standards", "contains": "CIS"}],
+    # Repo dependencies: dependency_type should be DIRECT
+    "Q21": [{"tool": ("harness_list", "scs_artifact_component"), "param": "dependency_type", "equals": "DIRECT"}],
+    # Dependency tree: purl must be passed to scs_component_dependencies
+    "Q22": [{"tool": ("harness_get", "scs_component_dependencies"), "param": "resource_id", "pattern": r"pkg:"}],
+    # Remediation: purl must be passed
+    "Q13": [{"tool": ("harness_get", "scs_component_remediation"), "param": "resource_id", "pattern": r"pkg:"}],
+    "Q23": [{"tool": ("harness_get", "scs_component_remediation"), "param": "resource_id", "pattern": r"pkg:"}],
+    "Q27": [{"tool": ("harness_get", "scs_component_remediation"), "param": "resource_id", "pattern": r"pkg:"}],
+    # Dependency tree disambiguation: must route to scs_component_dependencies, not scs_artifact_component
+    "Q28": [{"tool": ("harness_get", "scs_component_dependencies"), "param": "resource_id", "pattern": r"pkg:"}],
+    # BOM violations: enforcement_id must be extracted from artifact_security
+    "Q34": [{"tool": ("harness_list", "scs_bom_violation"), "param": "enforcement_id", "pattern": r".+"}],
+    "Q36": [{"tool": ("harness_list", "scs_bom_violation"), "param": "enforcement_id", "pattern": r".+"}],
+    "Q37": [{"tool": ("harness_list", "scs_bom_violation"), "param": "enforcement_id", "pattern": r".+"}],
+    # Enrichment: purl must be passed to scs_component_enrichment
+    "Q38": [{"tool": ("harness_get", "scs_component_enrichment"), "param": "resource_id", "pattern": r"pkg:"}],
+    # SBOM drift: action must be calculate
+    "Q40": [{"tool": ("harness_execute", "scs_sbom_drift"), "param": "action", "equals": "calculate"}],
+    # OSS risk filtering: oss_risk_filter must contain EOL values
+    "Q42": [{"tool": ("harness_list", "scs_artifact_component"), "param": "oss_risk_filter", "contains": "DEFINITE_EOL"}],
+}
+
+
+def _fmt_tool(spec: Any) -> str:
+    if isinstance(spec, (list, tuple)) and len(spec) == 2:
+        return f"{spec[0]}({spec[1]})"
+    return str(spec)
+
+
+def _fmt_tool_results(extracted: dict, max_per_tool: int = 800, max_total: int = 4000) -> str:
+    """Format tool results for inclusion in judge prompts.
+
+    Handles tool_results as either:
+    - A list of {name, is_error, content_length, content_preview} dicts (from extract_tools_from_events)
+    - A dict keyed by tool display name (legacy format)
+
+    Truncates each result and the total to keep the prompt within token limits.
+    Returns "(no tool results captured)" if none available.
+    """
+    raw_results = extracted.get("tool_results", {})
+    tools_called = extracted.get("tools_called", [])
+    if not raw_results and not tools_called:
+        return "(no tool results captured)"
+
+    parts = []
+    total_len = 0
+
+    if isinstance(raw_results, list):
+        # New format: list of result dicts with content_preview
+        for i, result in enumerate(raw_results):
+            tool_name = result.get("name", f"tool_{i}")
+            # Match with tools_called to get display name
+            display_name = tool_name
+            if i < len(tools_called):
+                display_name = _fmt_tool(tools_called[i])
+            is_error = result.get("is_error", False)
+            preview = result.get("content_preview", "")
+            if not preview:
+                preview = f"(content_length={result.get('content_length', 0)})"
+            else:
+                preview = preview[:max_per_tool]
+                if result.get("content_length", 0) > max_per_tool:
+                    preview += "... (truncated)"
+
+            error_tag = " [ERROR]" if is_error else ""
+            entry = f"### {display_name}{error_tag}\n{preview}"
+            if total_len + len(entry) > max_total:
+                parts.append("... (remaining tool results truncated)")
+                break
+            parts.append(entry)
+            total_len += len(entry)
+    elif isinstance(raw_results, dict):
+        # Legacy dict format
+        for tool_key, result in raw_results.items():
+            result_str = str(result)[:max_per_tool]
+            if len(str(result)) > max_per_tool:
+                result_str += "... (truncated)"
+            entry = f"### {tool_key}\n{result_str}"
+            if total_len + len(entry) > max_total:
+                parts.append("... (remaining tool results truncated)")
+                break
+            parts.append(entry)
+            total_len += len(entry)
+
+    return "\n\n".join(parts) if parts else "(no tool results captured)"
+
+
+# ---------------------------------------------------------------------------
+# Item-Level Evaluators
+# ---------------------------------------------------------------------------
+
+def trajectory_evaluator(*, output: Any, expected_output: Any, **kwargs) -> dict:
+    """Glass-box trajectory evaluation: checks if expected tools were called.
+
+    Scores:
+      1.0 = all expected tools present (superset ok)
+      0.0-0.99 = partial match (proportional to overlap)
+      0.0 = no overlap or no tools called when expected
+    """
+    expected_raw = expected_output.get("trajectory", [])
+    if not expected_raw:
+        # No expected tools — anything is fine
+        return {"name": "trajectory", "value": 1.0, "comment": "No trajectory expectation"}
+
+    actual_raw = output.get("tools_called", []) if isinstance(output, dict) else []
+
+    expected_set = set(tuple(t) if isinstance(t, list) else t for t in expected_raw)
+    actual_set = set(tuple(t) if isinstance(t, list) else t for t in actual_raw)
+
+    if not actual_set:
+        return {"name": "trajectory", "value": 0.0,
+                "comment": f"No tools called. Expected: {[_fmt_tool(t) for t in expected_set]}"}
+
+    if expected_set.issubset(actual_set):
+        extra = actual_set - expected_set
+        comment = "All expected tools called"
+        if extra:
+            comment += f". Extra tools: {[_fmt_tool(t) for t in extra]}"
+        return {"name": "trajectory", "value": 1.0, "comment": comment}
+
+    overlap = expected_set & actual_set
+    missing = expected_set - actual_set
+    unexpected = actual_set - expected_set
+    score = len(overlap) / len(expected_set)
+
+    comment_parts = []
+    if missing:
+        comment_parts.append(f"Missing: {[_fmt_tool(t) for t in missing]}")
+    if unexpected:
+        comment_parts.append(f"Unexpected: {[_fmt_tool(t) for t in unexpected]}")
+    return {"name": "trajectory", "value": round(score, 3), "comment": ". ".join(comment_parts)}
+
+
+def trajectory_order_evaluator(*, output: Any, expected_output: Any, **kwargs) -> dict:
+    """Checks if tools were called in the expected order (subsequence check).
+
+    A tool chain like [A, B, C] is correct if A appears before B and B before C
+    in the actual call sequence, even with extra tools interleaved.
+    """
+    expected_raw = expected_output.get("trajectory", [])
+    if not expected_raw:
+        return {"name": "trajectory_order", "value": 1.0, "comment": "No ordering expectation"}
+
+    actual_raw = output.get("tools_called", []) if isinstance(output, dict) else []
+    if not actual_raw:
+        return {"name": "trajectory_order", "value": 0.0, "comment": "No tools called"}
+
+    expected = [tuple(t) if isinstance(t, list) else t for t in expected_raw]
+    actual = [tuple(t) if isinstance(t, list) else t for t in actual_raw]
+
+    # Check if expected is a subsequence of actual
+    exp_idx = 0
+    for tool in actual:
+        if exp_idx < len(expected) and tool == expected[exp_idx]:
+            exp_idx += 1
+    if exp_idx == len(expected):
+        return {"name": "trajectory_order", "value": 1.0, "comment": "Tools called in expected order"}
+
+    return {"name": "trajectory_order", "value": round(exp_idx / len(expected), 3),
+            "comment": f"Order mismatch: matched {exp_idx}/{len(expected)} expected tools in sequence"}
+
+
+def parameter_evaluator(*, input: Any, output: Any, expected_output: Any, **kwargs) -> dict:
+    """Validates that tool calls included correct parameters.
+
+    Uses PARAM_VALIDATION_RULES keyed by query ID. Each rule checks
+    if a specific parameter was passed with the expected value/pattern.
+    """
+    query_id = input.get("id", "") if isinstance(input, dict) else ""
+    rules = PARAM_VALIDATION_RULES.get(query_id, [])
+    if not rules:
+        return {"name": "parameters", "value": 1.0, "comment": "No parameter rules for this query"}
+
+    tool_params = output.get("tool_params", {}) if isinstance(output, dict) else {}
+    passed = 0
+    total = len(rules)
+    details = []
+
+    for rule in rules:
+        tool_key = _fmt_tool(rule["tool"])
+        params = tool_params.get(tool_key, {})
+        param_name = rule["param"]
+        param_val = params.get(param_name)
+
+        if param_val is None:
+            # Check if param is in any tool call's args (tool_key might differ slightly)
+            found = False
+            for key, args in tool_params.items():
+                if param_name in args:
+                    param_val = args[param_name]
+                    found = True
+                    break
+            if not found:
+                details.append(f"MISS: {tool_key}.{param_name} not found")
+                continue
+
+        param_str = str(param_val)
+        if "equals" in rule:
+            if param_str.lower() == str(rule["equals"]).lower():
+                passed += 1
+                details.append(f"OK: {param_name}={param_str}")
+            else:
+                details.append(f"WRONG: {param_name}={param_str}, expected={rule['equals']}")
+        elif "contains" in rule:
+            if str(rule["contains"]).lower() in param_str.lower():
+                passed += 1
+                details.append(f"OK: {param_name} contains '{rule['contains']}'")
+            else:
+                details.append(f"MISS: {param_name}={param_str} doesn't contain '{rule['contains']}'")
+        elif "pattern" in rule:
+            if re.search(rule["pattern"], param_str):
+                passed += 1
+                details.append(f"OK: {param_name} matches pattern")
+            else:
+                details.append(f"MISS: {param_name}={param_str} doesn't match pattern '{rule['pattern']}'")
+
+    score = passed / total if total > 0 else 1.0
+    return {"name": "parameters", "value": round(score, 3), "comment": "; ".join(details)}
+
+
+def latency_evaluator(*, output: Any, **kwargs) -> dict:
+    """Scores based on response latency. Fast = 1.0, Slow = 0.5, Very slow = 0.0."""
+    duration = output.get("duration_s", 0) if isinstance(output, dict) else 0
+    if duration <= LATENCY_WARN_THRESHOLD_S:
+        return {"name": "latency", "value": 1.0, "comment": f"{duration:.1f}s — fast"}
+    elif duration <= LATENCY_FAIL_THRESHOLD_S:
+        return {"name": "latency", "value": 0.5, "comment": f"{duration:.1f}s — slow (>{LATENCY_WARN_THRESHOLD_S}s)"}
+    else:
+        return {"name": "latency", "value": 0.0, "comment": f"{duration:.1f}s — very slow (>{LATENCY_FAIL_THRESHOLD_S}s)"}
+
+
+def error_evaluator(*, output: Any, **kwargs) -> dict:
+    """Checks if the execution had errors. 1.0 = no errors, 0.0 = errors present."""
+    errors = output.get("errors", []) if isinstance(output, dict) else []
+    if not errors:
+        return {"name": "error_free", "value": 1.0, "comment": "No errors"}
+    return {"name": "error_free", "value": 0.0, "comment": f"Errors: {errors[:3]}"}
+
+
+def answer_presence_evaluator(*, output: Any, **kwargs) -> dict:
+    """Checks if a non-trivial answer was generated. Simple heuristic check."""
+    answer = ""
+    if isinstance(output, dict):
+        answer = output.get("answer", "") or output.get("final_answer", "")
+    elif isinstance(output, str):
+        answer = output
+
+    if not answer or len(answer.strip()) < 10:
+        return {"name": "answer_presence", "value": 0.0, "comment": "No meaningful answer generated"}
+    if len(answer.strip()) < 50:
+        return {"name": "answer_presence", "value": 0.5, "comment": f"Very short answer ({len(answer)} chars)"}
+    return {"name": "answer_presence", "value": 1.0, "comment": f"Answer present ({len(answer)} chars)"}
+
+
+# ---------------------------------------------------------------------------
+# LLM-as-Judge Answer Quality Evaluator
+# ---------------------------------------------------------------------------
+
+def _call_judge_openai(prompt: str, model: str, max_tokens: int = 1200,
+                       use_logprobs: bool = False) -> str | tuple[str, list | None]:
+    """Call OpenAI-compatible model for judging.
+
+    When use_logprobs=True, returns (text, logprobs_list) tuple for token
+    probability calibration per G-Eval methodology.
+    """
+    try:
+        import openai
+        client = openai.OpenAI()
+        kwargs: dict = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": max_tokens,
+            "temperature": 0.0,
+        }
+        if use_logprobs:
+            kwargs["logprobs"] = True
+            kwargs["top_logprobs"] = 5
+        response = client.chat.completions.create(**kwargs)
+        text = response.choices[0].message.content or ""
+        if use_logprobs:
+            lp = response.choices[0].logprobs
+            logprobs_data = lp.content if lp else None
+            return text, logprobs_data
+        return text
+    except Exception as e:
+        if use_logprobs:
+            return f"JUDGE_ERROR: {e}", None
+        return f"JUDGE_ERROR: {e}"
+
+
+def _calibrate_score_from_logprobs(logprobs_data: list | None, parsed_score: float) -> float:
+    """Compute calibrated score from token probability distribution (G-Eval).
+
+    Scans logprobs for tokens that look like score values (0.0-1.0 range) in
+    the JSON output. For each score token, computes the expected value by
+    weighting alternative score tokens by their probability.
+
+    Falls back to parsed_score if logprobs are unavailable or can't be
+    calibrated (e.g., Anthropic models, non-OpenAI providers).
+    """
+    import math
+
+    if not logprobs_data:
+        return parsed_score
+
+    # Look for the "score" key's value token in the logprobs
+    score_token_idx = None
+    for i, token_info in enumerate(logprobs_data):
+        token_text = getattr(token_info, 'token', '')
+        # Look for tokens that are the "score" key in JSON
+        if '"score"' in token_text or "'score'" in token_text:
+            # The value token should be 1-3 tokens after the key (skip `:` and space)
+            for j in range(i + 1, min(i + 4, len(logprobs_data))):
+                candidate = getattr(logprobs_data[j], 'token', '').strip()
+                try:
+                    val = float(candidate)
+                    if 0.0 <= val <= 1.0:
+                        score_token_idx = j
+                        break
+                except (ValueError, TypeError):
+                    continue
+            if score_token_idx is not None:
+                break
+
+    if score_token_idx is None:
+        return parsed_score
+
+    # Compute expected value from top_logprobs at this position
+    token_info = logprobs_data[score_token_idx]
+    top_logprobs = getattr(token_info, 'top_logprobs', [])
+    if not top_logprobs:
+        return parsed_score
+
+    weighted_sum = 0.0
+    prob_sum = 0.0
+    for alt in top_logprobs:
+        alt_token = getattr(alt, 'token', '').strip()
+        alt_logprob = getattr(alt, 'logprob', -100)
+        try:
+            alt_val = float(alt_token)
+            if 0.0 <= alt_val <= 1.0:
+                prob = math.exp(alt_logprob)
+                weighted_sum += alt_val * prob
+                prob_sum += prob
+        except (ValueError, TypeError):
+            continue
+
+    if prob_sum > 0:
+        return round(weighted_sum / prob_sum, 3)
+    return parsed_score
+
+
+def _extract_json_from_cot(raw: str) -> dict:
+    """Extract JSON object from a Chain-of-Thought response.
+
+    The rubric prompt produces step-by-step reasoning followed by a JSON
+    object on its own line. This function finds and parses that JSON,
+    handling cases where the model wraps it in markdown code fences.
+    Falls back to parsing the entire response as JSON for backward compat.
+    """
+    # Try parsing the whole response first (backward compatibility)
+    try:
+        return json.loads(raw.strip())
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # Strip markdown code fences if present
+    cleaned = raw.strip()
+    if "```json" in cleaned:
+        start = cleaned.index("```json") + len("```json")
+        end = cleaned.index("```", start) if "```" in cleaned[start:] else len(cleaned)
+        cleaned = cleaned[start:start + end].strip()
+        try:
+            return json.loads(cleaned)
+        except (json.JSONDecodeError, ValueError):
+            pass
+    elif "```" in cleaned:
+        # Generic code fence
+        parts = cleaned.split("```")
+        for part in parts[1::2]:  # odd indices are inside fences
+            part = part.strip()
+            if part.startswith("json"):
+                part = part[4:].strip()
+            try:
+                return json.loads(part)
+            except (json.JSONDecodeError, ValueError):
+                continue
+
+    # Scan lines from the end — JSON is typically the last thing output
+    lines = raw.strip().splitlines()
+    brace_depth = 0
+    json_start = -1
+    for i in range(len(lines) - 1, -1, -1):
+        line = lines[i].strip()
+        brace_depth += line.count("}") - line.count("{")
+        if brace_depth <= 0 and "{" in line:
+            json_start = i
+            break
+    if json_start >= 0:
+        candidate = "\n".join(lines[json_start:])
+        try:
+            return json.loads(candidate)
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    # Last resort: find first { to last }
+    first_brace = raw.find("{")
+    last_brace = raw.rfind("}")
+    if first_brace >= 0 and last_brace > first_brace:
+        try:
+            return json.loads(raw[first_brace:last_brace + 1])
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    raise json.JSONDecodeError("No valid JSON found in CoT response", raw, 0)
+
+
+def _call_judge_anthropic(prompt: str, model: str, max_tokens: int = 1200) -> str:
+    """Call Anthropic model for judging."""
+    try:
+        import anthropic
+        client = anthropic.Anthropic()
+        response = client.messages.create(
+            model=model,
+            max_tokens=max_tokens,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return response.content[0].text if response.content else ""
+    except Exception as e:
+        return f"JUDGE_ERROR: {e}"
+
+
+def _harness_eval_headers() -> dict[str, str]:
+    """Build auth headers for Harness ai-evals API.
+
+    Supports both x-api-key (PAT/SA tokens) and Bearer (OAuth) auth.
+    Auto-detects based on HARNESS_EVAL_AUTH_TYPE env var (default: x-api-key).
+    """
+    auth_type = os.getenv("HARNESS_EVAL_AUTH_TYPE", "x-api-key")
+    headers = {"Content-Type": "application/json"}
+    if auth_type == "bearer":
+        headers["Authorization"] = f"Bearer {HARNESS_EVAL_API_TOKEN}"
+    else:
+        headers["x-api-key"] = HARNESS_EVAL_API_TOKEN
+    return headers
+
+
+def _harness_eval_request(url: str, payload: dict, timeout: int = 30) -> dict:
+    """Make a single request to the Harness ai-evals API with error details."""
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=_harness_eval_headers(),
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def validate_harness_eval_connection() -> tuple[bool, str]:
+    """Test connectivity to the Harness ai-evals service.
+
+    Returns (success: bool, message: str).
+    Call this at startup to verify the service is reachable.
+    """
+    if not HARNESS_EVAL_API_URL or not HARNESS_EVAL_API_TOKEN:
+        return False, "HARNESS_EVAL_API_URL or HARNESS_EVAL_API_TOKEN not set"
+    try:
+        # Lightweight test: send a minimal scoring request
+        payload = {
+            "scorer_config": {
+                "type": "llm",
+                "name": "connection_test",
+                "model": "gpt-4.1-mini",
+                "prompt": "Respond with exactly: {\"score\": 1.0, \"reasoning\": \"test\"}",
+                "temperature": 0.0,
+                "max_tokens": 50,
+            },
+            "org": HARNESS_EVAL_ORG,
+            "project": HARNESS_EVAL_PROJECT,
+        }
+        url = f"{HARNESS_EVAL_API_URL.rstrip('/')}/evaluate/scorer/score"
+        result = _harness_eval_request(url, payload, timeout=15)
+        return True, f"Connected — response: {str(result)[:100]}"
+    except urllib.error.HTTPError as e:
+        body = ""
+        try:
+            body = e.read().decode("utf-8")[:200]
+        except Exception:
+            pass
+        return False, f"HTTP {e.code}: {e.reason} — {body}"
+    except Exception as e:
+        return False, f"Connection failed: {e}"
+
+
+def _call_judge_harness(prompt: str, model: str, max_retries: int = 2) -> str:
+    """Call Harness ai-evals LLM-as-Judge service via REST API.
+
+    Uses the /evaluate/scorer/* endpoint with an LLM judge scorer.
+    Falls back to direct Anthropic/OpenAI call if Harness ai-evals is unavailable.
+    Retries on transient failures (timeout, 5xx).
+    """
+    if not HARNESS_EVAL_API_URL or not HARNESS_EVAL_API_TOKEN:
+        provider, _ = _get_judge_config()
+        print(f"  [harness-judge] HARNESS_EVAL_API_URL or HARNESS_EVAL_API_TOKEN not set, falling back to {provider}")
+        return _call_judge_anthropic(prompt, model) if provider == "anthropic" else _call_judge_openai(prompt, model)
+
+    payload = {
+        "scorer_config": {
+            "type": "llm",
+            "name": "scs_answer_quality",
+            "model": model,
+            "prompt": prompt,
+            "temperature": 0.0,
+            "max_tokens": 1200,
+        },
+        "org": HARNESS_EVAL_ORG,
+        "project": HARNESS_EVAL_PROJECT,
+    }
+    url = f"{HARNESS_EVAL_API_URL.rstrip('/')}/evaluate/scorer/score"
+
+    last_error = None
+    for attempt in range(max_retries + 1):
+        try:
+            result = _harness_eval_request(url, payload, timeout=30)
+            # ai-evals returns: {"score": {"value": float, "comment": str, ...}}
+            # or directly: {"value": float, "reasoning": str}
+            if isinstance(result, dict):
+                score_obj = result.get("score", result.get("result", result))
+                if isinstance(score_obj, dict):
+                    score_val = score_obj.get("value", score_obj.get("score"))
+                    reasoning = score_obj.get("comment", score_obj.get("reasoning", ""))
+                    if score_val is not None:
+                        return json.dumps({"score": float(score_val), "reasoning": str(reasoning)})
+                # Try parsing the response as a direct score
+                if "score" in result and isinstance(result["score"], (int, float)):
+                    return json.dumps({"score": float(result["score"]), "reasoning": result.get("reasoning", "")})
+            return json.dumps({"score": 0.5, "reasoning": f"Unexpected response format: {str(result)[:200]}"})
+        except urllib.error.HTTPError as e:
+            last_error = e
+            # Retry on 5xx or 429 (rate limit)
+            if e.code >= 500 or e.code == 429:
+                if attempt < max_retries:
+                    wait = 2 ** attempt
+                    print(f"  [harness-judge] HTTP {e.code}, retrying in {wait}s (attempt {attempt + 1}/{max_retries})")
+                    time.sleep(wait)
+                    continue
+            # Non-retryable error — fall back
+            break
+        except (urllib.error.URLError, OSError, json.JSONDecodeError) as e:
+            last_error = e
+            if attempt < max_retries:
+                time.sleep(2 ** attempt)
+                continue
+            break
+        except Exception as e:
+            return f"JUDGE_ERROR: {e}"
+
+    # All retries exhausted — fall back to direct provider
+    provider, _ = _get_judge_config()
+    print(f"  [harness-judge] API error after {max_retries + 1} attempts: {last_error}, falling back to {provider}")
+    return _call_judge_anthropic(prompt, model) if provider == "anthropic" else _call_judge_openai(prompt, model)
+
+
+HARNESS_JUDGE_RUBRIC_PROMPT = """You are an expert evaluator for an AI agent that assists with Software Supply Chain Security (SCS).
+
+## User Query
+{query}
+
+## Agent's Response
+{answer}
+
+## Expected Behavior
+{observe}
+
+## Tools Called by Agent
+{tools_called}
+
+## Actual Tool Results (API Responses)
+{tool_results}
+
+## Multi-Criteria Rubric
+Evaluate the response on EACH criterion independently (0.0-1.0), then compute a weighted average.
+
+### 1. Task Completion (weight: 0.35)
+- 1.0: Fully addresses the user's request with complete, actionable information
+- 0.5: Partially addresses the request; some key information missing
+- 0.0: Fails to address the request or provides empty/irrelevant response
+
+### 2. Tool Usage Correctness (weight: 0.25)
+- 1.0: Uses the correct tools with correct parameters; no hallucinated tool calls
+- 0.5: Uses some correct tools but misses key ones or uses wrong parameters
+- 0.0: Uses completely wrong tools or fails to use any tools
+
+### 3. Factual Accuracy (weight: 0.20)
+- 1.0: All claims in the response are directly supported by the Actual Tool Results above; no hallucinated data
+- 0.5: Mostly accurate but some minor inconsistencies or unsupported claims vs the tool results
+- 0.0: Contains significant hallucinations or fabricated data not present in tool results
+
+### 4. Response Quality (weight: 0.20)
+- 1.0: Well-structured, clear, and actionable; appropriate level of detail
+- 0.5: Understandable but poorly organized or missing context
+- 0.0: Incoherent, overly verbose, or unusable
+
+## Evaluation Instructions (Chain-of-Thought)
+You MUST reason step-by-step before scoring. Follow this process exactly:
+
+Step 1: Read the user query and identify what was asked.
+Step 2: Check which tools were called and whether they match the expected behavior.
+Step 3: Compare the agent's response against the actual tool results — flag any claims not supported by the data.
+Step 4: Assess the overall response structure, clarity, and actionability.
+Step 5: Assign a score (0.0-1.0) to each criterion based on your analysis above.
+Step 6: Compute the weighted average: score = 0.35*task_completion + 0.25*tool_usage + 0.20*factual_accuracy + 0.20*response_quality.
+
+## Output Format
+First write your step-by-step analysis (Steps 1-6 above), then output the final scores as a JSON object on its own line:
+{{"task_completion": <float>, "tool_usage": <float>, "factual_accuracy": <float>, "response_quality": <float>, "score": <weighted_average_float>, "reasoning": "<one-sentence summary>"}}"""
+
+
+JUDGE_PROMPT_TEMPLATE = """You are evaluating an AI assistant's response to a user query about software supply chain security (SCS).
+
+## User Query
+{query}
+
+## Assistant's Response
+{answer}
+
+## Expected Behavior
+{observe}
+
+## Tools Called
+{tools_called}
+
+## Actual Tool Results (API Responses)
+{tool_results}
+
+## Evaluation Criteria
+Score the response on a scale of 0.0 to 1.0:
+- **1.0**: Response fully addresses the query, uses correct tools, provides accurate and actionable information
+- **0.75**: Response mostly addresses the query but misses minor details or has slight inaccuracies
+- **0.5**: Response partially addresses the query, key information is missing or incorrect
+- **0.25**: Response barely addresses the query, mostly irrelevant or incorrect
+- **0.0**: Response fails to address the query, is completely wrong, or is empty
+
+Consider:
+1. Does the response answer what the user actually asked?
+2. Is the information factually consistent with the Actual Tool Results provided above?
+3. Is the response well-structured and actionable?
+4. Does it avoid hallucinating data that is not present in the tool results?
+
+## Output Format
+Respond with ONLY a JSON object (no markdown):
+{{"score": <float 0.0-1.0>, "reasoning": "<brief explanation>"}}"""
+
+
+def answer_quality_evaluator(*, input: Any, output: Any, expected_output: Any, **kwargs) -> dict:
+    """LLM-as-Judge evaluation of answer quality.
+
+    Uses a fast model to evaluate whether the final answer is correct,
+    complete, well-formatted, and addresses the user's query.
+    """
+    judge_provider, judge_model = _get_judge_config()
+
+    query = input.get("query", "") if isinstance(input, dict) else str(input)
+    observe = expected_output.get("observe", "") if isinstance(expected_output, dict) else ""
+
+    answer = ""
+    tools_called_str = "(none)"
+    if isinstance(output, dict):
+        answer = output.get("answer", "") or output.get("final_answer", "")
+        tools = output.get("tools_called", [])
+        tools_called_str = ", ".join(_fmt_tool(t) for t in tools) if tools else "(none)"
+    elif isinstance(output, str):
+        answer = output
+
+    if not answer or len(answer.strip()) < 10:
+        return {"name": "answer_quality", "value": 0.0,
+                "comment": "No answer to evaluate"}
+
+    tool_results_str = _fmt_tool_results(output) if isinstance(output, dict) else "(none)"
+
+    prompt = JUDGE_PROMPT_TEMPLATE.format(
+        query=query,
+        answer=answer[:MAX_ANSWER_IN_PROMPT],
+        observe=observe,
+        tools_called=tools_called_str,
+        tool_results=tool_results_str,
+    )
+
+    if judge_provider == "anthropic":
+        raw = _call_judge_anthropic(prompt, judge_model)
+    else:
+        raw = _call_judge_openai(prompt, judge_model)
+
+    if raw.startswith("JUDGE_ERROR"):
+        return {"name": "answer_quality", "value": None, "comment": raw}
+
+    try:
+        # Extract JSON from response (handle potential markdown wrapping)
+        json_match = re.search(r'\{[^{}]*"score"[^{}]*\}', raw)
+        if json_match:
+            result = json.loads(json_match.group())
+            score = float(result.get("score", 0))
+            reasoning = result.get("reasoning", "")
+            return {"name": "answer_quality", "value": round(min(max(score, 0.0), 1.0), 3),
+                    "comment": reasoning[:MAX_COMMENT_LEN]}
+    except (json.JSONDecodeError, ValueError, TypeError):
+        pass
+
+    return {"name": "answer_quality", "value": None,
+            "comment": f"Failed to parse judge response: {raw[:200]}"}
+
+
+# ---------------------------------------------------------------------------
+# Run-Level Aggregate Evaluators
+# ---------------------------------------------------------------------------
+
+def _stddev(values: list[float]) -> float:
+    """Population standard deviation."""
+    if len(values) < 2:
+        return 0.0
+    mean = sum(values) / len(values)
+    variance = sum((x - mean) ** 2 for x in values) / len(values)
+    return variance ** 0.5
+
+
+def aggregate_trajectory_accuracy(*, item_results: list, **kwargs) -> dict:
+    """Average trajectory score across all items."""
+    scores = [
+        r["evaluations"]["trajectory"]["value"]
+        for r in item_results
+        if r.get("evaluations", {}).get("trajectory", {}).get("value") is not None
+    ]
+    if not scores:
+        return {"name": "avg_trajectory_accuracy", "value": None, "comment": "No trajectory scores"}
+    avg = sum(scores) / len(scores)
+    sd = _stddev(scores)
+    return {"name": "avg_trajectory_accuracy", "value": round(avg, 3),
+            "comment": f"Average over {len(scores)} items: {avg:.1%} (σ={sd:.3f})"}
+
+
+def aggregate_pass_rate(*, item_results: list, **kwargs) -> dict:
+    """Percentage of items with trajectory score == 1.0 (fully correct)."""
+    scores = [
+        r["evaluations"]["trajectory"]["value"]
+        for r in item_results
+        if r.get("evaluations", {}).get("trajectory", {}).get("value") is not None
+    ]
+    if not scores:
+        return {"name": "pass_rate", "value": None, "comment": "No scores"}
+    passed = sum(1 for s in scores if s == 1.0)
+    rate = passed / len(scores)
+    return {"name": "pass_rate", "value": round(rate, 3),
+            "comment": f"{passed}/{len(scores)} passed ({rate:.1%})"}
+
+
+# Approximate per-token costs (USD) for common models — used for cost estimation
+_TOKEN_COST_PER_1K = {
+    "claude-sonnet-4-20250514": {"prompt": 0.003, "completion": 0.015},
+    "gpt-4.1-mini": {"prompt": 0.0004, "completion": 0.0016},
+    "gpt-4.1": {"prompt": 0.002, "completion": 0.008},
+}
+_DEFAULT_COST_PER_1K = {"prompt": 0.003, "completion": 0.015}  # conservative default
+
+
+def aggregate_token_cost(*, item_results: list, **kwargs) -> dict:
+    """Aggregate token usage and estimated cost across all items.
+
+    Reads token_usage from each item's output dict and computes totals.
+    Returns the total token count as the value and cost breakdown as comment.
+    """
+    total_prompt = 0
+    total_completion = 0
+    items_with_usage = 0
+    for r in item_results:
+        usage = r.get("token_usage", {})
+        if not usage:
+            # Try extracting from evaluations metadata
+            continue
+        p = usage.get("prompt_tokens", 0)
+        c = usage.get("completion_tokens", 0)
+        if p or c:
+            total_prompt += p
+            total_completion += c
+            items_with_usage += 1
+
+    total = total_prompt + total_completion
+    if total == 0:
+        return {"name": "token_cost", "value": None, "comment": "No token usage data"}
+
+    # Estimate cost using default model pricing
+    model = os.getenv("EVAL_JUDGE_MODEL", "claude-sonnet-4-20250514")
+    costs = _TOKEN_COST_PER_1K.get(model, _DEFAULT_COST_PER_1K)
+    est_cost = (total_prompt / 1000 * costs["prompt"]) + (total_completion / 1000 * costs["completion"])
+
+    return {
+        "name": "token_cost",
+        "value": total,
+        "comment": f"prompt={total_prompt:,} completion={total_completion:,} total={total:,} "
+                   f"est_cost=${est_cost:.2f} ({items_with_usage} items, model={model})",
+    }
+
+
+def aggregate_quality_coverage(*, item_results: list, **kwargs) -> dict:
+    """Percentage of items with judge score >= QUALITY_COVERAGE_THRESHOLD.
+
+    Inspired by Sumeet Rai's Remediation Quality Index (RQI) coverage metric.
+    Uses harness_judge_score if available, falls back to answer_quality.
+    """
+    scores = []
+    for r in item_results:
+        evals = r.get("evaluations", {})
+        val = (evals.get("harness_judge_score", {}).get("value")
+               or evals.get("answer_quality", {}).get("value"))
+        if val is not None:
+            scores.append(val)
+
+    if not scores:
+        return {"name": "quality_coverage", "value": None,
+                "comment": "No judge scores available"}
+
+    above = sum(1 for s in scores if s >= QUALITY_COVERAGE_THRESHOLD)
+    rate = above / len(scores)
+    return {
+        "name": "quality_coverage",
+        "value": round(rate, 3),
+        "comment": f"{above}/{len(scores)} items >= {QUALITY_COVERAGE_THRESHOLD} threshold ({rate:.1%})",
+    }
+
+
+def aggregate_by_category(*, item_results: list, **kwargs) -> dict:
+    """Per-category pass rate breakdown using QUERY_CATEGORIES mapping.
+
+    Returns a single aggregate dict with per-category stats in the comment.
+    The value is the number of categories with 100% pass rate.
+    """
+    cat_scores: dict[str, list[float]] = {}
+    for r in item_results:
+        query_id = r.get("query_id", "")
+        # Strip per-turn suffix (e.g. M01-T1 → M01) for category lookup
+        base_id = query_id.split("-T")[0] if "-T" in query_id else query_id
+        category = QUERY_CATEGORIES.get(base_id, QUERY_CATEGORIES.get(query_id, "unknown"))
+        if category == "unsupported":
+            continue
+        traj_val = r.get("evaluations", {}).get("trajectory", {}).get("value")
+        if traj_val is not None:
+            cat_scores.setdefault(category, []).append(traj_val)
+
+    if not cat_scores:
+        return {"name": "category_breakdown", "value": None, "comment": "No categorized scores"}
+
+    parts = []
+    perfect_cats = 0
+    categories_detail = {}
+    for cat in sorted(cat_scores.keys()):
+        scores = cat_scores[cat]
+        avg = sum(scores) / len(scores)
+        passed = sum(1 for s in scores if s == 1.0)
+        if passed == len(scores):
+            perfect_cats += 1
+        parts.append(f"{cat}: {passed}/{len(scores)} ({avg:.0%})")
+        categories_detail[cat] = {
+            "pass_rate": round(passed / len(scores), 3),
+            "avg_trajectory": round(avg, 3),
+            "passed": passed,
+            "total": len(scores),
+        }
+
+    return {
+        "name": "category_breakdown",
+        "value": perfect_cats,
+        "comment": f"{perfect_cats}/{len(cat_scores)} categories at 100%. " + "; ".join(parts),
+        "categories": categories_detail,
+    }
+
+
+# Confidence level weights for MQI — higher confidence queries matter more
+CONFIDENCE_WEIGHTS: dict[str, float] = {
+    "Supported": 1.0,
+    "High": 1.0,
+    "Medium": 0.7,
+    "Low": 0.4,
+    "N/A": 0.2,
+    "": 0.2,       # empty string from query_def.get("confidence", "")
+}
+
+
+def aggregate_mqi(*, item_results: list, **kwargs) -> dict:
+    """MCP Quality Index (MQI) — confidence-weighted composite of all evaluator dimensions.
+
+    Combines trajectory, parameters, judge score, latency, error_free, and
+    answer_presence into a single 0.0-1.0 score per item. Items are then
+    averaged with weights based on their confidence level (Supported/High=1.0,
+    Medium=0.7, Low=0.4, N/A=0.2) so that high-confidence queries drive the
+    composite score more than exploratory/unsupported ones.
+    Inspired by Sumeet Rai's Remediation Quality Index (RQI).
+    """
+    item_mqis = []  # (mqi_score, confidence_weight)
+    for r in item_results:
+        evals = r.get("evaluations", {})
+        weighted_sum = 0.0
+        weight_sum = 0.0
+        for metric, weight in MQI_WEIGHTS.items():
+            val = evals.get(metric, {}).get("value")
+            if val is not None:
+                weighted_sum += val * weight
+                weight_sum += weight
+        if weight_sum > 0:
+            mqi_val = weighted_sum / weight_sum
+            conf = r.get("confidence", "N/A")
+            conf_weight = CONFIDENCE_WEIGHTS.get(conf, 0.5)
+            item_mqis.append((mqi_val, conf_weight))
+
+    if not item_mqis:
+        return {"name": "mqi", "value": None, "comment": "No evaluator scores available"}
+
+    # Confidence-weighted average
+    total_weight = sum(cw for _, cw in item_mqis)
+    if total_weight > 0:
+        avg_mqi = sum(mqi * cw for mqi, cw in item_mqis) / total_weight
+    else:
+        avg_mqi = sum(mqi for mqi, _ in item_mqis) / len(item_mqis)
+
+    # Also compute unweighted + stddev for stability insight
+    raw_scores = [mqi for mqi, _ in item_mqis]
+    unweighted = sum(raw_scores) / len(raw_scores)
+    sd = _stddev(raw_scores)
+
+    return {
+        "name": "mqi",
+        "value": round(avg_mqi, 3),
+        "comment": f"MCP Quality Index: {avg_mqi:.1%} (confidence-weighted) / "
+                   f"{unweighted:.1%} (unweighted) over {len(item_mqis)} items "
+                   f"(σ={sd:.3f})",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Evaluator Registry
+# ---------------------------------------------------------------------------
+
+# Fast evaluators (deterministic, no LLM calls)
+FAST_EVALUATORS = [
+    trajectory_evaluator,
+    trajectory_order_evaluator,
+    parameter_evaluator,
+    latency_evaluator,
+    error_evaluator,
+    answer_presence_evaluator,
+]
+
+# Full evaluators (includes LLM-as-Judge — adds cost and latency)
+FULL_EVALUATORS = FAST_EVALUATORS + [
+    answer_quality_evaluator,
+]
+
+RUN_EVALUATORS = [
+    aggregate_trajectory_accuracy,
+    aggregate_pass_rate,
+    aggregate_token_cost,
+    aggregate_quality_coverage,
+    aggregate_by_category,
+    aggregate_mqi,
+]
+
+# ---------------------------------------------------------------------------
+# Regression Detection
+# ---------------------------------------------------------------------------
+
+# Thresholds: if a metric drops by more than this fraction, flag it as a regression
+REGRESSION_THRESHOLDS = {
+    "correct_rate": 0.05,        # 5% drop in correct rate
+    "avg_trajectory_accuracy": 0.05,
+    "pass_rate": 0.05,
+    "quality_coverage": 0.05,    # 5% drop in items above judge threshold
+    "mqi": 0.05,                 # 5% drop in MCP Quality Index
+    "avg_duration_s": 0.20,      # 20% increase threshold (lower is better)
+    "total_tokens": 0.15,        # 15% increase threshold (lower is better)
+}
+
+
+def detect_regressions(current_summary: dict, previous_summary_path: str) -> list[dict]:
+    """Compare current run metrics against the previous run and flag regressions.
+
+    Returns a list of {metric, current, previous, delta, status} dicts.
+    status is one of: "regression", "improvement", "stable".
+    """
+    import pathlib
+    prev_path = pathlib.Path(previous_summary_path)
+    if not prev_path.exists():
+        return [{"metric": "_baseline", "status": "no_previous",
+                 "comment": f"No previous run found at {previous_summary_path}"}]
+
+    try:
+        with open(prev_path) as f:
+            prev = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        return [{"metric": "_baseline", "status": "error", "comment": f"Failed to load previous: {e}"}]
+
+    results = []
+    cur_s = current_summary.get("summary", {})
+    prev_s = prev.get("summary", {})
+
+    # Correct rate
+    cur_total = cur_s.get("total_queries", 0)
+    prev_total = prev_s.get("total_queries", 0)
+    if cur_total > 0 and prev_total > 0:
+        cur_rate = cur_s.get("tool_selection_correct", 0) / cur_total
+        prev_rate = prev_s.get("tool_selection_correct", 0) / prev_total
+        results.append(_compare_metric("correct_rate", cur_rate, prev_rate, higher_is_better=True))
+
+    # Avg duration
+    cur_dur = cur_s.get("avg_duration_s", 0)
+    prev_dur = prev_s.get("avg_duration_s", 0)
+    if cur_dur > 0 and prev_dur > 0:
+        results.append(_compare_metric("avg_duration_s", cur_dur, prev_dur, higher_is_better=False))
+
+    # Total tokens
+    cur_tok = cur_s.get("total_tokens", 0)
+    prev_tok = prev_s.get("total_tokens", 0)
+    if cur_tok > 0 and prev_tok > 0:
+        results.append(_compare_metric("total_tokens", cur_tok, prev_tok, higher_is_better=False))
+
+    # Run aggregates (if both have them)
+    cur_agg = current_summary.get("run_aggregates", {})
+    prev_agg = prev.get("run_aggregates", {})
+    for metric_name in ("avg_trajectory_accuracy", "pass_rate", "quality_coverage", "mqi"):
+        cur_val = cur_agg.get(metric_name, {}).get("value")
+        prev_val = prev_agg.get(metric_name, {}).get("value")
+        if cur_val is not None and prev_val is not None:
+            results.append(_compare_metric(metric_name, cur_val, prev_val, higher_is_better=True))
+
+    # Per-category regression detection
+    cur_cats = cur_agg.get("category_breakdown", {}).get("categories", {})
+    prev_cats = prev_agg.get("category_breakdown", {}).get("categories", {})
+    if cur_cats and prev_cats:
+        for cat in sorted(set(cur_cats) | set(prev_cats)):
+            cur_pr = cur_cats.get(cat, {}).get("pass_rate")
+            prev_pr = prev_cats.get(cat, {}).get("pass_rate")
+            if cur_pr is not None and prev_pr is not None:
+                results.append(_compare_metric(
+                    f"category:{cat}", cur_pr, prev_pr, higher_is_better=True
+                ))
+
+    return results
+
+
+def detect_flaky_queries(current_summary: dict, results_dir: str,
+                         history_depth: int = 5) -> list[dict]:
+    """Detect queries whose tool_selection flips between runs.
+
+    Loads up to `history_depth` previous summary files (sorted by modification
+    time) and builds a per-query history of tool_selection outcomes. A query is
+    flagged as "flaky" if it has 2+ distinct outcomes across the window.
+
+    Returns a list of {query_id, history, distinct_outcomes, flaky} dicts.
+    """
+    import pathlib, glob
+
+    results_path = pathlib.Path(results_dir)
+    # Find all timestamped result files, sorted newest-first
+    pattern = str(results_path / "smoke_test_results_*.json")
+    history_files = sorted(glob.glob(pattern), key=os.path.getmtime, reverse=True)
+
+    # Build per-query history: {query_id: [outcome1, outcome2, ...]}
+    query_history: dict[str, list[str]] = {}
+
+    # Add current run first (single-turn + multi-turn)
+    for r in current_summary.get("results", []):
+        qid = r.get("id", "")
+        outcome = r.get("scoring", {}).get("tool_selection", "UNKNOWN")
+        query_history.setdefault(qid, []).append(outcome)
+    for cr in current_summary.get("conversation_results", []):
+        qid = cr.get("id", "")
+        outcome = cr.get("scoring", {}).get("overall", "UNKNOWN")
+        query_history.setdefault(qid, []).append(outcome)
+
+    # Load previous runs (up to history_depth)
+    loaded = 0
+    for fpath in history_files:
+        if loaded >= history_depth:
+            break
+        try:
+            with open(fpath) as f:
+                prev = json.load(f)
+            for r in prev.get("results", []):
+                qid = r.get("id", "")
+                outcome = r.get("scoring", {}).get("tool_selection", "UNKNOWN")
+                query_history.setdefault(qid, []).append(outcome)
+            for cr in prev.get("conversation_results", []):
+                qid = cr.get("id", "")
+                outcome = cr.get("scoring", {}).get("overall", "UNKNOWN")
+                query_history.setdefault(qid, []).append(outcome)
+            loaded += 1
+        except (json.JSONDecodeError, OSError):
+            continue
+
+    # Identify flaky queries (2+ distinct outcomes)
+    flaky_results = []
+    for qid in sorted(query_history.keys()):
+        history = query_history[qid]
+        distinct = set(history)
+        is_flaky = len(distinct) >= 2 and len(history) >= 2
+        if is_flaky:
+            flaky_results.append({
+                "query_id": qid,
+                "history": history[:history_depth + 1],  # most recent first
+                "distinct_outcomes": sorted(distinct),
+                "flaky": True,
+                "flip_count": sum(1 for i in range(1, len(history)) if history[i] != history[i-1]),
+            })
+
+    return flaky_results
+
+
+def _compare_metric(name: str, current: float, previous: float, higher_is_better: bool) -> dict:
+    """Compare a single metric and determine regression status."""
+    if previous == 0:
+        delta_pct = 0.0
+    else:
+        delta_pct = (current - previous) / abs(previous)
+
+    threshold = REGRESSION_THRESHOLDS.get(name, 0.05)
+
+    if higher_is_better:
+        # For metrics where higher = better, regression = current < previous by threshold
+        if delta_pct < -threshold:
+            status = "regression"
+        elif delta_pct > threshold:
+            status = "improvement"
+        else:
+            status = "stable"
+    else:
+        # For metrics where lower = better (duration, tokens), regression = increase
+        if delta_pct > threshold:
+            status = "regression"
+        elif delta_pct < -threshold:
+            status = "improvement"
+        else:
+            status = "stable"
+
+    return {
+        "metric": name, "current": round(current, 4), "previous": round(previous, 4),
+        "delta_pct": round(delta_pct * 100, 1), "status": status,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Langfuse Integration Layer
+# ---------------------------------------------------------------------------
+
+class LangfuseIntegration:
+    """Wraps the smoke test execution with Langfuse tracing, experiments, and scoring.
+
+    Features:
+        - Experiments: A/B run comparison via dataset_item.link(trace)
+        - Session tracking: Per-turn traces with session_id for multi-turn conversations
+        - Span-level tracing: Child spans for individual tool calls and LLM generations
+        - Harness ai-evals: Rubric-based LLM-as-Judge scoring via REST API
+
+    Usage:
+        lf = LangfuseIntegration(enable_judge=True, use_harness_judge=True)
+        lf.sync_dataset(queries)
+        lf.sync_conversation_dataset(conversations)
+        # Post-run: score via _run_langfuse_scoring() in scs_llm_smoke_test.py
+        lf.flush()
+    """
+
+    def __init__(self, enable_judge: bool = False, experiment_prefix: str = "scs-smoke",
+                 use_harness_judge: bool = False):
+        try:
+            # Try newer SDK (>=3.10.6) first, fall back to legacy constructor
+            try:
+                from langfuse import get_client
+                self._langfuse = get_client()
+            except ImportError:
+                from langfuse import Langfuse
+                self._langfuse = Langfuse(
+                    host=LANGFUSE_HOST,
+                )
+            auth_ok = self._langfuse.auth_check()
+            if not auth_ok:
+                raise RuntimeError("Langfuse auth check failed — verify LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY")
+            print(f"  [langfuse] Connected to {LANGFUSE_HOST}")
+        except ImportError:
+            raise ImportError("langfuse package not installed. Run: pip install langfuse")
+
+        self._enable_judge = enable_judge
+        self._use_harness_judge = use_harness_judge
+        self._experiment_prefix = experiment_prefix
+        self._judge_provider, self._judge_model = _get_judge_config()
+        # Compute prompt version hash for tracking which prompt produced which scores
+        prompt_content = JUDGE_PROMPT_TEMPLATE + HARNESS_JUDGE_RUBRIC_PROMPT
+        self._prompt_version = hashlib.sha256(prompt_content.encode()).hexdigest()[:12]
+        # When harness judge is active, skip answer_quality_evaluator (redundant —
+        # the rubric judge in _run_harness_rubric_judge is strictly better).
+        # Use FAST_EVALUATORS only; harness rubric scores are added separately.
+        if use_harness_judge and enable_judge:
+            self._evaluators = FAST_EVALUATORS
+        elif enable_judge:
+            self._evaluators = FULL_EVALUATORS
+        else:
+            self._evaluators = FAST_EVALUATORS
+        # Experiment run name: prefix + timestamp for unique identification
+        self._experiment_run = f"{experiment_prefix}-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}"
+        # Dataset item caches for experiment linking
+        self._single_dataset_items: dict[str, Any] = {}  # query_id -> dataset_item
+        self._multi_dataset_items: dict[str, Any] = {}   # conv_id -> dataset_item
+
+        if enable_judge:
+            print(f"  [langfuse] Judge prompt version: {self._prompt_version}")
+
+        if use_harness_judge:
+            if HARNESS_EVAL_API_URL and HARNESS_EVAL_API_TOKEN:
+                ok, msg = validate_harness_eval_connection()
+                if ok:
+                    print(f"  [langfuse] Harness ai-evals judge CONNECTED ({HARNESS_EVAL_API_URL})")
+                else:
+                    print(f"  [langfuse] Harness ai-evals connection failed: {msg}")
+                    print(f"  [langfuse] Will fallback to direct {self._judge_provider} calls for judging")
+            else:
+                print(f"  [langfuse] Harness ai-evals judge requested but HARNESS_EVAL_API_URL/TOKEN not set — will fallback to {self._judge_provider}")
+
+    @property
+    def experiment_run_name(self) -> str:
+        """Return the current experiment run name for display."""
+        return self._experiment_run
+
+    def sync_dataset(self, queries: list[dict], dataset_name: str = DATASET_NAME_SINGLE) -> None:
+        """Create or update the Langfuse dataset from smoke test query definitions."""
+        try:
+            self._langfuse.create_dataset(name=dataset_name)
+            print(f"  [langfuse] Created dataset '{dataset_name}'")
+        except Exception:
+            print(f"  [langfuse] Dataset '{dataset_name}' already exists, updating items...")
+
+        for q in queries:
+            item = self._langfuse.create_dataset_item(
+                dataset_name=dataset_name,
+                input={
+                    "id": q["id"],
+                    "query": q["query"],
+                    "confidence": q.get("confidence", "N/A"),
+                },
+                expected_output={
+                    "trajectory": [list(t) for t in q.get("expected_tools", [])],
+                    "observe": q.get("observe", ""),
+                    "expected_intent": q.get("expected_intent", ""),
+                    "confidence": q.get("confidence", "N/A"),
+                },
+                metadata={
+                    "query_id": q["id"],
+                    "confidence": q.get("confidence", "N/A"),
+                },
+            )
+            self._single_dataset_items[q["id"]] = item
+        print(f"  [langfuse] Synced {len(queries)} items to '{dataset_name}'")
+
+    def sync_conversation_dataset(self, conversations: list[dict],
+                                  dataset_name: str = DATASET_NAME_MULTI) -> None:
+        """Create or update the Langfuse dataset for multi-turn conversations."""
+        try:
+            self._langfuse.create_dataset(name=dataset_name)
+        except Exception:
+            pass
+
+        for conv in conversations:
+            item = self._langfuse.create_dataset_item(
+                dataset_name=dataset_name,
+                input={
+                    "id": conv["id"],
+                    "title": conv["title"],
+                    "description": conv["description"],
+                    "turns": [
+                        {
+                            "turn": t["turn"],
+                            "query": t["query"],
+                            "expected_tools": [list(x) for x in t.get("expected_tools", [])],
+                            "observe": t.get("observe", ""),
+                        }
+                        for t in conv["turns"]
+                    ],
+                },
+                expected_output={
+                    "turn_trajectories": [
+                        [list(x) for x in t.get("expected_tools", [])]
+                        for t in conv["turns"]
+                    ],
+                },
+                metadata={"conversation_id": conv["id"], "num_turns": len(conv["turns"])},
+            )
+            self._multi_dataset_items[conv["id"]] = item
+        print(f"  [langfuse] Synced {len(conversations)} conversations to '{dataset_name}'")
+
+    # -------------------------------------------------------------------
+    # Span-Level Tracing: Creates child spans for each tool call
+    # -------------------------------------------------------------------
+    def _create_tool_spans(self, root_span: Any, extracted: dict) -> None:
+        """Create child spans on a root span for each tool call in the execution.
+
+        Uses SDK v3.7.0 API: root_span.start_span() / root_span.start_generation().
+        This enables granular Langfuse UI drill-down into individual tool
+        invocations, their parameters, and timing.
+        """
+        tools_called = extracted.get("tools_called", [])
+        tool_params = extracted.get("tool_params", {})
+        raw_results = extracted.get("tool_results", {})
+        # tool_results may be a list (from extract_tools_from_events) or a dict — normalize
+        tool_results = raw_results if isinstance(raw_results, dict) else {}
+
+        for i, tool_spec in enumerate(tools_called):
+            tool_name = tool_spec[0] if isinstance(tool_spec, (list, tuple)) else str(tool_spec)
+            resource_type = tool_spec[1] if isinstance(tool_spec, (list, tuple)) and len(tool_spec) > 1 else ""
+            display_name = f"{tool_name}({resource_type})" if resource_type else tool_name
+
+            # Find matching params and results
+            params = tool_params.get(display_name, tool_params.get(tool_name, {}))
+            result_data = tool_results.get(display_name, tool_results.get(tool_name, ""))
+
+            child = root_span.start_span(
+                name=display_name,
+                input=params,
+                metadata={
+                    "tool_name": tool_name,
+                    "resource_type": resource_type,
+                    "call_index": i,
+                },
+            )
+            child.update(output=str(result_data)[:MAX_TOOL_RESULT_OUTPUT] if result_data else "")
+            child.end()
+
+        # Create a generation span for the LLM's final answer synthesis
+        final_answer = extracted.get("final_answer", "")
+        token_usage = extracted.get("token_usage", {})
+        if final_answer:
+            usage = None
+            if token_usage:
+                usage = {
+                    "input": token_usage.get("prompt_tokens", 0),
+                    "output": token_usage.get("completion_tokens", 0),
+                    "total": token_usage.get("total_tokens", 0),
+                }
+            _, judge_model = _get_judge_config()
+            gen = root_span.start_generation(
+                name="answer-synthesis",
+                input=f"Synthesize answer from {len(tools_called)} tool calls",
+                model=judge_model,
+            )
+            gen.update(output=final_answer[:MAX_TRACE_OUTPUT], usage_details=usage)
+            gen.end()
+
+    # -------------------------------------------------------------------
+    # Experiment Linking: Links traces to dataset items for A/B comparison
+    # -------------------------------------------------------------------
+    def _link_to_dataset_item(self, trace_id: str, query_id: str, is_conversation: bool = False) -> None:
+        """Link a trace to its corresponding Langfuse dataset item for experiment tracking.
+
+        Uses SDK v3.7.0 API: dataset_run_items.create() to link trace → item → run.
+        This enables the Langfuse Experiments UI to compare runs across different
+        model versions, prompt changes, or configuration tweaks.
+        """
+        items = self._multi_dataset_items if is_conversation else self._single_dataset_items
+        dataset_item = items.get(query_id)
+        if dataset_item:
+            try:
+                self._langfuse.api.dataset_run_items.create(
+                    request={
+                        "datasetItemId": dataset_item.id,
+                        "traceId": trace_id,
+                        "runName": self._experiment_run,
+                    }
+                )
+            except Exception as e:
+                print(f"    [langfuse] Failed to link {query_id} to experiment: {e}")
+
+    # -------------------------------------------------------------------
+    # Single-Turn Trace + Score
+    # -------------------------------------------------------------------
+    def create_trace(self, query_def: dict, extracted: dict, duration_s: float,
+                     session_id: Optional[str] = None) -> str:
+        """Create a Langfuse trace for a single query execution with span-level detail.
+
+        Uses SDK v3.7.0: start_span() creates a root span (and implicitly a trace),
+        then update_trace() sets trace-level metadata (session_id, tags, etc.).
+        """
+        trace_id = self._langfuse.create_trace_id(seed=f"{self._experiment_run}-{query_def['id']}")
+        root = self._langfuse.start_span(
+            trace_context={"trace_id": trace_id},
+            name=f"scs-smoke-{query_def['id']}",
+            input={"query": query_def["query"], "id": query_def["id"]},
+        )
+        root.update_trace(
+            name=f"scs-smoke-{query_def['id']}",
+            session_id=session_id,
+            input={"query": query_def["query"], "id": query_def["id"]},
+            output=extracted.get("final_answer", "")[:MAX_TRACE_OUTPUT],
+            metadata={
+                "query_id": query_def["id"],
+                "confidence": query_def.get("confidence", "N/A"),
+                "tools_called": [list(t) for t in extracted.get("tools_called", [])],
+                "tool_params": extracted.get("tool_params", {}),
+                "duration_s": duration_s,
+                "token_usage": extracted.get("token_usage", {}),
+                "errors": extracted.get("errors", []),
+                "experiment_run": self._experiment_run,
+                "prompt_version": self._prompt_version,
+                "judge_model": self._judge_model,
+                "judge_provider": self._judge_provider,
+            },
+            tags=["scs-smoke-test", query_def.get("confidence", "N/A"), self._experiment_run],
+        )
+        # Span-level tracing: create child spans for each tool call
+        self._create_tool_spans(root, extracted)
+        root.end()
+        # Experiment linking: associate trace with dataset item
+        self._link_to_dataset_item(trace_id, query_def["id"], is_conversation=False)
+        return trace_id
+
+    @staticmethod
+    def _build_turn_extracted(turn_result: dict) -> dict:
+        """Build a normalized extracted dict from a turn result for scoring/tracing."""
+        return {
+            "tools_called": [tuple(t) if isinstance(t, list) else t for t in turn_result.get("tools_called", [])],
+            "tool_params": turn_result.get("tool_params", {}),
+            "tool_results": turn_result.get("tool_results", {}),
+            "final_answer": turn_result.get("final_answer", ""),
+            "token_usage": turn_result.get("token_usage", {}),
+            "chain_depth": len(turn_result.get("tools_called", [])),
+        }
+
+    def _push_scores(self, trace_id: Optional[str], scores: dict[str, Any]) -> None:
+        """Push a dict of {name: {value, comment}} scores to Langfuse for a trace."""
+        if not trace_id:
+            return
+        for name, score_data in scores.items():
+            if score_data.get("value") is not None:
+                self._langfuse.create_score(
+                    trace_id=trace_id,
+                    name=name,
+                    value=score_data["value"],
+                    comment=score_data.get("comment", "")[:MAX_COMMENT_LEN],
+                )
+
+    def score_single_query(self, query_def: dict, extracted: dict, duration_s: float,
+                           trace_id: Optional[str] = None) -> dict[str, Any]:
+        """Score a single query execution and push scores to Langfuse.
+
+        Returns dict of {evaluator_name: {value, comment}}.
+        If use_harness_judge is enabled, uses the Harness ai-evals rubric-based
+        scorer instead of the basic LLM-as-Judge prompt.
+        """
+        output = {
+            "answer": extracted.get("final_answer", ""),
+            "tools_called": [list(t) for t in extracted.get("tools_called", [])],
+            "tool_params": extracted.get("tool_params", {}),
+            "tool_results": extracted.get("tool_results", {}),
+            "duration_s": duration_s,
+            "token_usage": extracted.get("token_usage", {}),
+            "errors": extracted.get("errors", []),
+            "chain_depth": extracted.get("chain_depth", 0),
+        }
+        expected_output = {
+            "trajectory": [list(t) for t in query_def.get("expected_tools", [])],
+            "observe": query_def.get("observe", ""),
+            "confidence": query_def.get("confidence", "N/A"),
+        }
+        input_data = {
+            "id": query_def["id"],
+            "query": query_def["query"],
+            "confidence": query_def.get("confidence", "N/A"),
+        }
+
+        scores = {}
+        for evaluator in self._evaluators:
+            try:
+                result = evaluator(
+                    input=input_data,
+                    output=output,
+                    expected_output=expected_output,
+                )
+                if isinstance(result, dict) and result.get("value") is not None:
+                    scores[result["name"]] = {
+                        "value": result["value"],
+                        "comment": result.get("comment", ""),
+                    }
+            except Exception as e:
+                scores[evaluator.__name__] = {"value": None, "comment": f"Error: {e}"}
+
+        # Harness ai-evals rubric-based judge (additional multi-criteria scoring)
+        if self._use_harness_judge and self._enable_judge:
+            harness_scores = self._run_harness_rubric_judge(query_def, extracted, trace_id)
+            scores.update(harness_scores)
+
+        # Push all scores to Langfuse in one pass
+        self._push_scores(trace_id, scores)
+        return scores
+
+    def _run_harness_rubric_judge(self, query_def: dict, extracted: dict,
+                                  trace_id: Optional[str] = None) -> dict[str, Any]:
+        """Run Harness ai-evals rubric-based multi-criteria judge.
+
+        Returns sub-scores for task_completion, tool_usage, factual_accuracy,
+        response_quality, and an overall harness_judge_score.
+        """
+        scores = {}
+        tools_str = ", ".join(
+            _fmt_tool(t) for t in extracted.get("tools_called", [])
+        ) or "(none)"
+
+        tool_results_str = _fmt_tool_results(extracted)
+
+        prompt = HARNESS_JUDGE_RUBRIC_PROMPT.format(
+            query=query_def["query"],
+            answer=extracted.get("final_answer", "")[:MAX_ANSWER_IN_PROMPT],
+            observe=query_def.get("observe", ""),
+            tools_called=tools_str,
+            tool_results=tool_results_str,
+        )
+
+        try:
+            provider, model = _get_judge_config()
+            logprobs_data = None
+
+            # Try Harness ai-evals first (respects --harness-judge intent)
+            raw = _call_judge_harness(prompt, model)
+
+            # If Harness returned an error and provider is OpenAI, retry with
+            # direct OpenAI call + logprobs for token probability calibration.
+            # When Harness succeeds, trust its response without double-calling.
+            if raw.startswith("JUDGE_ERROR") and provider == "openai":
+                # Harness failed — retry with direct OpenAI + logprobs
+                result = _call_judge_openai(prompt, model, use_logprobs=True)
+                if isinstance(result, tuple):
+                    raw, logprobs_data = result
+                else:
+                    raw = result
+            elif not raw.startswith("JUDGE_ERROR") and provider == "openai":
+                # Harness succeeded — optionally get logprobs via a lightweight
+                # OpenAI call for calibration. Skip if it would double cost.
+                # We only calibrate when Harness isn't configured (fallback path).
+                # When Harness IS configured and returns valid JSON, trust it.
+                pass
+
+            if raw.startswith("JUDGE_ERROR"):
+                scores["harness_judge_score"] = {"value": None, "comment": raw}
+                return scores
+
+            # Parse JSON from CoT response (text reasoning followed by JSON)
+            parsed = _extract_json_from_cot(raw)
+            if isinstance(parsed, dict) and "score" in parsed:
+                overall = float(parsed["score"])
+                reasoning = parsed.get("reasoning", "")
+
+                # Apply token probability calibration if logprobs available
+                calibrated = _calibrate_score_from_logprobs(logprobs_data, overall)
+
+                scores["harness_judge_score"] = {
+                    "value": round(calibrated, 3),
+                    "comment": reasoning[:MAX_COMMENT_LEN],
+                }
+                if calibrated != overall:
+                    scores["harness_judge_score"]["comment"] += f" [calibrated: {overall:.3f}→{calibrated:.3f}]"
+
+                # Extract sub-criteria if present
+                for criterion in ["task_completion", "tool_usage", "factual_accuracy", "response_quality"]:
+                    if criterion in parsed:
+                        val = float(parsed[criterion])
+                        scores[f"hj_{criterion}"] = {"value": round(val, 3), "comment": ""}
+
+                # Push all sub-scores to Langfuse
+                self._push_scores(trace_id, scores)
+        except (json.JSONDecodeError, ValueError, TypeError) as e:
+            scores["harness_judge_score"] = {"value": None, "comment": f"Parse error: {e}"}
+
+        return scores
+
+    # -------------------------------------------------------------------
+    # Multi-Turn Conversation: Session Tracking + Per-Turn Traces
+    # -------------------------------------------------------------------
+    def create_conversation_trace(self, conv_def: dict, turn_results: list[dict],
+                                  total_duration: float) -> str:
+        """Create Langfuse traces for a multi-turn conversation with session tracking.
+
+        Creates:
+        1. A parent trace for the overall conversation
+        2. Per-turn child traces linked via session_id for turn-level analysis
+        3. Tool call spans within each turn trace
+        """
+        session_id = f"scs-smoke-{conv_def['id']}-{self._experiment_run}"
+
+        # Parent conversation trace via start_span + update_trace (SDK v3.7.0)
+        parent_trace_id = self._langfuse.create_trace_id(seed=f"{self._experiment_run}-{conv_def['id']}")
+        parent_root = self._langfuse.start_span(
+            trace_context={"trace_id": parent_trace_id},
+            name=f"scs-smoke-{conv_def['id']}",
+            input={"id": conv_def["id"], "title": conv_def["title"]},
+        )
+        parent_root.update_trace(
+            name=f"scs-smoke-{conv_def['id']}",
+            session_id=session_id,
+            input={"id": conv_def["id"], "title": conv_def["title"],
+                   "turns": [t["query"] for t in conv_def["turns"]]},
+            output=json.dumps({
+                "turns": [
+                    {
+                        "turn": tr.get("turn"),
+                        "tool_selection": tr.get("tool_selection"),
+                        "tools_called": tr.get("tools_called", []),
+                        "answer_preview": tr.get("final_answer", "")[:200],
+                    }
+                    for tr in turn_results
+                ],
+            }),
+            metadata={
+                "conversation_id": conv_def["id"],
+                "num_turns": len(conv_def["turns"]),
+                "total_duration_s": total_duration,
+                "experiment_run": self._experiment_run,
+                "prompt_version": self._prompt_version,
+                "judge_model": self._judge_model,
+                "judge_provider": self._judge_provider,
+            },
+            tags=["scs-smoke-test", "multi-turn", self._experiment_run],
+        )
+        parent_root.end()
+
+        # Per-turn traces with same session_id for session tracking
+        for turn_def, turn_result in zip(conv_def["turns"], turn_results):
+            turn_num = turn_def["turn"]
+            turn_trace_id = self._langfuse.create_trace_id(
+                seed=f"{self._experiment_run}-{conv_def['id']}-T{turn_num}"
+            )
+            turn_root = self._langfuse.start_span(
+                trace_context={"trace_id": turn_trace_id},
+                name=f"scs-smoke-{conv_def['id']}-T{turn_num}",
+                input={"query": turn_def["query"], "turn": turn_num},
+            )
+            turn_root.update_trace(
+                name=f"scs-smoke-{conv_def['id']}-T{turn_num}",
+                session_id=session_id,
+                input={"query": turn_def["query"], "turn": turn_num,
+                       "conversation_id": conv_def["id"]},
+                output=turn_result.get("final_answer", "")[:MAX_TRACE_OUTPUT],
+                metadata={
+                    "turn": turn_num,
+                    "conversation_id": conv_def["id"],
+                    "tool_selection": turn_result.get("tool_selection"),
+                    "tools_called": turn_result.get("tools_called", []),
+                    "duration_s": turn_result.get("duration_s", 0),
+                },
+                tags=["scs-smoke-test", "multi-turn", f"turn-{turn_num}"],
+            )
+            # Span-level tracing for each turn's tool calls
+            self._create_tool_spans(turn_root, self._build_turn_extracted(turn_result))
+            turn_root.end()
+
+        # Experiment linking: associate parent trace with dataset item
+        self._link_to_dataset_item(parent_trace_id, conv_def["id"], is_conversation=True)
+
+        return parent_trace_id
+
+    def score_conversation(self, conv_def: dict, turn_results: list[dict],
+                           total_duration: float, trace_id: Optional[str] = None) -> dict[str, Any]:
+        """Score a full conversation and push aggregate scores to Langfuse.
+
+        When judge is enabled, runs LLM-as-Judge on each turn and computes
+        an aggregate conversation-level judge score.
+
+        Returns conversation-level scores dict. Also attaches per-turn score
+        dicts directly onto each turn_result as ``turn_result["langfuse_scores"]``
+        so downstream MQI aggregation can include individual turn contributions.
+        """
+        scores = {}
+
+        # Per-turn trajectory scores
+        turn_trajectory_scores = []
+        for i, (turn_def, turn_result) in enumerate(zip(conv_def["turns"], turn_results)):
+            expected = [list(t) for t in turn_def.get("expected_tools", [])]
+            actual = turn_result.get("tools_called", [])
+            if not expected:
+                turn_trajectory_scores.append(1.0)
+                continue
+            result = trajectory_evaluator(
+                output={"tools_called": actual},
+                expected_output={"trajectory": expected},
+            )
+            turn_trajectory_scores.append(result.get("value", 0.0))
+
+        # Aggregate turn accuracy
+        if turn_trajectory_scores:
+            avg_turn_score = sum(turn_trajectory_scores) / len(turn_trajectory_scores)
+            scores["turn_trajectory_avg"] = {
+                "value": round(avg_turn_score, 3),
+                "comment": f"Per-turn scores: {[round(s, 2) for s in turn_trajectory_scores]}",
+            }
+
+        # Turns correct count
+        turns_with_expected = sum(1 for t in conv_def["turns"] if t.get("expected_tools"))
+        turns_correct = sum(1 for s in turn_trajectory_scores if s == 1.0)
+        if turns_with_expected > 0:
+            scores["turns_correct_rate"] = {
+                "value": round(turns_correct / turns_with_expected, 3),
+                "comment": f"{turns_correct}/{turns_with_expected} turns fully correct",
+            }
+
+        # Per-turn LLM-as-Judge scoring (when judge is enabled)
+        turn_judge_scores = []
+        if self._enable_judge:
+            for i, (turn_def, turn_result) in enumerate(zip(conv_def["turns"], turn_results)):
+                turn_num = turn_def.get("turn", i + 1)
+                turn_extracted = self._build_turn_extracted(turn_result)
+                turn_query_def = {
+                    "id": f"{conv_def['id']}-T{turn_num}",
+                    "query": turn_def["query"],
+                    "expected_tools": turn_def.get("expected_tools", []),
+                    "observe": turn_def.get("observe", ""),
+                }
+
+                # Get per-turn trace ID for score attachment
+                turn_trace_id = None
+                try:
+                    turn_trace_id = self._langfuse.create_trace_id(
+                        seed=f"{self._experiment_run}-{conv_def['id']}-T{turn_num}"
+                    )
+                except Exception:
+                    pass
+
+                if self._use_harness_judge:
+                    turn_scores = self._run_harness_rubric_judge(
+                        turn_query_def, turn_extracted, trace_id=turn_trace_id
+                    )
+                    judge_val = turn_scores.get("harness_judge_score", {}).get("value")
+                else:
+                    # Use answer_quality_evaluator for basic judge
+                    output = {
+                        "answer": turn_extracted.get("final_answer", ""),
+                        "tools_called": [list(t) for t in turn_extracted.get("tools_called", [])],
+                        "tool_results": turn_extracted.get("tool_results", []),
+                    }
+                    expected_output = {
+                        "trajectory": [list(t) for t in turn_def.get("expected_tools", [])],
+                        "observe": turn_def.get("observe", ""),
+                    }
+                    aq_result = answer_quality_evaluator(
+                        input={"id": turn_query_def["id"], "query": turn_def["query"]},
+                        output=output,
+                        expected_output=expected_output,
+                    )
+                    judge_val = aq_result.get("value")
+                    if turn_trace_id and judge_val is not None:
+                        self._langfuse.create_score(
+                            trace_id=turn_trace_id,
+                            name="answer_quality",
+                            value=judge_val,
+                            comment=aq_result.get("comment", "")[:500],
+                        )
+
+                if judge_val is not None:
+                    turn_judge_scores.append(judge_val)
+
+            # Aggregate conversation-level judge score
+            if turn_judge_scores:
+                avg_judge = sum(turn_judge_scores) / len(turn_judge_scores)
+                score_name = "harness_judge_score" if self._use_harness_judge else "answer_quality_avg"
+                scores[score_name] = {
+                    "value": round(avg_judge, 3),
+                    "comment": f"Per-turn: {[round(s, 2) for s in turn_judge_scores]}",
+                }
+
+        # Latency — per-turn average
+        per_turn_avg_dur = total_duration / max(len(turn_results), 1)
+
+        # Errors
+        all_errors = [e for tr in turn_results for e in tr.get("errors", [])]
+        scores["error_free"] = {
+            "value": 1.0 if not all_errors else 0.0,
+            "comment": "No errors" if not all_errors else f"Errors: {all_errors[:3]}",
+        }
+
+        # Latency (conversation level)
+        lat_result = latency_evaluator(output={"duration_s": total_duration})
+        scores["latency"] = {"value": lat_result["value"], "comment": lat_result["comment"]}
+
+        # --- Build per-turn score dicts and attach to turn_results ---
+        for i, turn_result in enumerate(turn_results):
+            turn_lf: dict[str, Any] = {}
+            # Trajectory
+            if i < len(turn_trajectory_scores):
+                turn_lf["trajectory"] = {
+                    "value": round(turn_trajectory_scores[i], 3),
+                    "comment": "",
+                }
+            # Judge score
+            if i < len(turn_judge_scores):
+                judge_name = "harness_judge_score" if self._use_harness_judge else "answer_quality"
+                turn_lf[judge_name] = {
+                    "value": round(turn_judge_scores[i], 3),
+                    "comment": "",
+                }
+            # Latency (per-turn)
+            turn_dur = turn_result.get("duration_s", per_turn_avg_dur)
+            turn_lat = latency_evaluator(output={"duration_s": turn_dur})
+            turn_lf["latency"] = {"value": turn_lat["value"], "comment": turn_lat["comment"]}
+            # Error-free (per-turn)
+            turn_errors = turn_result.get("errors", [])
+            turn_lf["error_free"] = {
+                "value": 1.0 if not turn_errors else 0.0,
+                "comment": "No errors" if not turn_errors else f"Errors: {turn_errors[:3]}",
+            }
+            turn_result["langfuse_scores"] = turn_lf
+
+        # Push to Langfuse
+        self._push_scores(trace_id, scores)
+        return scores
+
+    def push_run_aggregates(self, aggregates: dict[str, Any]) -> Optional[str]:
+        """Create a run-summary trace in Langfuse and attach aggregate scores.
+
+        This makes run-level metrics (avg_trajectory_accuracy, pass_rate,
+        token_cost) visible in the Langfuse UI alongside per-query traces.
+        Returns the trace_id of the summary trace.
+        """
+        if not aggregates:
+            return None
+        try:
+            trace_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, f"run-summary-{self._experiment_run}"))
+            root = self._langfuse.start_span(
+                trace_context={"trace_id": trace_id},
+                name=f"Run Summary: {self._experiment_run}",
+                input={"experiment_run": self._experiment_run, "aggregates": aggregates},
+            )
+            root.update_trace(
+                session_id=self._experiment_run,
+                tags=["run-summary", "aggregate"],
+                metadata={"experiment_run": self._experiment_run},
+            )
+            root.end()
+
+            for name, data in aggregates.items():
+                if data.get("value") is not None:
+                    self._langfuse.create_score(
+                        trace_id=trace_id,
+                        name=name,
+                        value=data["value"],
+                        comment=data.get("comment", "")[:500],
+                    )
+            print(f"  [langfuse] Pushed {len(aggregates)} run-level scores to trace {trace_id}")
+            return trace_id
+        except Exception as e:
+            print(f"  [langfuse] Failed to push run aggregates: {e}")
+            return None
+
+    def flush(self) -> None:
+        """Flush all pending Langfuse events."""
+        try:
+            self._langfuse.flush()
+            print("  [langfuse] Flushed all events")
+        except Exception as e:
+            print(f"  [langfuse] Flush error: {e}")
+
+    def shutdown(self) -> None:
+        """Shutdown Langfuse client."""
+        try:
+            self._langfuse.flush()
+            self._langfuse.shutdown()
+        except Exception:
+            pass

--- a/tests/e2e/scs_llm_smoke_test.py
+++ b/tests/e2e/scs_llm_smoke_test.py
@@ -834,8 +834,13 @@ def extract_tools_from_events(events: list[dict[str, Any]]) -> dict[str, Any]:
             if isinstance(data, dict):
                 for res in data.get("v", []):
                     content = res.get("content", "")
-                    content_len = len(content) if isinstance(content, str) else len(json.dumps(content))
-                    tool_results.append({"name": res.get("name"), "is_error": res.get("is_error", False), "content_length": content_len})
+                    content_str = content if isinstance(content, str) else json.dumps(content)
+                    content_len = len(content_str)
+                    tool_results.append({
+                        "name": res.get("name"), "is_error": res.get("is_error", False),
+                        "content_length": content_len,
+                        "content_preview": content_str[:1500],
+                    })
         elif event_type == "assistant_thought":
             if isinstance(data, dict):
                 v = data.get("v", "")
@@ -1336,6 +1341,11 @@ def write_results(summary: dict[str, Any]) -> tuple[Path, Path]:
     summary_path = OUTPUT_DIR / "smoke_test_summary.json"
     with open(results_path, "w") as f:
         json.dump(summary, f, indent=2, default=str)
+    # Timestamped copy for historical comparison (flaky detection, trend analysis)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    ts_path = OUTPUT_DIR / f"smoke_test_results_{ts}.json"
+    with open(ts_path, "w") as f:
+        json.dump(summary, f, indent=2, default=str)
     summary_only = {
         "run_metadata": summary["run_metadata"], "summary": summary["summary"],
         "scoring_table": [
@@ -1453,6 +1463,7 @@ def _run_langfuse_scoring(lf_integration, summary: dict[str, Any]) -> None:
             extracted = {
                 "tools_called": [tuple(t) for t in r["extracted"]["tools_called"]],
                 "tool_params": r["extracted"]["tool_params"],
+                "tool_results": r["extracted"].get("tool_results", {}),
                 "final_answer": r["extracted"]["final_answer"],
                 "final_answer_length": r["extracted"]["final_answer_length"],
                 "errors": r["extracted"]["errors"],
@@ -1485,9 +1496,77 @@ def _run_langfuse_scoring(lf_integration, summary: dict[str, Any]) -> None:
             score_summary = " | ".join(f"{k}={v['value']}" for k, v in scores.items() if v.get("value") is not None)
             print(f"    {cr['id']}: {score_summary}")
 
+    # --- Run-level aggregate evaluators ---
+    from langfuse_evaluators import RUN_EVALUATORS
+    query_confidence = {q["id"]: q.get("confidence", "N/A") or "N/A" for q in QUERIES}
+    item_results = []
+    for r in results:
+        lf_scores = r["scoring"].get("langfuse_scores", {})
+        if lf_scores:
+            item_results.append({
+                "query_id": r["id"],
+                "confidence": query_confidence.get(r["id"], r.get("confidence") or "N/A"),
+                "evaluations": lf_scores,
+                "token_usage": r["extracted"].get("token_usage", {}),
+            })
+    # Include multi-turn conversation scores in aggregation.
+    # When per-turn scores exist, use them exclusively (evaluations + token_usage)
+    # to avoid double-counting. When no per-turn scores exist (judge disabled),
+    # fall back to conversation-level aggregates.
+    for cr in conv_results:
+        lf_scores = cr["scoring"].get("langfuse_scores", {})
+        conv_usage = cr.get("aggregate", {}).get("total_token_usage", {})
+        turns = cr.get("turns", [])
+        has_per_turn = any(t.get("langfuse_scores") for t in turns)
+
+        if has_per_turn:
+            # Per-turn entries carry evaluations for MQI and token_usage for
+            # token_cost. No conv-level entry needed — per-turn token_usage
+            # already sums to total, adding conv_usage would double-count.
+            for turn in turns:
+                turn_lf = turn.get("langfuse_scores", {})
+                if turn_lf:
+                    item_results.append({
+                        "query_id": f"{cr['id']}-T{turn.get('turn', '?')}",
+                        "confidence": "High",
+                        "evaluations": turn_lf,
+                        "token_usage": turn.get("token_usage", {}),
+                    })
+        elif lf_scores or conv_usage:
+            # No per-turn scores — use conversation-level for everything
+            item_results.append({
+                "query_id": cr["id"],
+                "confidence": "High",
+                "evaluations": lf_scores or {},
+                "token_usage": conv_usage,
+            })
+    if item_results:
+        print(f"\n  Run-level aggregates ({len(item_results)} scored items):")
+        for run_eval in RUN_EVALUATORS:
+            try:
+                agg = run_eval(item_results=item_results)
+                if isinstance(agg, dict) and agg.get("value") is not None:
+                    val = agg["value"]
+                    val_str = f"{val:,.0f}" if agg["name"] == "token_cost" else f"{val:.3f}"
+                    print(f"    {agg['name']}: {val_str} — {agg.get('comment', '')}")
+                    summary.setdefault("run_aggregates", {})[agg["name"]] = {
+                        "value": agg["value"], "comment": agg.get("comment", ""),
+                    }
+            except Exception as e:
+                print(f"    {run_eval.__name__}: error — {e}")
+
+    # Push run aggregates to Langfuse
+    run_aggs = summary.get("run_aggregates", {})
+    if run_aggs:
+        lf_integration.push_run_aggregates(run_aggs)
+
     # --- Summary ---
     total_traces = len(results) + len(conv_results)
-    print(f"\n  [langfuse] Created {total_traces} traces with evaluator scores")
+    # Multi-turn creates per-turn traces too (parent + N turns per conversation)
+    per_turn_traces = sum(len(cr.get("turns", [])) for cr in conv_results)
+    total_all = total_traces + per_turn_traces
+    print(f"\n  [langfuse] Created {total_all} traces ({len(results)} single-turn + {len(conv_results)} conversation parents + {per_turn_traces} per-turn)")
+    print(f"  [langfuse] Experiment run: {lf_integration.experiment_run_name}")
     print(f"  [langfuse] View results at: {os.getenv('LANGFUSE_HOST', 'https://langfuse-prod.harness.io')}")
 
 
@@ -1519,6 +1598,19 @@ def main():
                         help="Enable LLM-as-Judge answer quality evaluation (requires --langfuse). "
                              "Uses EVAL_JUDGE_MODEL (default: gpt-4.1-mini) and EVAL_JUDGE_PROVIDER (default: openai). "
                              "Adds ~$0.01/query in LLM costs.")
+    parser.add_argument("--harness-judge", action="store_true", default=False,
+                        help="Use Harness ai-evals LLM-as-Judge service for rubric-based multi-criteria scoring "
+                             "(requires --langfuse --langfuse-judge). "
+                             "Requires HARNESS_EVAL_API_URL and HARNESS_EVAL_API_TOKEN env vars. "
+                             "Falls back to OpenAI if unavailable.")
+    parser.add_argument("--no-fail-on-regression", action="store_true", default=False,
+                        help="Do not exit with code 1 when regressions are detected. "
+                             "Useful for local development. CI pipelines should omit this flag.")
+    parser.add_argument("--deepeval", action="store_true", default=False,
+                        help="Enable DeepEval G-Eval metrics (requires pip install deepeval). "
+                             "Adds tool_correctness, answer_quality, and faithfulness scores "
+                             "using chain-of-thought + token probability calibration. "
+                             "Requires OPENAI_API_KEY. Optionally set DEEPEVAL_MODEL (default: gpt-4.1-mini).")
     parser.add_argument("--langfuse-sync-only", action="store_true", default=False,
                         help="Only sync datasets to Langfuse without running tests (requires --langfuse)")
     args = parser.parse_args()
@@ -1531,7 +1623,11 @@ def main():
     print(f"  History mode:      {args.history_mode}")
     print(f"  Concurrency:       {args.concurrency}{' (parallel)' if args.concurrency > 1 else ' (sequential)'}")
     print(f"  Skip N/A:          {args.skip_na}")
-    print(f"  Langfuse:          {args.langfuse}{'  (+ LLM judge)' if args.langfuse_judge else ''}")
+    judge_label = ""
+    if args.langfuse_judge:
+        judge_label = "  (+ Harness ai-evals judge)" if args.harness_judge else "  (+ LLM judge)"
+    print(f"  Langfuse:          {args.langfuse}{judge_label}")
+    print(f"  DeepEval:          {args.deepeval}")
     if query_ids:
         print(f"  Running IDs:       {query_ids}")
     else:
@@ -1543,7 +1639,11 @@ def main():
     if args.langfuse:
         try:
             from langfuse_evaluators import LangfuseIntegration
-            lf_integration = LangfuseIntegration(enable_judge=args.langfuse_judge)
+            lf_integration = LangfuseIntegration(
+                enable_judge=args.langfuse_judge,
+                use_harness_judge=args.harness_judge,
+            )
+            print(f"  [langfuse] Experiment run: {lf_integration.experiment_run_name}")
             lf_integration.sync_dataset(QUERIES)
             lf_integration.sync_conversation_dataset(CONVERSATIONS)
             if args.langfuse_sync_only:
@@ -1562,13 +1662,121 @@ def main():
 
     # --- Langfuse scoring (post-run) ---
     if lf_integration and summary:
-        print(f"\n{'#'*70}\n# LANGFUSE EVALUATION\n{'#'*70}")
+        print(f"\n{'#'*70}\n# LANGFUSE EVALUATION (experiment: {lf_integration.experiment_run_name})\n{'#'*70}")
         _run_langfuse_scoring(lf_integration, summary)
         lf_integration.flush()
+
+    # --- DeepEval scoring (optional, independent of Langfuse) ---
+    if args.deepeval and summary:
+        try:
+            from deepeval_evaluators import _check_deepeval, create_geval_metrics, run_deepeval_scoring, run_deepeval_aggregate
+            if not _check_deepeval():
+                print("\n  [deepeval] WARNING: deepeval package not installed. Run: pip install deepeval", file=sys.stderr)
+            else:
+                print(f"\n{'#'*70}\n# DEEPEVAL G-EVAL SCORING\n{'#'*70}")
+                metrics = create_geval_metrics()
+                query_lookup_de = {q["id"]: q for q in QUERIES}
+                all_deepeval_scores = []
+                for r in summary.get("results", []):
+                    qdef = query_lookup_de.get(r["id"])
+                    if not qdef:
+                        continue
+                    extracted = {
+                        "tools_called": [tuple(t) for t in r["extracted"]["tools_called"]],
+                        "tool_params": r["extracted"]["tool_params"],
+                        "tool_results": r["extracted"].get("tool_results", {}),
+                        "final_answer": r["extracted"]["final_answer"],
+                    }
+                    de_scores = run_deepeval_scoring(qdef, extracted, metrics)
+                    r["scoring"]["deepeval_scores"] = de_scores
+                    all_deepeval_scores.append(de_scores)
+                    score_str = " | ".join(f"{k}={v['value']}" for k, v in de_scores.items() if v.get("value") is not None)
+                    print(f"    {r['id']}: {score_str}")
+
+                    # Push DeepEval scores to Langfuse traces (when both are active)
+                    if lf_integration:
+                        try:
+                            trace_id = lf_integration._langfuse.create_trace_id(
+                                seed=f"{lf_integration._experiment_run}-{r['id']}"
+                            )
+                            for metric_name, metric_data in de_scores.items():
+                                if metric_data.get("value") is not None:
+                                    lf_integration._langfuse.create_score(
+                                        trace_id=trace_id,
+                                        name=metric_name,
+                                        value=metric_data["value"],
+                                        comment=metric_data.get("comment", "")[:500],
+                                    )
+                        except Exception as lf_err:
+                            print(f"      [deepeval→langfuse] {r['id']}: {lf_err}")
+
+                if all_deepeval_scores:
+                    aggs = run_deepeval_aggregate(all_deepeval_scores)
+                    print(f"\n  DeepEval Aggregates ({len(all_deepeval_scores)} items):")
+                    for name, data in aggs.items():
+                        print(f"    {name}: {data['value']:.3f} — {data['comment']}")
+                    summary.setdefault("deepeval_aggregates", {}).update(aggs)
+
+                if lf_integration:
+                    lf_integration.flush()
+                    print(f"  [deepeval→langfuse] Pushed scores to Langfuse traces")
+        except ImportError as e:
+            print(f"\n  [deepeval] WARNING: {e}", file=sys.stderr)
+        except Exception as e:
+            print(f"\n  [deepeval] ERROR: {e}", file=sys.stderr)
+
+    # --- Regression detection (compare against previous run BEFORE overwriting) ---
+    has_regression = False
+    prev_summary_path = OUTPUT_DIR / "smoke_test_summary.json"
+    try:
+        from langfuse_evaluators import detect_regressions
+        regressions = detect_regressions(summary, str(prev_summary_path))
+        if regressions and regressions[0].get("status") != "no_previous":
+            print(f"\n{'#'*70}\n# REGRESSION CHECK (vs previous run)\n{'#'*70}")
+            for r in regressions:
+                if r.get("status") == "error":
+                    print(f"  {r['metric']}: {r.get('comment', '')}")
+                    continue
+                icon = {"regression": "⚠️ ", "improvement": "✅ ", "stable": "   "}.get(r["status"], "   ")
+                delta = f"{r['delta_pct']:+.1f}%"
+                print(f"  {icon}{r['metric']:<30} {r['current']:<12} (was {r['previous']:<12}) {delta:<8} [{r['status']}]")
+                if r["status"] == "regression":
+                    has_regression = True
+            if has_regression:
+                print("\n  ⚠️  REGRESSIONS DETECTED — review changes before merging")
+            else:
+                print("\n  No regressions detected")
+            summary["regression_check"] = regressions
+            summary["has_regressions"] = has_regression
+    except ImportError:
+        pass
+    except Exception as e:
+        print(f"  [regression] Error: {e}")
+
+    # --- Flaky query detection (compare across last N runs) ---
+    try:
+        from langfuse_evaluators import detect_flaky_queries
+        flaky = detect_flaky_queries(summary, str(OUTPUT_DIR))
+        if flaky:
+            print(f"\n{'#'*70}\n# FLAKY QUERIES ({len(flaky)} detected)\n{'#'*70}")
+            for fq in flaky:
+                hist_str = " → ".join(fq["history"])
+                print(f"  🔄 {fq['query_id']:<10} {hist_str}  ({fq['flip_count']} flips, outcomes: {fq['distinct_outcomes']})")
+            summary["flaky_queries"] = flaky
+        else:
+            print(f"\n  No flaky queries detected")
+    except ImportError:
+        pass
+    except Exception as e:
+        print(f"  [flaky] Error: {e}")
 
     results_path, summary_path = write_results(summary)
     print_final_summary(summary)
     print(f"  Full results:  {results_path}\n  Summary:       {summary_path}\n")
+
+    # Exit non-zero if regressions detected (for CI gating)
+    if has_regression and not args.no_fail_on_regression:
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

### What
Adds a comprehensive evaluation and observability framework for the SCS LLM smoke tests, integrating Langfuse for tracing/scoring and LLM-as-Judge for automated answer quality assessment.

**New files:**
- [tests/e2e/langfuse_evaluators.py](cci:7://file:///Users/thecopyninja/IdeaProjects/mcp-server/tests/e2e/langfuse_evaluators.py:0:0-0:0) — Full Langfuse integration: trace creation, dataset sync, 8 per-query evaluators (trajectory, parameter validation, answer quality, latency, error-free, answer presence, factual accuracy, harness rubric judge), 7 run-level aggregate evaluators (MQI, trajectory accuracy, pass rate, token cost, category breakdown, quality coverage, regression detection), flaky query detection, and prompt version tracking.
- `tests/e2e/deepeval_evaluators.py` — DeepEval G-Eval metrics integration (tool correctness, answer quality, faithfulness) with optional Langfuse score push.
- [tests/e2e/LANGFUSE_README.md](cci:7://file:///Users/thecopyninja/IdeaProjects/mcp-server/tests/e2e/LANGFUSE_README.md:0:0-0:0) — Documentation covering all flags, evaluators, scoring methodology, A/B comparison workflow, and CI gating.

**Modified files:**
- [tests/e2e/scs_llm_smoke_test.py](cci:7://file:///Users/thecopyninja/IdeaProjects/mcp-server/tests/e2e/scs_llm_smoke_test.py:0:0-0:0) — Wires up `--langfuse`, `--langfuse-judge`, `--harness-judge`, `--deepeval`, `--no-fail-on-regression` flags; adds per-turn MQI scoring for multi-turn conversations; confidence-weighted aggregation (Supported/High=1.0, Medium=0.7, Low=0.4); timestamped result files for trend analysis; CI exit(1) gating on regression; flaky query detection across historical runs.

### Why
Previously, smoke test results were only available as local JSON files with basic tool-selection pass/fail metrics. There was no:
- Centralized observability for traces across runs
- Automated answer quality scoring (beyond tool selection correctness)
- Regression detection between consecutive runs
- Confidence-weighted composite metrics for A/B comparison
- Per-category breakdown to isolate which capability areas are degrading
- Flaky query detection to distinguish genuine regressions from non-deterministic LLM behavior

This framework enables data-driven prompt tuning, CI quality gates, and cross-run trend analysis via the Langfuse dashboard.

### Results

**Run 2 (concurrency 12, all changes active):**

| Metric | Value |
|--------|-------|
| **Single-turn** | 32/35 CORRECT (91.4%) |
| **Multi-turn** | 12/16 CORRECT, 37/50 turns (74.0%) |
| **Total time** | 424s |
| **Model** | claude-sonnet-4-20250514 |

### Interpretation
- Single-turn accuracy is stable at 91.4% — the 1 WRONG (Q31) and 2 PARTIALs are consistent across runs
- Multi-turn jumped from 66% → 74% turn accuracy between runs, with 4 conversations flipping from PARTIAL to CORRECT — this variance is expected with LLM non-determinism at concurrency 12
- Remaining weak spots (M02, M05, M10, M16) are consistent across runs, indicating prompt/toolset gaps rather than evaluation issues
- M16 (`scs_oss_risk_summary` not discovered) is a known P3-2 routing gap — the LLM doesn't call `harness_describe` for the new resource type
- The confidence-weighted MQI gives higher weight to Supported/High confidence queries, so exploratory Low/N/A queries don't drag down the composite score
- Flaky detection and per-category regression will become more valuable as timestamped result files accumulate across runs

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Other

## Checklist
- [x] Tests pass
- [ ] Typecheck passes (Python — no strict mypy configured for e2e tests)