### PR TITLE
fix: project list/search openInHarness URLs (org alias, nested project rows)

### DIFF
--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -5,7 +5,6 @@ import type { ResourceDefinition, ToolsetDefinition, ToolsetName, OperationName,
 import { createLogger } from "../utils/logger.js";
 import { buildDeepLink, appendStoreType } from "../utils/deep-links.js";
 
-// Import all toolsets
 import { pipelinesToolset } from "./toolsets/pipelines.js";
 import { agentsToolset } from "./toolsets/agents.js";
 import { servicesToolset } from "./toolsets/services.js";
@@ -39,6 +38,29 @@ import { governanceToolset } from "./toolsets/governance.js";
 import { freezeToolset } from "./toolsets/freeze.js";
 import { overridesToolset } from "./toolsets/overrides.js";
 import { aiEvalsToolset } from "./toolsets/ai-evals.js";
+
+/**
+ * Coerce API values to a string for deep-link placeholders. Objects (e.g. nested
+ * `project: { identifier }` in list rows) must not become "[object Object]".
+ */
+function scalarForDeepLink(value: unknown): string | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return undefined;
+}
+
+/**
+ * Many templates use `{org}` / `{project}` while request scope uses `orgIdentifier` /
+ * `projectIdentifier`. Mirror values so all placeholder names resolve.
+ */
+function applyDeepLinkParamAliases(params: Record<string, string>): void {
+  if (!params.org && params.orgIdentifier) params.org = params.orgIdentifier;
+  if (!params.project && params.projectIdentifier) params.project = params.projectIdentifier;
+  if (!params.orgIdentifier && params.org) params.orgIdentifier = params.org;
+  if (!params.projectIdentifier && params.project) params.projectIdentifier = params.project;
+}
 
 const log = createLogger("registry");
 
@@ -636,8 +658,9 @@ export class Registry {
             }
           }
         }
-        if (value) {
-          baseLinkParams[pathParamName] = String(value);
+        const scalar = scalarForDeepLink(value);
+        if (scalar) {
+          baseLinkParams[pathParamName] = scalar;
         }
       }
       // Resolve remaining {placeholder} tokens directly from response fields.
