### PR TITLE
feat: update prompts for InputSet CRUD and pipeline execution capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -807,6 +807,56 @@ Harness pipelines can be stored in three ways:
 }
 ```
 
+**List input sets for a pipeline:**
+
+```json
+{
+  "resource_type": "input_set",
+  "pipeline_id": "my-pipeline"
+}
+```
+
+**Get a specific input set:**
+
+```json
+{
+  "resource_type": "input_set",
+  "resource_id": "prod-inputs",
+  "pipeline_id": "my-pipeline"
+}
+```
+
+**Create an input set:**
+
+```json
+{
+  "resource_type": "input_set",
+  "pipeline_id": "my-pipeline",
+  "body": "inputSet:\n  name: Production Inputs\n  identifier: prod_inputs\n  pipeline:\n    identifier: my-pipeline\n    variables:\n      - name: env\n        type: String\n        value: production"
+}
+```
+
+**Update an input set:**
+
+```json
+{
+  "resource_type": "input_set",
+  "resource_id": "prod_inputs",
+  "pipeline_id": "my-pipeline",
+  "body": "inputSet:\n  name: Production Inputs\n  identifier: prod_inputs\n  pipeline:\n    identifier: my-pipeline\n    variables:\n      - name: env\n        type: String\n        value: production\n      - name: replicas\n        type: String\n        value: \"3\""
+}
+```
+
+**Delete an input set:**
+
+```json
+{
+  "resource_type": "input_set",
+  "resource_id": "prod_inputs",
+  "pipeline_id": "my-pipeline"
+}
+```
+
 ## Resource Types
 
 139 resource types organized across 30 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
@@ -826,7 +876,7 @@ Harness pipelines can be stored in three ways:
 | `execution` | x | x | | | | `interrupt` |
 | `trigger` | x | x | x | x | x | |
 | `pipeline_summary` | | x | | | | |
-| `input_set` | x | x | | | | |
+| `input_set` | x | x | x | x | x | |
 | `runtime_input_template` | | x | | | | |
 | `approval_instance` | x | | | | | `approve`, `reject` |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-mcp-v2",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "Give AI agents full access to the Harness.io platform — manage pipelines, deployments, cloud costs, chaos engineering, feature flags, SEI, and 125+ resource types through 11 MCP tools",
   "type": "module",
   "main": "build/index.js",

--- a/src/prompts/build-deploy-app.ts
+++ b/src/prompts/build-deploy-app.ts
@@ -111,7 +111,11 @@ Present the full pipeline YAML for review. Do NOT create it yet.
 
 ### Step 7 — Create & execute CI pipeline (with auto-retry)
 - After user confirms the YAML, create it using harness_create with resource_type="pipeline"
-- Execute it using harness_execute with resource_type="pipeline"
+- **Discover runtime inputs**: Call harness_get with resource_type="runtime_input_template" and resource_id=<pipeline_id> to see which \`<+input>\` placeholders need values
+- **Execute with shorthands**: Call harness_execute with resource_type="pipeline", action="run", resource_id=<pipeline_id>. For CI pipelines, pass the Git branch/tag directly as shorthand inputs:
+  - \`inputs: { branch: "main" }\` — auto-expands to the full codebase build structure
+  - Other shorthands: \`tag\`, \`pr_number\`, \`commit_sha\` (see harness_describe for details)
+  - For remaining \`<+input>\` values, pass them as flat key-value pairs in \`inputs\`
 - Monitor progress using harness_status — poll until the execution completes or fails
 
 **CI FAILURE RETRY LOOP (up to 5 attempts):**
@@ -171,7 +175,8 @@ Present the full pipeline YAML for review. Do NOT create it yet.
 
 ### Step 11 — Create & execute CD pipeline (with auto-retry)
 - After user confirms, create the CD pipeline using harness_create with resource_type="pipeline"
-- Execute it using harness_execute with resource_type="pipeline"
+- **Discover runtime inputs**: Call harness_get with resource_type="runtime_input_template" and resource_id=<pipeline_id> to see which \`<+input>\` placeholders need values
+- **Execute**: Call harness_execute with resource_type="pipeline", action="run", resource_id=<pipeline_id>, passing any required runtime inputs as flat key-value \`inputs\`
 - Monitor with harness_status — poll until the execution completes or fails
 
 **CD FAILURE RETRY LOOP (up to 3 attempts):**
@@ -208,6 +213,25 @@ If still failing after 3 attempts:
   - CD: execution status, deployment details, namespace
   - Links: Harness UI links to both pipelines, service, and environment
   - App URL: if determinable from the K8s service (LoadBalancer IP/hostname)
+
+### Step 13 — Optional: Create input sets for reusability
+If the pipelines have \`<+input>\` runtime placeholders, offer to create saved input sets so future runs don't require manual input:
+- Call harness_get with resource_type="runtime_input_template" and resource_id=<pipeline_id> for each pipeline to identify all placeholders
+- Suggest creating input sets (e.g., "dev-inputs", "prod-inputs") that pre-fill common values
+- Create using harness_create with resource_type="input_set", pipeline_id=<pipeline_id>, and a YAML body:
+  \`\`\`yaml
+  inputSet:
+    name: Dev Defaults
+    identifier: dev_defaults
+    pipeline:
+      identifier: <pipeline_id>
+      variables:
+        - name: env
+          type: String
+          value: dev
+  \`\`\`
+- Future runs can use: harness_execute with input_set_ids=["dev_defaults"] instead of passing inputs manually
+- This is optional — only create if the user wants reusable configurations
 
 ---
 

--- a/src/prompts/create-pipeline.ts
+++ b/src/prompts/create-pipeline.ts
@@ -63,9 +63,32 @@ Steps:
    Key: uses \`connectorRef\`. Does NOT have \`registryRef\`.
 
 6. Generate the pipeline YAML conforming to the schema, using the correct template from step 5
-7. Present the YAML for review before creating
+7. **Choose storage mode** — ask the user where to store the pipeline:
+   - **Inline (default)**: Stored in Harness. Simplest setup, no Git required. Just call harness_create with resource_type="pipeline" and the YAML body.
+   - **Remote (External Git)**: Stored in GitHub/GitLab/Bitbucket. Pass \`params: { store_type: "REMOTE", connector_ref: "<git_connector>", repo_name: "<repo>", branch: "main", file_path: ".harness/<pipeline_id>.yaml", commit_msg: "Add pipeline via MCP" }\`
+   - **Remote (Harness Code)**: Stored in a Harness Code repo. Pass \`params: { store_type: "REMOTE", is_harness_code_repo: true, repo_name: "<repo>", branch: "main", file_path: ".harness/<pipeline_id>.yaml", commit_msg: "Add pipeline via MCP" }\`
+8. Present the YAML for review before creating
 
-Do NOT create the pipeline until I confirm — just show me the YAML first.`,
+Do NOT create the pipeline until I confirm — just show me the YAML first.
+
+After the pipeline is created, if it contains \`<+input>\` runtime placeholders:
+9. **Suggest creating input sets** to save common configurations for future runs:
+   - Call harness_get with resource_type="runtime_input_template" and resource_id=<pipeline_id> to discover all \`<+input>\` placeholders
+   - Propose input sets for common scenarios (e.g., "dev-defaults", "prod-defaults") that pre-fill values
+   - Create using harness_create with resource_type="input_set", pipeline_id=<pipeline_id>, and a YAML body like:
+     \`\`\`yaml
+     inputSet:
+       name: Dev Defaults
+       identifier: dev_defaults
+       pipeline:
+         identifier: <pipeline_id>
+         variables:
+           - name: env
+             type: String
+             value: dev
+     \`\`\`
+   - This lets future runs use \`input_set_ids: ["dev_defaults"]\` instead of manual input each time
+   - This step is optional — only create if the user wants reusable run configurations`,
         },
       }],
     }),

