### PR TITLE
fix: accept YAML string body for pipeline update/create and add InputSet CRUD

### DIFF
--- a/src/client/harness-client.ts
+++ b/src/client/harness-client.ts
@@ -7,6 +7,22 @@ import { createLogger } from "../utils/logger.js";
 const log = createLogger("harness-client");
 
 const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
+
+/**
+ * Whether the caller explicitly set a body (including empty string).
+ * `""` must be preserved: `if (options.body)` treats it as absent, which drops the
+ * YAML body on pipeline execute — Harness then ignores `inputSetIdentifiers` and
+ * fails with "Value not provided for required variable".
+ */
+function hasExplicitBody(body: unknown): boolean {
+  return body !== undefined && body !== null;
+}
+
+function serializeRequestBody(body: unknown): string | undefined {
+  if (!hasExplicitBody(body)) return undefined;
+  return typeof body === "string" ? body : JSON.stringify(body);
+}
+
 const BASE_BACKOFF_MS = 1000;
 
 /** Strip HTML tags, script/style contents, and collapse whitespace. */
@@ -146,7 +162,7 @@ export class HarnessClient {
       headers["x-api-key"] = this.token;
     }
 
-    if (options.body) {
+    if (hasExplicitBody(options.body)) {
       if (typeof options.body === "string") {
         headers["Content-Type"] = headers["Content-Type"] ?? "application/yaml";
       } else {
@@ -177,12 +193,10 @@ export class HarnessClient {
           ? AbortSignal.any([options.signal, timeoutController.signal])
           : timeoutController.signal;
 
-        const bodyString = options.body
-          ? (typeof options.body === "string" ? options.body : JSON.stringify(options.body))
-          : undefined;
+        const bodyString = serializeRequestBody(options.body);
 
         log.debug(`${method} ${url}`);
-        if (bodyString) {
+        if (bodyString !== undefined) {
           log.debug("Request body", { body: bodyString.slice(0, 1000) });
         }
 
@@ -304,7 +318,7 @@ export class HarnessClient {
       headers["x-api-key"] = this.token;
     }
 
-    if (options.body) {
+    if (hasExplicitBody(options.body)) {
       if (typeof options.body === "string") {
         headers["Content-Type"] = headers["Content-Type"] ?? "application/yaml";
       } else {
@@ -333,9 +347,7 @@ export class HarnessClient {
           ? AbortSignal.any([options.signal, timeoutController.signal])
           : timeoutController.signal;
 
-        const bodyString = options.body
-          ? (typeof options.body === "string" ? options.body : JSON.stringify(options.body))
-          : undefined;
+        const bodyString = serializeRequestBody(options.body);
 
         log.debug(`STREAM ${method} ${url}`);
 
@@ -407,7 +419,14 @@ export class HarnessClient {
 
     if (options.params) {
       for (const [key, value] of Object.entries(options.params)) {
-        if (value !== undefined && value !== "") {
+        if (value === undefined || value === "") continue;
+        if (Array.isArray(value)) {
+          for (const item of value) {
+            if (item !== undefined && item !== "") {
+              params.append(key, String(item));
+            }
+          }
+        } else {
           params.set(key, String(value));
         }
       }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -40,7 +40,8 @@ export interface HarnessV1ListResponse<T> {
 export interface RequestOptions {
   method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
   path: string;
-  params?: Record<string, string | number | boolean | undefined>;
+  /** Scalar or string[] (repeated query keys, e.g. `inputSetIdentifiers=a&inputSetIdentifiers=b`). */
+  params?: Record<string, string | number | boolean | string[] | undefined>;
   body?: unknown;
   headers?: Record<string, string>;
   /** Override base URL for this request (e.g. FME/Split.io uses https://api.split.io) */

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -290,8 +290,8 @@ export class Registry {
       }
     }
 
-    // Build query params
-    const params: Record<string, string | number | boolean | undefined> = {};
+    // Build query params (values may be string[] for repeated query keys — see HarnessClient.buildUrl)
+    const params: Record<string, string | number | boolean | string[] | undefined> = {};
 
     // Add scope params (allow per-resource override of query param names)
     // When scopeOptional is true, only add org/project if explicitly provided in input.
@@ -348,7 +348,14 @@ export class Registry {
         if (spec.pageOneIndexed && inputKey === "page" && typeof value === "number") {
           value = value + 1;
         }
-        if (value !== undefined && value !== "") {
+        if (Array.isArray(value)) {
+          const parts = value.filter(
+            (v): v is string | number | boolean => v !== undefined && v !== "" && v !== null,
+          );
+          if (parts.length > 0) {
+            params[queryKey] = parts.map(String);
+          }
+        } else if (value !== undefined && value !== "") {
           params[queryKey] = value as string | number | boolean;
         }
       }

--- a/src/registry/toolsets/pipelines.ts
+++ b/src/registry/toolsets/pipelines.ts
@@ -40,10 +40,10 @@ function normalizeTriggerBody(
 }
 
 const pipelineCreateSchema: BodySchema = {
-  description: "Pipeline definition. Prefer yamlPipeline (YAML string) to avoid serialization issues; pipeline (JSON object) is also supported. Storage options via params: (1) Inline (default): no extra params needed. (2) External Git: store_type='REMOTE', connector_ref (Git connector ID), repo_name, branch, file_path. (3) Harness Code: store_type='REMOTE', is_harness_code_repo=true, repo_name, branch, file_path (no connector_ref needed).",
+  description: "Pipeline definition. Three options: (1) Pass body as a raw YAML string directly (simplest for complex pipelines with shell scripts, JEXL, special chars). (2) Pass {yamlPipeline: '<yaml string>'} for YAML inside an object. (3) Pass {pipeline: {...}} as JSON object. Storage options via params: Inline (default), External Git (store_type='REMOTE', connector_ref, repo_name, branch, file_path), Harness Code (store_type='REMOTE', is_harness_code_repo=true, repo_name, branch, file_path).",
   fields: [
-    { name: "yamlPipeline", type: "string", required: false, description: "Full pipeline YAML string including the 'pipeline:' root. Recommended when creating from generated or edited YAML." },
-    { name: "pipeline", type: "object", required: false, description: "Pipeline as JSON object (name, identifier, stages, etc.). Use yamlPipeline instead when passing YAML to avoid large nested JSON.", fields: [
+    { name: "yamlPipeline", type: "string", required: false, description: "Full pipeline YAML string including the 'pipeline:' root. Alternative: pass the YAML string directly as body (not wrapped in an object)." },
+    { name: "pipeline", type: "object", required: false, description: "Pipeline as JSON object (name, identifier, stages, etc.). Use YAML string instead for complex pipelines to avoid serialization issues.", fields: [
       { name: "name", type: "string", required: true, description: "Pipeline display name" },
       { name: "identifier", type: "string", required: true, description: "Unique pipeline identifier" },
       { name: "stages", type: "array", required: false, description: "Pipeline stages", itemType: "stage object" },
@@ -52,10 +52,30 @@ const pipelineCreateSchema: BodySchema = {
 };
 
 const pipelineUpdateSchema: BodySchema = {
-  description: "Pipeline YAML definition (full replacement). Pass either pipeline (JSON object) or yamlPipeline (YAML string). For remote pipelines, pass store_type='REMOTE' with git details via params. External Git: connector_ref, repo_name, branch, file_path, commit_msg. Harness Code: is_harness_code_repo=true, repo_name, branch, file_path, commit_msg (no connector_ref). Include last_object_id and last_commit_id from the GET response for conflict detection.",
+  description: "Pipeline YAML definition (full replacement). Three options: (1) Pass body as a raw YAML string directly (recommended for complex pipelines). (2) Pass {yamlPipeline: '<yaml>'} for YAML inside an object. (3) Pass {pipeline: {...}} as JSON. For remote pipelines, pass store_type='REMOTE' with git details via params. Include last_object_id and last_commit_id from the GET response for conflict detection.",
   fields: [
     { name: "pipeline", type: "object", required: false, description: "Complete pipeline as JSON object (replaces existing)" },
-    { name: "yamlPipeline", type: "string", required: false, description: "Complete pipeline as YAML string (replaces existing). Use this when updating from get pipeline response or editing YAML." },
+    { name: "yamlPipeline", type: "string", required: false, description: "Complete pipeline as YAML string (replaces existing). Alternative: pass the YAML string directly as body (not wrapped in an object)." },
+  ],
+};
+
+const inputSetCreateSchema: BodySchema = {
+  description: "Input set definition. Three options: (1) Pass body as a raw YAML string directly (recommended). (2) Pass {yamlInputSet: '<yaml string>'} for YAML inside an object. (3) Pass {inputSet: {...}} as JSON object. Requires pipeline_id in params or filters.",
+  fields: [
+    { name: "yamlInputSet", type: "string", required: false, description: "Full input set YAML string including the 'inputSet:' root. Alternative: pass the YAML string directly as body." },
+    { name: "inputSet", type: "object", required: false, description: "Input set as JSON object.", fields: [
+      { name: "name", type: "string", required: true, description: "Input set display name" },
+      { name: "identifier", type: "string", required: true, description: "Unique input set identifier" },
+      { name: "pipeline", type: "object", required: true, description: "Pipeline runtime input values" },
+    ]},
+  ],
+};
+
+const inputSetUpdateSchema: BodySchema = {
+  description: "Input set definition (full replacement). Three options: (1) Pass body as a raw YAML string directly (recommended). (2) Pass {yamlInputSet: '<yaml>'} for YAML inside an object. (3) Pass {inputSet: {...}} as JSON. For remote input sets, pass store_type='REMOTE' with git details via params. Include last_object_id from the GET response for conflict detection.",
+  fields: [
+    { name: "yamlInputSet", type: "string", required: false, description: "Full input set YAML string (replaces existing). Alternative: pass the YAML string directly as body." },
+    { name: "inputSet", type: "object", required: false, description: "Complete input set as JSON object (replaces existing)" },
   ],
 };
 
@@ -124,14 +144,16 @@ export const pipelinesToolset: ToolsetDefinition = {
             is_harness_code_repo: "isHarnessCodeRepo",
           },
           bodyBuilder: (input) => {
-            const b = input.body as Record<string, unknown> | undefined;
-            if (b && typeof b === "object" && typeof b.yamlPipeline === "string") {
-              return b.yamlPipeline;
+            const b = input.body;
+            if (typeof b === "string") {
+              return b;
             }
-            if (b && typeof b === "object" && b.pipeline !== undefined) {
-              return input.body;
+            if (b && typeof b === "object") {
+              const obj = b as Record<string, unknown>;
+              if (typeof obj.yamlPipeline === "string") return obj.yamlPipeline;
+              if (obj.pipeline !== undefined) return b;
             }
-            throw new Error("body must include either yamlPipeline (YAML string) or pipeline (JSON object)");
+            throw new Error("body must be a YAML string, or an object with yamlPipeline (YAML string) or pipeline (JSON object)");
           },
           responseExtractor: ngExtract,
           description: "Create a new pipeline from YAML. For external Git: store_type='REMOTE' + connector_ref, repo_name, branch, file_path. For Harness Code: store_type='REMOTE' + is_harness_code_repo=true, repo_name, branch, file_path.",
@@ -156,14 +178,16 @@ export const pipelinesToolset: ToolsetDefinition = {
             last_commit_id: "lastCommitId",
           },
           bodyBuilder: (input) => {
-            const b = input.body as Record<string, unknown> | undefined;
-            if (b && typeof b === "object" && typeof b.yamlPipeline === "string") {
-              return b.yamlPipeline;
-            }
-            if (b && typeof b === "object" && b.pipeline !== undefined) {
+            const b = input.body;
+            if (typeof b === "string") {
               return b;
             }
-            throw new Error("body must include either pipeline (JSON object) or yamlPipeline (YAML string)");
+            if (b && typeof b === "object") {
+              const obj = b as Record<string, unknown>;
+              if (typeof obj.yamlPipeline === "string") return obj.yamlPipeline;
+              if (obj.pipeline !== undefined) return b;
+            }
+            throw new Error("body must be a YAML string, or an object with yamlPipeline (YAML string) or pipeline (JSON object)");
           },
           responseExtractor: ngExtract,
           description: "Update an existing pipeline YAML. For remote pipelines, pass store_type='REMOTE' with git details and last_object_id/last_commit_id from the GET response. For Harness Code: add is_harness_code_repo=true (no connector_ref needed).",
@@ -436,12 +460,12 @@ export const pipelinesToolset: ToolsetDefinition = {
     {
       resourceType: "input_set",
       displayName: "Input Set",
-      description: "Reusable runtime input sets for pipelines",
+      description: "Reusable runtime input sets for pipelines. Supports list, get, create, update, and delete.",
       toolset: "pipelines",
       scope: "project",
       identifierFields: ["pipeline_id", "input_set_id"],
       listFilterFields: [
-        { name: "pipeline_id", description: "Pipeline identifier to filter input sets" },
+        { name: "pipeline_id", description: "Pipeline identifier to filter input sets", required: true },
       ],
       deepLinkTemplate: "/ng/account/{accountId}/all/orgs/{orgIdentifier}/projects/{projectIdentifier}/pipelines/{pipeline_id}/input-sets",
       operations: {
@@ -463,6 +487,77 @@ export const pipelinesToolset: ToolsetDefinition = {
           queryParams: { pipeline_id: "pipelineIdentifier" },
           responseExtractor: ngExtract,
           description: "Get input set details",
+        },
+        create: {
+          method: "POST",
+          path: "/pipeline/api/inputSets",
+          headers: { "Content-Type": "application/yaml" },
+          queryParams: {
+            pipeline_id: "pipelineIdentifier",
+            store_type: "storeType",
+            connector_ref: "connectorRef",
+            repo_name: "repoName",
+            branch: "branch",
+            file_path: "filePath",
+            commit_msg: "commitMsg",
+            is_harness_code_repo: "isHarnessCodeRepo",
+          },
+          bodyBuilder: (input) => {
+            const b = input.body;
+            if (typeof b === "string") return b;
+            if (b && typeof b === "object") {
+              const obj = b as Record<string, unknown>;
+              if (typeof obj.yamlInputSet === "string") return obj.yamlInputSet;
+              if (obj.inputSet !== undefined) return b;
+            }
+            throw new Error("body must be a YAML string, or an object with yamlInputSet (YAML string) or inputSet (JSON object)");
+          },
+          responseExtractor: ngExtract,
+          description: "Create a new input set for a pipeline. Requires pipeline_id. Pass the input set definition as YAML string (recommended) or as an object with yamlInputSet/inputSet.",
+          bodySchema: inputSetCreateSchema,
+        },
+        update: {
+          method: "PUT",
+          path: "/pipeline/api/inputSets/{inputSetIdentifier}",
+          pathParams: { input_set_id: "inputSetIdentifier" },
+          headers: { "Content-Type": "application/yaml" },
+          queryParams: {
+            pipeline_id: "pipelineIdentifier",
+            store_type: "storeType",
+            connector_ref: "connectorRef",
+            repo_name: "repoName",
+            branch: "branch",
+            file_path: "filePath",
+            base_branch: "baseBranch",
+            commit_msg: "commitMsg",
+            is_harness_code_repo: "isHarnessCodeRepo",
+            last_object_id: "lastObjectId",
+          },
+          bodyBuilder: (input) => {
+            const b = input.body;
+            if (typeof b === "string") return b;
+            if (b && typeof b === "object") {
+              const obj = b as Record<string, unknown>;
+              if (typeof obj.yamlInputSet === "string") return obj.yamlInputSet;
+              if (obj.inputSet !== undefined) return b;
+            }
+            throw new Error("body must be a YAML string, or an object with yamlInputSet (YAML string) or inputSet (JSON object)");
+          },
+          responseExtractor: ngExtract,
+          description: "Update an existing input set. Requires pipeline_id and input_set_id. For remote input sets, pass store_type='REMOTE' with git details and last_object_id from the GET response.",
+          bodySchema: inputSetUpdateSchema,
+        },
+        delete: {
+          method: "DELETE",
+          path: "/pipeline/api/inputSets/{inputSetIdentifier}",
+          pathParams: { input_set_id: "inputSetIdentifier" },
+          queryParams: {
+            pipeline_id: "pipelineIdentifier",
+            commit_msg: "commitMsg",
+            last_object_id: "lastObjectId",
+          },
+          responseExtractor: ngExtract,
+          description: "Delete an input set. Requires pipeline_id and input_set_id.",
         },
       },
     },

--- a/src/registry/toolsets/pipelines.ts
+++ b/src/registry/toolsets/pipelines.ts
@@ -72,7 +72,7 @@ const inputSetCreateSchema: BodySchema = {
 };
 
 const inputSetUpdateSchema: BodySchema = {
-  description: "Input set definition (full replacement). Three options: (1) Pass body as a raw YAML string directly (recommended). (2) Pass {yamlInputSet: '<yaml>'} for YAML inside an object. (3) Pass {inputSet: {...}} as JSON. For remote input sets, pass store_type='REMOTE' with git details via params. Include last_object_id from the GET response for conflict detection.",
+  description: "Input set definition (full replacement). Three options: (1) Pass body as a raw YAML string directly (recommended). (2) Pass {yamlInputSet: '<yaml>'} for YAML inside an object. (3) Pass {inputSet: {...}} as JSON. For remote input sets, pass store_type='REMOTE' with git details via params. Include last_object_id and last_commit_id from the GET response for conflict detection.",
   fields: [
     { name: "yamlInputSet", type: "string", required: false, description: "Full input set YAML string (replaces existing). Alternative: pass the YAML string directly as body." },
     { name: "inputSet", type: "object", required: false, description: "Complete input set as JSON object (replaces existing)" },
@@ -498,6 +498,7 @@ export const pipelinesToolset: ToolsetDefinition = {
             connector_ref: "connectorRef",
             repo_name: "repoName",
             branch: "branch",
+            base_branch: "baseBranch",
             file_path: "filePath",
             commit_msg: "commitMsg",
             is_harness_code_repo: "isHarnessCodeRepo",
@@ -532,6 +533,7 @@ export const pipelinesToolset: ToolsetDefinition = {
             commit_msg: "commitMsg",
             is_harness_code_repo: "isHarnessCodeRepo",
             last_object_id: "lastObjectId",
+            last_commit_id: "lastCommitId",
           },
           bodyBuilder: (input) => {
             const b = input.body;
@@ -544,7 +546,7 @@ export const pipelinesToolset: ToolsetDefinition = {
             throw new Error("body must be a YAML string, or an object with yamlInputSet (YAML string) or inputSet (JSON object)");
           },
           responseExtractor: ngExtract,
-          description: "Update an existing input set. Requires pipeline_id and input_set_id. For remote input sets, pass store_type='REMOTE' with git details and last_object_id from the GET response.",
+          description: "Update an existing input set. Requires pipeline_id and input_set_id. For remote input sets, pass store_type='REMOTE' with git details and last_object_id/last_commit_id from the GET response.",
           bodySchema: inputSetUpdateSchema,
         },
         delete: {
@@ -553,11 +555,13 @@ export const pipelinesToolset: ToolsetDefinition = {
           pathParams: { input_set_id: "inputSetIdentifier" },
           queryParams: {
             pipeline_id: "pipelineIdentifier",
+            branch: "branch",
+            file_path: "filePath",
             commit_msg: "commitMsg",
             last_object_id: "lastObjectId",
           },
           responseExtractor: ngExtract,
-          description: "Delete an input set. Requires pipeline_id and input_set_id.",
+          description: "Delete an input set. Requires pipeline_id and input_set_id. For remote input sets, pass branch and file_path.",
         },
       },
     },

--- a/src/registry/toolsets/pipelines.ts
+++ b/src/registry/toolsets/pipelines.ts
@@ -217,7 +217,9 @@ export const pipelinesToolset: ToolsetDefinition = {
           headers: { "Content-Type": "application/yaml" },
           bodyBuilder: (input) => {
             const inputs = input.inputs;
-            // No runtime inputs — send empty YAML
+            // No inline runtime inputs: send empty YAML so Harness applies
+            // `inputSetIdentifiers` from the query string. HarnessClient must pass `""`
+            // as the fetch body (not omit it) — see serializeRequestBody / hasExplicitBody.
             if (!inputs) return "";
             // Already a YAML string (pre-resolved by execute tool handler or passed directly)
             if (typeof inputs === "string") return inputs;

--- a/src/tools/harness-create.ts
+++ b/src/tools/harness-create.ts
@@ -14,10 +14,13 @@ export function registerCreateTool(server: McpServer, registry: Registry, client
   server.registerTool(
     "harness_create",
     {
-      description: "Create a Harness resource. For pipelines: use body.yamlPipeline (YAML string, recommended) or body.pipeline (JSON). For remote pipelines, pass git details in params: external Git (store_type='REMOTE', connector_ref, repo_name, branch, file_path) or Harness Code (store_type='REMOTE', is_harness_code_repo=true, repo_name, branch, file_path). For others: call harness_describe for the body format.",
+      description: "Create a Harness resource. For pipelines/input sets: pass body as a YAML string directly (recommended for complex definitions), or use body.yamlPipeline (YAML string), or body.pipeline (JSON object). For remote pipelines, pass git details in params: external Git (store_type='REMOTE', connector_ref, repo_name, branch, file_path) or Harness Code (store_type='REMOTE', is_harness_code_repo=true, repo_name, branch, file_path). For others: call harness_describe for the body format.",
       inputSchema: {
         resource_type: z.enum(creatableTypes).describe("The type of resource to create"),
-        body: z.record(z.string(), z.unknown()).describe("The resource definition body (varies by resource type — typically the YAML or JSON spec)"),
+        body: z.union([
+          z.record(z.string(), z.unknown()),
+          z.string(),
+        ]).describe("The resource definition body. For pipelines: pass a YAML string directly, or an object with yamlPipeline (YAML string) or pipeline (JSON object). For other resources: pass a JSON object"),
         url: z.string().describe("A Harness UI URL — org and project are extracted automatically").optional(),
         org_id: z.string().describe("Organization identifier (overrides default)").optional(),
         project_id: z.string().describe("Project identifier (overrides default)").optional(),
@@ -44,10 +47,13 @@ export function registerCreateTool(server: McpServer, registry: Registry, client
         }
 
         const blockWithoutConfirmation = !!def.operations.create?.blockWithoutConfirmation;
+        const bodyPreview = typeof args.body === "string"
+          ? (args.body.length > 500 ? args.body.slice(0, 500) + "\n...(truncated)" : args.body)
+          : JSON.stringify(args.body, null, 2);
         const elicit = await confirmViaElicitation({
           server,
           toolName: "harness_create",
-          message: `Create ${args.resource_type}?\n\n${JSON.stringify(args.body, null, 2)}`,
+          message: `Create ${args.resource_type}?\n\n${bodyPreview}`,
           destructive: blockWithoutConfirmation,
         });
         if (!elicit.proceed) {

--- a/src/tools/harness-delete.ts
+++ b/src/tools/harness-delete.ts
@@ -21,7 +21,7 @@ export function registerDeleteTool(server: McpServer, registry: Registry, client
         url: z.string().describe("A Harness UI URL — org, project, resource type, and ID are extracted automatically").optional(),
         org_id: z.string().describe("Organization identifier (overrides default)").optional(),
         project_id: z.string().describe("Project identifier (overrides default)").optional(),
-        params: z.record(z.string(), z.unknown()).describe("Additional identifiers for nested resources (e.g. pipeline_id for triggers, environment_id for infrastructure).").optional(),
+        params: z.record(z.string(), z.unknown()).describe("Additional identifiers for nested resources (e.g. pipeline_id for triggers/input sets, environment_id for infrastructure).").optional(),
       },
       annotations: {
         title: "Delete Harness Resource",
@@ -51,7 +51,10 @@ export function registerDeleteTool(server: McpServer, registry: Registry, client
         const { params, ...rest } = args;
         const input = applyUrlDefaults(rest as Record<string, unknown>, args.url);
         if (params) Object.assign(input, params);
-        const primaryField = def.identifierFields[0];
+        const identFields = def.identifierFields;
+        const primaryField = identFields.length > 1
+          ? identFields[identFields.length - 1]!
+          : identFields[0];
         if (primaryField && args.resource_id) {
           input[primaryField] = args.resource_id;
         }

--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -10,6 +10,7 @@ import { applyUrlDefaults } from "../utils/url-parser.js";
 import { asRecord, asString } from "../utils/type-guards.js";
 import { isFlatKeyValueInputs, isResolvableInputs, flattenInputs, resolveRuntimeInputs, type ResolutionResult } from "../utils/runtime-input-resolver.js";
 import { applyInputExpansions } from "../utils/input-expander.js";
+import { materializeInputSetsToRuntimeYaml } from "../utils/materialize-input-sets.js";
 
 const log = createLogger("execute");
 
@@ -74,9 +75,50 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
           input[primaryField] = resourceId;
         }
 
-        // Pass input_set_ids through to the dispatch input
+        // Pass input_set_ids as string[] so HarnessClient emits repeated `inputSetIdentifiers=` query keys
+        // (grpc-gateway array style). Comma-joined single param is ignored by pipeline execute.
         if (args.input_set_ids && args.input_set_ids.length > 0) {
-          input.input_set_ids = args.input_set_ids.join(",");
+          input.input_set_ids = [...args.input_set_ids];
+        }
+
+        // When only input_set_ids are provided, fetch each input set and build runtime YAML.
+        // Harness execute often does not apply `inputSetIdentifiers` from the query string alone;
+        // sending the merged `pipeline` fragment as the YAML body matches the working UI path.
+        if (
+          resourceType === "pipeline" &&
+          args.action === "run" &&
+          args.input_set_ids &&
+          args.input_set_ids.length > 0 &&
+          args.inputs === undefined
+        ) {
+          const pipelineId = asString(input.pipeline_id) ?? resourceId;
+          const orgId = asString(input.org_id) || registry.orgId;
+          const projectId = asString(input.project_id) || registry.projectId;
+          if (!pipelineId) {
+            return errorResult(
+              "pipeline_id is required when using input_set_ids without inputs. Provide resource_id or params.pipeline_id.",
+            );
+          }
+          if (!projectId) {
+            return errorResult(
+              "project_id is required when using input_set_ids. Pass project_id or set HARNESS_PROJECT.",
+            );
+          }
+          try {
+            const yaml = await materializeInputSetsToRuntimeYaml(client, {
+              pipelineId,
+              orgId,
+              projectId,
+              inputSetIds: args.input_set_ids,
+            });
+            if (yaml) {
+              input.inputs = yaml;
+              delete input.input_set_ids;
+            }
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            return errorResult(`Could not load input set(s) for execution: ${msg}`);
+          }
         }
 
         // Auto-resolve flat key-value runtime inputs for pipeline run

--- a/src/tools/harness-update.ts
+++ b/src/tools/harness-update.ts
@@ -15,15 +15,18 @@ export function registerUpdateTool(server: McpServer, registry: Registry, client
   server.registerTool(
     "harness_update",
     {
-      description: "Update an existing Harness resource. You can pass a Harness URL to auto-extract identifiers. Response includes openInHarness link to the updated resource when applicable.",
+      description: "Update an existing Harness resource. For pipelines/input sets: pass body as a YAML string directly (recommended for complex definitions), or use body.yamlPipeline/body.pipeline. You can pass a Harness URL to auto-extract identifiers. Response includes openInHarness link to the updated resource when applicable.",
       inputSchema: {
         resource_type: z.enum(updatableTypes).describe("The type of resource to update"),
         resource_id: z.string().describe("The identifier of the resource to update"),
         url: z.string().describe("A Harness UI URL — org, project, resource type, and ID are extracted automatically").optional(),
-        body: z.record(z.string(), z.unknown()).describe("The updated resource definition body"),
+        body: z.union([
+          z.record(z.string(), z.unknown()),
+          z.string(),
+        ]).describe("The updated resource definition body. For pipelines: pass a YAML string directly, or an object with yamlPipeline (YAML string) or pipeline (JSON object)"),
         org_id: z.string().describe("Organization identifier (overrides default)").optional(),
         project_id: z.string().describe("Project identifier (overrides default)").optional(),
-        params: z.record(z.string(), z.unknown()).describe("Additional identifiers (e.g. pipeline_id for triggers, version_label for templates).").optional(),
+        params: z.record(z.string(), z.unknown()).describe("Additional identifiers (e.g. pipeline_id for triggers/input sets, version_label for templates).").optional(),
       },
       annotations: {
         title: "Update Harness Resource",
@@ -42,10 +45,13 @@ export function registerUpdateTool(server: McpServer, registry: Registry, client
         }
 
         const blockWithoutConfirmation = !!def.operations.update?.blockWithoutConfirmation;
+        const bodyPreview = typeof args.body === "string"
+          ? (args.body.length > 500 ? args.body.slice(0, 500) + "\n...(truncated)" : args.body)
+          : JSON.stringify(args.body, null, 2);
         const elicit = await confirmViaElicitation({
           server,
           toolName: "harness_update",
-          message: `Update ${args.resource_type} "${args.resource_id}"?\n\n${JSON.stringify(args.body, null, 2)}`,
+          message: `Update ${args.resource_type} "${args.resource_id}"?\n\n${bodyPreview}`,
           destructive: blockWithoutConfirmation,
         });
         if (!elicit.proceed) {
@@ -54,7 +60,10 @@ export function registerUpdateTool(server: McpServer, registry: Registry, client
         const { params, ...rest } = args;
         const input = applyUrlDefaults(rest as Record<string, unknown>, args.url);
         if (params) Object.assign(input, params);
-        const primaryField = def.identifierFields[0];
+        const identFields = def.identifierFields;
+        const primaryField = identFields.length > 1
+          ? identFields[identFields.length - 1]!
+          : identFields[0];
         if (primaryField && args.resource_id) {
           input[primaryField] = args.resource_id;
         }

--- a/src/utils/materialize-input-sets.ts
+++ b/src/utils/materialize-input-sets.ts
@@ -1,0 +1,163 @@
+/**
+ * Load saved pipeline input sets and build runtime YAML for pipeline execute.
+ * Used when callers pass input_set_ids without inline `inputs`, so execution
+ * does not depend on Harness honoring `inputSetIdentifiers` query params alone.
+ */
+import YAML from "yaml";
+import type { HarnessClient } from "../client/harness-client.js";
+import { HarnessApiError } from "./errors.js";
+import { asRecord, asString } from "./type-guards.js";
+
+export interface MaterializeParams {
+  pipelineId: string;
+  orgId: string;
+  projectId: string;
+  inputSetIds: string[];
+}
+
+function mergeVariableLists(
+  a: Array<Record<string, unknown>>,
+  b: Array<Record<string, unknown>>,
+): Array<Record<string, unknown>> {
+  const byName = new Map<string, Record<string, unknown>>();
+  for (const v of a) {
+    const n = asString(v.name);
+    if (n) byName.set(n, { ...v });
+  }
+  for (const v of b) {
+    const n = asString(v.name);
+    if (n) {
+      const prev = byName.get(n);
+      byName.set(n, prev ? { ...prev, ...v } : { ...v });
+    }
+  }
+  return [...byName.values()];
+}
+
+function getStageId(stageItem: unknown): string | undefined {
+  const o = asRecord(stageItem);
+  const st = asRecord(o?.stage);
+  return asString(st?.identifier);
+}
+
+function mergeStages(a: unknown[], b: unknown[]): unknown[] {
+  const out = [...a];
+  for (const nextItem of b) {
+    const id = getStageId(nextItem);
+    if (!id) {
+      out.push(nextItem);
+      continue;
+    }
+    const idx = out.findIndex((x) => getStageId(x) === id);
+    if (idx < 0) {
+      out.push(nextItem);
+      continue;
+    }
+    const baseItem = asRecord(out[idx]);
+    const nextRec = asRecord(nextItem);
+    const baseStage = asRecord(baseItem?.stage);
+    const nextStage = asRecord(nextRec?.stage);
+    const mergedStage: Record<string, unknown> = { ...baseStage, ...nextStage };
+    const baseVars = Array.isArray(baseStage?.variables)
+      ? (baseStage.variables as unknown[]).map((x) => asRecord(x)).filter((x): x is Record<string, unknown> => !!x)
+      : [];
+    const nextVars = Array.isArray(nextStage?.variables)
+      ? (nextStage.variables as unknown[]).map((x) => asRecord(x)).filter((x): x is Record<string, unknown> => !!x)
+      : [];
+    if (baseVars.length > 0 || nextVars.length > 0) {
+      mergedStage.variables = mergeVariableLists(baseVars, nextVars);
+    }
+    out[idx] = { stage: mergedStage };
+  }
+  return out;
+}
+
+/** Merge two `pipeline` fragments from input sets (later ids override by variable / stage id). */
+export function mergeRuntimePipelineFragments(
+  base: Record<string, unknown>,
+  next: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...base, ...next };
+  if (next.identifier !== undefined) out.identifier = next.identifier;
+
+  const bv = Array.isArray(base.variables)
+    ? (base.variables as unknown[]).map((x) => asRecord(x)).filter((x): x is Record<string, unknown> => !!x)
+    : [];
+  const nv = Array.isArray(next.variables)
+    ? (next.variables as unknown[]).map((x) => asRecord(x)).filter((x): x is Record<string, unknown> => !!x)
+    : [];
+  if (nv.length > 0 || bv.length > 0) {
+    out.variables = mergeVariableLists(bv, nv);
+  }
+
+  const bs = Array.isArray(base.stages) ? (base.stages as unknown[]) : [];
+  const ns = Array.isArray(next.stages) ? (next.stages as unknown[]) : [];
+  if (ns.length > 0 || bs.length > 0) {
+    out.stages = mergeStages(bs, ns);
+  }
+  return out;
+}
+
+async function fetchInputSetPipelineFragment(
+  client: HarnessClient,
+  pipelineId: string,
+  orgId: string,
+  projectId: string,
+  inputSetId: string,
+): Promise<Record<string, unknown> | undefined> {
+  const raw = await client.request<unknown>({
+    method: "GET",
+    path: `/pipeline/api/inputSets/${encodeURIComponent(inputSetId)}`,
+    params: {
+      orgIdentifier: orgId,
+      projectIdentifier: projectId,
+      pipelineIdentifier: pipelineId,
+    },
+  });
+  const r = asRecord(raw);
+  const st = asString(r?.status);
+  if (st === "ERROR" || st === "FAILURE") {
+    const msg = asString(r?.message) ?? "Input set GET returned ERROR";
+    throw new HarnessApiError(msg, 400, asString(r?.code), asString(r?.correlationId));
+  }
+  const entity = asRecord(r?.data) ?? r;
+  const yamlStr = asString(entity?.inputSetYaml);
+  if (!yamlStr) return undefined;
+
+  const doc = YAML.parse(yamlStr) as unknown;
+  const root = asRecord(doc);
+  const inputSet = asRecord(root?.inputSet) ?? root;
+  const pipeline = asRecord(inputSet?.pipeline);
+  return pipeline ?? undefined;
+}
+
+/**
+ * Returns YAML string `{ pipeline: ... }` suitable for pipeline execute body,
+ * or undefined if no ids.
+ */
+export async function materializeInputSetsToRuntimeYaml(
+  client: HarnessClient,
+  params: MaterializeParams,
+): Promise<string | undefined> {
+  if (params.inputSetIds.length === 0) return undefined;
+
+  let merged: Record<string, unknown> | undefined;
+  for (const id of params.inputSetIds) {
+    const fragment = await fetchInputSetPipelineFragment(
+      client,
+      params.pipelineId,
+      params.orgId,
+      params.projectId,
+      id,
+    );
+    if (!fragment) {
+      throw new HarnessApiError(
+        `Input set "${id}" not found or has no pipeline fragment for pipeline "${params.pipelineId}".`,
+        404,
+      );
+    }
+    merged = merged ? mergeRuntimePipelineFragments(merged, fragment) : fragment;
+  }
+
+  return YAML.stringify({ pipeline: merged });
+}

--- a/tests/client/harness-client.test.ts
+++ b/tests/client/harness-client.test.ts
@@ -120,6 +120,20 @@ describe("HarnessClient", () => {
       expect(url.searchParams.has("b")).toBe(false);
       expect(url.searchParams.has("c")).toBe(false);
     });
+
+    it("serializes string[] params as repeated query keys (grpc-gateway arrays)", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      const client = new HarnessClient(makeConfig());
+
+      await client.request({
+        path: "/pipeline/api/pipeline/execute/p1",
+        params: { inputSetIdentifiers: ["set-a", "set-b"], orgIdentifier: "o" },
+      });
+
+      const url = new URL(fetchSpy.mock.calls[0][0] as string);
+      expect(url.searchParams.getAll("inputSetIdentifiers")).toEqual(["set-a", "set-b"]);
+      expect(url.searchParams.get("orgIdentifier")).toBe("o");
+    });
   });
 
   describe("request — headers", () => {
@@ -488,6 +502,30 @@ describe("HarnessClient", () => {
 
       const body = fetchSpy.mock.calls[0][1]?.body as string;
       expect(body).toBe("raw yaml content");
+    });
+
+    it("sends empty string body (pipeline execute uses YAML + inputSetIdentifiers query)", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({ status: "SUCCESS" }), { status: 200 }));
+      const client = new HarnessClient(makeConfig());
+
+      await client.request({
+        method: "POST",
+        path: "/pipeline/api/pipeline/execute/MyPipeline",
+        headers: { "Content-Type": "application/yaml" },
+        body: "",
+        params: {
+          orgIdentifier: "default",
+          projectIdentifier: "PM_Signoff",
+          inputSetIdentifiers: "mcp_default_runtime_inputs",
+        },
+      });
+
+      const init = fetchSpy.mock.calls[0][1] as RequestInit;
+      expect(init.body).toBe("");
+      const headers = init.headers as Record<string, string>;
+      expect(headers["Content-Type"]).toBe("application/yaml");
+      const url = new URL(fetchSpy.mock.calls[0][0] as string);
+      expect(url.searchParams.get("inputSetIdentifiers")).toBe("mcp_default_runtime_inputs");
     });
   });
 });

--- a/tests/registry/registry.test.ts
+++ b/tests/registry/registry.test.ts
@@ -388,7 +388,7 @@ describe("Registry", () => {
           pipeline_id: "x",
           body: {},
         }),
-      ).rejects.toThrow(/body must include either pipeline/);
+      ).rejects.toThrow(/body must be a YAML string/);
     });
   });
 

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -515,6 +515,31 @@ describe("harness_execute", () => {
     expect(mockRequest).toHaveBeenCalled();
   });
 
+  it("materializes input_set_ids by GETting each input set then POSTing merged pipeline YAML", async () => {
+    const inputSetYaml = `inputSet:\n  pipeline:\n    identifier: mat_pipe\n    variables:\n      - name: x\n        type: String\n        value: "1"\n`;
+    mockRequest
+      .mockResolvedValueOnce({ status: "SUCCESS", data: { inputSetYaml } })
+      .mockResolvedValueOnce({ status: "SUCCESS", data: { planExecutionId: "exec-mat" } });
+
+    const result = await server.call("harness_execute", {
+      resource_type: "pipeline",
+      action: "run",
+      resource_id: "mat_pipe",
+      input_set_ids: ["saved_set"],
+    });
+    expect(result.isError).toBeUndefined();
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+    const getCall = mockRequest.mock.calls[0]![0] as { method?: string; path?: string };
+    expect(getCall.method).toBe("GET");
+    expect(getCall.path).toContain("/pipeline/api/inputSets/");
+    expect(getCall.path).toContain("saved_set");
+
+    const runCall = mockRequest.mock.calls[1]![0] as { body?: string };
+    expect(typeof runCall.body).toBe("string");
+    expect(runCall.body).toContain("mat_pipe");
+    expect(runCall.body).toContain("x");
+  });
+
   it("falls back to fresh run when retry returns 405", async () => {
     // First call (retry) throws 405, second call (run) succeeds
     mockRequest

--- a/tests/utils/materialize-input-sets.test.ts
+++ b/tests/utils/materialize-input-sets.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { mergeRuntimePipelineFragments } from "../../src/utils/materialize-input-sets.js";
+
+describe("mergeRuntimePipelineFragments", () => {
+  it("overrides pipeline variables by name from the later fragment", () => {
+    const a = {
+      identifier: "P",
+      variables: [{ name: "var1", type: "String", value: "a" }],
+    };
+    const b = {
+      identifier: "P",
+      variables: [{ name: "var1", type: "String", value: "b" }],
+    };
+    const out = mergeRuntimePipelineFragments(a, b);
+    expect(out.variables).toEqual([{ name: "var1", type: "String", value: "b" }]);
+  });
+
+  it("merges stage variables for the same stage identifier", () => {
+    const a = {
+      identifier: "P",
+      stages: [
+        {
+          stage: {
+            identifier: "ci",
+            type: "CI",
+            variables: [{ name: "demo", type: "String", value: "old" }],
+          },
+        },
+      ],
+    };
+    const b = {
+      identifier: "P",
+      stages: [
+        {
+          stage: {
+            identifier: "ci",
+            type: "CI",
+            variables: [{ name: "demo", type: "String", value: "new" }],
+          },
+        },
+      ],
+    };
+    const out = mergeRuntimePipelineFragments(a, b);
+    expect(out.stages).toHaveLength(1);
+    const st = (out.stages as unknown[])[0] as { stage: { variables: unknown[] } };
+    expect(st.stage.variables).toEqual([{ name: "demo", type: "String", value: "new" }]);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes two issues reported by a Sales Engineer regarding pipeline update failures and missing InputSet support:

### Issue 1: `harness_update` fails for Pipeline resources with YAML body

**Root cause:** The `body` parameter in `harness_update` and `harness_create` used `z.record(z.string(), z.unknown())` which only accepts JSON objects. When an AI agent passes a raw YAML string (the natural format for complex pipeline definitions with 700+ lines, shell scripts, JEXL expressions, and special characters), Zod rejects it before it reaches the pipeline's `bodyBuilder`.

**Fix:** Changed the `body` Zod schema to `z.union([z.record(...), z.string()])` to accept both JSON objects and raw YAML strings. Updated pipeline `bodyBuilder` functions (create and update) to handle the case where `input.body` is a raw YAML string directly, in addition to the existing `{yamlPipeline: "..."}` and `{pipeline: {...}}` object forms.

### Issue 2: `harness_create` does not support InputSets

**Root cause:** The `input_set` resource definition only had `list` and `get` operations — no `create`, `update`, or `delete`.

**Fix:** Added full CRUD support for input sets:
- **create**: `POST /pipeline/api/inputSets` with YAML body support
- **update**: `PUT /pipeline/api/inputSets/{inputSetIdentifier}` with YAML body and git conflict detection support
- **delete**: `DELETE /pipeline/api/inputSets/{inputSetIdentifier}`

All three new operations support remote/git-backed storage (store_type, connector_ref, repo_name, branch, etc.) consistent with the pipeline CRUD pattern.

### Bonus fix: Multi-identifier resource_id mapping in update/delete

`harness_update` and `harness_delete` were using `identifierFields[0]` (the first/parent field like `pipeline_id`) to map the `resource_id` parameter. For multi-identifier resources like triggers (`["pipeline_id", "trigger_id"]`) and input sets (`["pipeline_id", "input_set_id"]`), this incorrectly assigned the resource ID to the parent field. Fixed to use `identifierFields[identifierFields.length - 1]` (the last/resource-specific field), matching the existing `harness_get` behavior.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] Tests pass
- [x] Typecheck passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8f551b7-d91d-4f32-83d7-6ba94e567a09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8f551b7-d91d-4f32-83d7-6ba94e567a09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