@@ -648,11 +671,13 @@ export class Registry {
         for (const token of remaining) {
           const key = token.slice(1, -1);
           if (key === "accountId" || baseLinkParams[key]) continue;
-          if (resultRecord[key] !== undefined) {
-            baseLinkParams[key] = String(resultRecord[key]);
+          const fromResult = scalarForDeepLink(resultRecord[key]);
+          if (fromResult !== undefined) {
+            baseLinkParams[key] = fromResult;
           }
         }
       }
+      applyDeepLinkParamAliases(baseLinkParams);
 
       // Only attach top-level openInHarness for single-item results (get/create/update),
       // not for list results where there's no single entity to link to.
@@ -696,14 +721,12 @@ export class Registry {
               const getPathParam = def.operations.get?.pathParams?.[field];
               const pathParamName = spec.pathParams?.[field] ?? getPathParam ?? field;
               // Look for the API param name directly in the item (e.g., pipelineIdentifier, identifier)
-              if (itemRecord[pathParamName] !== undefined) {
-                itemLinkParams[pathParamName] = String(itemRecord[pathParamName]);
-              } else if (itemRecord.identifier !== undefined) {
-                // Fall back to the generic "identifier" field for the primary identifier
-                itemLinkParams[pathParamName] = String(itemRecord.identifier);
-              } else if (itemRecord.name !== undefined) {
-                // Some APIs use "name" as the identifier (e.g., registry)
-                itemLinkParams[pathParamName] = String(itemRecord.name);
+              const topScalar =
+                scalarForDeepLink(itemRecord[pathParamName]) ??
+                scalarForDeepLink(itemRecord.identifier) ??
+                scalarForDeepLink(itemRecord.name);
+              if (topScalar !== undefined) {
+                itemLinkParams[pathParamName] = topScalar;
               } else {
                 // Check for nested wrapper objects (e.g., connector.identifier, service.identifier)
                 // Common wrapper keys used by Harness NG APIs
@@ -712,11 +735,11 @@ export class Registry {
                   const nested = itemRecord[wrapperKey];
                   if (nested && typeof nested === "object") {
                     const nestedRecord = nested as Record<string, unknown>;
-                    if (nestedRecord[pathParamName] !== undefined) {
-                      itemLinkParams[pathParamName] = String(nestedRecord[pathParamName]);
-                      break;
-                    } else if (nestedRecord.identifier !== undefined) {
-                      itemLinkParams[pathParamName] = String(nestedRecord.identifier);
+                    const nestedScalar =
+                      scalarForDeepLink(nestedRecord[pathParamName]) ??
+                      scalarForDeepLink(nestedRecord.identifier);
+                    if (nestedScalar !== undefined) {
+                      itemLinkParams[pathParamName] = nestedScalar;
                       break;
                     }
                   }
@@ -730,8 +753,9 @@ export class Registry {
             let match;
             while ((match = placeholderRegex.exec(def.deepLinkTemplate)) !== null) {
               const placeholder = match[1];
-              if (placeholder && !itemLinkParams[placeholder] && itemRecord[placeholder] !== undefined) {
-                itemLinkParams[placeholder] = String(itemRecord[placeholder]);
+              if (placeholder && !itemLinkParams[placeholder]) {
+                const s = scalarForDeepLink(itemRecord[placeholder]);
+                if (s !== undefined) itemLinkParams[placeholder] = s;
               }
             }
 
@@ -743,11 +767,12 @@ export class Registry {
               for (const token of remaining) {
                 const key = token.slice(1, -1); // strip { }
                 if (key === "accountId" || itemLinkParams[key]) continue;
-                if (itemRecord[key] !== undefined) {
-                  itemLinkParams[key] = String(itemRecord[key]);
-                }
+                const s = scalarForDeepLink(itemRecord[key]);
+                if (s !== undefined) itemLinkParams[key] = s;
               }
             }
+
+            applyDeepLinkParamAliases(itemLinkParams);
 
             let itemLink = buildDeepLink(
               this.config.HARNESS_BASE_URL,

--- a/tests/registry/registry.test.ts
+++ b/tests/registry/registry.test.ts
@@ -965,6 +965,53 @@ describe("Registry", () => {
       const call = mockRequest.mock.calls[0][0];
       expect(call.params?.orgIdentifier).toBeUndefined();
     });
+
+    it("project list: openInHarness substitutes org and project (nested project row + org_id)", async () => {
+      const mockRequest = vi.fn().mockResolvedValue({
+        data: {
+          content: [
+            {
+              project: { identifier: "quantum-lab", name: "Quantum Lab" },
+            },
+          ],
+          totalElements: 1,
+        },
+      });
+      const client = makeClient(mockRequest);
+      const registry = new Registry(
+        makeConfig({ HARNESS_TOOLSETS: "platform", HARNESS_ACCOUNT_ID: "acct1" }),
+      );
+
+      const result = (await registry.dispatch(client, "project", "list", {
+        org_id: "sandbox",
+        page: 0,
+        size: 10,
+      })) as { items: Array<Record<string, unknown>> };
+
+      const link = String(result.items[0].openInHarness);
+      expect(link).toContain("/orgs/sandbox/projects/quantum-lab");
+      expect(link).not.toContain("%5Bobject%20Object%5D");
+      expect(link).not.toContain("{org}");
+    });
+
+    it("project list: openInHarness uses flat identifier when row is not nested", async () => {
+      const mockRequest = vi.fn().mockResolvedValue({
+        data: {
+          content: [{ identifier: "flat-proj", name: "Flat" }],
+          totalElements: 1,
+        },
+      });
+      const client = makeClient(mockRequest);
+      const registry = new Registry(
+        makeConfig({ HARNESS_TOOLSETS: "platform", HARNESS_ACCOUNT_ID: "acct1" }),
+      );
+
+      const result = (await registry.dispatch(client, "project", "list", {
+        org_id: "myorg",
+      })) as { items: Array<Record<string, unknown>> };
+
+      expect(String(result.items[0].openInHarness)).toContain("/orgs/myorg/projects/flat-proj");
+    });
   });
 
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes malformed `openInHarness` links for `harness_list` / search on `resource_type: project`.

**Root cause**
- The project `deepLinkTemplate` uses `{org}` and `{project}`, but the registry only populated `orgIdentifier` and `projectIdentifier` from the request scope, so `{org}` was left literal in the URL.
- List rows that include a nested `project: { identifier, name }` object led to `String(project)` → `[object Object]` in the path when that field was used as a placeholder.

**Changes**
- After building link params, mirror `orgIdentifier` ↔ `org` and `projectIdentifier` ↔ `project` so short template names resolve.
- Use a small `scalarForDeepLink` helper so only string/number/boolean values become placeholders; nested objects fall through to nested unwrapping instead of `String(object)`.
- Regression tests for nested list rows and flat `identifier` rows.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [ ] Tests pass (Node/pnpm not available in this agent image; please run `pnpm test tests/registry/registry.test.ts` and `pnpm typecheck` locally)
- [ ] Typecheck passes
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://harness.slack.com/archives/D0ANP37TK8S/p1777562780993589?thread_ts=1777562780.993589&cid=D0ANP37TK8S)

<div><a href="https://cursor.com/agents/bc-e6df1358-623c-59aa-a89e-f9ea06c30629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6df1358-623c-59aa-a89e-f9ea06c30629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

