### PR TITLE
fix: [SSCA-6095] remove orchestration_id from scs_sbom_drift bodySchema

### DIFF
--- a/src/registry/toolsets/scs.ts
+++ b/src/registry/toolsets/scs.ts
@@ -828,7 +828,6 @@ export const scsToolset: ToolsetDefinition = {
           bodySchema: {
             description: "SBOM drift calculation request — specify what to compare against",
             fields: [
-              { name: "orchestration_id", type: "string", required: true, description: "Orchestration step execution ID (from artifact_security orchestration.id field)" },
               { name: "base", type: "string", required: true, description: "Baseline to compare against: 'last_generated_sbom' (previous version), 'baseline' (pinned baseline), or 'repository' (specific tag)" },
               { name: "variant", type: "object", required: false, description: "Only for base='repository': { type: 'tag', value: '<tag_name>' } — specifies which tag to compare against" },
             ],


### PR DESCRIPTION
## Summary

- Removes `orchestration_id` from the `bodySchema.fields` of the `scs_sbom_drift` calculate action. It is a **path parameter** (routed via `pathParams: { orchestration_id: "orchestration" }`), not a body field. Including it in `bodySchema` caused the body validation in `registry/index.ts` to always reject `harness_execute(scs_sbom_drift, action=calculate)` calls with `"Missing required fields for scs_sbom_drift: orchestration_id"` — regardless of how the LLM passed the parameter.

## Root Cause

The `bodySchema` validation at `registry/index.ts:392` checks `payload[f.name]` against the **body** object built by `bodyBuilder`. Since `bodyBuilder` only puts `base` and `variant` into the body (not `orchestration_id`), and `orchestration_id` is resolved via `pathParams` into the URL path, the validation always fails.

In eval testing, the LLM agent tried 6 different parameter placements (`params`, `body`, `resource_id`, combinations) — all rejected with the same error.

## Impact

This unblocks the entire SBOM drift detection chain:
1. `harness_execute(scs_sbom_drift, action=calculate)` → returns `drift_id`
2. `harness_list(scs_component_drift, drift_id=...)` → returns added/removed/modified packages

Confirmed working in eval tests — `scs_component_drift` was reached for the first time after this fix.

## Test plan

- [x] TypeScript build passes
- [x] All 245 SCS unit tests pass
- [x] Full SCS eval suite (62 cases) — no regressions, Q45 (component drift) now reaches `scs_component_drift`