--- a/src/prompts/debug-pipeline.ts
+++ b/src/prompts/debug-pipeline.ts
@@ -36,6 +36,10 @@ Then analyze the diagnostic payload:
 - **failure section**: failed stage, step, error message, and delegate
 - **child_pipeline section**: if present, the failure is in a chained pipeline — focus on the child's failure details
 - **failed_step_logs**: actual log output from the failed steps — look for error patterns, stack traces, and exit codes
+- **runtime input issues**: if the error mentions unresolved \`<+input>\` expressions or missing variables, check:
+  - Call harness_get with resource_type="runtime_input_template" and resource_id=<pipeline_id> to see which inputs the pipeline expects
+  - Call harness_list with resource_type="input_set", pipeline_id=<pipeline_id> to see available input sets that could provide the missing values
+  - Suggest the user either pass the missing values as \`inputs\` or use \`input_set_ids\` referencing a saved input set
 
 Provide actionable recommendations based on the combined evidence.`,
           },

--- a/src/prompts/migrate-to-template.ts
+++ b/src/prompts/migrate-to-template.ts
@@ -23,18 +23,36 @@ export function registerMigrateToTemplatePrompt(server: McpServer): void {
 Steps:
 1. **Get pipeline YAML**: Call harness_get with resource_type="pipeline", resource_id="${pipelineId}"${projectFilter} to fetch the full pipeline definition
 2. **List existing templates**: Call harness_list with resource_type="template"${projectFilter} to see what templates already exist (avoid duplicating)
-3. **Identify reusable patterns**: Analyze the pipeline for:
+3. **List existing input sets**: Call harness_list with resource_type="input_set", pipeline_id="${pipelineId}"${projectFilter} to see if input sets already exist for this pipeline
+4. **Identify reusable patterns**: Analyze the pipeline for:
    - Stages that could become **Stage templates** (e.g., deployment stages, approval stages)
    - Steps or step groups that could become **Step templates** (e.g., common build steps, deploy steps, notification steps)
    - Patterns repeated across stages that indicate template opportunity
-4. **Generate template YAML**: For each identified template:
+   - Hardcoded values that vary per environment or run (these become \`<+input>\` placeholders)
+5. **Generate template YAML**: For each identified template:
    - Extract the stage/step definition
-   - Parameterize hardcoded values as runtime inputs (<+input>)
+   - Parameterize hardcoded values as runtime inputs (\`<+input>\`)
    - Add template metadata (name, identifier, versionLabel, type)
-5. **Generate updated pipeline YAML**: Rewrite the pipeline to reference the new templates using templateRef and templateInputs
-6. **Present for review**: Show all template YAMLs and the updated pipeline YAML
+6. **Generate updated pipeline YAML**: Rewrite the pipeline to reference the new templates using templateRef and templateInputs
+7. **Generate input sets for common configurations**: For each set of \`<+input>\` placeholders introduced:
+   - Identify which values were previously hardcoded and extract them into named input sets
+   - Create input sets for common scenarios (e.g., "dev-defaults", "prod-defaults"):
+     \`\`\`yaml
+     inputSet:
+       name: Dev Defaults
+       identifier: dev_defaults
+       pipeline:
+         identifier: ${pipelineId}
+         variables:
+           - name: env
+             type: String
+             value: dev
+     \`\`\`
+   - This preserves the original behavior: running with \`input_set_ids: ["dev_defaults"]\` produces the same result as the pre-template pipeline
+   - Multiple input sets can be combined: \`input_set_ids: ["base_defaults", "prod_overrides"]\` (later sets override earlier ones by variable name)
+8. **Present for review**: Show all template YAMLs, the updated pipeline YAML, and proposed input sets
 
-Do NOT create templates or update the pipeline until I confirm the plan.`,
+Do NOT create templates, update the pipeline, or create input sets until I confirm the plan.`,
           },
         }],
       };

--- a/src/prompts/onboard-service.ts
+++ b/src/prompts/onboard-service.ts
@@ -23,12 +23,38 @@ Steps:
 2. **Review patterns**: Call harness_list with resource_type="service"${projectId ? ` and project_id="${projectId}"` : ""} to see existing service patterns in the project
 3. **Environments**: Call harness_list with resource_type="environment"${projectId ? ` and project_id="${projectId}"` : ""} to see available environments
 4. **Connectors**: Call harness_list with resource_type="connector"${projectId ? ` and project_id="${projectId}"` : ""} to see available infrastructure connectors
-5. **Create service**: Generate the service YAML definition following existing patterns
-6. **Create pipeline**: Generate a deployment pipeline YAML for the service with:
+5. **Check existing input sets**: Call harness_list with resource_type="input_set"${projectId ? ` and project_id="${projectId}"` : ""} to see if the project already uses input sets for parameterized deployments
+6. **Create service**: Generate the service YAML definition following existing patterns
+7. **Create pipeline**: Generate a deployment pipeline YAML for the service with:
    - Build stage (if applicable)
-   - Deploy to dev/staging/prod environments
+   - Deploy to dev/staging/prod environments using \`<+input>\` for environment-specific values (infrastructure, namespace, replicas, image tag)
    - Approval gates between staging and prod
-7. **Present for review**: Show all generated YAML before creating anything
+8. **Choose storage mode** — ask where to store the pipeline:
+   - **Inline (default)**: Stored in Harness — simplest setup
+   - **Remote (External Git)**: Stored in GitHub/GitLab/Bitbucket via a Git connector
+   - **Remote (Harness Code)**: Stored in a Harness Code repository
+9. **Create per-environment input sets**: Since the pipeline uses \`<+input>\` placeholders for multi-environment deployment, create input sets that pre-fill values for each target environment:
+   - \`${serviceName}-dev\` — dev infrastructure, namespace, lower replicas
+   - \`${serviceName}-staging\` — staging infrastructure, namespace
+   - \`${serviceName}-prod\` — prod infrastructure, namespace, higher replicas
+   - Example YAML for each:
+     \`\`\`yaml
+     inputSet:
+       name: ${serviceName} Dev
+       identifier: ${serviceName.replace(/[^a-zA-Z0-9]/g, "_")}_dev
+       pipeline:
+         identifier: <pipeline_id>
+         variables:
+           - name: env
+             type: String
+             value: dev
+           - name: namespace
+             type: String
+             value: dev
+     \`\`\`
+   - Create each using harness_create with resource_type="input_set" and pipeline_id=<pipeline_id>
+   - This lets future runs use: \`harness_execute(resource_type="pipeline", input_set_ids=["${serviceName.replace(/[^a-zA-Z0-9]/g, "_")}_dev"])\` instead of passing inputs manually
+10. **Present for review**: Show all generated YAML (service, pipeline, input sets) before creating anything
 
 Do NOT create any resources until I confirm — present the complete plan first with all YAML definitions.`,
         },


### PR DESCRIPTION
## Summary
- **Version bump** to 0.8.8 in `package.json`
- **README**: Updated `input_set` resource table to show full CRUD support (Create, Update, Delete) and added 5 InputSet tool examples (list, get, create, update, delete)
- **5 prompt templates updated** to leverage new InputSet CRUD, runtime input template discovery, CI codebase shorthands, `input_set_ids` execution, and pipeline storage mode selection:
  - `build-deploy-app.ts`: Discover runtime inputs before runs, use CI shorthands (`branch`/`tag`), optional input set creation post-deploy
  - `create-pipeline.ts`: Storage mode choice (inline/remote/Harness Code), suggest input sets for `<+input>` placeholders
  - `onboard-service.ts`: Per-environment input sets for multi-env deployments, storage mode selection
  - `migrate-to-template.ts`: Generate input sets alongside extracted templates to preserve original hardcoded values
  - `debug-pipeline.ts`: Check for unresolved runtime inputs as a failure cause, suggest input sets

## Test plan
- [x] `pnpm typecheck` passes (verified locally)
- [x] Verify prompts render correctly in MCP Inspector (`pnpm inspect`)
- [x] Test `build-deploy-app` prompt with a real repo to confirm runtime input discovery and CI shorthands work in the flow
- [x] Test `create-pipeline` prompt to verify storage mode question and input set suggestion flow
- [x] Test `onboard-service` prompt to verify per-environment input set generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)