### PR TITLE
fix(schemas): preserve pipeline_v1 and agent-pipeline after harness-schema sync

### DIFF
--- a/scripts/sync-schemas.js
+++ b/scripts/sync-schemas.js
@@ -1,14 +1,25 @@
 import fs from "fs";
 import path from "path";
 
-const SCHEMAS = ["pipeline", "template", "trigger"];
+/** Fetched from harness/harness-schema (v0 JSON). */
+const REMOTE_SCHEMAS = ["pipeline", "template", "trigger"];
+
+/**
+ * MCP-local schemas not published under harness-schema v0.
+ * Kept in-repo and wired into the index so VALID_SCHEMAS / schema:/// URIs stay stable.
+ */
+const LOCAL_SCHEMA_ENTRIES = [
+  { exportKey: `"pipeline_v1"`, importAs: "pipelineV1", fileBase: "pipeline-v1" },
+  { exportKey: `"agent-pipeline"`, importAs: "agentPipeline", fileBase: "agent-pipeline" },
+];
+
 const BASE_URL = "https://raw.githubusercontent.com/harness/harness-schema/main/v0";
 
 async function main() {
   const targetDir = "src/data/schemas";
   fs.mkdirSync(targetDir, { recursive: true });
 
-  for (const name of SCHEMAS) {
+  for (const name of REMOTE_SCHEMAS) {
     console.log(`Downloading ${name} schema...`);
     const res = await fetch(`${BASE_URL}/${name}.json`);
     if (!res.ok) {
@@ -27,12 +38,23 @@ async function main() {
     console.log(`Saved ${filePath}`);
   }
 
-  // Generate index.ts
+  // Generate index.ts (remote + local-only schema exports)
+  const remoteImports = REMOTE_SCHEMAS.map((name) => `import ${name} from "./${name}.js";`).join("\n");
+  const localImports = LOCAL_SCHEMA_ENTRIES.map(
+    (e) => `import ${e.importAs} from "./${e.fileBase}.js";`
+  ).join("\n");
+  const remoteProps = REMOTE_SCHEMAS.map((name) => `  ${name},`).join("\n");
+  const localProps = LOCAL_SCHEMA_ENTRIES.map(
+    (e) => `  ${e.exportKey}: ${e.importAs},`
+  ).join("\n");
+
   const indexContent = `// Auto-generated index of schemas
-${SCHEMAS.map(name => `import ${name} from "./${name}.js";`).join("\n")}
+${remoteImports}
+${localImports}
 
 export const SCHEMAS = {
-${SCHEMAS.map(name => `  ${name},`).join("\n")}
+${remoteProps}
+${localProps}
 } as const;
 
 export const VALID_SCHEMAS = Object.keys(SCHEMAS) as (keyof typeof SCHEMAS)[];

--- a/src/data/schemas/index.ts
+++ b/src/data/schemas/index.ts
@@ -2,11 +2,15 @@
 import pipeline from "./pipeline.js";
 import template from "./template.js";
 import trigger from "./trigger.js";
+import pipelineV1 from "./pipeline-v1.js";
+import agentPipeline from "./agent-pipeline.js";
 
 export const SCHEMAS = {
   pipeline,
   template,
   trigger,
+  "pipeline_v1": pipelineV1,
+  "agent-pipeline": agentPipeline,
 } as const;
 
 export const VALID_SCHEMAS = Object.keys(SCHEMAS) as (keyof typeof SCHEMAS)[];

--- a/src/data/schemas/index.ts
+++ b/src/data/schemas/index.ts
@@ -1,16 +1,12 @@
 // Auto-generated index of schemas
 import pipeline from "./pipeline.js";
-import pipelineV1 from "./pipeline-v1.js";
 import template from "./template.js";
 import trigger from "./trigger.js";
-import agentPipeline from "./agent-pipeline.js";
 
 export const SCHEMAS = {
   pipeline,
-  "pipeline_v1": pipelineV1,
   template,
   trigger,
-  "agent-pipeline": agentPipeline,
 } as const;
 
 export const VALID_SCHEMAS = Object.keys(SCHEMAS) as (keyof typeof SCHEMAS)[];

--- a/src/data/schemas/pipeline.ts
+++ b/src/data/schemas/pipeline.ts
@@ -735,6 +735,8 @@ const schema: Record<string, any> = {
                 "infrastructure" : {
                   "oneOf" : [ {
                     "$ref" : "#/definitions/pipeline/steps/custom/ContainerK8sInfra"
+                  }, {
+                    "$ref" : "#/definitions/pipeline/steps/custom/ContainerECSDirectInfra"
                   } ]
                 },
                 "metadata" : {
@@ -826,6 +828,8 @@ const schema: Record<string, any> = {
               "infrastructure" : {
                 "oneOf" : [ {
                   "$ref" : "#/definitions/pipeline/steps/custom/ContainerK8sInfra"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/custom/ContainerECSDirectInfra"
                 } ]
               },
               "metadata" : {
@@ -905,7 +909,7 @@ const schema: Record<string, any> = {
             "properties" : {
               "type" : {
                 "type" : "string",
-                "enum" : [ "KubernetesDirect", "VM" ]
+                "enum" : [ "KubernetesDirect", "VM", "ECSDirect" ]
               },
               "description" : {
                 "desc" : "This is the description for ContainerStepInfra"
@@ -1177,6 +1181,161 @@ const schema: Record<string, any> = {
               },
               "description" : {
                 "desc" : "This is the description for ContainerVolume"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "ContainerECSDirectInfra" : {
+            "title" : "ContainerECSDirectInfra",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/ContainerStepInfra"
+            }, {
+              "type" : "object",
+              "required" : [ "spec", "type" ],
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/pipeline/steps/custom/ECSDirectInfraYamlSpec"
+                },
+                "type" : {
+                  "type" : "string",
+                  "enum" : [ "ECSDirect" ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for ContainerECSDirectInfra"
+              }
+            }
+          },
+          "ECSDirectInfraYamlSpec" : {
+            "title" : "ECSDirectInfraYamlSpec",
+            "type" : "object",
+            "required" : [ "connectorRef" ],
+            "properties" : {
+              "connectorRef" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "harnessImageConnectorRef" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "cluster" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "region" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "subnets" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "securityGroups" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "taskRoleArn" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "executionRoleArn" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "initTimeout" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "enableExecuteCommand" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "logGroupName" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "volumes" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/CIVolume"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "containerSecurityContext" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/custom/SecurityContext"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "description" : {
+                "desc" : "This is the description for ECSDirectInfraYamlSpec"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
@@ -4964,6 +5123,9 @@ const schema: Record<string, any> = {
                 "format" : {
                   "type" : "string",
                   "enum" : [ "cyclonedx-json" ]
+                },
+                "cli_flags" : {
+                  "type" : "string"
                 }
               }
             } ],
@@ -5149,7 +5311,7 @@ const schema: Record<string, any> = {
             "properties" : {
               "type" : {
                 "type" : "string",
-                "enum" : [ "cosign" ]
+                "enum" : [ "cosign", "keyless", "keybased", "secret-manager" ]
               },
               "description" : {
                 "desc" : "This is the description for VerifyAttestation"
@@ -5175,23 +5337,55 @@ const schema: Record<string, any> = {
                       "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
                     }, {
                       "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
-                    } ],
-                    "properties" : {
-                      "cosignVariables" : {
-                        "type" : "array",
-                        "items" : {
-                          "type" : "object",
-                          "properties" : {
-                            "key" : {
-                              "type" : "string"
-                            },
-                            "value" : {
-                              "type" : "string"
-                            }
-                          }
-                        }
-                      }
-                    }
+                    } ]
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "keyless"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "type" : "object",
+                    "$ref" : "#/definitions/pipeline/steps/custom/KeylessVerifyAttestation"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "keybased"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "type" : "object",
+                    "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "secret-manager"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "type" : "object",
+                    "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
                   }
                 }
               }
@@ -5244,6 +5438,18 @@ const schema: Record<string, any> = {
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "additionalProperties" : false,
             "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
+          },
+          "KeylessVerifyAttestation" : {
+            "title" : "KeylessVerifyAttestation",
+            "type" : "object",
+            "properties" : {
+              "oidcProvider" : {
+                "type" : "string",
+                "enum" : [ "harness", "non-harness" ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false
           },
           "SbomDrift" : {
             "title" : "SbomDrift",
@@ -8528,6 +8734,522 @@ const schema: Record<string, any> = {
               }
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "FmeFlagDefinitionInstructionsStepNode" : {
+            "title" : "FmeFlagDefinitionInstructionsStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for FmeFlagDefinitionInstructionsStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "FmeFlagDefinitionInstructions" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "FmeFlagDefinitionInstructions"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagDefinitionInstructionsStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "FmeFlagDefinitionInstructionsStepInfo" : {
+            "title" : "FmeFlagDefinitionInstructionsStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "flagName", "environment", "instructions" ],
+              "properties" : {
+                "flagName" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/common/fme-flag-common-flag-name"
+                  }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                  } ]
+                },
+                "environment" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/common/fme-flag-common-environment"
+                  }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                  } ]
+                },
+                "instructions" : {
+                  "description" : "Ordered list of flag definition instructions to apply atomically. Each instruction type may appear at most once (validated when using a literal array; expressions are not checked).",
+                  "oneOf" : [ {
+                    "allOf" : [ {
+                      "type" : "array",
+                      "minItems" : 1,
+                      "items" : {
+                        "type" : "object",
+                        "additionalProperties" : false,
+                        "required" : [ "type", "value" ],
+                        "properties" : {
+                          "type" : {
+                            "type" : "string",
+                            "enum" : [ "SetDefaultTreatment", "SetBaselineTreatment", "SetTrackImpression", "SetLimitExposure", "UpdateIndividualTargets", "UpdateDynamicConfiguration", "SetTargetingRules" ]
+                          },
+                          "value" : { }
+                        },
+                        "allOf" : [ {
+                          "if" : {
+                            "properties" : {
+                              "type" : {
+                                "enum" : [ "SetDefaultTreatment" ]
+                              }
+                            }
+                          },
+                          "then" : {
+                            "properties" : {
+                              "value" : {
+                                "oneOf" : [ {
+                                  "$ref" : "#/definitions/pipeline/steps/common/fme-flag-common-treatments"
+                                }, {
+                                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                } ]
+                              }
+                            }
+                          }
+                        }, {
+                          "if" : {
+                            "properties" : {
+                              "type" : {
+                                "enum" : [ "SetBaselineTreatment" ]
+                              }
+                            }
+                          },
+                          "then" : {
+                            "properties" : {
+                              "value" : {
+                                "oneOf" : [ {
+                                  "$ref" : "#/definitions/pipeline/steps/common/fme-flag-common-treatments"
+                                }, {
+                                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                } ]
+                              }
+                            }
+                          }
+                        }, {
+                          "if" : {
+                            "properties" : {
+                              "type" : {
+                                "enum" : [ "SetTrackImpression" ]
+                              }
+                            }
+                          },
+                          "then" : {
+                            "properties" : {
+                              "value" : {
+                                "oneOf" : [ {
+                                  "type" : "boolean"
+                                }, {
+                                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                } ]
+                              }
+                            }
+                          }
+                        }, {
+                          "if" : {
+                            "properties" : {
+                              "type" : {
+                                "enum" : [ "SetLimitExposure" ]
+                              }
+                            }
+                          },
+                          "then" : {
+                            "properties" : {
+                              "value" : {
+                                "oneOf" : [ {
+                                  "type" : "integer",
+                                  "minimum" : 0,
+                                  "maximum" : 100
+                                }, {
+                                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                } ]
+                              }
+                            }
+                          }
+                        }, {
+                          "if" : {
+                            "properties" : {
+                              "type" : {
+                                "enum" : [ "UpdateIndividualTargets" ]
+                              }
+                            }
+                          },
+                          "then" : {
+                            "properties" : {
+                              "value" : {
+                                "oneOf" : [ {
+                                  "type" : "array",
+                                  "minItems" : 1,
+                                  "items" : {
+                                    "type" : "object",
+                                    "required" : [ "treatment", "actions" ],
+                                    "properties" : {
+                                      "treatment" : {
+                                        "$ref" : "#/definitions/pipeline/steps/common/fme-flag-common-treatments"
+                                      },
+                                      "actions" : {
+                                        "type" : "array",
+                                        "minItems" : 1,
+                                        "items" : {
+                                          "type" : "object",
+                                          "required" : [ "action", "value" ],
+                                          "properties" : {
+                                            "action" : {
+                                              "type" : "string",
+                                              "enum" : [ "AddKeys", "RemoveKeys", "AddSegments", "RemoveSegments", "SetKeys", "SetSegments" ]
+                                            },
+                                            "value" : {
+                                              "type" : "array",
+                                              "minItems" : 1,
+                                              "items" : {
+                                                "type" : "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }, {
+                                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                } ]
+                              }
+                            }
+                          }
+                        }, {
+                          "if" : {
+                            "properties" : {
+                              "type" : {
+                                "enum" : [ "UpdateDynamicConfiguration" ]
+                              }
+                            }
+                          },
+                          "then" : {
+                            "properties" : {
+                              "value" : {
+                                "oneOf" : [ {
+                                  "type" : "array",
+                                  "minItems" : 1,
+                                  "items" : {
+                                    "type" : "object",
+                                    "required" : [ "treatment", "configuration" ],
+                                    "properties" : {
+                                      "treatment" : {
+                                        "$ref" : "#/definitions/pipeline/steps/common/fme-flag-common-treatments"
+                                      },
+                                      "configuration" : {
+                                        "type" : [ "string", "null" ]
+                                      }
+                                    }
+                                  }
+                                }, {
+                                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                } ]
+                              }
+                            }
+                          }
+                        }, {
+                          "if" : {
+                            "properties" : {
+                              "type" : {
+                                "enum" : [ "SetTargetingRules" ]
+                              }
+                            }
+                          },
+                          "then" : {
+                            "properties" : {
+                              "value" : {
+                                "oneOf" : [ {
+                                  "type" : "array",
+                                  "items" : {
+                                    "type" : "object",
+                                    "required" : [ "condition", "allocation" ],
+                                    "properties" : {
+                                      "condition" : {
+                                        "description" : "Condition object containing rules",
+                                        "type" : "object",
+                                        "required" : [ "rules" ],
+                                        "properties" : {
+                                          "rules" : {
+                                            "description" : "List of condition rules",
+                                            "type" : "array",
+                                            "items" : {
+                                              "type" : "object",
+                                              "required" : [ "type" ],
+                                              "properties" : {
+                                                "type" : {
+                                                  "type" : "string",
+                                                  "enum" : [ "IN_SEGMENT", "IN_SPLIT", "BOOLEAN", "ON_DATE", "ON_OR_AFTER_DATE", "ON_OR_BEFORE_DATE", "BETWEEN_DATE", "EQUAL_SET", "ANY_OF_SET", "ALL_OF_SET", "PART_OF_SET", "EQUAL_NUMBER", "LESS_THAN_OR_EQUAL_NUMBER", "GREATER_THAN_OR_EQUAL_NUMBER", "BETWEEN_NUMBER", "IN_LIST_STRING", "STARTS_WITH_STRING", "ENDS_WITH_STRING", "CONTAINS_STRING", "MATCHES_STRING", "EQUAL_TO_SEMVER", "GREATER_THAN_OR_EQUAL_TO_SEMVER", "LESS_THAN_OR_EQUAL_TO_SEMVER", "BETWEEN_SEMVER", "IN_LIST_SEMVER" ]
+                                                },
+                                                "negate" : {
+                                                  "type" : "boolean",
+                                                  "default" : false
+                                                },
+                                                "feature_flag" : {
+                                                  "description" : "Feature flag name (only for IN_SPLIT type)",
+                                                  "oneOf" : [ {
+                                                    "$ref" : "#/definitions/pipeline/steps/common/fme-flag-common-flag-name"
+                                                  }, {
+                                                    "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                                  } ]
+                                                },
+                                                "attribute" : {
+                                                  "description" : "Attribute name for attribute-based matchers",
+                                                  "type" : "string"
+                                                },
+                                                "value" : {
+                                                  "description" : "Value for the matcher (can be single, multiple, or between)",
+                                                  "oneOf" : [ {
+                                                    "type" : "boolean"
+                                                  }, {
+                                                    "type" : "number"
+                                                  }, {
+                                                    "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                                                  }, {
+                                                    "type" : "array",
+                                                    "items" : {
+                                                      "oneOf" : [ {
+                                                        "type" : "number"
+                                                      }, {
+                                                        "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                                                      }, {
+                                                        "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                                      } ]
+                                                    }
+                                                  }, {
+                                                    "type" : "object",
+                                                    "required" : [ "from", "to" ],
+                                                    "properties" : {
+                                                      "from" : {
+                                                        "oneOf" : [ {
+                                                          "type" : "number"
+                                                        }, {
+                                                          "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                                                        }, {
+                                                          "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                                        } ]
+                                                      },
+                                                      "to" : {
+                                                        "oneOf" : [ {
+                                                          "type" : "number"
+                                                        }, {
+                                                          "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                                                        }, {
+                                                          "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                                        } ]
+                                                      }
+                                                    }
+                                                  }, {
+                                                    "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                                  } ]
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "allocation" : {
+                                        "description" : "Traffic allocation across treatments",
+                                        "oneOf" : [ {
+                                          "type" : "array",
+                                          "items" : {
+                                            "type" : "object",
+                                            "required" : [ "treatment", "size" ],
+                                            "properties" : {
+                                              "treatment" : {
+                                                "oneOf" : [ {
+                                                  "$ref" : "#/definitions/pipeline/steps/common/fme-flag-common-treatments"
+                                                }, {
+                                                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                                } ]
+                                              },
+                                              "size" : {
+                                                "oneOf" : [ {
+                                                  "type" : "integer",
+                                                  "minimum" : 0,
+                                                  "maximum" : 100
+                                                }, {
+                                                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                                } ]
+                                              }
+                                            }
+                                          }
+                                        }, {
+                                          "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                        } ]
+                                      }
+                                    }
+                                  }
+                                }, {
+                                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                } ]
+                              }
+                            }
+                          }
+                        } ]
+                      }
+                    }, {
+                      "type" : "array",
+                      "minContains" : 0,
+                      "maxContains" : 1,
+                      "contains" : {
+                        "type" : "object",
+                        "required" : [ "type" ],
+                        "properties" : {
+                          "type" : {
+                            "const" : "SetDefaultTreatment"
+                          }
+                        }
+                      }
+                    }, {
+                      "type" : "array",
+                      "minContains" : 0,
+                      "maxContains" : 1,
+                      "contains" : {
+                        "type" : "object",
+                        "required" : [ "type" ],
+                        "properties" : {
+                          "type" : {
+                            "const" : "SetBaselineTreatment"
+                          }
+                        }
+                      }
+                    }, {
+                      "type" : "array",
+                      "minContains" : 0,
+                      "maxContains" : 1,
+                      "contains" : {
+                        "type" : "object",
+                        "required" : [ "type" ],
+                        "properties" : {
+                          "type" : {
+                            "const" : "SetTrackImpression"
+                          }
+                        }
+                      }
+                    }, {
+                      "type" : "array",
+                      "minContains" : 0,
+                      "maxContains" : 1,
+                      "contains" : {
+                        "type" : "object",
+                        "required" : [ "type" ],
+                        "properties" : {
+                          "type" : {
+                            "const" : "SetLimitExposure"
+                          }
+                        }
+                      }
+                    }, {
+                      "type" : "array",
+                      "minContains" : 0,
+                      "maxContains" : 1,
+                      "contains" : {
+                        "type" : "object",
+                        "required" : [ "type" ],
+                        "properties" : {
+                          "type" : {
+                            "const" : "UpdateIndividualTargets"
+                          }
+                        }
+                      }
+                    }, {
+                      "type" : "array",
+                      "minContains" : 0,
+                      "maxContains" : 1,
+                      "contains" : {
+                        "type" : "object",
+                        "required" : [ "type" ],
+                        "properties" : {
+                          "type" : {
+                            "const" : "UpdateDynamicConfiguration"
+                          }
+                        }
+                      }
+                    }, {
+                      "type" : "array",
+                      "minContains" : 0,
+                      "maxContains" : 1,
+                      "contains" : {
+                        "type" : "object",
+                        "required" : [ "type" ],
+                        "properties" : {
+                          "type" : {
+                            "const" : "SetTargetingRules"
+                          }
+                        }
+                      }
+                    } ]
+                  }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "https://json-schema.org/draft/2019-09/schema"
           },
           "VmInfraSpec" : {
             "title" : "VmInfraSpec",
@@ -20826,6 +21548,34 @@ const schema: Record<string, any> = {
               }
             } ]
           },
+          "string-without-jexl" : {
+            "title" : "string-without-jexl",
+            "description" : "A plain string type that explicitly excludes JEXL expressions (e.g., <+input>, <+variable>).\n\nThis is used in oneOf schemas alongside common-jexl to prevent validation conflicts.\nWithout the 'not' constraint, both schemas would match JEXL expressions since both are \ntype: string, causing oneOf validation to fail (oneOf requires exactly one match).\n\nThe 'not' pattern ensures mutual exclusivity:\n- This schema matches: plain strings that don't start with <+\n- common-jexl matches: JEXL expressions like <+input>, <+variable>, etc.\n\nUse this when you need a field that accepts either a literal string OR a JEXL expression.\n",
+            "type" : "string",
+            "not" : {
+              "pattern" : "^<\\+.*>.*$"
+            }
+          },
+          "common-jexl" : {
+            "title" : "common-jexl",
+            "type" : "string",
+            "pattern" : "(<\\+.+>.*)"
+          },
+          "CIVolume" : {
+            "title" : "CIVolume",
+            "type" : "object",
+            "discriminator" : "type",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "EmptyDir", "PersistentVolumeClaim", "HostPath" ]
+              },
+              "description" : {
+                "desc" : "This is the description for CIVolume"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
           "FilesUploadStepNode" : {
             "title" : "FilesUploadStepNode",
             "type" : "object",
@@ -21256,21 +22006,6 @@ const schema: Record<string, any> = {
               },
               "description" : {
                 "desc" : "This is the description for K8sDirectInfraYamlSpec"
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#"
-          },
-          "CIVolume" : {
-            "title" : "CIVolume",
-            "type" : "object",
-            "discriminator" : "type",
-            "properties" : {
-              "type" : {
-                "type" : "string",
-                "enum" : [ "EmptyDir", "PersistentVolumeClaim", "HostPath" ]
-              },
-              "description" : {
-                "desc" : "This is the description for CIVolume"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
@@ -22577,7 +23312,7 @@ const schema: Record<string, any> = {
             "properties" : {
               "type" : {
                 "type" : "string",
-                "enum" : [ "cosign" ]
+                "enum" : [ "cosign", "keyless", "keybased", "secret-manager" ]
               },
               "description" : {
                 "desc" : "This is the description for SlsaVerifyAttestation"
@@ -22604,6 +23339,54 @@ const schema: Record<string, any> = {
                     }, {
                       "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
                     } ]
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "keyless"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "type" : "object",
+                    "$ref" : "#/definitions/pipeline/steps/common/KeylessSlsaVerifyAttestation"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "keybased"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "type" : "object",
+                    "$ref" : "#/definitions/pipeline/steps/common/CosignSlsaVerifyAttestation"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "secret-manager"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "type" : "object",
+                    "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
                   }
                 }
               }
@@ -22656,6 +23439,18 @@ const schema: Record<string, any> = {
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "additionalProperties" : false,
             "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestationSpec"
+          },
+          "KeylessSlsaVerifyAttestation" : {
+            "title" : "KeylessSlsaVerifyAttestation",
+            "type" : "object",
+            "properties" : {
+              "oidcProvider" : {
+                "type" : "string",
+                "enum" : [ "harness", "non-harness" ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false
           },
           "AiVerifyStepNode" : {
             "title" : "AiVerifyStepNode",
@@ -24743,7 +25538,7 @@ const schema: Record<string, any> = {
               "then" : {
                 "properties" : {
                   "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/LocalSourceSpec"
+                    "$ref" : "#/definitions/pipeline/steps/common/SlsaVerificationLocalSourceSpec"
                   }
                 }
               }
@@ -24933,6 +25728,58 @@ const schema: Record<string, any> = {
             "properties" : {
               "description" : {
                 "desc" : "Slsa Har source spec"
+              }
+            }
+          },
+          "SlsaVerificationLocalSourceSpec" : {
+            "title" : "SlsaVerificationLocalSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/SlsaVerificationSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "workspace", "type" ],
+              "properties" : {
+                "type" : {
+                  "type" : "string",
+                  "enum" : [ "manual", "auto" ]
+                },
+                "workspace" : {
+                  "type" : "string"
+                },
+                "artifact_name" : {
+                  "type" : "string",
+                  "description" : "Required when type is manual",
+                  "if" : {
+                    "properties" : {
+                      "type" : {
+                        "const" : "manual"
+                      }
+                    }
+                  },
+                  "then" : {
+                    "minLength" : 1
+                  }
+                },
+                "version" : {
+                  "type" : "string",
+                  "description" : "Required when type is manual",
+                  "if" : {
+                    "properties" : {
+                      "type" : {
+                        "const" : "manual"
+                      }
+                    }
+                  },
+                  "then" : {
+                    "minLength" : 1
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for LocalSourceSpec"
               }
             }
           },
@@ -26718,18 +27565,186 @@ const schema: Record<string, any> = {
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#"
           },
-          "string-without-jexl" : {
-            "title" : "string-without-jexl",
-            "description" : "A plain string type that explicitly excludes JEXL expressions (e.g., <+input>, <+variable>).\n\nThis is used in oneOf schemas alongside common-jexl to prevent validation conflicts.\nWithout the 'not' constraint, both schemas would match JEXL expressions since both are \ntype: string, causing oneOf validation to fail (oneOf requires exactly one match).\n\nThe 'not' pattern ensures mutual exclusivity:\n- This schema matches: plain strings that don't start with <+\n- common-jexl matches: JEXL expressions like <+input>, <+variable>, etc.\n\nUse this when you need a field that accepts either a literal string OR a JEXL expression.\n",
-            "type" : "string",
-            "not" : {
-              "pattern" : "^<\\+.*>.*$"
-            }
+          "AgentStepNode" : {
+            "title" : "AgentStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for AgentStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "Agent" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "Agent"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/AgentStepInfo"
+                  }
+                }
+              }
+            } ]
           },
-          "common-jexl" : {
-            "title" : "common-jexl",
-            "type" : "string",
-            "pattern" : "(<\\+.+>.*)"
+          "AgentStepInfo" : {
+            "title" : "AgentStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "agentName" ],
+              "properties" : {
+                "agentName" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                  }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                  } ]
+                },
+                "agentSettings" : {
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "not" : {
+                      "pattern" : "^<\\+.*>.*$"
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : true
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^(<\\+.+>.*)$",
+                    "minLength" : 1
+                  } ]
+                },
+                "llmConnector" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "mcpConnectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "agentName" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "agentSettings" : {
+                "oneOf" : [ {
+                  "type" : "string",
+                  "not" : {
+                    "pattern" : "^<\\+.*>.*$"
+                  }
+                }, {
+                  "type" : "object",
+                  "additionalProperties" : true
+                }, {
+                  "type" : "string",
+                  "pattern" : "^(<\\+.+>.*)$",
+                  "minLength" : 1
+                } ]
+              },
+              "llmConnector" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "mcpConnectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "description" : {
+                "desc" : "This is the description for AgentStepInfo"
+              }
+            }
           },
           "fme-flag-common-flag-name" : {
             "title" : "fme-flag-common-flag-name",
@@ -30959,8 +31974,14 @@ const schema: Record<string, any> = {
                   "$ref" : "#/definitions/pipeline/steps/ci/ParameterFieldListString"
                 },
                 "config" : {
-                  "type" : "string",
-                  "enum" : [ "default" ]
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "enum" : [ "default", "sast", "sca", "sast_sca" ]
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 },
                 "connectorRef" : {
                   "type" : "string"
@@ -31049,8 +32070,14 @@ const schema: Record<string, any> = {
                 "$ref" : "#/definitions/pipeline/steps/ci/ParameterFieldListString"
               },
               "config" : {
-                "type" : "string",
-                "enum" : [ "default" ]
+                "oneOf" : [ {
+                  "type" : "string",
+                  "enum" : [ "default", "sast", "sca", "sast_sca" ]
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
               },
               "connectorRef" : {
                 "type" : "string"
@@ -32601,6 +33628,168 @@ const schema: Record<string, any> = {
               },
               "description" : {
                 "desc" : "This is the description for UploadToS3StepInfo"
+              }
+            }
+          },
+          "AiTestAutomationStepNode" : {
+            "title" : "AiTestAutomationStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for AiTestAutomationStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "AiTestAutomation" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "AiTestAutomation"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/ci/AiTestAutomationStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "AiTestAutomationStepInfo" : {
+            "title" : "AiTestAutomationStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/ci/CIStepInfo"
+            }, {
+              "type" : "object",
+              "required" : [ "applicationName" ],
+              "properties" : {
+                "testType" : {
+                  "type" : "string",
+                  "enum" : [ "aiTestAutomation", "playwright" ],
+                  "description" : "Type of test: aiTestAutomation (default) or playwright"
+                },
+                "applicationName" : {
+                  "type" : "string",
+                  "description" : "Name of the application to test"
+                },
+                "environmentName" : {
+                  "type" : "string",
+                  "description" : "Name of the environment where test will be executed"
+                },
+                "testSuiteName" : {
+                  "type" : "string",
+                  "description" : "Name of the test suite to execute"
+                },
+                "tunnelName" : {
+                  "type" : "string",
+                  "description" : "Name of the tunnel to use"
+                },
+                "buildId" : {
+                  "type" : "string",
+                  "description" : "ID of the Playwright build to execute"
+                },
+                "executionAliasId" : {
+                  "type" : "string",
+                  "description" : "Execution alias ID for variable resolution"
+                },
+                "configOverride" : {
+                  "type" : "string",
+                  "description" : "Configuration override as JSON string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "applicationName" ],
+            "properties" : {
+              "testType" : {
+                "type" : "string",
+                "enum" : [ "aiTestAutomation", "playwright" ],
+                "description" : "Type of test: aiTestAutomation (default) or playwright"
+              },
+              "applicationName" : {
+                "type" : "string",
+                "description" : "Name of the application to test"
+              },
+              "environmentName" : {
+                "type" : "string",
+                "description" : "Name of the environment where test will be executed"
+              },
+              "testSuiteName" : {
+                "type" : "string",
+                "description" : "Name of the test suite to execute"
+              },
+              "tunnelName" : {
+                "type" : "string",
+                "description" : "Name of the tunnel to use"
+              },
+              "buildId" : {
+                "type" : "string",
+                "description" : "ID of the Playwright build to execute"
+              },
+              "executionAliasId" : {
+                "type" : "string",
+                "description" : "Execution alias ID for variable resolution"
+              },
+              "configOverride" : {
+                "type" : "string",
+                "description" : "Configuration override as JSON string"
+              },
+              "description" : {
+                "desc" : "This is the description for AiTestAutomationStepInfo"
               }
             }
           },
@@ -60946,6 +62135,15 @@ const schema: Record<string, any> = {
                   "minLength" : 1
                 } ]
               },
+              "waitForMerge" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
               "stringMap" : {
                 "$ref" : "#/definitions/pipeline/steps/common/ParameterFieldMapStringString"
               },
@@ -61066,201 +62264,6 @@ const schema: Record<string, any> = {
                 "desc" : "This is the description for UpdateReleaseRepoSecretNGVariable"
               }
             }
-          },
-          "ChaosStepNode" : {
-            "title" : "ChaosStepNode",
-            "type" : "object",
-            "required" : [ "identifier", "name", "spec", "type" ],
-            "properties" : {
-              "description" : {
-                "type" : "string",
-                "desc" : "This is the description for ChaosStepNode"
-              },
-              "enforce" : {
-                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
-              },
-              "failureStrategies" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "identifier" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
-              },
-              "name" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
-              },
-              "strategy" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "timeout" : {
-                "type" : "string",
-                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
-              },
-              "type" : {
-                "type" : "string",
-                "enum" : [ "Chaos" ]
-              },
-              "when" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "Chaos"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/cd/ChaosStepInfo"
-                  }
-                }
-              }
-            } ]
-          },
-          "ChaosStepInfo" : {
-            "title" : "ChaosStepInfo",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "identifier" : {
-                    "type" : "string"
-                  },
-                  "kind" : {
-                    "const" : "template"
-                  }
-                },
-                "required" : [ "identifier", "kind" ]
-              },
-              "then" : {
-                "required" : [ "hubRef", "infraReference" ]
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "type" : "object",
-            "required" : [ "expectedResilienceScore" ],
-            "properties" : {
-              "assertion" : {
-                "type" : "string"
-              },
-              "expectedResilienceScore" : {
-                "oneOf" : [ {
-                  "type" : "number",
-                  "format" : "double"
-                }, {
-                  "type" : "string",
-                  "pattern" : "(<\\+.+>.*)",
-                  "minLength" : 1
-                } ]
-              },
-              "experimentRef" : {
-                "type" : "string",
-                "minLength" : 1
-              },
-              "identifier" : {
-                "type" : "string",
-                "minLength" : 1
-              },
-              "kind" : {
-                "type" : "string",
-                "enum" : [ "experiment", "template" ]
-              },
-              "hubRef" : {
-                "type" : "string",
-                "minLength" : 1
-              },
-              "infraReference" : {
-                "oneOf" : [ {
-                  "type" : "string",
-                  "minLength" : 1,
-                  "not" : {
-                    "pattern" : "(<\\+.+>.*)"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "(<\\+.+>.*)",
-                  "minLength" : 1
-                } ]
-              },
-              "tasks" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "required" : [ "identifier" ],
-                    "properties" : {
-                      "identifier" : {
-                        "type" : "string",
-                        "minLength" : 1
-                      },
-                      "values" : {
-                        "type" : "array",
-                        "items" : {
-                          "type" : "object",
-                          "required" : [ "name", "value" ],
-                          "properties" : {
-                            "name" : {
-                              "type" : "string",
-                              "minLength" : 1
-                            },
-                            "value" : {
-                              "anyOf" : [ {
-                                "type" : "string"
-                              }, {
-                                "type" : "number"
-                              }, {
-                                "type" : "boolean"
-                              }, {
-                                "type" : "string",
-                                "pattern" : "(<\\+.+>.*)"
-                              } ]
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "(<\\+.+>.*)",
-                  "minLength" : 1
-                } ]
-              },
-              "description" : {
-                "desc" : "This is the description for ChaosStepInfo"
-              }
-            },
-            "anyOf" : [ {
-              "required" : [ "experimentRef" ]
-            }, {
-              "required" : [ "identifier" ]
-            } ]
           },
           "AiTestAutomationStepNode" : {
             "title" : "AiTestAutomationStepNode",
@@ -61558,6 +62561,407 @@ const schema: Record<string, any> = {
                 "desc" : "This is the description for TerragruntDestroyStepInfo"
               }
             }
+          },
+          "AIVerifyNGStepNode" : {
+            "title" : "AIVerifyNGStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for AIVerifyNGStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "AIVerifyNG" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "AIVerifyNG"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/AIVerifyNGStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "AIVerifyNGStepInfo" : {
+            "title" : "AIVerifyNGStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "healthSourceRefs", "dataCollectionWindow", "dataCollectionInfrastructure" ],
+              "properties" : {
+                "healthSourceRefs" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string",
+                      "minLength" : 1
+                    },
+                    "minItems" : 1
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "dataCollectionInfrastructure" : {
+                  "$ref" : "#/definitions/pipeline/steps/cd/DataCollectionInfrastructure"
+                },
+                "dataCollectionWindow" : {
+                  "description" : "Data collection window as a duration string '<n>m' (minutes) or '<n>h' (hours), e.g. '30m', '1h', '2h'; may also be a runtime expression.",
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "pattern" : "^[1-9][0-9]*[mMhH]$",
+                    "minLength" : 2
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "connectorRef" : {
+                  "type" : "string"
+                },
+                "envVariables" : {
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string"
+                  } ]
+                },
+                "imagePullPolicy" : {
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "enum" : [ "Always", "Never", "IfNotPresent" ]
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "privileged" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                },
+                "runAsUser" : {
+                  "oneOf" : [ {
+                    "type" : "integer",
+                    "format" : "int32"
+                  }, {
+                    "type" : "string"
+                  } ]
+                },
+                "preExecution" : {
+                  "type" : "string"
+                },
+                "optionalConfigurations" : {
+                  "description" : "Optional. Omit entirely or set any subset of nested fields (all nested fields are optional).",
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/cd/AIVerifyOptionalConfigurations"
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "healthSourceRefs", "dataCollectionWindow", "dataCollectionInfrastructure" ],
+            "properties" : {
+              "healthSourceRefs" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string",
+                    "minLength" : 1
+                  },
+                  "minItems" : 1
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "dataCollectionInfrastructure" : {
+                "$ref" : "#/definitions/pipeline/steps/cd/DataCollectionInfrastructure"
+              },
+              "dataCollectionWindow" : {
+                "description" : "Data collection window as a duration string '<n>m' (minutes) or '<n>h' (hours), e.g. '30m', '1h', '2h'; may also be a runtime expression.",
+                "oneOf" : [ {
+                  "type" : "string",
+                  "pattern" : "^[1-9][0-9]*[mMhH]$",
+                  "minLength" : 2
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "image" : {
+                "type" : "string"
+              },
+              "connectorRef" : {
+                "type" : "string"
+              },
+              "envVariables" : {
+                "oneOf" : [ {
+                  "type" : "object",
+                  "additionalProperties" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "imagePullPolicy" : {
+                "oneOf" : [ {
+                  "type" : "string",
+                  "enum" : [ "Always", "Never", "IfNotPresent" ]
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "privileged" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "runAsUser" : {
+                "oneOf" : [ {
+                  "type" : "integer",
+                  "format" : "int32"
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "preExecution" : {
+                "type" : "string"
+              },
+              "optionalConfigurations" : {
+                "description" : "Optional. Omit entirely or set any subset of nested fields (all nested fields are optional).",
+                "allOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/cd/AIVerifyOptionalConfigurations"
+                } ]
+              },
+              "description" : {
+                "desc" : "AI Verify NG Step - AI-powered deployment verification using health sources"
+              }
+            }
+          },
+          "DataCollectionInfrastructure" : {
+            "title" : "DataCollectionInfrastructure",
+            "type" : "object",
+            "required" : [ "type", "spec" ],
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "KubernetesDirect" ]
+              },
+              "spec" : {
+                "type" : "object",
+                "required" : [ "connectorRef", "namespace" ],
+                "properties" : {
+                  "connectorRef" : {
+                    "type" : "string"
+                  },
+                  "namespace" : {
+                    "type" : "string"
+                  },
+                  "resources" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/DataCollectionInfrastructureResources"
+                  }
+                }
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "DataCollectionInfrastructureResources" : {
+            "title" : "DataCollectionInfrastructureResources",
+            "description" : "Optional resource requests/limits for AI Verify data collection infrastructure. Omit the block entirely, or include only the fields you need; CPU and memory are optional under requests and limits.",
+            "type" : "object",
+            "properties" : {
+              "limits" : {
+                "$ref" : "#/definitions/pipeline/common/Limits"
+              },
+              "requests" : {
+                "$ref" : "#/definitions/pipeline/common/Limits"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "AIVerifyOptionalConfigurations" : {
+            "title" : "AIVerifyOptionalConfigurations",
+            "description" : "Optional cv-nextgen parity fields; not mapped to plugin env in current release. The parent step may omit optionalConfigurations entirely, or supply an empty object. When present, every property below remains optional; set only the fields you need.",
+            "type" : "object",
+            "required" : [ ],
+            "properties" : {
+              "sensitivity" : {
+                "oneOf" : [ {
+                  "type" : "string"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "verificationType" : {
+                "oneOf" : [ {
+                  "type" : "string"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "failOnNoAnalysis" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "controlNodeRegexPattern" : {
+                "oneOf" : [ {
+                  "type" : "string"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "testNodeRegexPattern" : {
+                "oneOf" : [ {
+                  "type" : "string"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "baselineEndTime" : {
+                "oneOf" : [ {
+                  "type" : "string"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "verificationStartTime" : {
+                "oneOf" : [ {
+                  "type" : "string"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
           },
           "AzureFunctionDeployStepNode" : {
             "title" : "AzureFunctionDeployStepNode",
@@ -69350,6 +70754,263 @@ const schema: Record<string, any> = {
               }
             }
           },
+          "SalesforceSourceBackupStepNode" : {
+            "title" : "SalesforceSourceBackupStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for SalesforceSourceBackupStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "SalesforceSourceBackup" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "SalesforceSourceBackup"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/SalesforceSourceBackupStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "SalesforceSourceBackupStepInfo" : {
+            "title" : "SalesforceSourceBackupStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "gitConnectorRef" : {
+                  "type" : "string"
+                },
+                "repoName" : {
+                  "type" : "string"
+                },
+                "branch" : {
+                  "type" : "string"
+                },
+                "branchAction" : {
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "enum" : [ "raisePR", "createNewBranch", "overwriteExistingBranch" ]
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "targetBranch" : {
+                  "type" : "string"
+                },
+                "prTitle" : {
+                  "type" : "string"
+                },
+                "prDescription" : {
+                  "type" : "string"
+                },
+                "connectorRef" : {
+                  "type" : "string"
+                },
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "commandOptions" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "imagePullPolicy" : {
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "enum" : [ "Always", "Never", "IfNotPresent" ]
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "privileged" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                },
+                "runAsUser" : {
+                  "oneOf" : [ {
+                    "type" : "integer",
+                    "format" : "int32"
+                  }, {
+                    "type" : "string"
+                  } ]
+                },
+                "preExecution" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "gitConnectorRef" : {
+                "type" : "string"
+              },
+              "repoName" : {
+                "type" : "string"
+              },
+              "branch" : {
+                "type" : "string"
+              },
+              "branchAction" : {
+                "oneOf" : [ {
+                  "type" : "string",
+                  "enum" : [ "raisePR", "createNewBranch", "overwriteExistingBranch" ]
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "targetBranch" : {
+                "type" : "string"
+              },
+              "prTitle" : {
+                "type" : "string"
+              },
+              "prDescription" : {
+                "type" : "string"
+              },
+              "connectorRef" : {
+                "type" : "string"
+              },
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "commandOptions" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "image" : {
+                "type" : "string"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "runAsUser" : {
+                "oneOf" : [ {
+                  "type" : "integer",
+                  "format" : "int32"
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "preExecution" : {
+                "type" : "string"
+              },
+              "description" : {
+                "desc" : "This is the description for SalesforceSourceBackupStepInfo"
+              }
+            }
+          },
           "SalesforceValidateStepNode" : {
             "title" : "SalesforceValidateStepNode",
             "type" : "object",
@@ -70199,6 +71860,669 @@ const schema: Record<string, any> = {
               },
               "description" : {
                 "desc" : "This is the description for SalesforceDeleteScratchOrgStepInfo"
+              }
+            }
+          },
+          "SalesforceDownloadDeployablesStepNode" : {
+            "title" : "SalesforceDownloadDeployablesStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for SalesforceDownloadDeployablesStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "SalesforceDownloadDeployables" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "SalesforceDownloadDeployables"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/SalesforceDownloadDeployablesStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "SalesforceDownloadDeployablesStepInfo" : {
+            "title" : "SalesforceDownloadDeployablesStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "source1Type" : {
+                  "type" : "string"
+                },
+                "source1Ref" : {
+                  "type" : "string"
+                },
+                "source2Type" : {
+                  "type" : "string"
+                },
+                "source2Ref" : {
+                  "type" : "string"
+                },
+                "metadataTypes" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "connectorRef" : {
+                  "type" : "string"
+                },
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "commandOptions" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "imagePullPolicy" : {
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "enum" : [ "Always", "Never", "IfNotPresent" ]
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "privileged" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                },
+                "runAsUser" : {
+                  "oneOf" : [ {
+                    "type" : "integer",
+                    "format" : "int32"
+                  }, {
+                    "type" : "string"
+                  } ]
+                },
+                "preExecution" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "source1Type" : {
+                "type" : "string"
+              },
+              "source1Ref" : {
+                "type" : "string"
+              },
+              "source2Type" : {
+                "type" : "string"
+              },
+              "source2Ref" : {
+                "type" : "string"
+              },
+              "metadataTypes" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              },
+              "connectorRef" : {
+                "type" : "string"
+              },
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "commandOptions" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "image" : {
+                "type" : "string"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "runAsUser" : {
+                "oneOf" : [ {
+                  "type" : "integer",
+                  "format" : "int32"
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "preExecution" : {
+                "type" : "string"
+              },
+              "description" : {
+                "desc" : "This is the description for SalesforceDownloadDeployablesStepInfo"
+              }
+            }
+          },
+          "SalesforceDownloadOrgStepNode" : {
+            "title" : "SalesforceDownloadOrgStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for SalesforceDownloadOrgStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "SalesforceDownloadOrg" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "SalesforceDownloadOrg"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/SalesforceDownloadOrgStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "SalesforceDownloadOrgStepInfo" : {
+            "title" : "SalesforceDownloadOrgStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "sourceRef" : {
+                  "type" : "string"
+                },
+                "downloadPath" : {
+                  "type" : "string"
+                },
+                "metadataTypes" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "connectorRef" : {
+                  "type" : "string"
+                },
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "commandOptions" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "imagePullPolicy" : {
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "enum" : [ "Always", "Never", "IfNotPresent" ]
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "privileged" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                },
+                "runAsUser" : {
+                  "oneOf" : [ {
+                    "type" : "integer",
+                    "format" : "int32"
+                  }, {
+                    "type" : "string"
+                  } ]
+                },
+                "preExecution" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "sourceRef" : {
+                "type" : "string"
+              },
+              "downloadPath" : {
+                "type" : "string"
+              },
+              "metadataTypes" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              },
+              "connectorRef" : {
+                "type" : "string"
+              },
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "commandOptions" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "image" : {
+                "type" : "string"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "runAsUser" : {
+                "oneOf" : [ {
+                  "type" : "integer",
+                  "format" : "int32"
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "preExecution" : {
+                "type" : "string"
+              },
+              "description" : {
+                "desc" : "This is the description for SalesforceDownloadOrgStepInfo"
+              }
+            }
+          },
+          "SalesforceEvaluateDiffStepNode" : {
+            "title" : "SalesforceEvaluateDiffStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for SalesforceEvaluateDiffStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "SalesforceEvaluateDiff" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "SalesforceEvaluateDiff"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/SalesforceEvaluateDiffStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "SalesforceEvaluateDiffStepInfo" : {
+            "title" : "SalesforceEvaluateDiffStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "connectorRef" : {
+                  "type" : "string"
+                },
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "commandOptions" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "imagePullPolicy" : {
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "enum" : [ "Always", "Never", "IfNotPresent" ]
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "privileged" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                },
+                "runAsUser" : {
+                  "oneOf" : [ {
+                    "type" : "integer",
+                    "format" : "int32"
+                  }, {
+                    "type" : "string"
+                  } ]
+                },
+                "preExecution" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "connectorRef" : {
+                "type" : "string"
+              },
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "commandOptions" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "image" : {
+                "type" : "string"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "runAsUser" : {
+                "oneOf" : [ {
+                  "type" : "integer",
+                  "format" : "int32"
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "preExecution" : {
+                "type" : "string"
+              },
+              "description" : {
+                "desc" : "This is the description for SalesforceEvaluateDiffStepInfo"
               }
             }
           },
@@ -71250,6 +73574,740 @@ const schema: Record<string, any> = {
                 "desc" : "This is the description for InheritElastigroupTrafficShiftSpec"
               }
             }
+          }
+        },
+        "resiliencetesting" : {
+          "ChaosStepNode" : {
+            "title" : "ChaosStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for ChaosStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "Chaos" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "Chaos"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "ChaosStepInfo" : {
+            "title" : "ChaosStepInfo",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "identifier" : {
+                    "type" : "string"
+                  },
+                  "kind" : {
+                    "const" : "template"
+                  }
+                },
+                "required" : [ "identifier", "kind" ]
+              },
+              "then" : {
+                "required" : [ "hubRef", "infraReference" ]
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "expectedResilienceScore" ],
+            "properties" : {
+              "assertion" : {
+                "type" : "string"
+              },
+              "expectedResilienceScore" : {
+                "oneOf" : [ {
+                  "type" : "number",
+                  "format" : "double"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "experimentRef" : {
+                "type" : "string",
+                "minLength" : 1
+              },
+              "identifier" : {
+                "type" : "string",
+                "minLength" : 1
+              },
+              "kind" : {
+                "type" : "string",
+                "enum" : [ "experiment", "template" ]
+              },
+              "hubRef" : {
+                "type" : "string",
+                "minLength" : 1
+              },
+              "infraReference" : {
+                "oneOf" : [ {
+                  "type" : "string",
+                  "minLength" : 1,
+                  "not" : {
+                    "pattern" : "(<\\+.+>.*)"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "tasks" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "required" : [ "identifier" ],
+                    "properties" : {
+                      "identifier" : {
+                        "type" : "string",
+                        "minLength" : 1
+                      },
+                      "values" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "required" : [ "name", "value" ],
+                          "properties" : {
+                            "name" : {
+                              "type" : "string",
+                              "minLength" : 1
+                            },
+                            "value" : {
+                              "anyOf" : [ {
+                                "type" : "string"
+                              }, {
+                                "type" : "number"
+                              }, {
+                                "type" : "boolean"
+                              }, {
+                                "type" : "string",
+                                "pattern" : "(<\\+.+>.*)"
+                              } ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "description" : {
+                "desc" : "This is the description for ChaosStepInfo"
+              }
+            },
+            "anyOf" : [ {
+              "required" : [ "experimentRef" ]
+            }, {
+              "required" : [ "identifier" ]
+            } ]
+          },
+          "LoadTestStepNode" : {
+            "title" : "LoadTestStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for LoadTestStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "LoadTest" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "LoadTest"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/resiliencetesting/LoadTestStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "LoadTestStepInfo" : {
+            "title" : "LoadTestStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "loadTestRef" ],
+              "properties" : {
+                "loadTestRef" : {
+                  "type" : "string",
+                  "minLength" : 1
+                },
+                "targetUsers" : {
+                  "oneOf" : [ {
+                    "type" : "integer"
+                  }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                  } ]
+                },
+                "rampUpTimeSec" : {
+                  "oneOf" : [ {
+                    "type" : "integer"
+                  }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                  } ]
+                },
+                "durationSeconds" : {
+                  "oneOf" : [ {
+                    "type" : "integer"
+                  }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "ChaosProbeNode" : {
+            "title" : "ChaosProbeNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for ChaosProbeNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "ChaosProbe" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "ChaosProbe"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosProbeInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "ChaosProbeInfo" : {
+            "title" : "ChaosProbeInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "identity", "duration", "infraReference" ],
+              "properties" : {
+                "identity" : {
+                  "type" : "string"
+                },
+                "duration" : {
+                  "type" : "string"
+                },
+                "infraReference" : {
+                  "type" : "string"
+                },
+                "tasks" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "required" : [ "identifier" ],
+                      "properties" : {
+                        "identifier" : {
+                          "type" : "string",
+                          "minLength" : 1
+                        },
+                        "values" : {
+                          "type" : "array",
+                          "items" : {
+                            "type" : "object",
+                            "required" : [ "name", "value" ],
+                            "properties" : {
+                              "name" : {
+                                "type" : "string",
+                                "minLength" : 1
+                              },
+                              "value" : {
+                                "anyOf" : [ {
+                                  "type" : "string"
+                                }, {
+                                  "type" : "number"
+                                }, {
+                                  "type" : "boolean"
+                                }, {
+                                  "type" : "string",
+                                  "pattern" : "(<\\+.+>.*)"
+                                } ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "ChaosActionNode" : {
+            "title" : "ChaosActionNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for ChaosActionNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "ChaosAction" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "ChaosAction"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosActionInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "ChaosActionInfo" : {
+            "title" : "ChaosActionInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "identity", "duration", "infraReference" ],
+              "properties" : {
+                "identity" : {
+                  "type" : "string"
+                },
+                "duration" : {
+                  "type" : "string"
+                },
+                "infraReference" : {
+                  "type" : "string"
+                },
+                "tasks" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "required" : [ "identifier" ],
+                      "properties" : {
+                        "identifier" : {
+                          "type" : "string",
+                          "minLength" : 1
+                        },
+                        "values" : {
+                          "type" : "array",
+                          "items" : {
+                            "type" : "object",
+                            "required" : [ "name", "value" ],
+                            "properties" : {
+                              "name" : {
+                                "type" : "string",
+                                "minLength" : 1
+                              },
+                              "value" : {
+                                "anyOf" : [ {
+                                  "type" : "string"
+                                }, {
+                                  "type" : "number"
+                                }, {
+                                  "type" : "boolean"
+                                }, {
+                                  "type" : "string",
+                                  "pattern" : "(<\\+.+>.*)"
+                                } ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "ChaosFaultNode" : {
+            "title" : "ChaosFaultNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for ChaosFaultNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "ChaosFault" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "ChaosFault"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosFaultInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "ChaosFaultInfo" : {
+            "title" : "ChaosFaultInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "identity", "infraReference" ],
+              "properties" : {
+                "identity" : {
+                  "type" : "string"
+                },
+                "infraReference" : {
+                  "type" : "string"
+                },
+                "tasks" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "required" : [ "identifier" ],
+                      "properties" : {
+                        "identifier" : {
+                          "type" : "string",
+                          "minLength" : 1
+                        },
+                        "values" : {
+                          "type" : "array",
+                          "items" : {
+                            "type" : "object",
+                            "required" : [ "name", "value" ],
+                            "properties" : {
+                              "name" : {
+                                "type" : "string",
+                                "minLength" : 1
+                              },
+                              "value" : {
+                                "anyOf" : [ {
+                                  "type" : "string"
+                                }, {
+                                  "type" : "number"
+                                }, {
+                                  "type" : "boolean"
+                                }, {
+                                  "type" : "string",
+                                  "pattern" : "(<\\+.+>.*)"
+                                } ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#"
           }
         },
         "cvng" : {
@@ -73572,429 +76630,6 @@ const schema: Record<string, any> = {
               }
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#"
-          },
-          "ChaosProbeNode" : {
-            "title" : "ChaosProbeNode",
-            "type" : "object",
-            "required" : [ "identifier", "name", "spec", "type" ],
-            "properties" : {
-              "description" : {
-                "type" : "string",
-                "desc" : "This is the description for ChaosProbeNode"
-              },
-              "enforce" : {
-                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
-              },
-              "failureStrategies" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "identifier" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
-              },
-              "name" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
-              },
-              "strategy" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "timeout" : {
-                "type" : "string",
-                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
-              },
-              "type" : {
-                "type" : "string",
-                "enum" : [ "ChaosProbe" ]
-              },
-              "when" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "ChaosProbe"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/drtest/ChaosProbeInfo"
-                  }
-                }
-              }
-            } ]
-          },
-          "ChaosProbeInfo" : {
-            "title" : "ChaosProbeInfo",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/common/StepSpecType"
-            }, {
-              "type" : "object",
-              "required" : [ "identity", "duration", "infraReference" ],
-              "properties" : {
-                "identity" : {
-                  "type" : "string"
-                },
-                "duration" : {
-                  "type" : "string"
-                },
-                "infraReference" : {
-                  "type" : "string"
-                },
-                "tasks" : {
-                  "oneOf" : [ {
-                    "type" : "array",
-                    "items" : {
-                      "type" : "object",
-                      "required" : [ "identifier" ],
-                      "properties" : {
-                        "identifier" : {
-                          "type" : "string",
-                          "minLength" : 1
-                        },
-                        "values" : {
-                          "type" : "array",
-                          "items" : {
-                            "type" : "object",
-                            "required" : [ "name", "value" ],
-                            "properties" : {
-                              "name" : {
-                                "type" : "string",
-                                "minLength" : 1
-                              },
-                              "value" : {
-                                "anyOf" : [ {
-                                  "type" : "string"
-                                }, {
-                                  "type" : "number"
-                                }, {
-                                  "type" : "boolean"
-                                }, {
-                                  "type" : "string",
-                                  "pattern" : "(<\\+.+>.*)"
-                                } ]
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#"
-          },
-          "ChaosActionNode" : {
-            "title" : "ChaosActionNode",
-            "type" : "object",
-            "required" : [ "identifier", "name", "spec", "type" ],
-            "properties" : {
-              "description" : {
-                "type" : "string",
-                "desc" : "This is the description for ChaosActionNode"
-              },
-              "enforce" : {
-                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
-              },
-              "failureStrategies" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "identifier" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
-              },
-              "name" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
-              },
-              "strategy" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "timeout" : {
-                "type" : "string",
-                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
-              },
-              "type" : {
-                "type" : "string",
-                "enum" : [ "ChaosAction" ]
-              },
-              "when" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "ChaosAction"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/drtest/ChaosActionInfo"
-                  }
-                }
-              }
-            } ]
-          },
-          "ChaosActionInfo" : {
-            "title" : "ChaosActionInfo",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/common/StepSpecType"
-            }, {
-              "type" : "object",
-              "required" : [ "identity", "duration", "infraReference" ],
-              "properties" : {
-                "identity" : {
-                  "type" : "string"
-                },
-                "duration" : {
-                  "type" : "string"
-                },
-                "infraReference" : {
-                  "type" : "string"
-                },
-                "tasks" : {
-                  "oneOf" : [ {
-                    "type" : "array",
-                    "items" : {
-                      "type" : "object",
-                      "required" : [ "identifier" ],
-                      "properties" : {
-                        "identifier" : {
-                          "type" : "string",
-                          "minLength" : 1
-                        },
-                        "values" : {
-                          "type" : "array",
-                          "items" : {
-                            "type" : "object",
-                            "required" : [ "name", "value" ],
-                            "properties" : {
-                              "name" : {
-                                "type" : "string",
-                                "minLength" : 1
-                              },
-                              "value" : {
-                                "anyOf" : [ {
-                                  "type" : "string"
-                                }, {
-                                  "type" : "number"
-                                }, {
-                                  "type" : "boolean"
-                                }, {
-                                  "type" : "string",
-                                  "pattern" : "(<\\+.+>.*)"
-                                } ]
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#"
-          },
-          "ChaosFaultNode" : {
-            "title" : "ChaosFaultNode",
-            "type" : "object",
-            "required" : [ "identifier", "name", "spec", "type" ],
-            "properties" : {
-              "description" : {
-                "type" : "string",
-                "desc" : "This is the description for ChaosFaultNode"
-              },
-              "enforce" : {
-                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
-              },
-              "failureStrategies" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "identifier" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
-              },
-              "name" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
-              },
-              "strategy" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "timeout" : {
-                "type" : "string",
-                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
-              },
-              "type" : {
-                "type" : "string",
-                "enum" : [ "ChaosFault" ]
-              },
-              "when" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "ChaosFault"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/drtest/ChaosFaultInfo"
-                  }
-                }
-              }
-            } ]
-          },
-          "ChaosFaultInfo" : {
-            "title" : "ChaosFaultInfo",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/common/StepSpecType"
-            }, {
-              "type" : "object",
-              "required" : [ "identity", "infraReference" ],
-              "properties" : {
-                "identity" : {
-                  "type" : "string"
-                },
-                "infraReference" : {
-                  "type" : "string"
-                },
-                "tasks" : {
-                  "oneOf" : [ {
-                    "type" : "array",
-                    "items" : {
-                      "type" : "object",
-                      "required" : [ "identifier" ],
-                      "properties" : {
-                        "identifier" : {
-                          "type" : "string",
-                          "minLength" : 1
-                        },
-                        "values" : {
-                          "type" : "array",
-                          "items" : {
-                            "type" : "object",
-                            "required" : [ "name", "value" ],
-                            "properties" : {
-                              "name" : {
-                                "type" : "string",
-                                "minLength" : 1
-                              },
-                              "value" : {
-                                "anyOf" : [ {
-                                  "type" : "string"
-                                }, {
-                                  "type" : "number"
-                                }, {
-                                  "type" : "boolean"
-                                }, {
-                                  "type" : "string",
-                                  "pattern" : "(<\\+.+>.*)"
-                                } ]
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#"
           }
         }
       },
@@ -75240,7 +77875,7 @@ const schema: Record<string, any> = {
           "properties" : {
             "type" : {
               "type" : "string",
-              "enum" : [ "KubernetesDirect", "Delegate", "Noop", "VM" ]
+              "enum" : [ "KubernetesDirect", "Delegate", "Noop", "VM", "ECSDirect" ]
             },
             "description" : {
               "desc" : "This is the description for StepGroupInfra"
@@ -75269,6 +77904,30 @@ const schema: Record<string, any> = {
           "properties" : {
             "description" : {
               "desc" : "This is the description for VMInfra"
+            }
+          }
+        },
+        "ECSDirectInfra" : {
+          "title" : "ECSDirectInfra",
+          "allOf" : [ {
+            "$ref" : "#/definitions/pipeline/common/StepGroupInfra"
+          }, {
+            "type" : "object",
+            "required" : [ "spec", "type" ],
+            "properties" : {
+              "spec" : {
+                "$ref" : "#/definitions/pipeline/steps/custom/ECSDirectInfraYamlSpec"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "ECSDirect" ]
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#",
+          "properties" : {
+            "description" : {
+              "desc" : "This is the description for ECSDirectInfra"
             }
           }
         }
@@ -77230,7 +79889,15 @@ const schema: Record<string, any> = {
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/UpdateReleaseRepoStepNode"
                 }, {
-                  "$ref" : "#/definitions/pipeline/steps/cd/ChaosStepNode"
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/LoadTestStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosProbeNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosActionNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosFaultNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/AiTestAutomationStepNode"
                 }, {
@@ -77295,6 +79962,8 @@ const schema: Record<string, any> = {
                   "$ref" : "#/definitions/pipeline/steps/common/RunStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/AiVerifyStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/AIVerifyNGStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/PluginStepNode"
                 }, {
@@ -77390,6 +80059,8 @@ const schema: Record<string, any> = {
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/SalesforceRollbackStepNode"
                 }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/SalesforceSourceBackupStepNode"
+                }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/SalesforceValidateStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/SalesforceQuickDeployStepNode"
@@ -77397,6 +80068,12 @@ const schema: Record<string, any> = {
                   "$ref" : "#/definitions/pipeline/steps/cd/SalesforceCreateScratchOrgStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/SalesforceDeleteScratchOrgStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/SalesforceDownloadDeployablesStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/SalesforceDownloadOrgStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/SalesforceEvaluateDiffStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/idp/IDPSlackNotifyStepNode"
                 }, {
@@ -77427,6 +80104,8 @@ const schema: Record<string, any> = {
                   "$ref" : "#/definitions/pipeline/steps/common/FlywayCommandStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/WizScanNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/AgentStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagCreateStepNode"
                 }, {
@@ -77475,6 +80154,8 @@ const schema: Record<string, any> = {
                   "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagsetDeleteStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagAddRemoveFlagsetsStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagDefinitionInstructionsStepNode"
                 } ]
               },
               "stepGroup" : {
@@ -77840,6 +80521,8 @@ const schema: Record<string, any> = {
                   "$ref" : "#/definitions/pipeline/common/K8sDirectInfra"
                 }, {
                   "$ref" : "#/definitions/pipeline/common/VMInfra"
+                }, {
+                  "$ref" : "#/definitions/pipeline/common/ECSDirectInfra"
                 } ]
               },
               "steps" : {
@@ -85060,6 +87743,8 @@ const schema: Record<string, any> = {
                 "oneOf" : [ {
                   "$ref" : "#/definitions/pipeline/common/StepElementConfig"
                 }, {
+                  "$ref" : "#/definitions/pipeline/steps/ci/AiTestAutomationStepNode"
+                }, {
                   "$ref" : "#/definitions/pipeline/steps/ci/ArtifactoryUploadNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/ci/HarUploadNode"
@@ -85235,6 +87920,8 @@ const schema: Record<string, any> = {
                   "$ref" : "#/definitions/pipeline/steps/common/SastScanNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/ScaScanNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/AgentStepNode"
                 } ]
               },
               "stepGroup" : {
@@ -85455,23 +88142,7 @@ const schema: Record<string, any> = {
                       "$ref" : "#/definitions/pipeline/stages/ci/CosignAttestationV1"
                     }, {
                       "$ref" : "#/definitions/pipeline/stages/ci/CosignSecretManagerAttestation"
-                    } ],
-                    "properties" : {
-                      "cosignVariables" : {
-                        "type" : "array",
-                        "items" : {
-                          "type" : "object",
-                          "properties" : {
-                            "key" : {
-                              "type" : "string"
-                            },
-                            "value" : {
-                              "type" : "string"
-                            }
-                          }
-                        }
-                      }
-                    }
+                    } ]
                   }
                 }
               }
@@ -86398,7 +89069,15 @@ const schema: Record<string, any> = {
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/ShellScriptProvisionStepNode"
                 }, {
-                  "$ref" : "#/definitions/pipeline/steps/cd/ChaosStepNode"
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/LoadTestStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosProbeNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosActionNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosFaultNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/AiTestAutomationStepNode"
                 }, {
@@ -86562,7 +89241,13 @@ const schema: Record<string, any> = {
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagAddRemoveFlagsetsStepNode"
                 }, {
+                  "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagDefinitionInstructionsStepNode"
+                }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/GCEProvisionBackendServiceStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/EcsScaleStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/AgentStepNode"
                 } ]
               },
               "stepGroup" : {
@@ -86674,6 +89359,8 @@ const schema: Record<string, any> = {
                   "$ref" : "#/definitions/pipeline/common/K8sDirectInfra"
                 }, {
                   "$ref" : "#/definitions/pipeline/common/VMInfra"
+                }, {
+                  "$ref" : "#/definitions/pipeline/common/ECSDirectInfra"
                 } ]
               },
               "steps" : {
@@ -86922,7 +89609,7 @@ const schema: Record<string, any> = {
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/ShellScriptProvisionStepNode"
                 }, {
-                  "$ref" : "#/definitions/pipeline/steps/cd/ChaosStepNode"
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/TerragruntPlanStepNode"
                 }, {
@@ -87074,6 +89761,8 @@ const schema: Record<string, any> = {
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/SalesforceRollbackStepNode"
                 }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/SalesforceSourceBackupStepNode"
+                }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/SalesforceValidateStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/SalesforceQuickDeployStepNode"
@@ -87081,6 +89770,12 @@ const schema: Record<string, any> = {
                   "$ref" : "#/definitions/pipeline/steps/cd/SalesforceCreateScratchOrgStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/SalesforceDeleteScratchOrgStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/SalesforceDownloadDeployablesStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/SalesforceDownloadOrgStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/SalesforceEvaluateDiffStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/idp/IDPSlackNotifyStepNode"
                 }, {
@@ -87135,6 +89830,8 @@ const schema: Record<string, any> = {
                   "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagsetDeleteStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagAddRemoveFlagsetsStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagDefinitionInstructionsStepNode"
                 } ]
               },
               "stepGroup" : {
@@ -87803,11 +90500,13 @@ const schema: Record<string, any> = {
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/drtest/DRTestSlackNotifyStepNode"
                 }, {
-                  "$ref" : "#/definitions/pipeline/steps/drtest/ChaosProbeNode"
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosProbeNode"
                 }, {
-                  "$ref" : "#/definitions/pipeline/steps/drtest/ChaosActionNode"
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosActionNode"
                 }, {
-                  "$ref" : "#/definitions/pipeline/steps/drtest/ChaosFaultNode"
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosFaultNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/LoadTestStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/custom/EmailStepNode"
                 }, {
@@ -87944,6 +90643,8 @@ const schema: Record<string, any> = {
                   "$ref" : "#/definitions/pipeline/common/K8sDirectInfra"
                 }, {
                   "$ref" : "#/definitions/pipeline/common/VMInfra"
+                }, {
+                  "$ref" : "#/definitions/pipeline/common/ECSDirectInfra"
                 } ]
               },
               "steps" : {

--- a/src/data/schemas/template.ts
+++ b/src/data/schemas/template.ts
@@ -125,9 +125,13 @@ const schema: Record<string, any> = {
               }, {
                 "$ref" : "#/definitions/pipeline/steps/cd/BambooBuildStepNode_template"
               }, {
-                "$ref" : "#/definitions/pipeline/steps/cd/ChaosStepNode_template"
+                "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosStepNode_template"
+              }, {
+                "$ref" : "#/definitions/pipeline/steps/resiliencetesting/LoadTestStepNode_template"
               }, {
                 "$ref" : "#/definitions/pipeline/steps/cd/AiTestAutomationStepNode_template"
+              }, {
+                "$ref" : "#/definitions/pipeline/steps/ci/AiTestAutomationStepNode_template"
               }, {
                 "$ref" : "#/definitions/pipeline/steps/cd/CloudformationCreateStackStepNode_template"
               }, {
@@ -319,6 +323,8 @@ const schema: Record<string, any> = {
               }, {
                 "$ref" : "#/definitions/pipeline/steps/ci/RunTestStepNode_template"
               }, {
+                "$ref" : "#/definitions/pipeline/steps/ci/RunTestStepV2Node_template"
+              }, {
                 "$ref" : "#/definitions/pipeline/steps/ci/S3UploadNode_template"
               }, {
                 "$ref" : "#/definitions/pipeline/steps/ci/SaveCacheGCSNode_template"
@@ -433,6 +439,8 @@ const schema: Record<string, any> = {
               }, {
                 "$ref" : "#/definitions/pipeline/steps/common/AiVerifyStepNode_template"
               }, {
+                "$ref" : "#/definitions/pipeline/steps/cd/AIVerifyNGStepNode_template"
+              }, {
                 "$ref" : "#/definitions/pipeline/steps/common/SecurityNode_template"
               }, {
                 "$ref" : "#/definitions/pipeline/steps/common/SemgrepScanNode_template"
@@ -544,6 +552,8 @@ const schema: Record<string, any> = {
                 "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagsetDeleteStepNode_template"
               }, {
                 "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagAddRemoveFlagsetsStepNode_template"
+              }, {
+                "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagDefinitionInstructionsStepNode_template"
               }, {
                 "$ref" : "#/definitions/pipeline/steps/cvng/CVAnalyzeDeploymentStepNode_template"
               }, {
@@ -658,6 +668,8 @@ const schema: Record<string, any> = {
                 "$ref" : "#/definitions/pipeline/steps/common/DBSchemaRollbackSQLNode_template"
               }, {
                 "$ref" : "#/definitions/pipeline/steps/common/FlywayCommandStepNode_template"
+              }, {
+                "$ref" : "#/definitions/pipeline/steps/common/AgentStepNode_template"
               } ]
             },
             "tags" : {
@@ -7090,189 +7102,6 @@ const schema: Record<string, any> = {
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
-          },
-          "ChaosStepNode_template" : {
-            "title" : "ChaosStepNode_template",
-            "type" : "object",
-            "required" : [ "spec", "type" ],
-            "properties" : {
-              "enforce" : {
-                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
-              },
-              "failureStrategies" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "strategy" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "timeout" : {
-                "type" : "string",
-                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
-              },
-              "type" : {
-                "type" : "string",
-                "enum" : [ "Chaos" ]
-              },
-              "when" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "Chaos"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/cd/ChaosStepInfo"
-                  }
-                }
-              }
-            } ]
-          },
-          "ChaosStepInfo" : {
-            "title" : "ChaosStepInfo",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "identifier" : {
-                    "type" : "string"
-                  },
-                  "kind" : {
-                    "const" : "template"
-                  }
-                },
-                "required" : [ "identifier", "kind" ]
-              },
-              "then" : {
-                "required" : [ "hubRef", "infraReference" ]
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "type" : "object",
-            "required" : [ "expectedResilienceScore" ],
-            "properties" : {
-              "assertion" : {
-                "type" : "string"
-              },
-              "expectedResilienceScore" : {
-                "oneOf" : [ {
-                  "type" : "number",
-                  "format" : "double"
-                }, {
-                  "type" : "string",
-                  "pattern" : "(<\\+.+>.*)",
-                  "minLength" : 1
-                } ]
-              },
-              "experimentRef" : {
-                "type" : "string",
-                "minLength" : 1
-              },
-              "identifier" : {
-                "type" : "string",
-                "minLength" : 1
-              },
-              "kind" : {
-                "type" : "string",
-                "enum" : [ "experiment", "template" ]
-              },
-              "hubRef" : {
-                "type" : "string",
-                "minLength" : 1
-              },
-              "infraReference" : {
-                "oneOf" : [ {
-                  "type" : "string",
-                  "minLength" : 1,
-                  "not" : {
-                    "pattern" : "(<\\+.+>.*)"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "(<\\+.+>.*)",
-                  "minLength" : 1
-                } ]
-              },
-              "tasks" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "required" : [ "identifier" ],
-                    "properties" : {
-                      "identifier" : {
-                        "type" : "string",
-                        "minLength" : 1
-                      },
-                      "values" : {
-                        "type" : "array",
-                        "items" : {
-                          "type" : "object",
-                          "required" : [ "name", "value" ],
-                          "properties" : {
-                            "name" : {
-                              "type" : "string",
-                              "minLength" : 1
-                            },
-                            "value" : {
-                              "anyOf" : [ {
-                                "type" : "string"
-                              }, {
-                                "type" : "number"
-                              }, {
-                                "type" : "boolean"
-                              }, {
-                                "type" : "string",
-                                "pattern" : "(<\\+.+>.*)"
-                              } ]
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "(<\\+.+>.*)",
-                  "minLength" : 1
-                } ]
-              },
-              "description" : {
-                "desc" : "This is the description for ChaosStepInfo"
-              }
-            },
-            "anyOf" : [ {
-              "required" : [ "experimentRef" ]
-            }, {
-              "required" : [ "identifier" ]
-            } ]
           },
           "AiTestAutomationStepNode_template" : {
             "title" : "AiTestAutomationStepNode_template",
@@ -24586,6 +24415,15 @@ const schema: Record<string, any> = {
                   "minLength" : 1
                 } ]
               },
+              "waitForMerge" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
               "stringMap" : {
                 "$ref" : "#/definitions/pipeline/steps/common/ParameterFieldMapStringString"
               },
@@ -24706,6 +24544,395 @@ const schema: Record<string, any> = {
                 "desc" : "This is the description for UpdateReleaseRepoSecretNGVariable"
               }
             }
+          },
+          "AIVerifyNGStepNode_template" : {
+            "title" : "AIVerifyNGStepNode_template",
+            "type" : "object",
+            "required" : [ "spec", "type" ],
+            "properties" : {
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "AIVerifyNG" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "AIVerifyNG"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/AIVerifyNGStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "AIVerifyNGStepInfo" : {
+            "title" : "AIVerifyNGStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "healthSourceRefs", "dataCollectionWindow", "dataCollectionInfrastructure" ],
+              "properties" : {
+                "healthSourceRefs" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string",
+                      "minLength" : 1
+                    },
+                    "minItems" : 1
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "dataCollectionInfrastructure" : {
+                  "$ref" : "#/definitions/pipeline/steps/cd/DataCollectionInfrastructure"
+                },
+                "dataCollectionWindow" : {
+                  "description" : "Data collection window as a duration string '<n>m' (minutes) or '<n>h' (hours), e.g. '30m', '1h', '2h'; may also be a runtime expression.",
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "pattern" : "^[1-9][0-9]*[mMhH]$",
+                    "minLength" : 2
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "connectorRef" : {
+                  "type" : "string"
+                },
+                "envVariables" : {
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string"
+                  } ]
+                },
+                "imagePullPolicy" : {
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "enum" : [ "Always", "Never", "IfNotPresent" ]
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "privileged" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                },
+                "runAsUser" : {
+                  "oneOf" : [ {
+                    "type" : "integer",
+                    "format" : "int32"
+                  }, {
+                    "type" : "string"
+                  } ]
+                },
+                "preExecution" : {
+                  "type" : "string"
+                },
+                "optionalConfigurations" : {
+                  "description" : "Optional. Omit entirely or set any subset of nested fields (all nested fields are optional).",
+                  "allOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/cd/AIVerifyOptionalConfigurations"
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "healthSourceRefs", "dataCollectionWindow", "dataCollectionInfrastructure" ],
+            "properties" : {
+              "healthSourceRefs" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string",
+                    "minLength" : 1
+                  },
+                  "minItems" : 1
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "dataCollectionInfrastructure" : {
+                "$ref" : "#/definitions/pipeline/steps/cd/DataCollectionInfrastructure"
+              },
+              "dataCollectionWindow" : {
+                "description" : "Data collection window as a duration string '<n>m' (minutes) or '<n>h' (hours), e.g. '30m', '1h', '2h'; may also be a runtime expression.",
+                "oneOf" : [ {
+                  "type" : "string",
+                  "pattern" : "^[1-9][0-9]*[mMhH]$",
+                  "minLength" : 2
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "image" : {
+                "type" : "string"
+              },
+              "connectorRef" : {
+                "type" : "string"
+              },
+              "envVariables" : {
+                "oneOf" : [ {
+                  "type" : "object",
+                  "additionalProperties" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "imagePullPolicy" : {
+                "oneOf" : [ {
+                  "type" : "string",
+                  "enum" : [ "Always", "Never", "IfNotPresent" ]
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "privileged" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "runAsUser" : {
+                "oneOf" : [ {
+                  "type" : "integer",
+                  "format" : "int32"
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "preExecution" : {
+                "type" : "string"
+              },
+              "optionalConfigurations" : {
+                "description" : "Optional. Omit entirely or set any subset of nested fields (all nested fields are optional).",
+                "allOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/cd/AIVerifyOptionalConfigurations"
+                } ]
+              },
+              "description" : {
+                "desc" : "AI Verify NG Step - AI-powered deployment verification using health sources"
+              }
+            }
+          },
+          "DataCollectionInfrastructure" : {
+            "title" : "DataCollectionInfrastructure",
+            "type" : "object",
+            "required" : [ "type", "spec" ],
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "KubernetesDirect" ]
+              },
+              "spec" : {
+                "type" : "object",
+                "required" : [ "connectorRef", "namespace" ],
+                "properties" : {
+                  "connectorRef" : {
+                    "type" : "string"
+                  },
+                  "namespace" : {
+                    "type" : "string"
+                  },
+                  "resources" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/DataCollectionInfrastructureResources"
+                  }
+                }
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "DataCollectionInfrastructureResources" : {
+            "title" : "DataCollectionInfrastructureResources",
+            "description" : "Optional resource requests/limits for AI Verify data collection infrastructure. Omit the block entirely, or include only the fields you need; CPU and memory are optional under requests and limits.",
+            "type" : "object",
+            "properties" : {
+              "limits" : {
+                "$ref" : "#/definitions/pipeline/common/Limits"
+              },
+              "requests" : {
+                "$ref" : "#/definitions/pipeline/common/Limits"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "AIVerifyOptionalConfigurations" : {
+            "title" : "AIVerifyOptionalConfigurations",
+            "description" : "Optional cv-nextgen parity fields; not mapped to plugin env in current release. The parent step may omit optionalConfigurations entirely, or supply an empty object. When present, every property below remains optional; set only the fields you need.",
+            "type" : "object",
+            "required" : [ ],
+            "properties" : {
+              "sensitivity" : {
+                "oneOf" : [ {
+                  "type" : "string"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "verificationType" : {
+                "oneOf" : [ {
+                  "type" : "string"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "failOnNoAnalysis" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "controlNodeRegexPattern" : {
+                "oneOf" : [ {
+                  "type" : "string"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "testNodeRegexPattern" : {
+                "oneOf" : [ {
+                  "type" : "string"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "baselineEndTime" : {
+                "oneOf" : [ {
+                  "type" : "string"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "verificationStartTime" : {
+                "oneOf" : [ {
+                  "type" : "string"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
           },
           "K8sBGStageScaleDownStepNode_template" : {
             "title" : "K8sBGStageScaleDownStepNode_template",
@@ -30415,83 +30642,6 @@ const schema: Record<string, any> = {
               }
             } ]
           },
-          "ChaosStepNode" : {
-            "title" : "ChaosStepNode",
-            "type" : "object",
-            "required" : [ "identifier", "name", "spec", "type" ],
-            "properties" : {
-              "description" : {
-                "type" : "string",
-                "desc" : "This is the description for ChaosStepNode"
-              },
-              "enforce" : {
-                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
-              },
-              "failureStrategies" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "identifier" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
-              },
-              "name" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
-              },
-              "strategy" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "timeout" : {
-                "type" : "string",
-                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
-              },
-              "type" : {
-                "type" : "string",
-                "enum" : [ "Chaos" ]
-              },
-              "when" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "Chaos"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/cd/ChaosStepInfo"
-                  }
-                }
-              }
-            } ]
-          },
           "AiTestAutomationStepNode" : {
             "title" : "AiTestAutomationStepNode",
             "type" : "object",
@@ -31946,6 +32096,83 @@ const schema: Record<string, any> = {
                 "desc" : "This is the description for GCEProvisionBackendServiceStepInfo"
               }
             }
+          },
+          "EcsScaleStepNode" : {
+            "title" : "EcsScaleStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for EcsScaleStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "EcsScale" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "EcsScale"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/EcsScaleStepInfo"
+                  }
+                }
+              }
+            } ]
           },
           "MergePRStepNode" : {
             "title" : "MergePRStepNode",
@@ -37532,83 +37759,6 @@ const schema: Record<string, any> = {
               }
             } ]
           },
-          "EcsScaleStepNode" : {
-            "title" : "EcsScaleStepNode",
-            "type" : "object",
-            "required" : [ "identifier", "name", "type" ],
-            "properties" : {
-              "description" : {
-                "type" : "string",
-                "desc" : "This is the description for EcsScaleStepNode"
-              },
-              "enforce" : {
-                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
-              },
-              "failureStrategies" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "identifier" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
-              },
-              "name" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
-              },
-              "strategy" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "timeout" : {
-                "type" : "string",
-                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
-              },
-              "type" : {
-                "type" : "string",
-                "enum" : [ "EcsScale" ]
-              },
-              "when" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "EcsScale"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/cd/EcsScaleStepInfo"
-                  }
-                }
-              }
-            } ]
-          },
           "AsgBlueGreenDeployStepNode" : {
             "title" : "AsgBlueGreenDeployStepNode",
             "type" : "object",
@@ -38143,6 +38293,83 @@ const schema: Record<string, any> = {
                 "properties" : {
                   "spec" : {
                     "$ref" : "#/definitions/pipeline/steps/cd/UpdateReleaseRepoStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "AIVerifyNGStepNode" : {
+            "title" : "AIVerifyNGStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for AIVerifyNGStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "AIVerifyNG" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "AIVerifyNG"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/AIVerifyNGStepInfo"
                   }
                 }
               }
@@ -41182,6 +41409,263 @@ const schema: Record<string, any> = {
               }
             }
           },
+          "SalesforceSourceBackupStepNode" : {
+            "title" : "SalesforceSourceBackupStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for SalesforceSourceBackupStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "SalesforceSourceBackup" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "SalesforceSourceBackup"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/SalesforceSourceBackupStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "SalesforceSourceBackupStepInfo" : {
+            "title" : "SalesforceSourceBackupStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "gitConnectorRef" : {
+                  "type" : "string"
+                },
+                "repoName" : {
+                  "type" : "string"
+                },
+                "branch" : {
+                  "type" : "string"
+                },
+                "branchAction" : {
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "enum" : [ "raisePR", "createNewBranch", "overwriteExistingBranch" ]
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "targetBranch" : {
+                  "type" : "string"
+                },
+                "prTitle" : {
+                  "type" : "string"
+                },
+                "prDescription" : {
+                  "type" : "string"
+                },
+                "connectorRef" : {
+                  "type" : "string"
+                },
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "commandOptions" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "imagePullPolicy" : {
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "enum" : [ "Always", "Never", "IfNotPresent" ]
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "privileged" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                },
+                "runAsUser" : {
+                  "oneOf" : [ {
+                    "type" : "integer",
+                    "format" : "int32"
+                  }, {
+                    "type" : "string"
+                  } ]
+                },
+                "preExecution" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "gitConnectorRef" : {
+                "type" : "string"
+              },
+              "repoName" : {
+                "type" : "string"
+              },
+              "branch" : {
+                "type" : "string"
+              },
+              "branchAction" : {
+                "oneOf" : [ {
+                  "type" : "string",
+                  "enum" : [ "raisePR", "createNewBranch", "overwriteExistingBranch" ]
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "targetBranch" : {
+                "type" : "string"
+              },
+              "prTitle" : {
+                "type" : "string"
+              },
+              "prDescription" : {
+                "type" : "string"
+              },
+              "connectorRef" : {
+                "type" : "string"
+              },
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "commandOptions" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "image" : {
+                "type" : "string"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "runAsUser" : {
+                "oneOf" : [ {
+                  "type" : "integer",
+                  "format" : "int32"
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "preExecution" : {
+                "type" : "string"
+              },
+              "description" : {
+                "desc" : "This is the description for SalesforceSourceBackupStepInfo"
+              }
+            }
+          },
           "SalesforceValidateStepNode" : {
             "title" : "SalesforceValidateStepNode",
             "type" : "object",
@@ -42031,6 +42515,669 @@ const schema: Record<string, any> = {
               },
               "description" : {
                 "desc" : "This is the description for SalesforceDeleteScratchOrgStepInfo"
+              }
+            }
+          },
+          "SalesforceDownloadDeployablesStepNode" : {
+            "title" : "SalesforceDownloadDeployablesStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for SalesforceDownloadDeployablesStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "SalesforceDownloadDeployables" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "SalesforceDownloadDeployables"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/SalesforceDownloadDeployablesStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "SalesforceDownloadDeployablesStepInfo" : {
+            "title" : "SalesforceDownloadDeployablesStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "source1Type" : {
+                  "type" : "string"
+                },
+                "source1Ref" : {
+                  "type" : "string"
+                },
+                "source2Type" : {
+                  "type" : "string"
+                },
+                "source2Ref" : {
+                  "type" : "string"
+                },
+                "metadataTypes" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "connectorRef" : {
+                  "type" : "string"
+                },
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "commandOptions" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "imagePullPolicy" : {
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "enum" : [ "Always", "Never", "IfNotPresent" ]
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "privileged" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                },
+                "runAsUser" : {
+                  "oneOf" : [ {
+                    "type" : "integer",
+                    "format" : "int32"
+                  }, {
+                    "type" : "string"
+                  } ]
+                },
+                "preExecution" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "source1Type" : {
+                "type" : "string"
+              },
+              "source1Ref" : {
+                "type" : "string"
+              },
+              "source2Type" : {
+                "type" : "string"
+              },
+              "source2Ref" : {
+                "type" : "string"
+              },
+              "metadataTypes" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              },
+              "connectorRef" : {
+                "type" : "string"
+              },
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "commandOptions" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "image" : {
+                "type" : "string"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "runAsUser" : {
+                "oneOf" : [ {
+                  "type" : "integer",
+                  "format" : "int32"
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "preExecution" : {
+                "type" : "string"
+              },
+              "description" : {
+                "desc" : "This is the description for SalesforceDownloadDeployablesStepInfo"
+              }
+            }
+          },
+          "SalesforceDownloadOrgStepNode" : {
+            "title" : "SalesforceDownloadOrgStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for SalesforceDownloadOrgStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "SalesforceDownloadOrg" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "SalesforceDownloadOrg"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/SalesforceDownloadOrgStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "SalesforceDownloadOrgStepInfo" : {
+            "title" : "SalesforceDownloadOrgStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "sourceRef" : {
+                  "type" : "string"
+                },
+                "downloadPath" : {
+                  "type" : "string"
+                },
+                "metadataTypes" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "connectorRef" : {
+                  "type" : "string"
+                },
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "commandOptions" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "imagePullPolicy" : {
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "enum" : [ "Always", "Never", "IfNotPresent" ]
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "privileged" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                },
+                "runAsUser" : {
+                  "oneOf" : [ {
+                    "type" : "integer",
+                    "format" : "int32"
+                  }, {
+                    "type" : "string"
+                  } ]
+                },
+                "preExecution" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "sourceRef" : {
+                "type" : "string"
+              },
+              "downloadPath" : {
+                "type" : "string"
+              },
+              "metadataTypes" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              },
+              "connectorRef" : {
+                "type" : "string"
+              },
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "commandOptions" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "image" : {
+                "type" : "string"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "runAsUser" : {
+                "oneOf" : [ {
+                  "type" : "integer",
+                  "format" : "int32"
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "preExecution" : {
+                "type" : "string"
+              },
+              "description" : {
+                "desc" : "This is the description for SalesforceDownloadOrgStepInfo"
+              }
+            }
+          },
+          "SalesforceEvaluateDiffStepNode" : {
+            "title" : "SalesforceEvaluateDiffStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for SalesforceEvaluateDiffStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "SalesforceEvaluateDiff" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "SalesforceEvaluateDiff"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/SalesforceEvaluateDiffStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "SalesforceEvaluateDiffStepInfo" : {
+            "title" : "SalesforceEvaluateDiffStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "connectorRef" : {
+                  "type" : "string"
+                },
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "commandOptions" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "imagePullPolicy" : {
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "enum" : [ "Always", "Never", "IfNotPresent" ]
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "privileged" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                },
+                "runAsUser" : {
+                  "oneOf" : [ {
+                    "type" : "integer",
+                    "format" : "int32"
+                  }, {
+                    "type" : "string"
+                  } ]
+                },
+                "preExecution" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "connectorRef" : {
+                "type" : "string"
+              },
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "commandOptions" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "image" : {
+                "type" : "string"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "runAsUser" : {
+                "oneOf" : [ {
+                  "type" : "integer",
+                  "format" : "int32"
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "preExecution" : {
+                "type" : "string"
+              },
+              "description" : {
+                "desc" : "This is the description for SalesforceEvaluateDiffStepInfo"
               }
             }
           },
@@ -43146,7 +44293,7 @@ const schema: Record<string, any> = {
             "properties" : {
               "type" : {
                 "type" : "string",
-                "enum" : [ "cosign" ]
+                "enum" : [ "cosign", "keyless", "keybased", "secret-manager" ]
               },
               "description" : {
                 "desc" : "This is the description for VerifyAttestation"
@@ -43172,23 +44319,55 @@ const schema: Record<string, any> = {
                       "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
                     }, {
                       "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
-                    } ],
-                    "properties" : {
-                      "cosignVariables" : {
-                        "type" : "array",
-                        "items" : {
-                          "type" : "object",
-                          "properties" : {
-                            "key" : {
-                              "type" : "string"
-                            },
-                            "value" : {
-                              "type" : "string"
-                            }
-                          }
-                        }
-                      }
-                    }
+                    } ]
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "keyless"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "type" : "object",
+                    "$ref" : "#/definitions/pipeline/steps/custom/KeylessVerifyAttestation"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "keybased"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "type" : "object",
+                    "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "secret-manager"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "type" : "object",
+                    "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
                   }
                 }
               }
@@ -43241,6 +44420,18 @@ const schema: Record<string, any> = {
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "additionalProperties" : false,
             "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
+          },
+          "KeylessVerifyAttestation" : {
+            "title" : "KeylessVerifyAttestation",
+            "type" : "object",
+            "properties" : {
+              "oidcProvider" : {
+                "type" : "string",
+                "enum" : [ "harness", "non-harness" ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false
           },
           "Attestation" : {
             "title" : "Attestation",
@@ -43477,6 +44668,9 @@ const schema: Record<string, any> = {
                 "format" : {
                   "type" : "string",
                   "enum" : [ "cyclonedx-json" ]
+                },
+                "cli_flags" : {
+                  "type" : "string"
                 }
               }
             } ],
@@ -43775,6 +44969,8 @@ const schema: Record<string, any> = {
                 "infrastructure" : {
                   "oneOf" : [ {
                     "$ref" : "#/definitions/pipeline/steps/custom/ContainerK8sInfra"
+                  }, {
+                    "$ref" : "#/definitions/pipeline/steps/custom/ContainerECSDirectInfra"
                   } ]
                 },
                 "metadata" : {
@@ -43866,6 +45062,8 @@ const schema: Record<string, any> = {
               "infrastructure" : {
                 "oneOf" : [ {
                   "$ref" : "#/definitions/pipeline/steps/custom/ContainerK8sInfra"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/custom/ContainerECSDirectInfra"
                 } ]
               },
               "metadata" : {
@@ -43945,7 +45143,7 @@ const schema: Record<string, any> = {
             "properties" : {
               "type" : {
                 "type" : "string",
-                "enum" : [ "KubernetesDirect", "VM" ]
+                "enum" : [ "KubernetesDirect", "VM", "ECSDirect" ]
               },
               "description" : {
                 "desc" : "This is the description for ContainerStepInfra"
@@ -44217,6 +45415,161 @@ const schema: Record<string, any> = {
               },
               "description" : {
                 "desc" : "This is the description for ContainerVolume"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "ContainerECSDirectInfra" : {
+            "title" : "ContainerECSDirectInfra",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/ContainerStepInfra"
+            }, {
+              "type" : "object",
+              "required" : [ "spec", "type" ],
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/pipeline/steps/custom/ECSDirectInfraYamlSpec"
+                },
+                "type" : {
+                  "type" : "string",
+                  "enum" : [ "ECSDirect" ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for ContainerECSDirectInfra"
+              }
+            }
+          },
+          "ECSDirectInfraYamlSpec" : {
+            "title" : "ECSDirectInfraYamlSpec",
+            "type" : "object",
+            "required" : [ "connectorRef" ],
+            "properties" : {
+              "connectorRef" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "harnessImageConnectorRef" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "cluster" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "region" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "subnets" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "securityGroups" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "taskRoleArn" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "executionRoleArn" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "initTimeout" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "enableExecuteCommand" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "logGroupName" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "volumes" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/CIVolume"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "containerSecurityContext" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/custom/SecurityContext"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "description" : {
+                "desc" : "This is the description for ECSDirectInfraYamlSpec"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
@@ -50256,6 +51609,510 @@ const schema: Record<string, any> = {
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#"
           },
+          "FmeFlagDefinitionInstructionsStepNode_template" : {
+            "title" : "FmeFlagDefinitionInstructionsStepNode_template",
+            "type" : "object",
+            "required" : [ "spec", "type" ],
+            "properties" : {
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "FmeFlagDefinitionInstructions" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "FmeFlagDefinitionInstructions"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagDefinitionInstructionsStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "FmeFlagDefinitionInstructionsStepInfo" : {
+            "title" : "FmeFlagDefinitionInstructionsStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "flagName", "environment", "instructions" ],
+              "properties" : {
+                "flagName" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/common/fme-flag-common-flag-name"
+                  }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                  } ]
+                },
+                "environment" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/common/fme-flag-common-environment"
+                  }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                  } ]
+                },
+                "instructions" : {
+                  "description" : "Ordered list of flag definition instructions to apply atomically. Each instruction type may appear at most once (validated when using a literal array; expressions are not checked).",
+                  "oneOf" : [ {
+                    "allOf" : [ {
+                      "type" : "array",
+                      "minItems" : 1,
+                      "items" : {
+                        "type" : "object",
+                        "additionalProperties" : false,
+                        "required" : [ "type", "value" ],
+                        "properties" : {
+                          "type" : {
+                            "type" : "string",
+                            "enum" : [ "SetDefaultTreatment", "SetBaselineTreatment", "SetTrackImpression", "SetLimitExposure", "UpdateIndividualTargets", "UpdateDynamicConfiguration", "SetTargetingRules" ]
+                          },
+                          "value" : { }
+                        },
+                        "allOf" : [ {
+                          "if" : {
+                            "properties" : {
+                              "type" : {
+                                "enum" : [ "SetDefaultTreatment" ]
+                              }
+                            }
+                          },
+                          "then" : {
+                            "properties" : {
+                              "value" : {
+                                "oneOf" : [ {
+                                  "$ref" : "#/definitions/pipeline/steps/common/fme-flag-common-treatments"
+                                }, {
+                                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                } ]
+                              }
+                            }
+                          }
+                        }, {
+                          "if" : {
+                            "properties" : {
+                              "type" : {
+                                "enum" : [ "SetBaselineTreatment" ]
+                              }
+                            }
+                          },
+                          "then" : {
+                            "properties" : {
+                              "value" : {
+                                "oneOf" : [ {
+                                  "$ref" : "#/definitions/pipeline/steps/common/fme-flag-common-treatments"
+                                }, {
+                                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                } ]
+                              }
+                            }
+                          }
+                        }, {
+                          "if" : {
+                            "properties" : {
+                              "type" : {
+                                "enum" : [ "SetTrackImpression" ]
+                              }
+                            }
+                          },
+                          "then" : {
+                            "properties" : {
+                              "value" : {
+                                "oneOf" : [ {
+                                  "type" : "boolean"
+                                }, {
+                                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                } ]
+                              }
+                            }
+                          }
+                        }, {
+                          "if" : {
+                            "properties" : {
+                              "type" : {
+                                "enum" : [ "SetLimitExposure" ]
+                              }
+                            }
+                          },
+                          "then" : {
+                            "properties" : {
+                              "value" : {
+                                "oneOf" : [ {
+                                  "type" : "integer",
+                                  "minimum" : 0,
+                                  "maximum" : 100
+                                }, {
+                                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                } ]
+                              }
+                            }
+                          }
+                        }, {
+                          "if" : {
+                            "properties" : {
+                              "type" : {
+                                "enum" : [ "UpdateIndividualTargets" ]
+                              }
+                            }
+                          },
+                          "then" : {
+                            "properties" : {
+                              "value" : {
+                                "oneOf" : [ {
+                                  "type" : "array",
+                                  "minItems" : 1,
+                                  "items" : {
+                                    "type" : "object",
+                                    "required" : [ "treatment", "actions" ],
+                                    "properties" : {
+                                      "treatment" : {
+                                        "$ref" : "#/definitions/pipeline/steps/common/fme-flag-common-treatments"
+                                      },
+                                      "actions" : {
+                                        "type" : "array",
+                                        "minItems" : 1,
+                                        "items" : {
+                                          "type" : "object",
+                                          "required" : [ "action", "value" ],
+                                          "properties" : {
+                                            "action" : {
+                                              "type" : "string",
+                                              "enum" : [ "AddKeys", "RemoveKeys", "AddSegments", "RemoveSegments", "SetKeys", "SetSegments" ]
+                                            },
+                                            "value" : {
+                                              "type" : "array",
+                                              "minItems" : 1,
+                                              "items" : {
+                                                "type" : "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }, {
+                                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                } ]
+                              }
+                            }
+                          }
+                        }, {
+                          "if" : {
+                            "properties" : {
+                              "type" : {
+                                "enum" : [ "UpdateDynamicConfiguration" ]
+                              }
+                            }
+                          },
+                          "then" : {
+                            "properties" : {
+                              "value" : {
+                                "oneOf" : [ {
+                                  "type" : "array",
+                                  "minItems" : 1,
+                                  "items" : {
+                                    "type" : "object",
+                                    "required" : [ "treatment", "configuration" ],
+                                    "properties" : {
+                                      "treatment" : {
+                                        "$ref" : "#/definitions/pipeline/steps/common/fme-flag-common-treatments"
+                                      },
+                                      "configuration" : {
+                                        "type" : [ "string", "null" ]
+                                      }
+                                    }
+                                  }
+                                }, {
+                                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                } ]
+                              }
+                            }
+                          }
+                        }, {
+                          "if" : {
+                            "properties" : {
+                              "type" : {
+                                "enum" : [ "SetTargetingRules" ]
+                              }
+                            }
+                          },
+                          "then" : {
+                            "properties" : {
+                              "value" : {
+                                "oneOf" : [ {
+                                  "type" : "array",
+                                  "items" : {
+                                    "type" : "object",
+                                    "required" : [ "condition", "allocation" ],
+                                    "properties" : {
+                                      "condition" : {
+                                        "description" : "Condition object containing rules",
+                                        "type" : "object",
+                                        "required" : [ "rules" ],
+                                        "properties" : {
+                                          "rules" : {
+                                            "description" : "List of condition rules",
+                                            "type" : "array",
+                                            "items" : {
+                                              "type" : "object",
+                                              "required" : [ "type" ],
+                                              "properties" : {
+                                                "type" : {
+                                                  "type" : "string",
+                                                  "enum" : [ "IN_SEGMENT", "IN_SPLIT", "BOOLEAN", "ON_DATE", "ON_OR_AFTER_DATE", "ON_OR_BEFORE_DATE", "BETWEEN_DATE", "EQUAL_SET", "ANY_OF_SET", "ALL_OF_SET", "PART_OF_SET", "EQUAL_NUMBER", "LESS_THAN_OR_EQUAL_NUMBER", "GREATER_THAN_OR_EQUAL_NUMBER", "BETWEEN_NUMBER", "IN_LIST_STRING", "STARTS_WITH_STRING", "ENDS_WITH_STRING", "CONTAINS_STRING", "MATCHES_STRING", "EQUAL_TO_SEMVER", "GREATER_THAN_OR_EQUAL_TO_SEMVER", "LESS_THAN_OR_EQUAL_TO_SEMVER", "BETWEEN_SEMVER", "IN_LIST_SEMVER" ]
+                                                },
+                                                "negate" : {
+                                                  "type" : "boolean",
+                                                  "default" : false
+                                                },
+                                                "feature_flag" : {
+                                                  "description" : "Feature flag name (only for IN_SPLIT type)",
+                                                  "oneOf" : [ {
+                                                    "$ref" : "#/definitions/pipeline/steps/common/fme-flag-common-flag-name"
+                                                  }, {
+                                                    "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                                  } ]
+                                                },
+                                                "attribute" : {
+                                                  "description" : "Attribute name for attribute-based matchers",
+                                                  "type" : "string"
+                                                },
+                                                "value" : {
+                                                  "description" : "Value for the matcher (can be single, multiple, or between)",
+                                                  "oneOf" : [ {
+                                                    "type" : "boolean"
+                                                  }, {
+                                                    "type" : "number"
+                                                  }, {
+                                                    "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                                                  }, {
+                                                    "type" : "array",
+                                                    "items" : {
+                                                      "oneOf" : [ {
+                                                        "type" : "number"
+                                                      }, {
+                                                        "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                                                      }, {
+                                                        "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                                      } ]
+                                                    }
+                                                  }, {
+                                                    "type" : "object",
+                                                    "required" : [ "from", "to" ],
+                                                    "properties" : {
+                                                      "from" : {
+                                                        "oneOf" : [ {
+                                                          "type" : "number"
+                                                        }, {
+                                                          "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                                                        }, {
+                                                          "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                                        } ]
+                                                      },
+                                                      "to" : {
+                                                        "oneOf" : [ {
+                                                          "type" : "number"
+                                                        }, {
+                                                          "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                                                        }, {
+                                                          "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                                        } ]
+                                                      }
+                                                    }
+                                                  }, {
+                                                    "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                                  } ]
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "allocation" : {
+                                        "description" : "Traffic allocation across treatments",
+                                        "oneOf" : [ {
+                                          "type" : "array",
+                                          "items" : {
+                                            "type" : "object",
+                                            "required" : [ "treatment", "size" ],
+                                            "properties" : {
+                                              "treatment" : {
+                                                "oneOf" : [ {
+                                                  "$ref" : "#/definitions/pipeline/steps/common/fme-flag-common-treatments"
+                                                }, {
+                                                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                                } ]
+                                              },
+                                              "size" : {
+                                                "oneOf" : [ {
+                                                  "type" : "integer",
+                                                  "minimum" : 0,
+                                                  "maximum" : 100
+                                                }, {
+                                                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                                } ]
+                                              }
+                                            }
+                                          }
+                                        }, {
+                                          "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                        } ]
+                                      }
+                                    }
+                                  }
+                                }, {
+                                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                                } ]
+                              }
+                            }
+                          }
+                        } ]
+                      }
+                    }, {
+                      "type" : "array",
+                      "minContains" : 0,
+                      "maxContains" : 1,
+                      "contains" : {
+                        "type" : "object",
+                        "required" : [ "type" ],
+                        "properties" : {
+                          "type" : {
+                            "const" : "SetDefaultTreatment"
+                          }
+                        }
+                      }
+                    }, {
+                      "type" : "array",
+                      "minContains" : 0,
+                      "maxContains" : 1,
+                      "contains" : {
+                        "type" : "object",
+                        "required" : [ "type" ],
+                        "properties" : {
+                          "type" : {
+                            "const" : "SetBaselineTreatment"
+                          }
+                        }
+                      }
+                    }, {
+                      "type" : "array",
+                      "minContains" : 0,
+                      "maxContains" : 1,
+                      "contains" : {
+                        "type" : "object",
+                        "required" : [ "type" ],
+                        "properties" : {
+                          "type" : {
+                            "const" : "SetTrackImpression"
+                          }
+                        }
+                      }
+                    }, {
+                      "type" : "array",
+                      "minContains" : 0,
+                      "maxContains" : 1,
+                      "contains" : {
+                        "type" : "object",
+                        "required" : [ "type" ],
+                        "properties" : {
+                          "type" : {
+                            "const" : "SetLimitExposure"
+                          }
+                        }
+                      }
+                    }, {
+                      "type" : "array",
+                      "minContains" : 0,
+                      "maxContains" : 1,
+                      "contains" : {
+                        "type" : "object",
+                        "required" : [ "type" ],
+                        "properties" : {
+                          "type" : {
+                            "const" : "UpdateIndividualTargets"
+                          }
+                        }
+                      }
+                    }, {
+                      "type" : "array",
+                      "minContains" : 0,
+                      "maxContains" : 1,
+                      "contains" : {
+                        "type" : "object",
+                        "required" : [ "type" ],
+                        "properties" : {
+                          "type" : {
+                            "const" : "UpdateDynamicConfiguration"
+                          }
+                        }
+                      }
+                    }, {
+                      "type" : "array",
+                      "minContains" : 0,
+                      "maxContains" : 1,
+                      "contains" : {
+                        "type" : "object",
+                        "required" : [ "type" ],
+                        "properties" : {
+                          "type" : {
+                            "const" : "SetTargetingRules"
+                          }
+                        }
+                      }
+                    } ]
+                  }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "https://json-schema.org/draft/2019-09/schema"
+          },
           "EventListenerStepNode_template" : {
             "title" : "EventListenerStepNode_template",
             "type" : "object",
@@ -53870,6 +55727,83 @@ const schema: Record<string, any> = {
               }
             } ]
           },
+          "FmeFlagDefinitionInstructionsStepNode" : {
+            "title" : "FmeFlagDefinitionInstructionsStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for FmeFlagDefinitionInstructionsStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "FmeFlagDefinitionInstructions" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "FmeFlagDefinitionInstructions"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagDefinitionInstructionsStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
           "VmInfraSpec" : {
             "title" : "VmInfraSpec",
             "type" : "object",
@@ -54134,7 +56068,876 @@ const schema: Record<string, any> = {
             }
           }
         },
+        "resiliencetesting" : {
+          "ChaosStepNode_template" : {
+            "title" : "ChaosStepNode_template",
+            "type" : "object",
+            "required" : [ "spec", "type" ],
+            "properties" : {
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "Chaos" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "Chaos"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "ChaosStepInfo" : {
+            "title" : "ChaosStepInfo",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "identifier" : {
+                    "type" : "string"
+                  },
+                  "kind" : {
+                    "const" : "template"
+                  }
+                },
+                "required" : [ "identifier", "kind" ]
+              },
+              "then" : {
+                "required" : [ "hubRef", "infraReference" ]
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "expectedResilienceScore" ],
+            "properties" : {
+              "assertion" : {
+                "type" : "string"
+              },
+              "expectedResilienceScore" : {
+                "oneOf" : [ {
+                  "type" : "number",
+                  "format" : "double"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "experimentRef" : {
+                "type" : "string",
+                "minLength" : 1
+              },
+              "identifier" : {
+                "type" : "string",
+                "minLength" : 1
+              },
+              "kind" : {
+                "type" : "string",
+                "enum" : [ "experiment", "template" ]
+              },
+              "hubRef" : {
+                "type" : "string",
+                "minLength" : 1
+              },
+              "infraReference" : {
+                "oneOf" : [ {
+                  "type" : "string",
+                  "minLength" : 1,
+                  "not" : {
+                    "pattern" : "(<\\+.+>.*)"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "tasks" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "required" : [ "identifier" ],
+                    "properties" : {
+                      "identifier" : {
+                        "type" : "string",
+                        "minLength" : 1
+                      },
+                      "values" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "required" : [ "name", "value" ],
+                          "properties" : {
+                            "name" : {
+                              "type" : "string",
+                              "minLength" : 1
+                            },
+                            "value" : {
+                              "anyOf" : [ {
+                                "type" : "string"
+                              }, {
+                                "type" : "number"
+                              }, {
+                                "type" : "boolean"
+                              }, {
+                                "type" : "string",
+                                "pattern" : "(<\\+.+>.*)"
+                              } ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "description" : {
+                "desc" : "This is the description for ChaosStepInfo"
+              }
+            },
+            "anyOf" : [ {
+              "required" : [ "experimentRef" ]
+            }, {
+              "required" : [ "identifier" ]
+            } ]
+          },
+          "LoadTestStepNode_template" : {
+            "title" : "LoadTestStepNode_template",
+            "type" : "object",
+            "required" : [ "spec", "type" ],
+            "properties" : {
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "LoadTest" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "LoadTest"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/resiliencetesting/LoadTestStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "LoadTestStepInfo" : {
+            "title" : "LoadTestStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "loadTestRef" ],
+              "properties" : {
+                "loadTestRef" : {
+                  "type" : "string",
+                  "minLength" : 1
+                },
+                "targetUsers" : {
+                  "oneOf" : [ {
+                    "type" : "integer"
+                  }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                  } ]
+                },
+                "rampUpTimeSec" : {
+                  "oneOf" : [ {
+                    "type" : "integer"
+                  }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                  } ]
+                },
+                "durationSeconds" : {
+                  "oneOf" : [ {
+                    "type" : "integer"
+                  }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "ChaosStepNode" : {
+            "title" : "ChaosStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for ChaosStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "Chaos" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "Chaos"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "LoadTestStepNode" : {
+            "title" : "LoadTestStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for LoadTestStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "LoadTest" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "LoadTest"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/resiliencetesting/LoadTestStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "ChaosProbeNode" : {
+            "title" : "ChaosProbeNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for ChaosProbeNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "ChaosProbe" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "ChaosProbe"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosProbeInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "ChaosProbeInfo" : {
+            "title" : "ChaosProbeInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "identity", "duration", "infraReference" ],
+              "properties" : {
+                "identity" : {
+                  "type" : "string"
+                },
+                "duration" : {
+                  "type" : "string"
+                },
+                "infraReference" : {
+                  "type" : "string"
+                },
+                "tasks" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "required" : [ "identifier" ],
+                      "properties" : {
+                        "identifier" : {
+                          "type" : "string",
+                          "minLength" : 1
+                        },
+                        "values" : {
+                          "type" : "array",
+                          "items" : {
+                            "type" : "object",
+                            "required" : [ "name", "value" ],
+                            "properties" : {
+                              "name" : {
+                                "type" : "string",
+                                "minLength" : 1
+                              },
+                              "value" : {
+                                "anyOf" : [ {
+                                  "type" : "string"
+                                }, {
+                                  "type" : "number"
+                                }, {
+                                  "type" : "boolean"
+                                }, {
+                                  "type" : "string",
+                                  "pattern" : "(<\\+.+>.*)"
+                                } ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "ChaosActionNode" : {
+            "title" : "ChaosActionNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for ChaosActionNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "ChaosAction" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "ChaosAction"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosActionInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "ChaosActionInfo" : {
+            "title" : "ChaosActionInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "identity", "duration", "infraReference" ],
+              "properties" : {
+                "identity" : {
+                  "type" : "string"
+                },
+                "duration" : {
+                  "type" : "string"
+                },
+                "infraReference" : {
+                  "type" : "string"
+                },
+                "tasks" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "required" : [ "identifier" ],
+                      "properties" : {
+                        "identifier" : {
+                          "type" : "string",
+                          "minLength" : 1
+                        },
+                        "values" : {
+                          "type" : "array",
+                          "items" : {
+                            "type" : "object",
+                            "required" : [ "name", "value" ],
+                            "properties" : {
+                              "name" : {
+                                "type" : "string",
+                                "minLength" : 1
+                              },
+                              "value" : {
+                                "anyOf" : [ {
+                                  "type" : "string"
+                                }, {
+                                  "type" : "number"
+                                }, {
+                                  "type" : "boolean"
+                                }, {
+                                  "type" : "string",
+                                  "pattern" : "(<\\+.+>.*)"
+                                } ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "ChaosFaultNode" : {
+            "title" : "ChaosFaultNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for ChaosFaultNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "ChaosFault" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "ChaosFault"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosFaultInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "ChaosFaultInfo" : {
+            "title" : "ChaosFaultInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "identity", "infraReference" ],
+              "properties" : {
+                "identity" : {
+                  "type" : "string"
+                },
+                "infraReference" : {
+                  "type" : "string"
+                },
+                "tasks" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "object",
+                      "required" : [ "identifier" ],
+                      "properties" : {
+                        "identifier" : {
+                          "type" : "string",
+                          "minLength" : 1
+                        },
+                        "values" : {
+                          "type" : "array",
+                          "items" : {
+                            "type" : "object",
+                            "required" : [ "name", "value" ],
+                            "properties" : {
+                              "name" : {
+                                "type" : "string",
+                                "minLength" : 1
+                              },
+                              "value" : {
+                                "anyOf" : [ {
+                                  "type" : "string"
+                                }, {
+                                  "type" : "number"
+                                }, {
+                                  "type" : "boolean"
+                                }, {
+                                  "type" : "string",
+                                  "pattern" : "(<\\+.+>.*)"
+                                } ]
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          }
+        },
         "common" : {
+          "common-jexl" : {
+            "title" : "common-jexl",
+            "type" : "string",
+            "pattern" : "(<\\+.+>.*)"
+          },
           "ParameterFieldMapStringString" : {
             "title" : "ParameterFieldMapStringString",
             "type" : "object",
@@ -69316,8 +72119,14 @@ const schema: Record<string, any> = {
                   "$ref" : "#/definitions/pipeline/steps/ci/ParameterFieldListString"
                 },
                 "config" : {
-                  "type" : "string",
-                  "enum" : [ "default" ]
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "enum" : [ "default", "sast", "sca", "sast_sca" ]
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 },
                 "connectorRef" : {
                   "type" : "string"
@@ -69406,8 +72215,14 @@ const schema: Record<string, any> = {
                 "$ref" : "#/definitions/pipeline/steps/ci/ParameterFieldListString"
               },
               "config" : {
-                "type" : "string",
-                "enum" : [ "default" ]
+                "oneOf" : [ {
+                  "type" : "string",
+                  "enum" : [ "default", "sast", "sca", "sast_sca" ]
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
               },
               "connectorRef" : {
                 "type" : "string"
@@ -70268,10 +73083,20 @@ const schema: Record<string, any> = {
               "pattern" : "^<\\+.*>.*$"
             }
           },
-          "common-jexl" : {
-            "title" : "common-jexl",
-            "type" : "string",
-            "pattern" : "(<\\+.+>.*)"
+          "CIVolume" : {
+            "title" : "CIVolume",
+            "type" : "object",
+            "discriminator" : "type",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "EmptyDir", "PersistentVolumeClaim", "HostPath" ]
+              },
+              "description" : {
+                "desc" : "This is the description for CIVolume"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
           },
           "fme-flag-common-flag-name" : {
             "title" : "fme-flag-common-flag-name",
@@ -72395,7 +75220,7 @@ const schema: Record<string, any> = {
               "then" : {
                 "properties" : {
                   "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/LocalSourceSpec"
+                    "$ref" : "#/definitions/pipeline/steps/common/SlsaVerificationLocalSourceSpec"
                   }
                 }
               }
@@ -72588,10 +75413,10 @@ const schema: Record<string, any> = {
               }
             }
           },
-          "LocalSourceSpec" : {
-            "title" : "LocalSourceSpec",
+          "SlsaVerificationLocalSourceSpec" : {
+            "title" : "SlsaVerificationLocalSourceSpec",
             "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/SlsaVerificationSource"
+              "$ref" : "#/definitions/pipeline/steps/common/SlsaVerificationSourceSpec"
             }, {
               "type" : "object",
               "required" : [ "workspace", "type" ],
@@ -72646,7 +75471,7 @@ const schema: Record<string, any> = {
             "properties" : {
               "type" : {
                 "type" : "string",
-                "enum" : [ "cosign" ]
+                "enum" : [ "cosign", "keyless", "keybased", "secret-manager" ]
               },
               "description" : {
                 "desc" : "This is the description for SlsaVerifyAttestation"
@@ -72673,6 +75498,54 @@ const schema: Record<string, any> = {
                     }, {
                       "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
                     } ]
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "keyless"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "type" : "object",
+                    "$ref" : "#/definitions/pipeline/steps/common/KeylessSlsaVerifyAttestation"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "keybased"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "type" : "object",
+                    "$ref" : "#/definitions/pipeline/steps/common/CosignSlsaVerifyAttestation"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "secret-manager"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "type" : "object",
+                    "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
                   }
                 }
               }
@@ -72725,6 +75598,18 @@ const schema: Record<string, any> = {
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "additionalProperties" : false,
             "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestationSpec"
+          },
+          "KeylessSlsaVerifyAttestation" : {
+            "title" : "KeylessSlsaVerifyAttestation",
+            "type" : "object",
+            "properties" : {
+              "oidcProvider" : {
+                "type" : "string",
+                "enum" : [ "harness", "non-harness" ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false
           },
           "WizScanNode_template" : {
             "title" : "WizScanNode_template",
@@ -73725,6 +76610,58 @@ const schema: Record<string, any> = {
             "properties" : {
               "description" : {
                 "desc" : "This is the description for GarSourceSpec"
+              }
+            }
+          },
+          "LocalSourceSpec" : {
+            "title" : "LocalSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "workspace", "type" ],
+              "properties" : {
+                "type" : {
+                  "type" : "string",
+                  "enum" : [ "manual", "auto" ]
+                },
+                "workspace" : {
+                  "type" : "string"
+                },
+                "artifact_name" : {
+                  "type" : "string",
+                  "description" : "Required when type is manual",
+                  "if" : {
+                    "properties" : {
+                      "type" : {
+                        "const" : "manual"
+                      }
+                    }
+                  },
+                  "then" : {
+                    "minLength" : 1
+                  }
+                },
+                "version" : {
+                  "type" : "string",
+                  "description" : "Required when type is manual",
+                  "if" : {
+                    "properties" : {
+                      "type" : {
+                        "const" : "manual"
+                      }
+                    }
+                  },
+                  "then" : {
+                    "minLength" : 1
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for LocalSourceSpec"
               }
             }
           },
@@ -75383,6 +78320,175 @@ const schema: Record<string, any> = {
               }
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "AgentStepNode_template" : {
+            "title" : "AgentStepNode_template",
+            "type" : "object",
+            "required" : [ "spec", "type" ],
+            "properties" : {
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "Agent" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "Agent"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/AgentStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "AgentStepInfo" : {
+            "title" : "AgentStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "agentName" ],
+              "properties" : {
+                "agentName" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                  }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                  } ]
+                },
+                "agentSettings" : {
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "not" : {
+                      "pattern" : "^<\\+.*>.*$"
+                    }
+                  }, {
+                    "type" : "object",
+                    "additionalProperties" : true
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^(<\\+.+>.*)$",
+                    "minLength" : 1
+                  } ]
+                },
+                "llmConnector" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "mcpConnectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "agentName" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/common-jexl"
+                } ]
+              },
+              "agentSettings" : {
+                "oneOf" : [ {
+                  "type" : "string",
+                  "not" : {
+                    "pattern" : "^<\\+.*>.*$"
+                  }
+                }, {
+                  "type" : "object",
+                  "additionalProperties" : true
+                }, {
+                  "type" : "string",
+                  "pattern" : "^(<\\+.+>.*)$",
+                  "minLength" : 1
+                } ]
+              },
+              "llmConnector" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/string-without-jexl"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "mcpConnectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "description" : {
+                "desc" : "This is the description for AgentStepInfo"
+              }
+            }
           },
           "BackgroundStepNode" : {
             "title" : "BackgroundStepNode",
@@ -77057,6 +80163,83 @@ const schema: Record<string, any> = {
                 "properties" : {
                   "spec" : {
                     "$ref" : "#/definitions/pipeline/steps/common/WizStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "AgentStepNode" : {
+            "title" : "AgentStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for AgentStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "Agent" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "Agent"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/AgentStepInfo"
                   }
                 }
               }
@@ -82655,21 +85838,6 @@ const schema: Record<string, any> = {
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
           },
-          "CIVolume" : {
-            "title" : "CIVolume",
-            "type" : "object",
-            "discriminator" : "type",
-            "properties" : {
-              "type" : {
-                "type" : "string",
-                "enum" : [ "EmptyDir", "PersistentVolumeClaim", "HostPath" ]
-              },
-              "description" : {
-                "desc" : "This is the description for CIVolume"
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#"
-          },
           "UseFromStageInfraYaml" : {
             "title" : "UseFromStageInfraYaml",
             "allOf" : [ {
@@ -82926,6 +86094,167 @@ const schema: Record<string, any> = {
           }
         },
         "ci" : {
+          "AiTestAutomationStepNode_template" : {
+            "title" : "AiTestAutomationStepNode_template",
+            "type" : "object",
+            "required" : [ "spec", "type" ],
+            "properties" : {
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "AiTestAutomation" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "AiTestAutomation"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/ci/AiTestAutomationStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "AiTestAutomationStepInfo" : {
+            "title" : "AiTestAutomationStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/ci/CIStepInfo"
+            }, {
+              "type" : "object",
+              "required" : [ "applicationName" ],
+              "properties" : {
+                "testType" : {
+                  "type" : "string",
+                  "enum" : [ "aiTestAutomation", "playwright" ],
+                  "description" : "Type of test: aiTestAutomation (default) or playwright"
+                },
+                "applicationName" : {
+                  "type" : "string",
+                  "description" : "Name of the application to test"
+                },
+                "environmentName" : {
+                  "type" : "string",
+                  "description" : "Name of the environment where test will be executed"
+                },
+                "testSuiteName" : {
+                  "type" : "string",
+                  "description" : "Name of the test suite to execute"
+                },
+                "tunnelName" : {
+                  "type" : "string",
+                  "description" : "Name of the tunnel to use"
+                },
+                "buildId" : {
+                  "type" : "string",
+                  "description" : "ID of the Playwright build to execute"
+                },
+                "executionAliasId" : {
+                  "type" : "string",
+                  "description" : "Execution alias ID for variable resolution"
+                },
+                "configOverride" : {
+                  "type" : "string",
+                  "description" : "Configuration override as JSON string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "applicationName" ],
+            "properties" : {
+              "testType" : {
+                "type" : "string",
+                "enum" : [ "aiTestAutomation", "playwright" ],
+                "description" : "Type of test: aiTestAutomation (default) or playwright"
+              },
+              "applicationName" : {
+                "type" : "string",
+                "description" : "Name of the application to test"
+              },
+              "environmentName" : {
+                "type" : "string",
+                "description" : "Name of the environment where test will be executed"
+              },
+              "testSuiteName" : {
+                "type" : "string",
+                "description" : "Name of the test suite to execute"
+              },
+              "tunnelName" : {
+                "type" : "string",
+                "description" : "Name of the tunnel to use"
+              },
+              "buildId" : {
+                "type" : "string",
+                "description" : "ID of the Playwright build to execute"
+              },
+              "executionAliasId" : {
+                "type" : "string",
+                "description" : "Execution alias ID for variable resolution"
+              },
+              "configOverride" : {
+                "type" : "string",
+                "description" : "Configuration override as JSON string"
+              },
+              "description" : {
+                "desc" : "This is the description for AiTestAutomationStepInfo"
+              }
+            }
+          },
+          "CIStepInfo" : {
+            "title" : "CIStepInfo",
+            "type" : "object",
+            "discriminator" : "type",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for CIStepInfo"
+              }
+            }
+          },
           "ArtifactoryUploadNode_template" : {
             "title" : "ArtifactoryUploadNode_template",
             "type" : "object",
@@ -83061,17 +86390,6 @@ const schema: Record<string, any> = {
               },
               "description" : {
                 "desc" : "This is the description for UploadToArtifactoryStepInfo"
-              }
-            }
-          },
-          "CIStepInfo" : {
-            "title" : "CIStepInfo",
-            "type" : "object",
-            "discriminator" : "type",
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for CIStepInfo"
               }
             }
           },
@@ -86511,6 +89829,250 @@ const schema: Record<string, any> = {
               }
             }
           },
+          "RunTestStepV2Node_template" : {
+            "title" : "RunTestStepV2Node_template",
+            "type" : "object",
+            "required" : [ "spec", "type" ],
+            "properties" : {
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "Test" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "Test"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/ci/RunTestStepV2Info"
+                  }
+                }
+              }
+            } ]
+          },
+          "RunTestStepV2Info" : {
+            "title" : "RunTestStepV2Info",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "command" : {
+                  "type" : "string"
+                },
+                "connectorRef" : {
+                  "type" : "string"
+                },
+                "envVariables" : {
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string"
+                  } ]
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "imagePullPolicy" : {
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "enum" : [ "Always", "Never", "IfNotPresent" ]
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "outputVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "anyOf" : [ {
+                      "$ref" : "#/definitions/pipeline/common/NumberNGVariable"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/common/SecretNGVariable"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/common/StringNGVariable"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/common/OutputNGVariable"
+                    } ]
+                  }
+                },
+                "privileged" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "reports" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/common/UnitTestReport"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                },
+                "runAsUser" : {
+                  "oneOf" : [ {
+                    "type" : "integer",
+                    "format" : "int32"
+                  }, {
+                    "type" : "string"
+                  } ]
+                },
+                "shell" : {
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "enum" : [ "Sh", "Bash", "Powershell", "Pwsh", "Python" ]
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "command" : {
+                "type" : "string"
+              },
+              "connectorRef" : {
+                "type" : "string"
+              },
+              "envVariables" : {
+                "oneOf" : [ {
+                  "type" : "object",
+                  "additionalProperties" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "image" : {
+                "type" : "string"
+              },
+              "imagePullPolicy" : {
+                "oneOf" : [ {
+                  "type" : "string",
+                  "enum" : [ "Always", "Never", "IfNotPresent" ]
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "outputVariables" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/OutputNGVariable"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "privileged" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "reports" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/UnitTestReport"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "runAsUser" : {
+                "oneOf" : [ {
+                  "type" : "integer",
+                  "format" : "int32"
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "shell" : {
+                "oneOf" : [ {
+                  "type" : "string",
+                  "enum" : [ "Sh", "Bash", "Powershell", "Pwsh", "Python" ]
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "description" : {
+                "desc" : "This is the description for RunTestStepV2Info"
+              }
+            }
+          },
           "S3UploadNode_template" : {
             "title" : "S3UploadNode_template",
             "type" : "object",
@@ -87444,6 +91006,83 @@ const schema: Record<string, any> = {
                 "properties" : {
                   "spec" : {
                     "$ref" : "#/definitions/pipeline/steps/ci/UploadToS3StepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "AiTestAutomationStepNode" : {
+            "title" : "AiTestAutomationStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for AiTestAutomationStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "AiTestAutomation" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "AiTestAutomation"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/ci/AiTestAutomationStepInfo"
                   }
                 }
               }
@@ -88864,185 +92503,6 @@ const schema: Record<string, any> = {
                 }
               }
             } ]
-          },
-          "RunTestStepV2Info" : {
-            "title" : "RunTestStepV2Info",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/common/StepSpecType"
-            }, {
-              "type" : "object",
-              "properties" : {
-                "command" : {
-                  "type" : "string"
-                },
-                "connectorRef" : {
-                  "type" : "string"
-                },
-                "envVariables" : {
-                  "oneOf" : [ {
-                    "type" : "object",
-                    "additionalProperties" : {
-                      "type" : "string"
-                    }
-                  }, {
-                    "type" : "string"
-                  } ]
-                },
-                "image" : {
-                  "type" : "string"
-                },
-                "imagePullPolicy" : {
-                  "oneOf" : [ {
-                    "type" : "string",
-                    "enum" : [ "Always", "Never", "IfNotPresent" ]
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                },
-                "outputVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "anyOf" : [ {
-                      "$ref" : "#/definitions/pipeline/common/NumberNGVariable"
-                    }, {
-                      "$ref" : "#/definitions/pipeline/common/SecretNGVariable"
-                    }, {
-                      "$ref" : "#/definitions/pipeline/common/StringNGVariable"
-                    }, {
-                      "$ref" : "#/definitions/pipeline/common/OutputNGVariable"
-                    } ]
-                  }
-                },
-                "privileged" : {
-                  "oneOf" : [ {
-                    "type" : "boolean"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
-                },
-                "reports" : {
-                  "oneOf" : [ {
-                    "$ref" : "#/definitions/pipeline/steps/common/UnitTestReport"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
-                },
-                "resources" : {
-                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
-                },
-                "runAsUser" : {
-                  "oneOf" : [ {
-                    "type" : "integer",
-                    "format" : "int32"
-                  }, {
-                    "type" : "string"
-                  } ]
-                },
-                "shell" : {
-                  "oneOf" : [ {
-                    "type" : "string",
-                    "enum" : [ "Sh", "Bash", "Powershell", "Pwsh", "Python" ]
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "type" : "object",
-            "properties" : {
-              "command" : {
-                "type" : "string"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "envVariables" : {
-                "oneOf" : [ {
-                  "type" : "object",
-                  "additionalProperties" : {
-                    "type" : "string"
-                  }
-                }, {
-                  "type" : "string"
-                } ]
-              },
-              "image" : {
-                "type" : "string"
-              },
-              "imagePullPolicy" : {
-                "oneOf" : [ {
-                  "type" : "string",
-                  "enum" : [ "Always", "Never", "IfNotPresent" ]
-                }, {
-                  "type" : "string",
-                  "pattern" : "(<\\+.+>.*)",
-                  "minLength" : 1
-                } ]
-              },
-              "outputVariables" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/common/OutputNGVariable"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
-              },
-              "privileged" : {
-                "oneOf" : [ {
-                  "type" : "boolean"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
-              },
-              "reports" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/steps/common/UnitTestReport"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|selectManyFrom|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
-              },
-              "resources" : {
-                "$ref" : "#/definitions/pipeline/common/ContainerResource"
-              },
-              "runAsUser" : {
-                "oneOf" : [ {
-                  "type" : "integer",
-                  "format" : "int32"
-                }, {
-                  "type" : "string"
-                } ]
-              },
-              "shell" : {
-                "oneOf" : [ {
-                  "type" : "string",
-                  "enum" : [ "Sh", "Bash", "Powershell", "Pwsh", "Python" ]
-                }, {
-                  "type" : "string",
-                  "pattern" : "(<\\+.+>.*)",
-                  "minLength" : 1
-                } ]
-              },
-              "description" : {
-                "desc" : "This is the description for RunTestStepV2Info"
-              }
-            }
           },
           "SaveCacheGCSNode" : {
             "title" : "SaveCacheGCSNode",
@@ -94803,429 +98263,6 @@ const schema: Record<string, any> = {
               }
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#"
-          },
-          "ChaosProbeNode" : {
-            "title" : "ChaosProbeNode",
-            "type" : "object",
-            "required" : [ "identifier", "name", "spec", "type" ],
-            "properties" : {
-              "description" : {
-                "type" : "string",
-                "desc" : "This is the description for ChaosProbeNode"
-              },
-              "enforce" : {
-                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
-              },
-              "failureStrategies" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "identifier" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
-              },
-              "name" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
-              },
-              "strategy" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "timeout" : {
-                "type" : "string",
-                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
-              },
-              "type" : {
-                "type" : "string",
-                "enum" : [ "ChaosProbe" ]
-              },
-              "when" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "ChaosProbe"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/drtest/ChaosProbeInfo"
-                  }
-                }
-              }
-            } ]
-          },
-          "ChaosProbeInfo" : {
-            "title" : "ChaosProbeInfo",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/common/StepSpecType"
-            }, {
-              "type" : "object",
-              "required" : [ "identity", "duration", "infraReference" ],
-              "properties" : {
-                "identity" : {
-                  "type" : "string"
-                },
-                "duration" : {
-                  "type" : "string"
-                },
-                "infraReference" : {
-                  "type" : "string"
-                },
-                "tasks" : {
-                  "oneOf" : [ {
-                    "type" : "array",
-                    "items" : {
-                      "type" : "object",
-                      "required" : [ "identifier" ],
-                      "properties" : {
-                        "identifier" : {
-                          "type" : "string",
-                          "minLength" : 1
-                        },
-                        "values" : {
-                          "type" : "array",
-                          "items" : {
-                            "type" : "object",
-                            "required" : [ "name", "value" ],
-                            "properties" : {
-                              "name" : {
-                                "type" : "string",
-                                "minLength" : 1
-                              },
-                              "value" : {
-                                "anyOf" : [ {
-                                  "type" : "string"
-                                }, {
-                                  "type" : "number"
-                                }, {
-                                  "type" : "boolean"
-                                }, {
-                                  "type" : "string",
-                                  "pattern" : "(<\\+.+>.*)"
-                                } ]
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#"
-          },
-          "ChaosActionNode" : {
-            "title" : "ChaosActionNode",
-            "type" : "object",
-            "required" : [ "identifier", "name", "spec", "type" ],
-            "properties" : {
-              "description" : {
-                "type" : "string",
-                "desc" : "This is the description for ChaosActionNode"
-              },
-              "enforce" : {
-                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
-              },
-              "failureStrategies" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "identifier" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
-              },
-              "name" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
-              },
-              "strategy" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "timeout" : {
-                "type" : "string",
-                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
-              },
-              "type" : {
-                "type" : "string",
-                "enum" : [ "ChaosAction" ]
-              },
-              "when" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "ChaosAction"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/drtest/ChaosActionInfo"
-                  }
-                }
-              }
-            } ]
-          },
-          "ChaosActionInfo" : {
-            "title" : "ChaosActionInfo",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/common/StepSpecType"
-            }, {
-              "type" : "object",
-              "required" : [ "identity", "duration", "infraReference" ],
-              "properties" : {
-                "identity" : {
-                  "type" : "string"
-                },
-                "duration" : {
-                  "type" : "string"
-                },
-                "infraReference" : {
-                  "type" : "string"
-                },
-                "tasks" : {
-                  "oneOf" : [ {
-                    "type" : "array",
-                    "items" : {
-                      "type" : "object",
-                      "required" : [ "identifier" ],
-                      "properties" : {
-                        "identifier" : {
-                          "type" : "string",
-                          "minLength" : 1
-                        },
-                        "values" : {
-                          "type" : "array",
-                          "items" : {
-                            "type" : "object",
-                            "required" : [ "name", "value" ],
-                            "properties" : {
-                              "name" : {
-                                "type" : "string",
-                                "minLength" : 1
-                              },
-                              "value" : {
-                                "anyOf" : [ {
-                                  "type" : "string"
-                                }, {
-                                  "type" : "number"
-                                }, {
-                                  "type" : "boolean"
-                                }, {
-                                  "type" : "string",
-                                  "pattern" : "(<\\+.+>.*)"
-                                } ]
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#"
-          },
-          "ChaosFaultNode" : {
-            "title" : "ChaosFaultNode",
-            "type" : "object",
-            "required" : [ "identifier", "name", "spec", "type" ],
-            "properties" : {
-              "description" : {
-                "type" : "string",
-                "desc" : "This is the description for ChaosFaultNode"
-              },
-              "enforce" : {
-                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
-              },
-              "failureStrategies" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "identifier" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
-              },
-              "name" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
-              },
-              "strategy" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "timeout" : {
-                "type" : "string",
-                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
-              },
-              "type" : {
-                "type" : "string",
-                "enum" : [ "ChaosFault" ]
-              },
-              "when" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "ChaosFault"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/drtest/ChaosFaultInfo"
-                  }
-                }
-              }
-            } ]
-          },
-          "ChaosFaultInfo" : {
-            "title" : "ChaosFaultInfo",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/common/StepSpecType"
-            }, {
-              "type" : "object",
-              "required" : [ "identity", "infraReference" ],
-              "properties" : {
-                "identity" : {
-                  "type" : "string"
-                },
-                "infraReference" : {
-                  "type" : "string"
-                },
-                "tasks" : {
-                  "oneOf" : [ {
-                    "type" : "array",
-                    "items" : {
-                      "type" : "object",
-                      "required" : [ "identifier" ],
-                      "properties" : {
-                        "identifier" : {
-                          "type" : "string",
-                          "minLength" : 1
-                        },
-                        "values" : {
-                          "type" : "array",
-                          "items" : {
-                            "type" : "object",
-                            "required" : [ "name", "value" ],
-                            "properties" : {
-                              "name" : {
-                                "type" : "string",
-                                "minLength" : 1
-                              },
-                              "value" : {
-                                "anyOf" : [ {
-                                  "type" : "string"
-                                }, {
-                                  "type" : "number"
-                                }, {
-                                  "type" : "boolean"
-                                }, {
-                                  "type" : "string",
-                                  "pattern" : "(<\\+.+>.*)"
-                                } ]
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#"
           }
         }
       },
@@ -96471,7 +99508,7 @@ const schema: Record<string, any> = {
           "properties" : {
             "type" : {
               "type" : "string",
-              "enum" : [ "KubernetesDirect", "Delegate", "Noop", "VM" ]
+              "enum" : [ "KubernetesDirect", "Delegate", "Noop", "VM", "ECSDirect" ]
             },
             "description" : {
               "desc" : "This is the description for StepGroupInfra"
@@ -96500,6 +99537,30 @@ const schema: Record<string, any> = {
           "properties" : {
             "description" : {
               "desc" : "This is the description for VMInfra"
+            }
+          }
+        },
+        "ECSDirectInfra" : {
+          "title" : "ECSDirectInfra",
+          "allOf" : [ {
+            "$ref" : "#/definitions/pipeline/common/StepGroupInfra"
+          }, {
+            "type" : "object",
+            "required" : [ "spec", "type" ],
+            "properties" : {
+              "spec" : {
+                "$ref" : "#/definitions/pipeline/steps/custom/ECSDirectInfraYamlSpec"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "ECSDirect" ]
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#",
+          "properties" : {
+            "description" : {
+              "desc" : "This is the description for ECSDirectInfra"
             }
           }
         }
@@ -97693,7 +100754,15 @@ const schema: Record<string, any> = {
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/UpdateReleaseRepoStepNode"
                 }, {
-                  "$ref" : "#/definitions/pipeline/steps/cd/ChaosStepNode"
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/LoadTestStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosProbeNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosActionNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosFaultNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/AiTestAutomationStepNode"
                 }, {
@@ -97758,6 +100827,8 @@ const schema: Record<string, any> = {
                   "$ref" : "#/definitions/pipeline/steps/common/RunStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/AiVerifyStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/AIVerifyNGStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/PluginStepNode"
                 }, {
@@ -97853,6 +100924,8 @@ const schema: Record<string, any> = {
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/SalesforceRollbackStepNode"
                 }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/SalesforceSourceBackupStepNode"
+                }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/SalesforceValidateStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/SalesforceQuickDeployStepNode"
@@ -97860,6 +100933,12 @@ const schema: Record<string, any> = {
                   "$ref" : "#/definitions/pipeline/steps/cd/SalesforceCreateScratchOrgStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/SalesforceDeleteScratchOrgStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/SalesforceDownloadDeployablesStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/SalesforceDownloadOrgStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/SalesforceEvaluateDiffStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/idp/IDPSlackNotifyStepNode"
                 }, {
@@ -97890,6 +100969,8 @@ const schema: Record<string, any> = {
                   "$ref" : "#/definitions/pipeline/steps/common/FlywayCommandStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/WizScanNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/AgentStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagCreateStepNode"
                 }, {
@@ -97938,6 +101019,8 @@ const schema: Record<string, any> = {
                   "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagsetDeleteStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagAddRemoveFlagsetsStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagDefinitionInstructionsStepNode"
                 } ]
               },
               "stepGroup" : {
@@ -98069,6 +101152,8 @@ const schema: Record<string, any> = {
                   "$ref" : "#/definitions/pipeline/common/K8sDirectInfra"
                 }, {
                   "$ref" : "#/definitions/pipeline/common/VMInfra"
+                }, {
+                  "$ref" : "#/definitions/pipeline/common/ECSDirectInfra"
                 } ]
               },
               "steps" : {
@@ -105199,7 +108284,15 @@ const schema: Record<string, any> = {
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/ShellScriptProvisionStepNode"
                 }, {
-                  "$ref" : "#/definitions/pipeline/steps/cd/ChaosStepNode"
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/LoadTestStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosProbeNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosActionNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosFaultNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/AiTestAutomationStepNode"
                 }, {
@@ -105363,7 +108456,13 @@ const schema: Record<string, any> = {
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagAddRemoveFlagsetsStepNode"
                 }, {
+                  "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagDefinitionInstructionsStepNode"
+                }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/GCEProvisionBackendServiceStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/EcsScaleStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/AgentStepNode"
                 } ]
               },
               "stepGroup" : {
@@ -105475,6 +108574,8 @@ const schema: Record<string, any> = {
                   "$ref" : "#/definitions/pipeline/common/K8sDirectInfra"
                 }, {
                   "$ref" : "#/definitions/pipeline/common/VMInfra"
+                }, {
+                  "$ref" : "#/definitions/pipeline/common/ECSDirectInfra"
                 } ]
               },
               "steps" : {
@@ -106725,6 +109826,8 @@ const schema: Record<string, any> = {
                 "oneOf" : [ {
                   "$ref" : "#/definitions/pipeline/common/StepElementConfig"
                 }, {
+                  "$ref" : "#/definitions/pipeline/steps/ci/AiTestAutomationStepNode"
+                }, {
                   "$ref" : "#/definitions/pipeline/steps/ci/ArtifactoryUploadNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/ci/HarUploadNode"
@@ -106900,6 +110003,8 @@ const schema: Record<string, any> = {
                   "$ref" : "#/definitions/pipeline/steps/common/SastScanNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/ScaScanNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/AgentStepNode"
                 } ]
               },
               "stepGroup" : {
@@ -107120,23 +110225,7 @@ const schema: Record<string, any> = {
                       "$ref" : "#/definitions/pipeline/stages/ci/CosignAttestationV1"
                     }, {
                       "$ref" : "#/definitions/pipeline/stages/ci/CosignSecretManagerAttestation"
-                    } ],
-                    "properties" : {
-                      "cosignVariables" : {
-                        "type" : "array",
-                        "items" : {
-                          "type" : "object",
-                          "properties" : {
-                            "key" : {
-                              "type" : "string"
-                            },
-                            "value" : {
-                              "type" : "string"
-                            }
-                          }
-                        }
-                      }
-                    }
+                    } ]
                   }
                 }
               }
@@ -107498,7 +110587,7 @@ const schema: Record<string, any> = {
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/ShellScriptProvisionStepNode"
                 }, {
-                  "$ref" : "#/definitions/pipeline/steps/cd/ChaosStepNode"
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/TerragruntPlanStepNode"
                 }, {
@@ -107650,6 +110739,8 @@ const schema: Record<string, any> = {
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/SalesforceRollbackStepNode"
                 }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/SalesforceSourceBackupStepNode"
+                }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/SalesforceValidateStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/SalesforceQuickDeployStepNode"
@@ -107657,6 +110748,12 @@ const schema: Record<string, any> = {
                   "$ref" : "#/definitions/pipeline/steps/cd/SalesforceCreateScratchOrgStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/SalesforceDeleteScratchOrgStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/SalesforceDownloadDeployablesStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/SalesforceDownloadOrgStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/SalesforceEvaluateDiffStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/idp/IDPSlackNotifyStepNode"
                 }, {
@@ -107711,6 +110808,8 @@ const schema: Record<string, any> = {
                   "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagsetDeleteStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagAddRemoveFlagsetsStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/custom/FmeFlagDefinitionInstructionsStepNode"
                 } ]
               },
               "stepGroup" : {
@@ -109689,11 +112788,13 @@ const schema: Record<string, any> = {
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/drtest/DRTestSlackNotifyStepNode"
                 }, {
-                  "$ref" : "#/definitions/pipeline/steps/drtest/ChaosProbeNode"
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosProbeNode"
                 }, {
-                  "$ref" : "#/definitions/pipeline/steps/drtest/ChaosActionNode"
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosActionNode"
                 }, {
-                  "$ref" : "#/definitions/pipeline/steps/drtest/ChaosFaultNode"
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/ChaosFaultNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/resiliencetesting/LoadTestStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/custom/EmailStepNode"
                 }, {
@@ -109830,6 +112931,8 @@ const schema: Record<string, any> = {
                   "$ref" : "#/definitions/pipeline/common/K8sDirectInfra"
                 }, {
                   "$ref" : "#/definitions/pipeline/common/VMInfra"
+                }, {
+                  "$ref" : "#/definitions/pipeline/common/ECSDirectInfra"
                 } ]
               },
               "steps" : {

--- a/src/data/schemas/trigger.ts
+++ b/src/data/schemas/trigger.ts
@@ -2,3517 +2,4077 @@
 // @ts-nocheck
 
 const schema: Record<string, any> = {
-  "$schema" : "http://json-schema.org/draft-07/schema#",
-  "type" : "object",
-  "title" : "trigger",
-  "required" : [ "trigger" ],
-  "properties" : {
-    "trigger" : {
-      "$ref" : "#/definitions/trigger/trigger"
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "trigger",
+  "required": [
+    "trigger"
+  ],
+  "properties": {
+    "trigger": {
+      "$ref": "#/definitions/trigger/trigger"
     }
   },
-  "definitions" : {
-    "trigger" : {
-      "trigger" : {
-        "type" : "object",
-        "title" : "trigger",
-        "required" : [ "identifier", "orgIdentifier", "projectIdentifier" ],
-        "properties" : {
-          "description" : {
-            "type" : "string"
+  "definitions": {
+    "trigger": {
+      "trigger": {
+        "type": "object",
+        "title": "trigger",
+        "required": [
+          "identifier",
+          "orgIdentifier",
+          "projectIdentifier"
+        ],
+        "properties": {
+          "description": {
+            "type": "string"
           },
-          "enabled" : {
-            "type" : "boolean"
+          "enabled": {
+            "type": "boolean"
           },
-          "encryptedWebhookSecretIdentifier" : {
-            "type" : "string"
+          "encryptedWebhookSecretIdentifier": {
+            "type": "string"
           },
-          "identifier" : {
-            "type" : "string",
-            "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+          "identifier": {
+            "type": "string",
+            "pattern": "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
           },
-          "inputSetRefs" : {
-            "oneOf" : [ {
-              "type" : "array",
-              "items" : {
-                "type" : "string"
+          "inputSetRefs": {
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "string",
+                "pattern": "(<\\+.+>.*)",
+                "minLength": 1
               }
-            }, {
-              "type" : "string",
-              "pattern" : "(<\\+.+>.*)",
-              "minLength" : 1
-            } ]
+            ]
           },
-          "inputYaml" : {
-            "type" : "string"
+          "inputYaml": {
+            "type": "string"
           },
-          "name" : {
-            "type" : "string",
-            "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+          "name": {
+            "type": "string",
+            "pattern": "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
           },
-          "orgIdentifier" : {
-            "type" : "string"
+          "orgIdentifier": {
+            "type": "string"
           },
-          "pipelineBranchName" : {
-            "type" : "string"
+          "pipelineBranchName": {
+            "type": "string"
           },
-          "pipelineIdentifier" : {
-            "type" : "string"
+          "pipelineIdentifier": {
+            "type": "string"
           },
-          "projectIdentifier" : {
-            "type" : "string"
+          "projectIdentifier": {
+            "type": "string"
           },
-          "source" : {
-            "$ref" : "#/definitions/trigger/trigger_source"
+          "source": {
+            "$ref": "#/definitions/trigger/trigger_source"
           },
-          "stagesToExecute" : {
-            "oneOf" : [ {
-              "type" : "array",
-              "items" : {
-                "type" : "string"
+          "stagesToExecute": {
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "string",
+                "pattern": "(<\\+.+>.*)",
+                "minLength": 1
               }
-            }, {
-              "type" : "string",
-              "pattern" : "(<\\+.+>.*)",
-              "minLength" : 1
-            } ]
+            ]
           },
-          "tags" : {
-            "type" : "object",
-            "additionalProperties" : {
-              "type" : "string"
+          "tags": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
             }
           }
         },
-        "$schema" : "http://json-schema.org/draft-07/schema#"
+        "$schema": "http://json-schema.org/draft-07/schema#"
       },
-      "trigger_source" : {
-        "title" : "trigger_source",
-        "type" : "object",
-        "properties" : {
-          "pollInterval" : {
-            "type" : "string",
-            "pattern" : "(((([1-9])+\\d*[mh])+(\\s/?\\d+[mh])*)|(^$)|(0))$"
+      "trigger_source": {
+        "title": "trigger_source",
+        "type": "object",
+        "properties": {
+          "pollInterval": {
+            "type": "string",
+            "pattern": "(((([1-9])+\\d*[mh])+(\\s/?\\d+[mh])*)|(^$)|(0))$"
           },
-          "type" : {
-            "type" : "string",
-            "enum" : [ "Webhook", "Artifact", "Manifest", "Scheduled", "MultiRegionArtifact" ]
+          "type": {
+            "type": "string",
+            "enum": [
+              "Webhook",
+              "Artifact",
+              "Manifest",
+              "Scheduled",
+              "MultiRegionArtifact",
+              "SystemEvent"
+            ]
           },
-          "webhookId" : {
-            "type" : "string"
+          "webhookId": {
+            "type": "string"
           }
         },
-        "$schema" : "http://json-schema.org/draft-07/schema#",
-        "allOf" : [ {
-          "if" : {
-            "properties" : {
-              "type" : {
-                "const" : "Artifact"
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "const": "Artifact"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "spec": {
+                  "$ref": "#/definitions/trigger/trigger_type/artifact_trigger"
+                }
               }
             }
           },
-          "then" : {
-            "properties" : {
-              "spec" : {
-                "$ref" : "#/definitions/trigger/trigger_type/artifact_trigger"
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "const": "Manifest"
+                }
               }
-            }
-          }
-        }, {
-          "if" : {
-            "properties" : {
-              "type" : {
-                "const" : "Manifest"
-              }
-            }
-          },
-          "then" : {
-            "properties" : {
-              "spec" : {
-                "$ref" : "#/definitions/trigger/trigger_type/manifest_trigger"
-              }
-            }
-          }
-        }, {
-          "if" : {
-            "properties" : {
-              "type" : {
-                "const" : "MultiRegionArtifact"
+            },
+            "then": {
+              "properties": {
+                "spec": {
+                  "$ref": "#/definitions/trigger/trigger_type/manifest_trigger"
+                }
               }
             }
           },
-          "then" : {
-            "properties" : {
-              "spec" : {
-                "$ref" : "#/definitions/trigger/trigger_type/multi_region_trigger"
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "const": "MultiRegionArtifact"
+                }
               }
-            }
-          }
-        }, {
-          "if" : {
-            "properties" : {
-              "type" : {
-                "const" : "Scheduled"
-              }
-            }
-          },
-          "then" : {
-            "properties" : {
-              "spec" : {
-                "$ref" : "#/definitions/trigger/trigger_type/scheduled_trigger"
-              }
-            }
-          }
-        }, {
-          "if" : {
-            "properties" : {
-              "type" : {
-                "const" : "Webhook"
+            },
+            "then": {
+              "properties": {
+                "spec": {
+                  "$ref": "#/definitions/trigger/trigger_type/multi_region_trigger"
+                }
               }
             }
           },
-          "then" : {
-            "properties" : {
-              "spec" : {
-                "$ref" : "#/definitions/trigger/trigger_type/webhook_trigger"
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "const": "Scheduled"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "spec": {
+                  "$ref": "#/definitions/trigger/trigger_type/scheduled_trigger"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "const": "Webhook"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "spec": {
+                  "$ref": "#/definitions/trigger/trigger_type/webhook_trigger"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "const": "SystemEvent"
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "spec": {
+                  "$ref": "#/definitions/trigger/trigger_type/system_event_trigger"
+                }
               }
             }
           }
-        } ]
+        ]
       },
-      "trigger_type" : {
-        "artifact_trigger" : {
-          "title" : "artifact_trigger",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/trigger_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "artifactRef" : {
-                "type" : "string"
-              },
-              "stageIdentifier" : {
-                "type" : "string"
-              },
-              "type" : {
-                "type" : "string",
-                "enum" : [ "Gcr", "Ecr", "DockerRegistry", "Nexus3Registry", "Nexus2Registry", "ArtifactoryRegistry", "Acr", "AmazonS3", "Jenkins", "CustomArtifact", "GoogleArtifactRegistry", "GithubPackageRegistry", "AzureArtifacts", "AmazonMachineImage", "GoogleCloudStorage", "GceImage", "Bamboo" ]
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Acr"
+      "trigger_type": {
+        "artifact_trigger": {
+          "title": "artifact_trigger",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/trigger_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "artifactRef": {
+                  "type": "string"
+                },
+                "stageIdentifier": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "Gcr",
+                    "Ecr",
+                    "DockerRegistry",
+                    "Nexus3Registry",
+                    "Nexus2Registry",
+                    "ArtifactoryRegistry",
+                    "Acr",
+                    "AmazonS3",
+                    "Jenkins",
+                    "CustomArtifact",
+                    "GoogleArtifactRegistry",
+                    "GithubPackageRegistry",
+                    "AzureArtifacts",
+                    "AmazonMachineImage",
+                    "GoogleCloudStorage",
+                    "GceImage",
+                    "Bamboo"
+                  ]
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/acr_spec"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "AmazonMachineImage"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/ami_registry_spec"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "AmazonS3"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/amazon_s3_registry"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "ArtifactoryRegistry"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/artifactory_registry"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "AzureArtifacts"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/azure_artifact"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Bamboo"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/bamboo"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "CustomArtifact"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/custom_artifact"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "DockerRegistry"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/docker_registry"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Ecr"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/ecr"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Gcr"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/gcr"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "GithubPackageRegistry"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/github_packages"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "GoogleArtifactRegistry"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/gar_spec"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "GoogleCloudStorage"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/google_cloud"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "GceImage"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/gce_image_registry_spec"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Jenkins"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/jenkins_registry"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Nexus2Registry"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/nexus"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Nexus3Registry"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/nexus_registry"
-                }
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "manifest_trigger" : {
-          "title" : "manifest_trigger",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/trigger_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "manifestRef" : {
-                "type" : "string"
-              },
-              "stageIdentifier" : {
-                "type" : "string"
-              },
-              "type" : {
-                "type" : "string",
-                "enum" : [ "HelmChart" ]
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "HelmChart"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/manifest_trigger/helm_spec"
-                }
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "multi_region_trigger" : {
-          "title" : "multi_region_trigger",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/trigger_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "artifactRef" : {
-                "type" : "string"
-              },
-              "eventConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Acr"
+                  }
                 }
               },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "metaDataConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "sources" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/multi_region_artifact/artifact_type_spec_wrapper"
-                }
-              },
-              "stageIdentifier" : {
-                "type" : "string"
-              },
-              "type" : {
-                "type" : "string",
-                "enum" : [ "Gcr", "Ecr", "DockerRegistry", "Nexus3Registry", "Nexus2Registry", "ArtifactoryRegistry", "Acr", "AmazonS3", "Jenkins", "CustomArtifact", "GoogleArtifactRegistry", "GithubPackageRegistry", "AzureArtifacts", "AmazonMachineImage", "GoogleCloudStorage", "Bamboo" ]
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "scheduled_trigger" : {
-          "title" : "scheduled_trigger",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/trigger_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "type" : {
-                "type" : "string"
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Cron"
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/acr_spec"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/scheduled_trigger/cron_trigger_spec"
-                }
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "webhook_trigger" : {
-          "title" : "webhook_trigger",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/trigger_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "type" : {
-                "type" : "string",
-                "enum" : [ "AzureRepo", "Github", "Gitlab", "Bitbucket", "Custom", "AwsCodeCommit", "Harness", "EventRelay", "HarnessArtifactRegistry" ]
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "AwsCodeCommit"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/aws_commit_spec"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "AzureRepo"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/azure_repo_spec"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Bitbucket"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/bitbucket_spec"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Custom"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/custom_trigger_spec"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Github"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/github_spec"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Gitlab"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_spec"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Harness"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/harness_spec"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "EventRelay"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "AmazonMachineImage"
+                  }
                 }
               },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/trigger/webhook_trigger/event_bridge_spec"
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/ami_registry_spec"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "AmazonS3"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/amazon_s3_registry"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "ArtifactoryRegistry"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/artifactory_registry"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "AzureArtifacts"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/azure_artifact"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Bamboo"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/bamboo"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "CustomArtifact"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/custom_artifact"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "DockerRegistry"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/docker_registry"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Ecr"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/ecr"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Gcr"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/gcr"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "GithubPackageRegistry"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/github_packages"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "GoogleArtifactRegistry"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/gar_spec"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "GoogleCloudStorage"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/google_cloud"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "GceImage"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/gce_image_registry_spec"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Jenkins"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/jenkins_registry"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Nexus2Registry"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/nexus"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Nexus3Registry"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/nexus_registry"
                   }
                 }
               }
             }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "HarnessArtifactRegistry"
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "manifest_trigger": {
+          "title": "manifest_trigger",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/trigger_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "manifestRef": {
+                  "type": "string"
+                },
+                "stageIdentifier": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "HelmChart"
+                  ]
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/harness_artifact_registry_spec"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "HelmChart"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/manifest_trigger/helm_spec"
+                  }
                 }
               }
             }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "multi_region_trigger": {
+          "title": "multi_region_trigger",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/trigger_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "artifactRef": {
+                  "type": "string"
+                },
+                "eventConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "metaDataConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "sources": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/multi_region_artifact/artifact_type_spec_wrapper"
+                  }
+                },
+                "stageIdentifier": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "Gcr",
+                    "Ecr",
+                    "DockerRegistry",
+                    "Nexus3Registry",
+                    "Nexus2Registry",
+                    "ArtifactoryRegistry",
+                    "Acr",
+                    "AmazonS3",
+                    "Jenkins",
+                    "CustomArtifact",
+                    "GoogleArtifactRegistry",
+                    "GithubPackageRegistry",
+                    "AzureArtifacts",
+                    "AmazonMachineImage",
+                    "GoogleCloudStorage",
+                    "Bamboo"
+                  ]
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "scheduled_trigger": {
+          "title": "scheduled_trigger",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/trigger_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Cron"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/scheduled_trigger/cron_trigger_spec"
+                  }
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "system_event_trigger": {
+          "title": "system_event_trigger",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/trigger_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "Pipeline"
+                  ]
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Pipeline"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/system_event_trigger/pipeline_system_event_spec"
+                  }
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "webhook_trigger": {
+          "title": "webhook_trigger",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/trigger_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "AzureRepo",
+                    "Github",
+                    "Gitlab",
+                    "Bitbucket",
+                    "Custom",
+                    "AwsCodeCommit",
+                    "Harness",
+                    "EventRelay",
+                    "HarnessArtifactRegistry"
+                  ]
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "AwsCodeCommit"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/aws_commit_spec"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "AzureRepo"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/azure_repo_spec"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Bitbucket"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/bitbucket_spec"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Custom"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/custom_trigger_spec"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Github"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/github_spec"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Gitlab"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/gitlab_spec"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Harness"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/harness_spec"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "EventRelay"
+                  }
+                },
+                "then": {
+                  "properties": {
+                    "spec": {
+                      "$ref": "#/definitions/trigger/webhook_trigger/event_bridge_spec"
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "HarnessArtifactRegistry"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/harness_artifact_registry_spec"
+                  }
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
         }
       },
-      "trigger_spec" : {
-        "title" : "trigger_spec",
-        "type" : "object",
-        "discriminator" : "type",
-        "$schema" : "http://json-schema.org/draft-07/schema#"
+      "trigger_spec": {
+        "title": "trigger_spec",
+        "type": "object",
+        "discriminator": "type",
+        "$schema": "http://json-schema.org/draft-07/schema#"
       },
-      "artifact_trigger" : {
-        "acr_spec" : {
-          "title" : "acr_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "eventConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "metaDataConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "registry" : {
-                "type" : "string"
-              },
-              "repository" : {
-                "type" : "string"
-              },
-              "subscriptionId" : {
-                "type" : "string"
-              },
-              "tag" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "artifact_type_spec" : {
-          "title" : "artifact_type_spec",
-          "type" : "object",
-          "discriminator" : "type",
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "ami_registry_spec" : {
-          "title" : "ami_registry_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "eventConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "filters" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/ami_filter"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "metaDataConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "region" : {
-                "type" : "string"
-              },
-              "tags" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/ami_tag"
-                }
-              },
-              "version" : {
-                "type" : "string"
-              },
-              "versionRegex" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "ami_filter" : {
-          "title" : "ami_filter",
-          "type" : "object",
-          "properties" : {
-            "name" : {
-              "type" : "string"
+      "artifact_trigger": {
+        "acr_spec": {
+          "title": "acr_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/artifact_trigger/artifact_type_spec"
             },
-            "value" : {
-              "type" : "string"
+            {
+              "type": "object",
+              "properties": {
+                "connectorRef": {
+                  "type": "string"
+                },
+                "eventConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "metaDataConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "registry": {
+                  "type": "string"
+                },
+                "repository": {
+                  "type": "string"
+                },
+                "subscriptionId": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "artifact_type_spec": {
+          "title": "artifact_type_spec",
+          "type": "object",
+          "discriminator": "type",
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "ami_registry_spec": {
+          "title": "ami_registry_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "connectorRef": {
+                  "type": "string"
+                },
+                "eventConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "filters": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/ami_filter"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "metaDataConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "region": {
+                  "type": "string"
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/ami_tag"
+                  }
+                },
+                "version": {
+                  "type": "string"
+                },
+                "versionRegex": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "ami_filter": {
+          "title": "ami_filter",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
             }
           },
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+          "$schema": "http://json-schema.org/draft-07/schema#"
         },
-        "ami_tag" : {
-          "title" : "ami_tag",
-          "type" : "object",
-          "properties" : {
-            "name" : {
-              "type" : "string"
+        "ami_tag": {
+          "title": "ami_tag",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
             },
-            "value" : {
-              "type" : "string"
+            "value": {
+              "type": "string"
             }
           },
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+          "$schema": "http://json-schema.org/draft-07/schema#"
         },
-        "amazon_s3_registry" : {
-          "title" : "amazon_s3_registry",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "bucketName" : {
-                "type" : "string"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "eventConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "filePathRegex" : {
-                "type" : "string"
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "metaDataConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "region" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "artifactory_registry" : {
-          "title" : "artifactory_registry",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "artifactDirectory" : {
-                "type" : "string"
-              },
-              "artifactFilter" : {
-                "type" : "string"
-              },
-              "artifactPath" : {
-                "type" : "string"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "eventConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "metaDataConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "repository" : {
-                "type" : "string"
-              },
-              "repositoryFormat" : {
-                "type" : "string"
-              },
-              "repositoryUrl" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "azure_artifact" : {
-          "title" : "azure_artifact",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "eventConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "feed" : {
-                "type" : "string"
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "metaDataConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "packageName" : {
-                "type" : "string"
-              },
-              "packageType" : {
-                "type" : "string"
-              },
-              "project" : {
-                "type" : "string"
-              },
-              "version" : {
-                "type" : "string"
-              },
-              "versionRegex" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "bamboo" : {
-          "title" : "bamboo",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "artifactPaths" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
-              },
-              "build" : {
-                "type" : "string"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "eventConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "metaDataConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "planKey" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "custom_artifact" : {
-          "title" : "custom_artifact",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "artifactsArrayPath" : {
-                "type" : "string"
-              },
-              "eventConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "inputs" : {
-                "type" : "array",
-                "items" : {
-                  "oneOf" : [ {
-                    "$ref" : "#/definitions/pipeline/numberVariable"
-                  }, {
-                    "$ref" : "#/definitions/pipeline/secretVariable"
-                  }, {
-                    "$ref" : "#/definitions/pipeline/stringVariable"
-                  } ]
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "metaDataConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "metadata" : {
-                "type" : "object",
-                "additionalProperties" : {
-                  "type" : "string"
-                }
-              },
-              "script" : {
-                "type" : "string"
-              },
-              "version" : {
-                "type" : "string"
-              },
-              "versionPath" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "docker_registry" : {
-          "title" : "docker_registry",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "eventConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "imagePath" : {
-                "type" : "string"
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "metaDataConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "tag" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "ecr" : {
-          "title" : "ecr",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "eventConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "imagePath" : {
-                "type" : "string"
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "metaDataConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "region" : {
-                "type" : "string"
-              },
-              "registryId" : {
-                "type" : "string"
-              },
-              "tag" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "gcr" : {
-          "title" : "gcr",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "eventConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "imagePath" : {
-                "type" : "string"
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "metaDataConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "registryHostname" : {
-                "type" : "string"
-              },
-              "tag" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "github_packages" : {
-          "title" : "github_packages",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "eventConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "metaDataConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "org" : {
-                "type" : "string"
-              },
-              "packageName" : {
-                "type" : "string"
-              },
-              "packageType" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "gar_spec" : {
-          "title" : "gar_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "eventConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "metaDataConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "pkg" : {
-                "type" : "string"
-              },
-              "project" : {
-                "type" : "string"
-              },
-              "region" : {
-                "type" : "string"
-              },
-              "repositoryName" : {
-                "type" : "string"
-              },
-              "version" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "google_cloud" : {
-          "title" : "google_cloud",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "artifactPath" : {
-                "type" : "string"
-              },
-              "bucket" : {
-                "type" : "string"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "eventConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "metaDataConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "project" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "gce_image_registry_spec" : {
-          "title" : "gce_image_registry_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "eventConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "filters" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/gce_image_filter"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "labels" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/gce_image_label"
-                }
-              },
-              "metaDataConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "project" : {
-                "type" : "string"
-              },
-              "version" : {
-                "type" : "string"
-              },
-              "versionRegex" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "gce_image_filter" : {
-          "title" : "gce_image_filter",
-          "type" : "object",
-          "properties" : {
-            "name" : {
-              "type" : "string"
+        "amazon_s3_registry": {
+          "title": "amazon_s3_registry",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/artifact_trigger/artifact_type_spec"
             },
-            "value" : {
-              "type" : "string"
+            {
+              "type": "object",
+              "properties": {
+                "bucketName": {
+                  "type": "string"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "eventConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "filePathRegex": {
+                  "type": "string"
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "metaDataConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "region": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "artifactory_registry": {
+          "title": "artifactory_registry",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "artifactDirectory": {
+                  "type": "string"
+                },
+                "artifactFilter": {
+                  "type": "string"
+                },
+                "artifactPath": {
+                  "type": "string"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "eventConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "metaDataConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repository": {
+                  "type": "string"
+                },
+                "repositoryFormat": {
+                  "type": "string"
+                },
+                "repositoryUrl": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "azure_artifact": {
+          "title": "azure_artifact",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "connectorRef": {
+                  "type": "string"
+                },
+                "eventConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "feed": {
+                  "type": "string"
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "metaDataConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "packageName": {
+                  "type": "string"
+                },
+                "packageType": {
+                  "type": "string"
+                },
+                "project": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                },
+                "versionRegex": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "bamboo": {
+          "title": "bamboo",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "artifactPaths": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "build": {
+                  "type": "string"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "eventConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "metaDataConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "planKey": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "custom_artifact": {
+          "title": "custom_artifact",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "artifactsArrayPath": {
+                  "type": "string"
+                },
+                "eventConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "inputs": {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "#/definitions/pipeline/numberVariable"
+                      },
+                      {
+                        "$ref": "#/definitions/pipeline/secretVariable"
+                      },
+                      {
+                        "$ref": "#/definitions/pipeline/stringVariable"
+                      }
+                    ]
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "metaDataConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "metadata": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "script": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                },
+                "versionPath": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "docker_registry": {
+          "title": "docker_registry",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "connectorRef": {
+                  "type": "string"
+                },
+                "eventConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "imagePath": {
+                  "type": "string"
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "metaDataConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "tag": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "ecr": {
+          "title": "ecr",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "connectorRef": {
+                  "type": "string"
+                },
+                "eventConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "imagePath": {
+                  "type": "string"
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "metaDataConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "region": {
+                  "type": "string"
+                },
+                "registryId": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "gcr": {
+          "title": "gcr",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "connectorRef": {
+                  "type": "string"
+                },
+                "eventConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "imagePath": {
+                  "type": "string"
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "metaDataConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "registryHostname": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "github_packages": {
+          "title": "github_packages",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "connectorRef": {
+                  "type": "string"
+                },
+                "eventConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "metaDataConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "org": {
+                  "type": "string"
+                },
+                "packageName": {
+                  "type": "string"
+                },
+                "packageType": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "gar_spec": {
+          "title": "gar_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "connectorRef": {
+                  "type": "string"
+                },
+                "eventConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "metaDataConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "pkg": {
+                  "type": "string"
+                },
+                "project": {
+                  "type": "string"
+                },
+                "region": {
+                  "type": "string"
+                },
+                "repositoryName": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "google_cloud": {
+          "title": "google_cloud",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "artifactPath": {
+                  "type": "string"
+                },
+                "bucket": {
+                  "type": "string"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "eventConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "metaDataConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "project": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "gce_image_registry_spec": {
+          "title": "gce_image_registry_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "connectorRef": {
+                  "type": "string"
+                },
+                "eventConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "filters": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/gce_image_filter"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "labels": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/gce_image_label"
+                  }
+                },
+                "metaDataConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "project": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                },
+                "versionRegex": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "gce_image_filter": {
+          "title": "gce_image_filter",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
             }
           },
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+          "$schema": "http://json-schema.org/draft-07/schema#"
         },
-        "gce_image_label" : {
-          "title" : "gce_image_label",
-          "type" : "object",
-          "properties" : {
-            "name" : {
-              "type" : "string"
+        "gce_image_label": {
+          "title": "gce_image_label",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
             },
-            "value" : {
-              "type" : "string"
+            "value": {
+              "type": "string"
             }
           },
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+          "$schema": "http://json-schema.org/draft-07/schema#"
         },
-        "jenkins_registry" : {
-          "title" : "jenkins_registry",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "artifactPath" : {
-                "type" : "string"
-              },
-              "build" : {
-                "type" : "string"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "eventConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "jobName" : {
-                "type" : "string"
-              },
-              "metaDataConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
+        "jenkins_registry": {
+          "title": "jenkins_registry",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "artifactPath": {
+                  "type": "string"
+                },
+                "build": {
+                  "type": "string"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "eventConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "jobName": {
+                  "type": "string"
+                },
+                "metaDataConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
                 }
               }
             }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
         },
-        "nexus" : {
-          "title" : "nexus",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "artifactId" : {
-                "type" : "string"
-              },
-              "classifier" : {
-                "type" : "string"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "eventConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
+        "nexus": {
+          "title": "nexus",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "artifactId": {
+                  "type": "string"
+                },
+                "classifier": {
+                  "type": "string"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "eventConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "extension": {
+                  "type": "string"
+                },
+                "groupId": {
+                  "type": "string"
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "metaDataConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "packageName": {
+                  "type": "string"
+                },
+                "repositoryFormat": {
+                  "type": "string"
+                },
+                "repositoryName": {
+                  "type": "string"
+                },
+                "repositoryUrl": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
                 }
-              },
-              "extension" : {
-                "type" : "string"
-              },
-              "groupId" : {
-                "type" : "string"
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "metaDataConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "packageName" : {
-                "type" : "string"
-              },
-              "repositoryFormat" : {
-                "type" : "string"
-              },
-              "repositoryName" : {
-                "type" : "string"
-              },
-              "repositoryUrl" : {
-                "type" : "string"
-              },
-              "tag" : {
-                "type" : "string"
               }
             }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
         },
-        "nexus_registry" : {
-          "title" : "nexus_registry",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "artifactId" : {
-                "type" : "string"
-              },
-              "classifier" : {
-                "type" : "string"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "eventConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
+        "nexus_registry": {
+          "title": "nexus_registry",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "artifactId": {
+                  "type": "string"
+                },
+                "classifier": {
+                  "type": "string"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "eventConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "extension": {
+                  "type": "string"
+                },
+                "group": {
+                  "type": "string"
+                },
+                "groupId": {
+                  "type": "string"
+                },
+                "imagePath": {
+                  "type": "string"
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "metaDataConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "packageName": {
+                  "type": "string"
+                },
+                "repository": {
+                  "type": "string"
+                },
+                "repositoryFormat": {
+                  "type": "string"
+                },
+                "repositoryUrl": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
                 }
-              },
-              "extension" : {
-                "type" : "string"
-              },
-              "group" : {
-                "type" : "string"
-              },
-              "groupId" : {
-                "type" : "string"
-              },
-              "imagePath" : {
-                "type" : "string"
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "metaDataConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "packageName" : {
-                "type" : "string"
-              },
-              "repository" : {
-                "type" : "string"
-              },
-              "repositoryFormat" : {
-                "type" : "string"
-              },
-              "repositoryUrl" : {
-                "type" : "string"
-              },
-              "tag" : {
-                "type" : "string"
               }
             }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
         }
       },
-      "trigger_event_data" : {
-        "title" : "trigger_event_data",
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
+      "trigger_event_data": {
+        "title": "trigger_event_data",
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
           },
-          "operator" : {
-            "type" : "string",
-            "enum" : [ "In", "Equals", "NotEquals", "NotIn", "Regex", "EndsWith", "StartsWith", "Contains", "DoesNotContain" ]
+          "operator": {
+            "type": "string",
+            "enum": [
+              "In",
+              "Equals",
+              "NotEquals",
+              "NotIn",
+              "Regex",
+              "EndsWith",
+              "StartsWith",
+              "Contains",
+              "DoesNotContain"
+            ]
           },
-          "value" : {
-            "type" : "string"
+          "value": {
+            "type": "string"
           }
         },
-        "$schema" : "http://json-schema.org/draft-07/schema#"
+        "$schema": "http://json-schema.org/draft-07/schema#"
       },
-      "manifest_trigger" : {
-        "helm_spec" : {
-          "title" : "helm_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/manifest_trigger/manifest_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "chartName" : {
-                "type" : "string"
-              },
-              "chartVersion" : {
-                "type" : "string"
-              },
-              "eventConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
+      "manifest_trigger": {
+        "helm_spec": {
+          "title": "helm_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/manifest_trigger/manifest_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "chartName": {
+                  "type": "string"
+                },
+                "chartVersion": {
+                  "type": "string"
+                },
+                "eventConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "helmVersion": {
+                  "type": "string",
+                  "enum": [
+                    "V2",
+                    "V3",
+                    "V380"
+                  ]
+                },
+                "store": {
+                  "$ref": "#/definitions/trigger/manifest_trigger/build_store"
                 }
-              },
-              "helmVersion" : {
-                "type" : "string",
-                "enum" : [ "V2", "V3", "V380" ]
-              },
-              "store" : {
-                "$ref" : "#/definitions/trigger/manifest_trigger/build_store"
               }
             }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
         },
-        "manifest_spec" : {
-          "title" : "manifest_spec",
-          "type" : "object",
-          "discriminator" : "type",
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+        "manifest_spec": {
+          "title": "manifest_spec",
+          "type": "object",
+          "discriminator": "type",
+          "$schema": "http://json-schema.org/draft-07/schema#"
         },
-        "build_store" : {
-          "title" : "build_store",
-          "type" : "object",
-          "properties" : {
-            "type" : {
-              "type" : "string",
-              "enum" : [ "Http", "S3", "Gcs" ]
+        "build_store": {
+          "title": "build_store",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "Http",
+                "S3",
+                "Gcs"
+              ]
             }
           },
-          "$schema" : "http://json-schema.org/draft-07/schema#",
-          "allOf" : [ {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Gcs"
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Gcs"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/manifest_trigger/gcs_build_store_spec"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/manifest_trigger/gcs_build_store_spec"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Http"
+                  }
                 }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Http"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/manifest_trigger/http_build_store_spec"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "S3"
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/manifest_trigger/http_build_store_spec"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/manifest_trigger/s3_build_store_spec"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "S3"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/manifest_trigger/s3_build_store_spec"
+                  }
                 }
               }
             }
-          } ]
+          ]
         },
-        "gcs_build_store_spec" : {
-          "title" : "gcs_build_store_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/manifest_trigger/build_store_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "bucketName" : {
-                "type" : "string"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "folderPath" : {
-                "type" : "string"
+        "gcs_build_store_spec": {
+          "title": "gcs_build_store_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/manifest_trigger/build_store_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "bucketName": {
+                  "type": "string"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "folderPath": {
+                  "type": "string"
+                }
               }
             }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
         },
-        "build_store_spec" : {
-          "title" : "build_store_spec",
-          "type" : "object",
-          "discriminator" : "type",
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+        "build_store_spec": {
+          "title": "build_store_spec",
+          "type": "object",
+          "discriminator": "type",
+          "$schema": "http://json-schema.org/draft-07/schema#"
         },
-        "http_build_store_spec" : {
-          "title" : "http_build_store_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/manifest_trigger/build_store_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "connectorRef" : {
-                "type" : "string"
+        "http_build_store_spec": {
+          "title": "http_build_store_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/manifest_trigger/build_store_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "connectorRef": {
+                  "type": "string"
+                }
               }
             }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
         },
-        "s3_build_store_spec" : {
-          "title" : "s3_build_store_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/manifest_trigger/build_store_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "bucketName" : {
-                "type" : "string"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "folderPath" : {
-                "type" : "string"
-              },
-              "region" : {
-                "type" : "string"
+        "s3_build_store_spec": {
+          "title": "s3_build_store_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/manifest_trigger/build_store_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "bucketName": {
+                  "type": "string"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "folderPath": {
+                  "type": "string"
+                },
+                "region": {
+                  "type": "string"
+                }
               }
             }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
         }
       },
-      "multi_region_artifact" : {
-        "artifact_type_spec_wrapper" : {
-          "title" : "artifact_type_spec_wrapper",
-          "type" : "object",
-          "properties" : { },
-          "$schema" : "http://json-schema.org/draft-07/schema#",
-          "allOf" : [ {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Acr"
+      "multi_region_artifact": {
+        "artifact_type_spec_wrapper": {
+          "title": "artifact_type_spec_wrapper",
+          "type": "object",
+          "properties": {},
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Acr"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/acr_spec"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/acr_spec"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "AmazonMachineImage"
+                  }
                 }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "AmazonMachineImage"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/ami_registry_spec"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "AmazonS3"
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/ami_registry_spec"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/amazon_s3_registry"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "AmazonS3"
+                  }
                 }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "ArtifactoryRegistry"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/artifactory_registry"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "AzureArtifacts"
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/amazon_s3_registry"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/azure_artifact"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "ArtifactoryRegistry"
+                  }
                 }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Bamboo"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/bamboo"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "CustomArtifact"
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/artifactory_registry"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/custom_artifact"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "AzureArtifacts"
+                  }
                 }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "DockerRegistry"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/docker_registry"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Ecr"
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/azure_artifact"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/ecr"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Bamboo"
+                  }
                 }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Gcr"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/gcr"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "GithubPackageRegistry"
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/bamboo"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/github_packages"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "CustomArtifact"
+                  }
                 }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "GoogleArtifactRegistry"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/gar_spec"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "GoogleCloudStorage"
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/custom_artifact"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/google_cloud"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "DockerRegistry"
+                  }
                 }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Jenkins"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/jenkins_registry"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Nexus2Registry"
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/docker_registry"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/nexus"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Ecr"
+                  }
                 }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Nexus3Registry"
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/ecr"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/artifact_trigger/nexus_registry"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Gcr"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/gcr"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "GithubPackageRegistry"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/github_packages"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "GoogleArtifactRegistry"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/gar_spec"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "GoogleCloudStorage"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/google_cloud"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Jenkins"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/jenkins_registry"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Nexus2Registry"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/nexus"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Nexus3Registry"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/artifact_trigger/nexus_registry"
+                  }
                 }
               }
             }
-          } ]
+          ]
         }
       },
-      "scheduled_trigger" : {
-        "cron_trigger_spec" : {
-          "title" : "cron_trigger_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/scheduled_trigger/scheduled_trigger_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "expression" : {
-                "type" : "string"
-              },
-              "type" : {
-                "type" : "string"
-              },
-              "timezone" : {
-                "type" : "string"
+      "scheduled_trigger": {
+        "cron_trigger_spec": {
+          "title": "cron_trigger_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/scheduled_trigger/scheduled_trigger_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "expression": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "timezone": {
+                  "type": "string"
+                }
               }
             }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
         },
-        "scheduled_trigger_spec" : {
-          "title" : "scheduled_trigger_spec",
-          "type" : "object",
-          "discriminator" : "type",
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+        "scheduled_trigger_spec": {
+          "title": "scheduled_trigger_spec",
+          "type": "object",
+          "discriminator": "type",
+          "$schema": "http://json-schema.org/draft-07/schema#"
         }
       },
-      "webhook_trigger" : {
-        "aws_commit_spec" : {
-          "title" : "aws_commit_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "type" : {
-                "type" : "string",
-                "enum" : [ "Push" ]
+      "system_event_trigger": {
+        "pipeline_system_event_spec": {
+          "title": "pipeline_system_event_spec",
+          "type": "object",
+          "properties": {
+            "eventType": {
+              "type": "string",
+              "enum": [
+                "PipelineFailure",
+                "PipelineSuccess"
+              ]
+            },
+            "payloadConditions": {
+              "type": "array",
+              "description": "Optional conditions on the event payload. Supported key: 'sourcePipeline'. Supports all operators: equals, not-equals, in, not-in, regex, starts-with, ends-with, contains, does-not-contain. ALL conditions must pass. Empty list = match any source pipeline.",
+              "items": {
+                "type": "object",
+                "required": [
+                  "key",
+                  "operator",
+                  "value"
+                ],
+                "properties": {
+                  "key": {
+                    "type": "string",
+                    "description": "The field to evaluate. Supported value: 'sourcePipeline'."
+                  },
+                  "operator": {
+                    "type": "string",
+                    "enum": [
+                      "equals",
+                      "not-equals",
+                      "in",
+                      "not-in",
+                      "regex",
+                      "starts-with",
+                      "ends-with",
+                      "contains",
+                      "does-not-contain"
+                    ],
+                    "description": "The comparison operator."
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The value to compare against."
+                  }
+                }
               }
             }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Push"
+          },
+          "required": [
+            "eventType"
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        }
+      },
+      "webhook_trigger": {
+        "aws_commit_spec": {
+          "title": "aws_commit_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "Push"
+                  ]
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/aws_commit_push_spec"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Push"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/aws_commit_push_spec"
+                  }
                 }
               }
             }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
         },
-        "webhook_trigger_spec" : {
-          "title" : "webhook_trigger_spec",
-          "type" : "object",
-          "discriminator" : "type",
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+        "webhook_trigger_spec": {
+          "title": "webhook_trigger_spec",
+          "type": "object",
+          "discriminator": "type",
+          "$schema": "http://json-schema.org/draft-07/schema#"
         },
-        "aws_commit_push_spec" : {
-          "title" : "aws_commit_push_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/aws_commit_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
+        "aws_commit_push_spec": {
+          "title": "aws_commit_push_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/aws_commit_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "connectorRef": {
+                  "type": "string"
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repoName": {
+                  "type": "string"
                 }
-              },
-              "repoName" : {
-                "type" : "string"
               }
             }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
         },
-        "aws_commit_event_spec" : {
-          "title" : "aws_commit_event_spec",
-          "type" : "object",
-          "discriminator" : "type",
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+        "aws_commit_event_spec": {
+          "title": "aws_commit_event_spec",
+          "type": "object",
+          "discriminator": "type",
+          "$schema": "http://json-schema.org/draft-07/schema#"
         },
-        "azure_repo_spec" : {
-          "title" : "azure_repo_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "type" : {
-                "type" : "string",
-                "enum" : [ "PullRequest", "Push", "IssueComment" ]
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "IssueComment"
+        "azure_repo_spec": {
+          "title": "azure_repo_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "PullRequest",
+                    "Push",
+                    "IssueComment"
+                  ]
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/azure_issue_comment_spec"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "IssueComment"
+                  }
                 }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "PullRequest"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/azure_repo_pr_spec"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Push"
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/azure_issue_comment_spec"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/azure_repo_push_spec"
-                }
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "azure_issue_comment_spec" : {
-          "title" : "azure_issue_comment_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/azure_repo_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "actions" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string",
-                  "enum" : [ "Create", "Edit", "Delete" ]
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "PullRequest"
+                  }
                 }
               },
-              "autoAbortPreviousExecutions" : {
-                "type" : "boolean"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "repoName" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "azure_repo_event_spec" : {
-          "title" : "azure_repo_event_spec",
-          "type" : "object",
-          "discriminator" : "type",
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "azure_repo_pr_spec" : {
-          "title" : "azure_repo_pr_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/azure_repo_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "actions" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string",
-                  "enum" : [ "Create", "Update", "Merge" ]
-                }
-              },
-              "autoAbortPreviousExecutions" : {
-                "type" : "boolean"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "repoName" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "azure_repo_push_spec" : {
-          "title" : "azure_repo_push_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/azure_repo_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "autoAbortPreviousExecutions" : {
-                "type" : "boolean"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "repoName" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "bitbucket_spec" : {
-          "title" : "bitbucket_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "type" : {
-                "type" : "string",
-                "enum" : [ "PullRequest", "Push", "PRComment" ]
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "PRComment"
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/azure_repo_pr_spec"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/bitbucket_pr_comment_spec"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Push"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/azure_repo_push_spec"
+                  }
                 }
               }
             }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "PullRequest"
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "azure_issue_comment_spec": {
+          "title": "azure_issue_comment_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/azure_repo_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "actions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "Create",
+                      "Edit",
+                      "Delete"
+                    ]
+                  }
+                },
+                "autoAbortPreviousExecutions": {
+                  "type": "boolean"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repoName": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "azure_repo_event_spec": {
+          "title": "azure_repo_event_spec",
+          "type": "object",
+          "discriminator": "type",
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "azure_repo_pr_spec": {
+          "title": "azure_repo_pr_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/azure_repo_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "actions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "Create",
+                      "Update",
+                      "Merge"
+                    ]
+                  }
+                },
+                "autoAbortPreviousExecutions": {
+                  "type": "boolean"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repoName": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "azure_repo_push_spec": {
+          "title": "azure_repo_push_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/azure_repo_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "autoAbortPreviousExecutions": {
+                  "type": "boolean"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repoName": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "bitbucket_spec": {
+          "title": "bitbucket_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "PullRequest",
+                    "Push",
+                    "PRComment"
+                  ]
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/bitbucket_pr_spec"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Push"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/bitbucket_push_spec"
-                }
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "bitbucket_pr_comment_spec" : {
-          "title" : "bitbucket_pr_comment_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/bitbucket_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "actions" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string",
-                  "enum" : [ "Create", "Edit", "Delete" ]
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "PRComment"
+                  }
                 }
               },
-              "autoAbortPreviousExecutions" : {
-                "type" : "boolean"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "repoName" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "bitbucket_event_spec" : {
-          "title" : "bitbucket_event_spec",
-          "type" : "object",
-          "discriminator" : "type",
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "bitbucket_pr_spec" : {
-          "title" : "bitbucket_pr_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/bitbucket_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "actions" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string",
-                  "enum" : [ "Create", "Update", "Merge", "Decline" ]
-                }
-              },
-              "autoAbortPreviousExecutions" : {
-                "type" : "boolean"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "repoName" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "bitbucket_push_spec" : {
-          "title" : "bitbucket_push_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/bitbucket_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "autoAbortPreviousExecutions" : {
-                "type" : "boolean"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "repoName" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "custom_trigger_spec" : {
-          "title" : "custom_trigger_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "github_spec" : {
-          "title" : "github_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "type" : {
-                "type" : "string",
-                "enum" : [ "PullRequest", "Push", "IssueComment", "Release", "Delete", "Create" ]
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "IssueComment"
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/bitbucket_pr_comment_spec"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/github_issue_comment_spec"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "PullRequest"
+                  }
                 }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "PullRequest"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/github_pr_spec"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Push"
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/bitbucket_pr_spec"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/github_push_spec"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Push"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/bitbucket_push_spec"
+                  }
                 }
               }
             }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Release"
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "bitbucket_pr_comment_spec": {
+          "title": "bitbucket_pr_comment_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/bitbucket_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "actions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "Create",
+                      "Edit",
+                      "Delete"
+                    ]
+                  }
+                },
+                "autoAbortPreviousExecutions": {
+                  "type": "boolean"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repoName": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "bitbucket_event_spec": {
+          "title": "bitbucket_event_spec",
+          "type": "object",
+          "discriminator": "type",
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "bitbucket_pr_spec": {
+          "title": "bitbucket_pr_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/bitbucket_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "actions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "Create",
+                      "Update",
+                      "Merge",
+                      "Decline"
+                    ]
+                  }
+                },
+                "autoAbortPreviousExecutions": {
+                  "type": "boolean"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repoName": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "bitbucket_push_spec": {
+          "title": "bitbucket_push_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/bitbucket_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "autoAbortPreviousExecutions": {
+                  "type": "boolean"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repoName": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "custom_trigger_spec": {
+          "title": "custom_trigger_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "github_spec": {
+          "title": "github_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "PullRequest",
+                    "Push",
+                    "IssueComment",
+                    "Release",
+                    "Delete",
+                    "Create"
+                  ]
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/github_release_spec"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "IssueComment"
+                  }
                 }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Delete"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/github_delete_spec"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Create"
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/github_issue_comment_spec"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/github_create_spec"
-                }
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "github_issue_comment_spec" : {
-          "title" : "github_issue_comment_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/github_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "actions" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string",
-                  "enum" : [ "Create", "Edit", "Delete" ]
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "PullRequest"
+                  }
                 }
               },
-              "autoAbortPreviousExecutions" : {
-                "type" : "boolean"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "repoName" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "github_event_spec" : {
-          "title" : "github_event_spec",
-          "type" : "object",
-          "discriminator" : "type",
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "github_pr_spec" : {
-          "title" : "github_pr_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/github_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "actions" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string",
-                  "enum" : [ "Close", "Edit", "Open", "Reopen", "Label", "Unlabel", "Synchronize", "ReadyForReview" ]
-                }
-              },
-              "autoAbortPreviousExecutions" : {
-                "type" : "boolean"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "repoName" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "github_push_spec" : {
-          "title" : "github_push_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/github_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "autoAbortPreviousExecutions" : {
-                "type" : "boolean"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "repoName" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "github_release_spec" : {
-          "title" : "github_release_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/github_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "actions" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string",
-                  "enum" : [ "Create", "Edit", "Delete", "Prerelease", "Publish", "Release", "Unpublish" ]
-                }
-              },
-              "autoAbortPreviousExecutions" : {
-                "type" : "boolean"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "repoName" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "github_delete_spec" : {
-          "title" : "github_delete_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/github_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "repoName" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "github_create_spec" : {
-          "title" : "github_create_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/github_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "repoName" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "gitlab_spec" : {
-          "title" : "gitlab_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "type" : {
-                "type" : "string",
-                "enum" : [ "MergeRequest", "Push", "MRComment", "Tag", "PipelineHook" ]
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "MRComment"
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/github_pr_spec"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_mr_comment_spec"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Push"
+                  }
                 }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "MergeRequest"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_pr_spec"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Push"
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/github_push_spec"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_push_spec"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Release"
+                  }
                 }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Tag"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_tag_spec"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "PipelineHook"
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/github_release_spec"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_pipeline_hook_spec"
-                }
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "gitlab_mr_comment_spec" : {
-          "title" : "gitlab_mr_comment_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "actions" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string",
-                  "enum" : [ "Create" ]
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Delete"
+                  }
                 }
               },
-              "autoAbortPreviousExecutions" : {
-                "type" : "boolean"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "repoName" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "gitlab_event_spec" : {
-          "title" : "gitlab_event_spec",
-          "type" : "object",
-          "discriminator" : "type",
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "gitlab_pr_spec" : {
-          "title" : "gitlab_pr_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "actions" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string",
-                  "enum" : [ "Open", "Close", "Reopen", "Merge", "Update", "Sync" ]
-                }
-              },
-              "autoAbortPreviousExecutions" : {
-                "type" : "boolean"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "repoName" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "gitlab_push_spec" : {
-          "title" : "gitlab_push_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "autoAbortPreviousExecutions" : {
-                "type" : "boolean"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "repoName" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "gitlab_tag_spec" : {
-          "title" : "gitlab_tag_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "autoAbortPreviousExecutions" : {
-                "type" : "boolean"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "repoName" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "gitlab_pipeline_hook_spec" : {
-          "title" : "gitlab_pipeline_hook_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "autoAbortPreviousExecutions" : {
-                "type" : "boolean"
-              },
-              "connectorRef" : {
-                "type" : "string"
-              },
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "repoName" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "harness_spec" : {
-          "title" : "harness_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "type" : {
-                "type" : "string",
-                "enum" : [ "PullRequest", "Push", "Branch", "Tag" ]
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "PullRequest"
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/github_delete_spec"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/harness_pr_spec"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Create"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/github_create_spec"
+                  }
                 }
               }
             }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Push"
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "github_issue_comment_spec": {
+          "title": "github_issue_comment_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/github_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "actions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "Create",
+                      "Edit",
+                      "Delete"
+                    ]
+                  }
+                },
+                "autoAbortPreviousExecutions": {
+                  "type": "boolean"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repoName": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "github_event_spec": {
+          "title": "github_event_spec",
+          "type": "object",
+          "discriminator": "type",
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "github_pr_spec": {
+          "title": "github_pr_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/github_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "actions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "Close",
+                      "Edit",
+                      "Open",
+                      "Reopen",
+                      "Label",
+                      "Unlabel",
+                      "Synchronize",
+                      "ReadyForReview"
+                    ]
+                  }
+                },
+                "autoAbortPreviousExecutions": {
+                  "type": "boolean"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repoName": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "github_push_spec": {
+          "title": "github_push_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/github_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "autoAbortPreviousExecutions": {
+                  "type": "boolean"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repoName": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "github_release_spec": {
+          "title": "github_release_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/github_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "actions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "Create",
+                      "Edit",
+                      "Delete",
+                      "Prerelease",
+                      "Publish",
+                      "Release",
+                      "Unpublish"
+                    ]
+                  }
+                },
+                "autoAbortPreviousExecutions": {
+                  "type": "boolean"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repoName": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "github_delete_spec": {
+          "title": "github_delete_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/github_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "connectorRef": {
+                  "type": "string"
+                },
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repoName": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "github_create_spec": {
+          "title": "github_create_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/github_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "connectorRef": {
+                  "type": "string"
+                },
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repoName": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "gitlab_spec": {
+          "title": "gitlab_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "MergeRequest",
+                    "Push",
+                    "MRComment",
+                    "Tag",
+                    "PipelineHook"
+                  ]
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/harness_push_spec"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "MRComment"
+                  }
                 }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Branch"
-                }
-              }
-            },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/harness_branch_spec"
-                }
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Tag"
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/gitlab_mr_comment_spec"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/harness_tag_spec"
-                }
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "harness_pr_spec" : {
-          "title" : "harness_pr_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/harness_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "actions" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string",
-                  "enum" : [ "Create", "Update", "Reopen", "Merge", "Comment" ]
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "MergeRequest"
+                  }
                 }
               },
-              "autoAbortPreviousExecutions" : {
-                "type" : "boolean"
-              },
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "repoName" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "harness_event_spec" : {
-          "title" : "harness_event_spec",
-          "type" : "object",
-          "discriminator" : "type",
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "harness_push_spec" : {
-          "title" : "harness_push_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/harness_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "autoAbortPreviousExecutions" : {
-                "type" : "boolean"
-              },
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "repoName" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "harness_branch_spec" : {
-          "title" : "harness_branch_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/harness_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "actions" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string",
-                  "enum" : [ "Create", "Delete" ]
-                }
-              },
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "repoName" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "harness_tag_spec" : {
-          "title" : "harness_tag_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/harness_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "actions" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string",
-                  "enum" : [ "Create", "Delete" ]
-                }
-              },
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "repoName" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "event_bridge_spec" : {
-          "title" : "event_bridge_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "autoAbortPreviousExecutions" : {
-                "type" : "boolean"
-              },
-              "webhookIdentifier" : {
-                "type" : "string"
-              }
-            }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "harness_artifact_registry_spec" : {
-          "title" : "harness_artifact_registry_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "type" : {
-                "type" : "string",
-                "enum" : [ "Artifact" ]
-              }
-            }
-          }, {
-            "if" : {
-              "properties" : {
-                "type" : {
-                  "const" : "Artifact"
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/gitlab_pr_spec"
+                  }
                 }
               }
             },
-            "then" : {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/trigger/webhook_trigger/har_artifact_spec"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Push"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/gitlab_push_spec"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Tag"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/gitlab_tag_spec"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "PipelineHook"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/gitlab_pipeline_hook_spec"
+                  }
                 }
               }
             }
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
         },
-        "har_artifact_spec" : {
-          "title" : "har_artifact_spec",
-          "allOf" : [ {
-            "$ref" : "#/definitions/trigger/webhook_trigger/har_event_spec"
-          }, {
-            "type" : "object",
-            "properties" : {
-              "actions" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string",
-                  "enum" : [ "ArtifactCreation", "ArtifactDeletion" ]
+        "gitlab_mr_comment_spec": {
+          "title": "gitlab_mr_comment_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/gitlab_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "actions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "Create"
+                    ]
+                  }
+                },
+                "autoAbortPreviousExecutions": {
+                  "type": "boolean"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repoName": {
+                  "type": "string"
                 }
-              },
-              "autoAbortPreviousExecutions" : {
-                "type" : "boolean"
-              },
-              "headerConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "gitlab_event_spec": {
+          "title": "gitlab_event_spec",
+          "type": "object",
+          "discriminator": "type",
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "gitlab_pr_spec": {
+          "title": "gitlab_pr_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/gitlab_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "actions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "Open",
+                      "Close",
+                      "Reopen",
+                      "Merge",
+                      "Update",
+                      "Sync"
+                    ]
+                  }
+                },
+                "autoAbortPreviousExecutions": {
+                  "type": "boolean"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repoName": {
+                  "type": "string"
                 }
-              },
-              "jexlCondition" : {
-                "type" : "string"
-              },
-              "payloadConditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "gitlab_push_spec": {
+          "title": "gitlab_push_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/gitlab_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "autoAbortPreviousExecutions": {
+                  "type": "boolean"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repoName": {
+                  "type": "string"
                 }
-              },
-              "registryName" : {
-                "type" : "string"
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "gitlab_tag_spec": {
+          "title": "gitlab_tag_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/gitlab_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "autoAbortPreviousExecutions": {
+                  "type": "boolean"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repoName": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "gitlab_pipeline_hook_spec": {
+          "title": "gitlab_pipeline_hook_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/gitlab_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "autoAbortPreviousExecutions": {
+                  "type": "boolean"
+                },
+                "connectorRef": {
+                  "type": "string"
+                },
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repoName": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "harness_spec": {
+          "title": "harness_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "PullRequest",
+                    "Push",
+                    "Branch",
+                    "Tag"
+                  ]
+                }
               }
             },
-            "required" : [ "registryName" ]
-          } ],
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "PullRequest"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/harness_pr_spec"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Push"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/harness_push_spec"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Branch"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/harness_branch_spec"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Tag"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/harness_tag_spec"
+                  }
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
         },
-        "har_event_spec" : {
-          "title" : "har_event_spec",
-          "type" : "object",
-          "discriminator" : "type",
-          "$schema" : "http://json-schema.org/draft-07/schema#"
+        "harness_pr_spec": {
+          "title": "harness_pr_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/harness_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "actions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "Create",
+                      "Update",
+                      "Reopen",
+                      "Merge",
+                      "Comment"
+                    ]
+                  }
+                },
+                "autoAbortPreviousExecutions": {
+                  "type": "boolean"
+                },
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repoName": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "harness_event_spec": {
+          "title": "harness_event_spec",
+          "type": "object",
+          "discriminator": "type",
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "harness_push_spec": {
+          "title": "harness_push_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/harness_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "autoAbortPreviousExecutions": {
+                  "type": "boolean"
+                },
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repoName": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "harness_branch_spec": {
+          "title": "harness_branch_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/harness_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "actions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "Create",
+                      "Delete"
+                    ]
+                  }
+                },
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repoName": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "harness_tag_spec": {
+          "title": "harness_tag_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/harness_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "actions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "Create",
+                      "Delete"
+                    ]
+                  }
+                },
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "repoName": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "event_bridge_spec": {
+          "title": "event_bridge_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "autoAbortPreviousExecutions": {
+                  "type": "boolean"
+                },
+                "webhookIdentifier": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "harness_artifact_registry_spec": {
+          "title": "harness_artifact_registry_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "Artifact"
+                  ]
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "Artifact"
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "spec": {
+                    "$ref": "#/definitions/trigger/webhook_trigger/har_artifact_spec"
+                  }
+                }
+              }
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "har_artifact_spec": {
+          "title": "har_artifact_spec",
+          "allOf": [
+            {
+              "$ref": "#/definitions/trigger/webhook_trigger/har_event_spec"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "actions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "ArtifactCreation",
+                      "ArtifactDeletion"
+                    ]
+                  }
+                },
+                "autoAbortPreviousExecutions": {
+                  "type": "boolean"
+                },
+                "headerConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "jexlCondition": {
+                  "type": "string"
+                },
+                "payloadConditions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/trigger/trigger_event_data"
+                  }
+                },
+                "registryName": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "registryName"
+              ]
+            }
+          ],
+          "$schema": "http://json-schema.org/draft-07/schema#"
+        },
+        "har_event_spec": {
+          "title": "har_event_spec",
+          "type": "object",
+          "discriminator": "type",
+          "$schema": "http://json-schema.org/draft-07/schema#"
         }
       }
     },
-    "pipeline" : {
-      "numberVariable" : {
-        "title" : "numberVariable",
-        "type" : "object",
-        "required" : [ "value" ],
-        "properties" : {
-          "name" : {
-            "type" : "string",
-            "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.$]{0,63}$"
+    "pipeline": {
+      "numberVariable": {
+        "title": "numberVariable",
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[a-zA-Z_][0-9a-zA-Z_\\.$]{0,63}$"
           },
-          "default" : {
-            "type" : "number",
-            "format" : "double"
+          "default": {
+            "type": "number",
+            "format": "double"
           },
-          "type" : {
-            "type" : "string",
-            "enum" : [ "Number" ]
+          "type": {
+            "type": "string",
+            "enum": [
+              "Number"
+            ]
           },
-          "value" : {
-            "oneOf" : [ {
-              "type" : "number",
-              "format" : "double"
-            }, {
-              "type" : "string",
-              "pattern" : "((^[+-]?[0-9]*\\.?[0-9]+$)|(<\\+.+>.*))"
-            } ]
+          "value": {
+            "oneOf": [
+              {
+                "type": "number",
+                "format": "double"
+              },
+              {
+                "type": "string",
+                "pattern": "((^[+-]?[0-9]*\\.?[0-9]+$)|(<\\+.+>.*))"
+              }
+            ]
           },
-          "description" : {
-            "type" : "string"
+          "description": {
+            "type": "string"
           },
-          "required" : {
-            "type" : "boolean"
+          "required": {
+            "type": "boolean"
           },
-          "metadata" : {
-            "type" : "string"
+          "metadata": {
+            "type": "string"
           }
         },
-        "$schema" : "http://json-schema.org/draft-07/schema#"
+        "$schema": "http://json-schema.org/draft-07/schema#"
       },
-      "secretVariable" : {
-        "title" : "secretVariable",
-        "type" : "object",
-        "required" : [ "value" ],
-        "properties" : {
-          "name" : {
-            "type" : "string",
-            "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.$]{0,63}$"
+      "secretVariable": {
+        "title": "secretVariable",
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[a-zA-Z_][0-9a-zA-Z_\\.$]{0,63}$"
           },
-          "default" : {
-            "type" : "string"
+          "default": {
+            "type": "string"
           },
-          "type" : {
-            "type" : "string",
-            "enum" : [ "Secret" ]
+          "type": {
+            "type": "string",
+            "enum": [
+              "Secret"
+            ]
           },
-          "value" : {
-            "type" : "string"
+          "value": {
+            "type": "string"
           },
-          "description" : {
-            "type" : "string"
+          "description": {
+            "type": "string"
           },
-          "required" : {
-            "type" : "boolean"
+          "required": {
+            "type": "boolean"
           },
-          "metadata" : {
-            "type" : "string"
+          "metadata": {
+            "type": "string"
           }
         },
-        "$schema" : "http://json-schema.org/draft-07/schema#"
+        "$schema": "http://json-schema.org/draft-07/schema#"
       },
-      "stringVariable" : {
-        "title" : "stringVariable",
-        "type" : "object",
-        "required" : [ "value" ],
-        "properties" : {
-          "name" : {
-            "type" : "string",
-            "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.$]{0,63}$"
+      "stringVariable": {
+        "title": "stringVariable",
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[a-zA-Z_][0-9a-zA-Z_\\.$]{0,63}$"
           },
-          "default" : {
-            "type" : "string"
+          "default": {
+            "type": "string"
           },
-          "type" : {
-            "type" : "string",
-            "enum" : [ "String" ]
+          "type": {
+            "type": "string",
+            "enum": [
+              "String"
+            ]
           },
-          "value" : {
-            "type" : "string"
+          "value": {
+            "type": "string"
           },
-          "description" : {
-            "type" : "string"
+          "description": {
+            "type": "string"
           },
-          "required" : {
-            "type" : "boolean"
+          "required": {
+            "type": "boolean"
           },
-          "metadata" : {
-            "type" : "string"
+          "metadata": {
+            "type": "string"
           }
         },
-        "$schema" : "http://json-schema.org/draft-07/schema#"
+        "$schema": "http://json-schema.org/draft-07/schema#"
       }
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

[PR #61](https://github.com/harness/mcp-server/pull/61) auto-syncs `pipeline`, `template`, and `trigger` from `harness/harness-schema` but regenerated `src/data/schemas/index.ts` without `pipeline_v1` and `agent-pipeline`. Those types are not published under harness-schema v0 yet remain part of the MCP contract (`VALID_SCHEMAS`, `harness_schema`, `schema:///...` resources, registry hints for v1 pipelines, and agent YAML validation).

This change merges the synced JSON into this branch and restores the index entries. `scripts/sync-schemas.js` is updated so future workflow runs always append the MCP-local schemas to the generated index instead of dropping them.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] Tests pass (`pnpm test`)
- [x] Typecheck passes (`pnpm typecheck`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34dfd83a-9a2f-4623-aef9-f78ecf34cfb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34dfd83a-9a2f-4623-aef9-f78ecf34cfb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

