### PR TITLE
fix: prevent Claude Desktop crash from native resvg module

### DIFF
--- a/scripts/prepare-mcpb.js
+++ b/scripts/prepare-mcpb.js
@@ -35,5 +35,8 @@ copyFileSync(join(root, "mcp-directory", "manifest.json"), join(outDir, "manifes
 
 run("npm", ["install", "--omit=dev", "--ignore-scripts", "--package-lock=false"], { cwd: outDir });
 
-console.error(`[mcpb] Prepared ${outDir}`);
-console.error("[mcpb] Archive this directory so icon.png and manifest.json are at the bundle root.");
+const mcpbPath = join(root, "mcp-server.mcpb");
+rmSync(mcpbPath, { force: true });
+run("zip", ["-r", mcpbPath, "."], { cwd: outDir });
+
+console.error(`[mcpb] Bundle created: ${mcpbPath}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { randomUUID } from "node:crypto";
+import { appendFileSync } from "node:fs";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
@@ -100,8 +101,7 @@ function logToFile(message: string, data?: Record<string, unknown>): void {
     const logPath = process.env.HARNESS_MCP_LOG_FILE
       ?? (process.env.HOME ? `${process.env.HOME}/.claude/harness-mcp.log` : undefined);
     if (logPath) {
-      // Sync write — process may exit immediately after this
-      require("node:fs").appendFileSync(logPath, entry + "\n");
+      appendFileSync(logPath, entry + "\n");
     }
     // Also try stderr in case it's still alive
     console.error(entry);

--- a/src/tools/harness-diagnose.ts
+++ b/src/tools/harness-diagnose.ts
@@ -114,7 +114,7 @@ export function registerDiagnoseTool(server: McpServer, registry: Registry, clie
             }
 
             if (archSvg) {
-              return mixedResult(result, archSvg);
+              return await mixedResult(result, archSvg);
             }
 
             // Fallback: timeline or flow from execution data
@@ -124,7 +124,7 @@ export function registerDiagnoseTool(server: McpServer, registry: Registry, clie
               const svg = visualType === "flow"
                 ? renderStageFlowSvg(summaryData, { width: visualWidth })
                 : renderTimelineSvg(summaryData, { width: visualWidth, showSteps: hasSteps });
-              return mixedResult(result, svg);
+              return await mixedResult(result, svg);
             }
           } catch (err) {
             logDiag.warn("SVG rendering failed, returning text-only", { error: String(err) });

--- a/src/tools/harness-list.ts
+++ b/src/tools/harness-list.ts
@@ -82,7 +82,7 @@ export function registerListTool(server: McpServer, registry: Registry, client: 
               const visual = renderListVisual(resourceType, items, vt);
               if (visual) {
                 (result as Record<string, unknown>).analysis = visual.analysis;
-                return mixedResult(result, visual.svg);
+                return await mixedResult(result, visual.svg);
               }
             } catch (err) {
               log.warn("Visual rendering failed, returning text-only", { error: String(err) });

--- a/src/tools/harness-status.ts
+++ b/src/tools/harness-status.ts
@@ -217,7 +217,7 @@ export function registerStatusTool(
             const healthData = toProjectHealthData(status, orgId, projectId);
             if (healthData) {
               const svg = renderStatusSummarySvg(healthData);
-              return mixedResult(status, svg);
+              return await mixedResult(status, svg);
             }
           } catch (err) {
             log.warn("SVG rendering failed, returning text-only", { error: String(err) });

--- a/src/utils/response-formatter.ts
+++ b/src/utils/response-formatter.ts
@@ -31,8 +31,8 @@ export function errorResult(message: string): ToolResult {
   };
 }
 
-export function imageResult(svgString: string): ToolResult {
-  const data = svgToPngBase64(svgString);
+export async function imageResult(svgString: string): Promise<ToolResult> {
+  const data = await svgToPngBase64(svgString);
   return {
     content: [{ type: "image", data, mimeType: "image/png" }],
   };
@@ -43,9 +43,9 @@ export interface MixedResultOptions {
   scale?: number;
 }
 
-export function mixedResult(data: unknown, svgString: string, options?: MixedResultOptions): ToolResult {
+export async function mixedResult(data: unknown, svgString: string, options?: MixedResultOptions): Promise<ToolResult> {
   const scale = options?.scale ?? 3;
-  const imageData = svgToPngBase64(svgString, { scale });
+  const imageData = await svgToPngBase64(svgString, { scale });
   return {
     content: [
       { type: "text", text: JSON.stringify(data) },

--- a/src/utils/svg/render-png.ts
+++ b/src/utils/svg/render-png.ts
@@ -3,23 +3,26 @@
  *
  * MCP clients (Cursor, Claude Desktop) reject image/svg+xml — only raster
  * formats are supported. This converts our SVG strings to PNG buffers.
+ *
+ * The import is dynamic because @resvg/resvg-js ships a native .node binary
+ * that can fail to load when the host Node ABI doesn't match (e.g. Claude
+ * Desktop's embedded Node). A top-level import would crash the entire server
+ * at startup; dynamic import confines the failure to PNG rendering only.
  */
-
-import { Resvg } from "@resvg/resvg-js";
 
 export interface RenderPngOptions {
   /** Scale factor for higher DPI output. Default 2 (retina). */
   scale?: number;
 }
 
-export function svgToPngBase64(svgString: string, options?: RenderPngOptions): string {
+export async function svgToPngBase64(svgString: string, options?: RenderPngOptions): Promise<string> {
   const scale = options?.scale ?? 2;
+
+  const { Resvg } = await import("@resvg/resvg-js");
 
   const resvg = new Resvg(svgString, {
     fitTo: { mode: "zoom", value: scale },
     font: {
-      // Avoid scanning OS font dirs — can exceed CI test timeouts on Node 20 runners;
-      // our SVG builders set explicit font-family stacks resvg can resolve without that scan.
       loadSystemFonts: false,
     },
   });

--- a/tests/utils/response-formatter.test.ts
+++ b/tests/utils/response-formatter.test.ts
@@ -47,9 +47,9 @@ describe("errorResult", () => {
 });
 
 describe("imageResult", () => {
-  it("returns base64-encoded PNG as image content", { timeout: 15_000 }, () => {
+  it("returns base64-encoded PNG as image content", { timeout: 15_000 }, async () => {
     const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect width="100" height="100" fill="red"/></svg>';
-    const result = imageResult(svg);
+    const result = await imageResult(svg);
     expect(result.content).toHaveLength(1);
     expect(result.content[0]!.type).toBe("image");
     const img = result.content[0] as { type: "image"; data: string; mimeType: string };
@@ -62,18 +62,18 @@ describe("imageResult", () => {
     expect(buf[3]).toBe(0x47); // 'G'
   });
 
-  it("does not set isError", { timeout: 15_000 }, () => {
+  it("does not set isError", { timeout: 15_000 }, async () => {
     const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10"/></svg>';
-    const result = imageResult(svg);
+    const result = await imageResult(svg);
     expect(result.isError).toBeUndefined();
   });
 });
 
 describe("mixedResult", () => {
-  it("returns text first, then PNG image", { timeout: 15_000 }, () => {
+  it("returns text first, then PNG image", { timeout: 15_000 }, async () => {
     const data = { count: 5 };
     const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect width="100" height="100" fill="blue"/></svg>';
-    const result = mixedResult(data, svg);
+    const result = await mixedResult(data, svg);
     expect(result.content).toHaveLength(2);
     expect(result.content[0]!.type).toBe("text");
     expect(result.content[1]!.type).toBe("image");


### PR DESCRIPTION
## Summary
- **Root cause**: `@resvg/resvg-js` ships a native `.node` binary that was imported at the top level of `render-png.ts`. Claude Desktop uses its own embedded Node.js runtime, and when the ABI version doesn't match the compiled binary, the process crashes immediately after MCP initialization (~500ms after `initialize` response).
- Convert the `@resvg/resvg-js` import from top-level to dynamic `await import()` so the native binary only loads when PNG rendering is actually requested — startup no longer depends on ABI compatibility.
- Fix `logToFile` in `index.ts` which used `require("node:fs")` in ESM context (always fails silently in the try/catch).
- `prepare-mcpb.js` now creates the `.mcpb` zip automatically from `dist/mcpb/` — no more manual zip step that could forget `node_modules`.

## Test plan
- [x] `pnpm build` succeeds with no type errors
- [x] `echo '{"method":"initialize",...}' | node build/index.js stdio` responds correctly
- [x] `pnpm prepare:mcpb` produces a `.mcpb` bundle with `node_modules/` included
- [x] Install the `.mcpb` in Claude Desktop — server connects without "Server disconnected" error
- [x] Visual rendering (harness_diagnose with include_visual) still produces PNG output

🤖 Generated with [Claude Code](https://claude.com/claude-code)