### PR TITLE
fix: use correct pipeline resource type in pipeline-yaml resource discovery

### DIFF
--- a/src/resources/pipeline-yaml.ts
+++ b/src/resources/pipeline-yaml.ts
@@ -8,10 +8,13 @@ import { createLogger } from "../utils/logger.js";
 const log = createLogger("resource:pipeline-yaml");
 
 export function registerPipelineYamlResource(server: McpServer, registry: Registry, client: HarnessClient, config: Config): void {
+  // Use the correct pipeline resource type based on version
+  const pipelineResourceType = (config.HARNESS_PIPELINE_VERSION ?? "0") === "0" ? "pipeline_v1" : "pipeline";
+
   const template = new ResourceTemplate("pipeline:///{pipelineId}", {
     list: async () => {
       try {
-        const result = await registry.dispatch(client, "pipeline", "list", {
+        const result = await registry.dispatch(client, pipelineResourceType, "list", {
           org_id: config.HARNESS_ORG,
           project_id: config.HARNESS_PROJECT ?? "",
           size: 20,
@@ -60,7 +63,7 @@ export function registerPipelineYamlResource(server: McpServer, registry: Regist
 
       log.info("Fetching pipeline YAML", { pipelineId, orgId, projectId });
 
-      const result = await registry.dispatch(client, "pipeline", "get", {
+      const result = await registry.dispatch(client, pipelineResourceType, "get", {
         pipeline_id: pipelineId,
         org_id: orgId,
         project_id: projectId,


### PR DESCRIPTION
## Summary
- Fixes pipeline-yaml resource discovery failing with "Unknown resource_type 'pipeline'" error
- Dynamically selects `pipeline_v1` or `pipeline` based on `HARNESS_PIPELINE_VERSION` config
- Matches the registry's filtering logic

## Root Cause
The `pipeline-yaml` resource was hardcoded to use `"pipeline"` resource type on lines 14 and 63. However, the registry filters out either `"pipeline"` or `"pipeline_v1"` based on `HARNESS_PIPELINE_VERSION`:
- When `HARNESS_PIPELINE_VERSION=0` (v1 pipelines), only `"pipeline_v1"` is available
- When `HARNESS_PIPELINE_VERSION=1`, only `"pipeline"` is available

This caused resource discovery to fail and break SSE streams in production.

## Fix
Added logic to determine the correct resource type:
```typescript
const pipelineResourceType = (config.HARNESS_PIPELINE_VERSION ?? "0") === "0" ? "pipeline_v1" : "pipeline";
```

## Test Plan
- [x] Built and tested locally
- [x] Verified no TypeScript errors
- [ ] Deploy to QA and verify SSE stream no longer breaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)