### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-mcp-v2",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "description": "Give AI agents full access to the Harness.io platform — manage pipelines, deployments, cloud costs, chaos engineering, feature flags, SEI, and 125+ resource types through 11 MCP tools",
   "type": "module",
   "main": "build/index.js",


### PR DESCRIPTION
## Summary
- Bumps package version from `0.8.8` → `0.9.0` in preparation for manual npm publish

## Test plan
- [x] Verify `package.json` version is `0.9.0`
- [x] `pnpm build` succeeds
- [x] Publish via `pnpm publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)