### PR TITLE
test: add CCM cost category and JSON-string body coercion coverage

### DIFF
--- a/tests/registry/registry.test.ts
+++ b/tests/registry/registry.test.ts
@@ -469,6 +469,73 @@ describe("Registry", () => {
     });
   });
 
+  describe("cost category create — account body injection", () => {
+    let registry: Registry;
+
+    it("injects accountId into the request body", async () => {
+      registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ccm" }));
+      const mockRequest = vi.fn().mockResolvedValue({ data: { uuid: "category-1" } });
+      const client = makeClient(mockRequest);
+
+      await registry.dispatch(client, "cost_category", "create", {
+        body: {
+          name: "Engineering",
+          costTargets: [
+            {
+              name: "Development",
+              rules: [
+                {
+                  viewConditions: [
+                    {
+                      type: "VIEW_ID_CONDITION",
+                      viewField: {
+                        fieldId: "labels.value",
+                        fieldName: "env",
+                        identifierName: "Label V2",
+                        identifier: "LABEL_V2",
+                      },
+                      viewOperator: "IN",
+                      values: ["dev"],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      expect(mockRequest).toHaveBeenCalledOnce();
+      const call = mockRequest.mock.calls[0][0];
+      expect(call.method).toBe("POST");
+      expect(call.path).toBe("/ccm/api/business-mapping");
+      expect(call.body).toMatchObject({
+        accountId: "test-account",
+        name: "Engineering",
+      });
+      expect(call.body.accountIdentifier).toBeUndefined();
+    });
+
+    it("uses the resolved account ID for body injection", async () => {
+      registry = new Registry(makeConfig({ HARNESS_ACCOUNT_ID: "internal", HARNESS_TOOLSETS: "ccm" }), {
+        accountIdResolver: () => "resolved-account",
+      });
+      const mockRequest = vi.fn().mockResolvedValue({ data: { uuid: "category-1" } });
+      const client = makeClient(mockRequest);
+
+      await registry.dispatch(client, "cost_category", "create", {
+        body: {
+          name: "Engineering",
+          costTargets: [{ name: "Development", rules: [] }],
+        },
+      });
+
+      const call = mockRequest.mock.calls[0][0];
+      expect(call.body.accountId).toBe("resolved-account");
+      expect(call.body.accountId).not.toBe("internal");
+    });
+  });
+
   describe("resolved account ID propagation", () => {
     it("passes the resolved account ID to pathBuilder and deep links", async () => {
       const mockRequest = vi.fn().mockResolvedValue({

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -436,6 +436,30 @@ describe("harness_create", () => {
     expect(parsed.openInHarness).toBeDefined();
     expect(parsed.openInHarness).not.toContain("storeType=");
   });
+
+  it("coerces JSON-string bodies before dispatch", async () => {
+    registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ccm" }));
+    mockRequest = vi.fn().mockResolvedValue({ data: { uuid: "category-1" } });
+    client = makeClient(mockRequest);
+    const ccmServer = makeMcpServer("accept");
+    const { registerCreateTool } = await import("../../src/tools/harness-create.js");
+    registerCreateTool(ccmServer, registry, client);
+
+    const result = await ccmServer.call("harness_create", {
+      resource_type: "cost_category",
+      body: JSON.stringify({
+        name: "Engineering",
+        costTargets: [{ name: "Development", rules: [] }],
+      }),
+    });
+
+    expect(result.isError).toBeUndefined();
+    const callArgs = mockRequest.mock.calls[0]![0] as { body: Record<string, unknown> };
+    expect(callArgs.body).toMatchObject({
+      accountId: "test-account",
+      name: "Engineering",
+    });
+  });
 });
 
 describe("harness_update", () => {
@@ -490,6 +514,28 @@ describe("harness_update", () => {
     });
     expect(result.isError).toBeUndefined();
     expect(mockRequest).toHaveBeenCalledOnce();
+  });
+
+  it("coerces JSON-string bodies before dispatch", async () => {
+    registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "platform" }));
+    mockRequest = vi.fn().mockResolvedValue({ data: { identifier: "proj1" } });
+    client = makeClient(mockRequest);
+    const platformServer = makeMcpServer("accept");
+    const { registerUpdateTool } = await import("../../src/tools/harness-update.js");
+    registerUpdateTool(platformServer, registry, client);
+
+    const result = await platformServer.call("harness_update", {
+      resource_type: "project",
+      resource_id: "proj1",
+      body: JSON.stringify({ name: "Project One", identifier: "proj1" }),
+    });
+
+    expect(result.isError).toBeUndefined();
+    const callArgs = mockRequest.mock.calls[0]![0] as { body: { project?: Record<string, unknown> } };
+    expect(callArgs.body.project).toMatchObject({
+      name: "Project One",
+      identifier: "proj1",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds test coverage for `cost_category` create with `injectAccountInBody: "accountId"` (both static and resolver-backed accounts)
- Adds test coverage for JSON-string body coercion in `harness_create` and `harness_update`
- Cherry-picked from PR #99 (now superseded — all code changes already on main via CCM-32274)

## Test plan
- [x] `pnpm test tests/registry/registry.test.ts tests/tools/tool-handlers.test.ts` — 131 pass
- [x] `pnpm test` — 1036 pass
- [x] `pnpm build` — clean

Supersedes test portion of #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)