### PR TITLE
fix: [SSCA-6347]: correct policy_set type filter for SBOM enforcement

### DIFF
--- a/src/registry/toolsets/governance.ts
+++ b/src/registry/toolsets/governance.ts
@@ -30,8 +30,8 @@ const policySetCreateSchema: BodySchema = {
   fields: [
     { name: "identifier", type: "string", required: true, description: "Unique identifier for the policy set" },
     { name: "name", type: "string", required: true, description: "Display name" },
-    { name: "action", type: "string", required: true, description: "Enforcement action: onrun, onsave, onpush, etc." },
-    { name: "type", type: "string", required: true, description: "Entity type: pipeline, connector, service, environment, etc." },
+    { name: "action", type: "string", required: true, description: "Enforcement action: onrun, onsave, onpush, onstep (SBOM enforcement), onstepstart." },
+    { name: "type", type: "string", required: true, description: "Entity type. For SBOM/SSCA enforcement use 'sbom' (the policies inside this set use 'sbom_enforcement'). Other values: pipeline, connector, service, environment, secret, template, infrastructure." },
     { name: "enabled", type: "boolean", required: true, description: "Whether the policy set is enabled" },
     { name: "description", type: "string", required: false, description: "Description of the policy set" },
     { name: "policies", type: "array", required: false, description: "Policies to include: [{ identifier, severity }]", itemType: "{ identifier: string, severity: 'warning' | 'error' }" },
@@ -43,8 +43,8 @@ const policySetUpdateSchema: BodySchema = {
   description: "OPA policy set update",
   fields: [
     { name: "name", type: "string", required: false, description: "Updated display name" },
-    { name: "action", type: "string", required: false, description: "Updated enforcement action" },
-    { name: "type", type: "string", required: false, description: "Updated entity type" },
+    { name: "action", type: "string", required: false, description: "Updated enforcement action: onrun, onsave, onpush, onstep (SBOM enforcement), onstepstart." },
+    { name: "type", type: "string", required: false, description: "Updated entity type. For SBOM/SSCA enforcement use 'sbom' (policies inside use 'sbom_enforcement'). Other values: pipeline, connector, service, environment, secret, template, infrastructure." },
     { name: "enabled", type: "boolean", required: false, description: "Enable or disable the policy set" },
     { name: "description", type: "string", required: false, description: "Updated description" },
     { name: "policies", type: "array", required: false, description: "Updated policies: [{ identifier, severity }]", itemType: "{ identifier: string, severity: 'warning' | 'error' }" },
@@ -84,7 +84,7 @@ export const governanceToolset: ToolsetDefinition = {
       deepLinkTemplate: "/ng/account/{accountId}/all/orgs/{orgIdentifier}/projects/{projectIdentifier}/settings/governance/policies/edit/{identifier}",
       listFilterFields: [
         { name: "search_term", description: "Filter policies by name or keyword" },
-        { name: "type", description: "Filter by policy entity type. For SBOM/SSCA enforcement use 'sbom_enforcement'. Other known values: pipeline, connector, service, environment, secret, template, infrastructure. Unknown values return an empty list rather than an error." },
+        { name: "type", description: "Filter by policy entity type. For SBOM/SSCA enforcement use 'sbom_enforcement'. Unknown values return an empty list rather than an error.", enum: ["sbom_enforcement", "pipeline", "connector", "service", "environment", "secret", "template", "infrastructure"] },
         { name: "sort", description: "Sort field" },
         { name: "identifier_filter", description: "Filter by policy identifier" },
         { name: "exclude_rego", description: "Exclude rego source from list response", type: "boolean" },
@@ -165,8 +165,8 @@ export const governanceToolset: ToolsetDefinition = {
       deepLinkTemplate: "/ng/account/{accountId}/all/orgs/{orgIdentifier}/projects/{projectIdentifier}/settings/governance/policy-sets/{identifier}",
       listFilterFields: [
         { name: "search_term", description: "Filter policy sets by name or keyword" },
-        { name: "type", description: "Filter by policy-set entity type. For SBOM/SSCA enforcement use 'sbom' (NOT 'sbom_enforcement' or 'ssca_enforcement' — those are valid only for the policy resource and return empty on policy sets). Other known values: pipeline, connector, service, environment, secret, template, infrastructure." },
-        { name: "action", description: "Filter by enforcement action. SBOM enforcement uses 'onstep'. Other values: onrun (pipeline), onsave, onpush, onstepstart." },
+        { name: "type", description: "Filter by policy-set entity type. For SBOM/SSCA enforcement use 'sbom' (NOT 'sbom_enforcement' or 'ssca_enforcement' — those are valid only for the policy resource and return empty on policy sets).", enum: ["sbom", "pipeline", "connector", "service", "environment", "secret", "template", "infrastructure"] },
+        { name: "action", description: "Filter by enforcement action. SBOM enforcement uses 'onstep'. Other values: onrun (pipeline), onsave, onpush, onstepstart.", enum: ["onrun", "onsave", "onpush", "onstep", "onstepstart"] },
         { name: "sort", description: "Sort field" },
         { name: "identifier_filter", description: "Filter by policy set identifier" },
       ],
@@ -231,8 +231,8 @@ export const governanceToolset: ToolsetDefinition = {
       deepLinkTemplate: "/ng/account/{accountId}/all/orgs/{orgIdentifier}/projects/{projectIdentifier}/settings/governance/evaluation/{id}",
       listFilterFields: [
         { name: "entity", description: "Filter by entity identifier" },
-        { name: "type", description: "Filter by entity type (pipeline, connector, service, etc.)" },
-        { name: "action", description: "Filter by action (onrun, onsave, etc.)" },
+        { name: "type", description: "Filter by entity type. Matches the evaluated policy_set's type — for SBOM/SSCA enforcement use 'sbom' (NOT 'sbom_enforcement'; that is the policy-level type, not the evaluation-level type).", enum: ["sbom", "pipeline", "connector", "service", "environment", "secret", "template", "infrastructure"] },
+        { name: "action", description: "Filter by enforcement action. SBOM enforcement uses 'onstep'. Other values: onrun (pipeline), onsave, onpush, onstepstart.", enum: ["onrun", "onsave", "onpush", "onstep", "onstepstart"] },
         { name: "status", description: "Filter by evaluation status" },
         { name: "execution_id", description: "Filter by pipeline execution ID" },
         { name: "created_date_from", description: "Filter evaluations created after this date (ISO 8601)" },

--- a/src/registry/toolsets/governance.ts
+++ b/src/registry/toolsets/governance.ts
@@ -68,7 +68,10 @@ export const governanceToolset: ToolsetDefinition = {
       displayName: "OPA Policy",
       description: "OPA Rego policy for Harness governance. Supports full CRUD. "
         + "Use this for SCS/SBOM enforcement — create deny-list or allow-list policies that control which components are permitted in your supply chain. "
-        + "Policies are written in Rego and evaluated against SBOM components during enforcement.",
+        + "Policies are written in Rego and evaluated against SBOM components during enforcement. "
+        + "To list SBOM/SSCA-enforcement policies specifically, pass filter type='sbom_enforcement' "
+        + "(note: individual policies use 'sbom_enforcement' while the policy sets that contain them use type='sbom' — "
+        + "see the policy_set resource for details on this asymmetry).",
       searchAliases: ["opa policy", "rego policy", "deny list", "allow list", "sbom policy", "governance policy", "supply chain policy"],
       relatedResources: [
         { resourceType: "policy_set", relationship: "parent", description: "Group policies into policy sets with enforcement actions" },
@@ -81,6 +84,7 @@ export const governanceToolset: ToolsetDefinition = {
       deepLinkTemplate: "/ng/account/{accountId}/all/orgs/{orgIdentifier}/projects/{projectIdentifier}/settings/governance/policies/edit/{identifier}",
       listFilterFields: [
         { name: "search_term", description: "Filter policies by name or keyword" },
+        { name: "type", description: "Filter by policy entity type. For SBOM/SSCA enforcement use 'sbom_enforcement'. Other known values: pipeline, connector, service, environment, secret, template, infrastructure. Unknown values return an empty list rather than an error." },
         { name: "sort", description: "Sort field" },
         { name: "identifier_filter", description: "Filter by policy identifier" },
         { name: "exclude_rego", description: "Exclude rego source from list response", type: "boolean" },
@@ -95,6 +99,7 @@ export const governanceToolset: ToolsetDefinition = {
             page: "page",
             size: "per_page",
             sort: "sort",
+            type: "type",
             identifier_filter: "identifierFilter",
             exclude_rego: "excludeRegoFromResponse",
             include_policy_set_count: "includePolicySetCount",
@@ -140,14 +145,19 @@ export const governanceToolset: ToolsetDefinition = {
     {
       resourceType: "policy_set",
       displayName: "OPA Policy Set",
-      description: "Policy set grouping OPA policies with enforcement action and entity type. Supports full CRUD. "
-        + "For SCS/SBOM enforcement, create a policy set with type 'ssca_enforcement' to apply deny-list or allow-list rules during artifact scans. "
-        + "Policy sets control when and how policies are evaluated (on pipeline run, on save, etc.).",
+      description: "Policy set grouping OPA policies with an enforcement action and an entity type. Supports full CRUD. "
+        + "For SCS/SBOM enforcement, use filter type='sbom' to list the policy sets that apply deny-list or allow-list rules during artifact scans — "
+        + "the SBOM enforcement step (e.g. action='onstep') binds these sets to the artifact pipeline. "
+        + "IMPORTANT TYPE ASYMMETRY: policy sets use type='sbom', while the individual policies they contain use type='sbom_enforcement'. "
+        + "Do NOT pass type='sbom_enforcement' or type='ssca_enforcement' when listing policy sets — both return an empty result even when "
+        + "SBOM policy sets exist in the project. Other supported types: pipeline, connector, service, environment, secret, template, infrastructure. "
+        + "Policy sets control when and how policies are evaluated (on pipeline run, on save, on step, etc.).",
       searchAliases: ["policy set", "enforcement rules", "sbom enforcement", "supply chain enforcement", "governance rules"],
       relatedResources: [
-        { resourceType: "policy", relationship: "child", description: "Individual policies contained in this set" },
+        { resourceType: "policy", relationship: "child", description: "Individual policies contained in this set (use type='sbom_enforcement' to list SBOM policies)" },
         { resourceType: "policy_evaluation", relationship: "child", description: "Evaluation results for this policy set" },
         { resourceType: "scs_compliance_result", relationship: "sibling", description: "SCS compliance results showing enforcement outcomes" },
+        { resourceType: "scs_bom_violation", relationship: "sibling", description: "BOM enforcement violations — each violation references the policy set identifier that fired it" },
       ],
       toolset: "governance",
       scope: "project",
@@ -155,8 +165,8 @@ export const governanceToolset: ToolsetDefinition = {
       deepLinkTemplate: "/ng/account/{accountId}/all/orgs/{orgIdentifier}/projects/{projectIdentifier}/settings/governance/policy-sets/{identifier}",
       listFilterFields: [
         { name: "search_term", description: "Filter policy sets by name or keyword" },
-        { name: "type", description: "Filter by entity type (pipeline, connector, service, environment, etc.)" },
-        { name: "action", description: "Filter by enforcement action (onrun, onsave, onpush, etc.)" },
+        { name: "type", description: "Filter by policy-set entity type. For SBOM/SSCA enforcement use 'sbom' (NOT 'sbom_enforcement' or 'ssca_enforcement' — those are valid only for the policy resource and return empty on policy sets). Other known values: pipeline, connector, service, environment, secret, template, infrastructure." },
+        { name: "action", description: "Filter by enforcement action. SBOM enforcement uses 'onstep'. Other values: onrun (pipeline), onsave, onpush, onstepstart." },
         { name: "sort", description: "Sort field" },
         { name: "identifier_filter", description: "Filter by policy set identifier" },
       ],

--- a/src/registry/toolsets/scs.ts
+++ b/src/registry/toolsets/scs.ts
@@ -730,7 +730,8 @@ export const scsToolset: ToolsetDefinition = {
       relatedResources: [
         { resourceType: "artifact_security", relationship: "parent", description: "Get enforcement_id from artifact overview (violations.enforcementId)" },
         { resourceType: "scs_compliance_result", relationship: "sibling", description: "Compliance scan results (CIS/OWASP checks) — different from BOM enforcement violations" },
-        { resourceType: "policy", relationship: "sibling", description: "OPA policies that define enforcement rules — use governance toolset to manage" },
+        { resourceType: "policy_set", relationship: "sibling", description: "OPA policy set that fired this violation — the set referenced by the policySetRef on each violation. List via governance toolset with filter type='sbom' (NOT 'sbom_enforcement' or 'ssca_enforcement' — those return an empty list for policy sets)." },
+        { resourceType: "policy", relationship: "sibling", description: "Individual OPA policies bound to the firing policy set. List via governance toolset with filter type='sbom_enforcement'." },
       ],
       toolset: "scs",
       scope: "project",

--- a/tests/registry/governance.test.ts
+++ b/tests/registry/governance.test.ts
@@ -47,6 +47,26 @@ describe("P3-10: policy resource SCS enhancements", () => {
     expect(res.description).toContain("enforcement");
   });
 
+  // SSCA-6347 — policies use type='sbom_enforcement' (asymmetric with policy_set's 'sbom').
+  it("description documents the sbom_enforcement type filter for SBOM/SSCA policies", () => {
+    const res = findResource("policy");
+    expect(res.description).toContain("type='sbom_enforcement'");
+  });
+
+  it("list operation exposes the 'type' query param (required for SBOM-enforcement filtering)", () => {
+    const spec = getOp("policy", "list");
+    // Without this param wired, the agent cannot round-trip type='sbom_enforcement' to /pm/api/v1/policies.
+    expect(spec.queryParams).toBeDefined();
+    expect(spec.queryParams!.type).toBe("type");
+  });
+
+  it("list filter includes 'type' with sbom_enforcement guidance", () => {
+    const res = findResource("policy");
+    const typeFilter = res.listFilterFields!.find((f) => f.name === "type");
+    expect(typeFilter).toBeDefined();
+    expect(typeFilter!.description).toContain("sbom_enforcement");
+  });
+
   it("has searchAliases including SCS-specific terms", () => {
     const res = findResource("policy");
     expect(res.searchAliases).toBeDefined();
@@ -127,11 +147,26 @@ describe("P3-10: policy_set resource SCS enhancements", () => {
     expect(() => findResource("policy_set")).not.toThrow();
   });
 
-  it("description mentions SCS/SBOM enforcement and ssca_enforcement type", () => {
+  // SSCA-6347 regression — this test previously asserted the buggy value 'ssca_enforcement'
+  // which baked the routing bug into the contract. Now we assert the corrected guidance:
+  // policy sets for SBOM enforcement are filterable by type='sbom', and the description must
+  // actively warn against the wrong values the agent used to pass.
+  it("description mentions SCS/SBOM enforcement with the correct type='sbom' and warns against 'ssca_enforcement'/'sbom_enforcement'", () => {
     const res = findResource("policy_set");
     expect(res.description).toContain("SCS");
     expect(res.description).toContain("SBOM");
+    expect(res.description).toContain("type='sbom'");
+    // Explicit warning against the two wrong values AIDA kept using.
     expect(res.description).toContain("ssca_enforcement");
+    expect(res.description).toContain("sbom_enforcement");
+    expect(res.description).toMatch(/Do NOT pass type='sbom_enforcement' or type='ssca_enforcement'/);
+  });
+
+  it("description documents the policy-vs-policy_set type asymmetry", () => {
+    const res = findResource("policy_set");
+    // The asymmetry is the thing that bit us: sets use 'sbom', policies use 'sbom_enforcement'.
+    // If someone flattens these back to a single value, the SSCA-6347 bug returns.
+    expect(res.description).toMatch(/IMPORTANT TYPE ASYMMETRY/i);
   });
 
   it("description explains policy set enforcement purpose", () => {
@@ -192,6 +227,31 @@ describe("P3-10: policy_set resource SCS enhancements", () => {
     const filterNames = res.listFilterFields!.map((f) => f.name);
     expect(filterNames).toContain("type");
     expect(filterNames).toContain("action");
+  });
+
+  it("list filter 'type' documents the correct SBOM value and the two wrong ones", () => {
+    const res = findResource("policy_set");
+    const typeFilter = res.listFilterFields!.find((f) => f.name === "type");
+    expect(typeFilter).toBeDefined();
+    // Filter description must surface the correct value so LLM auto-completion points it at 'sbom'.
+    expect(typeFilter!.description).toContain("'sbom'");
+    expect(typeFilter!.description).toContain("NOT 'sbom_enforcement' or 'ssca_enforcement'");
+  });
+
+  it("list filter 'action' names the SBOM enforcement action", () => {
+    const res = findResource("policy_set");
+    const actionFilter = res.listFilterFields!.find((f) => f.name === "action");
+    expect(actionFilter).toBeDefined();
+    // The SBOM enforcement step binds with action='onstep' — same value demo-plan.md uses.
+    expect(actionFilter!.description).toContain("onstep");
+  });
+
+  it("relatedResources includes scs_bom_violation sibling so the violation → policy_set → policy chain is discoverable", () => {
+    const res = findResource("policy_set");
+    const bomRef = res.relatedResources!.find((rel) => rel.resourceType === "scs_bom_violation");
+    expect(bomRef).toBeDefined();
+    expect(bomRef!.relationship).toBe("sibling");
+    expect(bomRef!.description.length).toBeGreaterThan(0);
   });
 
   it("list operation uses correct OPA service path", () => {

--- a/tests/registry/governance.test.ts
+++ b/tests/registry/governance.test.ts
@@ -278,4 +278,98 @@ describe("P3-10: policy_evaluation resource structural integrity", () => {
     expect(spec.method).toBe("GET");
     expect(spec.path).toContain("/evaluations");
   });
+
+  // SSCA-6347 review feedback — same asymmetry used to leak into evaluation
+  // filters. The 'type' filter here matches the evaluated policy_set's type,
+  // so SBOM/SSCA enforcement must be discoverable as 'sbom'.
+  it("list filter 'type' documents 'sbom' for SBOM/SSCA enforcement (not 'sbom_enforcement')", () => {
+    const res = findResource("policy_evaluation");
+    const typeFilter = res.listFilterFields!.find((f) => f.name === "type");
+    expect(typeFilter).toBeDefined();
+    expect(typeFilter!.description).toContain("'sbom'");
+    expect(typeFilter!.description).toContain("NOT 'sbom_enforcement'");
+  });
+
+  it("list filter 'action' names the SBOM enforcement action ('onstep')", () => {
+    const res = findResource("policy_evaluation");
+    const actionFilter = res.listFilterFields!.find((f) => f.name === "action");
+    expect(actionFilter).toBeDefined();
+    expect(actionFilter!.description).toContain("onstep");
+  });
+});
+
+// ─── SSCA-6347 review feedback: machine-readable enums on type/action ────────
+
+describe("SSCA-6347 review: filter enums make asymmetry structural", () => {
+  it("policy.type filter declares an enum including 'sbom_enforcement'", () => {
+    const res = findResource("policy");
+    const typeFilter = res.listFilterFields!.find((f) => f.name === "type");
+    expect(typeFilter?.enum).toBeDefined();
+    expect(typeFilter!.enum).toContain("sbom_enforcement");
+    // The wrong value for policies must not be advertised.
+    expect(typeFilter!.enum).not.toContain("sbom");
+  });
+
+  it("policy_set.type filter declares an enum including 'sbom' but not 'sbom_enforcement'", () => {
+    const res = findResource("policy_set");
+    const typeFilter = res.listFilterFields!.find((f) => f.name === "type");
+    expect(typeFilter?.enum).toBeDefined();
+    expect(typeFilter!.enum).toContain("sbom");
+    // The two wrong values the agent used to pass must never be in the enum.
+    expect(typeFilter!.enum).not.toContain("sbom_enforcement");
+    expect(typeFilter!.enum).not.toContain("ssca_enforcement");
+  });
+
+  it("policy_set.action filter declares an enum including 'onstep'", () => {
+    const res = findResource("policy_set");
+    const actionFilter = res.listFilterFields!.find((f) => f.name === "action");
+    expect(actionFilter?.enum).toBeDefined();
+    expect(actionFilter!.enum).toEqual(
+      expect.arrayContaining(["onrun", "onsave", "onpush", "onstep", "onstepstart"]),
+    );
+  });
+
+  it("policy_evaluation.type filter declares an enum including 'sbom' but not 'sbom_enforcement'", () => {
+    const res = findResource("policy_evaluation");
+    const typeFilter = res.listFilterFields!.find((f) => f.name === "type");
+    expect(typeFilter?.enum).toBeDefined();
+    expect(typeFilter!.enum).toContain("sbom");
+    expect(typeFilter!.enum).not.toContain("sbom_enforcement");
+  });
+
+  it("policy_evaluation.action filter declares an enum including 'onstep'", () => {
+    const res = findResource("policy_evaluation");
+    const actionFilter = res.listFilterFields!.find((f) => f.name === "action");
+    expect(actionFilter?.enum).toBeDefined();
+    expect(actionFilter!.enum).toContain("onstep");
+  });
+});
+
+// ─── SSCA-6347 review feedback: body-schema type fields document 'sbom' ──────
+
+describe("SSCA-6347 review: policy_set body schemas document SBOM type", () => {
+  it("policy_set create schema's 'type' field mentions 'sbom' for SBOM enforcement", () => {
+    const spec = getOp("policy_set", "create");
+    const typeField = spec.bodySchema!.fields.find((f) => f.name === "type");
+    expect(typeField).toBeDefined();
+    expect(typeField!.description).toContain("'sbom'");
+    // Surface the asymmetry at the create surface too — a caller authoring a
+    // policy set from bodySchema alone must know policies use a different value.
+    expect(typeField!.description).toContain("sbom_enforcement");
+  });
+
+  it("policy_set update schema's 'type' field mentions 'sbom' for SBOM enforcement", () => {
+    const spec = getOp("policy_set", "update");
+    const typeField = spec.bodySchema!.fields.find((f) => f.name === "type");
+    expect(typeField).toBeDefined();
+    expect(typeField!.description).toContain("'sbom'");
+    expect(typeField!.description).toContain("sbom_enforcement");
+  });
+
+  it("policy_set create schema's 'action' field names the SBOM enforcement action", () => {
+    const spec = getOp("policy_set", "create");
+    const actionField = spec.bodySchema!.fields.find((f) => f.name === "action");
+    expect(actionField).toBeDefined();
+    expect(actionField!.description).toContain("onstep");
+  });
 });

--- a/tests/registry/scs.test.ts
+++ b/tests/registry/scs.test.ts
@@ -1254,6 +1254,35 @@ describe("P3-1: scs_bom_violation resource", () => {
     expect(sibling!.relationship).toBe("sibling");
   });
 
+  // SSCA-6347 — the violation → policy_set → policy chain is the AC test case.
+  // Without a direct pointer to policy_set, the agent cannot discover the set that fired
+  // the violation and falls back to (wrongly) asking "no SSCA policy sets configured".
+  it("relatedResources links to governance policy_set as sibling (SSCA-6347 chain: violation → policy_set → policy)", () => {
+    const res = findResource("scs_bom_violation");
+    const sibling = res.relatedResources!.find((r) => r.resourceType === "policy_set");
+    expect(sibling).toBeDefined();
+    expect(sibling!.relationship).toBe("sibling");
+    // The sibling description must point the agent at the correct type='sbom' filter so it
+    // doesn't regress to the broken type='ssca_enforcement' / type='sbom_enforcement' query.
+    expect(sibling!.description).toContain("type='sbom'");
+    expect(sibling!.description).toMatch(/NOT 'sbom_enforcement' or 'ssca_enforcement'/);
+  });
+
+  it("governance cross-toolset chain is complete: scs_bom_violation \u2194 policy_set \u2194 policy", () => {
+    // End-to-end structural assertion for the AC chain. A broken link at any hop sends the
+    // agent back into the SSCA-6347 failure mode (empty list, "none configured" reply).
+    const violation = findResource("scs_bom_violation");
+    const violationPolicySetRef = violation.relatedResources!.find((r) => r.resourceType === "policy_set");
+    const violationPolicyRef = violation.relatedResources!.find((r) => r.resourceType === "policy");
+    expect(violationPolicySetRef).toBeDefined();
+    expect(violationPolicyRef).toBeDefined();
+
+    // policy_set → scs_bom_violation (back-edge) is asserted in governance.test.ts; here we
+    // just confirm the agent can walk both legs from the violation without leaving scs.ts.
+    expect(violationPolicySetRef!.description.length).toBeGreaterThan(0);
+    expect(violationPolicyRef!.description.length).toBeGreaterThan(0);
+  });
+
   it("artifact_security relatedResources includes scs_bom_violation", () => {
     const res = findResource("artifact_security");
     const child = res.relatedResources!.find((r) => r.resourceType === "scs_bom_violation");


### PR DESCRIPTION
## Description

### What
Fix the governance MCP toolset's `policy_set.list` so the agent can enumerate SBOM policy sets. Previously the `policy_set` resource told the agent to filter SBOM enforcement policy sets with `type='ssca_enforcement'`, but the backend (`GET /pm/api/v1/policysets`) stores SBOM policy sets under `type='sbom'`. Every call returned an empty list and AIDA incorrectly answered "no SSCA enforcement policy sets configured at any scope" on projects like `SSCA / SSCA_Sanity_Automation` that have 10 configured sets (including `opa_policy_set_for_at`).

Changes:
- `policy_set` resource: description now prescribes `type='sbom'`, warns against both wrong values (`sbom_enforcement` and `ssca_enforcement`), documents the policy-vs-policy_set type asymmetry, and names `action='onstep'` for the SBOM enforcement step.
- `policy` resource: expose the `type` query param and `listFilterField` so `type='sbom_enforcement'` round-trips to `/pm/api/v1/policies`.
- `scs_bom_violation` ([scs.ts](cci:7://file:///Users/thecopyninja/IdeaProjects/mcp-server/src/registry/toolsets/scs.ts:0:0-0:0)): add `policy_set` as a sibling `relatedResource` with explicit type-filter guidance so the agent can walk the `violation → policy_set → policy` chain.
- Governance tests: remove the obsolete assertion that baked the bug into the contract; add regression coverage for the corrected type guidance, the new policy `type` query param, the asymmetry banner, and the `scs_bom_violation` back-edge.
- SCS tests: add end-to-end regression for the `scs_bom_violation ↔ policy_set ↔ policy` chain.

### Why
Closes the last SSCA-6347 AC blocker: "Integration/regression test covers the governance cross-toolset chain: SCS artifact violation → governance policy set → governance policy." Without this fix the demo prompt "show me the OPA policy sets used by SSCA enforcement" returns an empty list and the agent fabricates a "none configured" response even when sets exist.

### References
- **Jira:** [SSCA-6347](https://harness.atlassian.net/browse/SSCA-6347)
- **PRD:** N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] Tests pass
- [x] Typecheck passes

[SSCA-6347]: https://harness.atlassian.net/browse/SSCA-6347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