### PR TITLE
feat: pluggable audit sink abstraction (P9)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,3 +46,14 @@ HARNESS_MCP_LOG_FILE=
 # only those toolsets. The legacy name agent-pipelines is accepted as agents.
 # Available: pipelines,agents,services,environments,infrastructure,connectors,secrets,logs,audit,delegates,repositories,registries,templates,dashboards,idp,pull-requests,feature-flags,gitops,chaos,ccm,sei,scs,sto,access_control,settings,platform,visualizations,governance,freeze,overrides,ai-evals
 HARNESS_TOOLSETS=
+
+# Audit sinks — all optional
+# JSONL file: append audit events as newline-delimited JSON
+HARNESS_AUDIT_FILE=
+# Webhook: POST audit event batches to an HTTP endpoint
+HARNESS_AUDIT_WEBHOOK_URL=
+HARNESS_AUDIT_WEBHOOK_TOKEN=
+HARNESS_AUDIT_WEBHOOK_BATCH_SIZE=10
+HARNESS_AUDIT_WEBHOOK_FLUSH_MS=5000
+# OTel: emits audit span events when @opentelemetry/api is installed
+# and OTEL_EXPORTER_OTLP_ENDPOINT is set (no config needed here)

--- a/.env.example
+++ b/.env.example
@@ -55,5 +55,8 @@ HARNESS_AUDIT_WEBHOOK_URL=
 HARNESS_AUDIT_WEBHOOK_TOKEN=
 HARNESS_AUDIT_WEBHOOK_BATCH_SIZE=10
 HARNESS_AUDIT_WEBHOOK_FLUSH_MS=5000
-# OTel: emits audit span events when @opentelemetry/api is installed
-# and OTEL_EXPORTER_OTLP_ENDPOINT is set (no config needed here)
+# OTel: emits audit spans when OTel packages are installed.
+# Standalone mode bootstraps its own TracerProvider — just set the endpoint.
+# Packages: @opentelemetry/api @opentelemetry/sdk-trace-node
+#           @opentelemetry/exporter-trace-otlp-http @opentelemetry/resources
+OTEL_EXPORTER_OTLP_ENDPOINT=

--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/exporter-trace-otlp-http": ">=0.52.0 || ^0.200.0",
-    "@opentelemetry/resources": ">=1.25.0 || ^2.0.0",
-    "@opentelemetry/sdk-trace-node": ">=1.25.0 || ^2.0.0"
+    "@opentelemetry/exporter-trace-otlp-http": "^0.200.0",
+    "@opentelemetry/resources": "^2.0.0",
+    "@opentelemetry/sdk-trace-node": "^2.0.0"
   },
   "peerDependenciesMeta": {
     "@opentelemetry/api": {

--- a/package.json
+++ b/package.json
@@ -58,10 +58,10 @@
     "zod": "^4.0.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.50.0",
-    "@opentelemetry/resources": "^1.0.0",
-    "@opentelemetry/sdk-trace-node": "^1.0.0"
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-trace-otlp-http": ">=0.52.0 || ^0.200.0",
+    "@opentelemetry/resources": ">=1.25.0 || ^2.0.0",
+    "@opentelemetry/sdk-trace-node": ">=1.25.0 || ^2.0.0"
   },
   "peerDependenciesMeta": {
     "@opentelemetry/api": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,14 @@
     "yaml": "^2.8.3",
     "zod": "^4.0.0"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@opentelemetry/api": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/express": "^5.0.6",
     "@types/jsonwebtoken": "^9.0.10",

--- a/package.json
+++ b/package.json
@@ -58,14 +58,30 @@
     "zod": "^4.0.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.0"
+    "@opentelemetry/api": "^1.0.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.50.0",
+    "@opentelemetry/resources": "^1.0.0",
+    "@opentelemetry/sdk-trace-node": "^1.0.0"
   },
   "peerDependenciesMeta": {
     "@opentelemetry/api": {
       "optional": true
+    },
+    "@opentelemetry/sdk-trace-node": {
+      "optional": true
+    },
+    "@opentelemetry/exporter-trace-otlp-http": {
+      "optional": true
+    },
+    "@opentelemetry/resources": {
+      "optional": true
     }
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.216.0",
+    "@opentelemetry/resources": "^2.7.1",
+    "@opentelemetry/sdk-trace-node": "^2.7.1",
     "@types/express": "^5.0.6",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^22.13.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,18 @@ importers:
         specifier: ^4.0.0
         version: 4.3.6
     devDependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
+      '@opentelemetry/exporter-trace-otlp-http':
+        specifier: ^0.216.0
+        version: 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources':
+        specifier: ^2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^2.7.1
+        version: 2.7.1(@opentelemetry/api@1.9.1)
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -236,6 +248,108 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@opentelemetry/api-logs@0.216.0':
+    resolution: {integrity: sha512-KmGTgvxTJ0J01d4mOeX1wMV5NUTNf9HebIuOOGDfIn0a/IrnXIQbOnlylDyl9tkDv4h0DUpdI/GqCdLzfTkUXg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@2.7.1':
+    resolution: {integrity: sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.7.1':
+    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-trace-otlp-http@0.216.0':
+    resolution: {integrity: sha512-DhWjvj0PUPFwFnhOEivpum8sJzj6FTuyx88zff+oHVLUhfd6cLyw4AIai/F4j0PZqYZBFuMT/OTMUd9wdXnBEQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.216.0':
+    resolution: {integrity: sha512-sSnvb5f+FYa4mfYxj03rmmUh+aDwo3jok62dgIWUDw8ZCUPzEbgtv/YhZyKUSlKNNey7Uc5xmJgmtTLLIV6UDQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.216.0':
+    resolution: {integrity: sha512-g4Rb6sAsxQAo11eDjixfKxelruBsQFdJ8Wo23FCj7D6OXbidgXMu2xaRSYs4RdlomzAXSJuc86RcS3xmE8A6uA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.7.1':
+    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.216.0':
+    resolution: {integrity: sha512-KB3rcwQuitq0JbbsCcNdqMhRJX3kArAYz/ovb0jGRaBQAIrt2roik3xQXuhYxS37zx0jSkUZcJu1z3Y2UCxbDA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.7.1':
+    resolution: {integrity: sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.7.1':
+    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.7.1':
+    resolution: {integrity: sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.1':
+    resolution: {integrity: sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@resvg/resvg-js-android-arm-eabi@2.6.2':
     resolution: {integrity: sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==}
@@ -874,6 +988,9 @@ packages:
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -959,6 +1076,10 @@ packages:
   postcss@8.5.9:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
+
+  protobufjs@8.0.1:
+    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
+    engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -1307,6 +1428,106 @@ snapshots:
       zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
+
+  '@opentelemetry/api-logs@0.216.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.216.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-exporter-base@0.216.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.216.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.216.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.216.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+      protobufjs: 8.0.1
+
+  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-logs@0.216.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.216.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-trace-node@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/semantic-conventions@1.40.0': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.1
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.1': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@resvg/resvg-js-android-arm-eabi@2.6.2':
     optional: true
@@ -1904,6 +2125,8 @@ snapshots:
 
   lodash.once@4.1.1: {}
 
+  long@5.3.2: {}
+
   loupe@3.2.1: {}
 
   magic-string@0.30.21:
@@ -1961,6 +2184,21 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  protobufjs@8.0.1:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.1
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.19.12
+      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:

--- a/scripts/verify-otel.js
+++ b/scripts/verify-otel.js
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+
+/**
+ * Verification script for the OTel audit sink.
+ *
+ * Usage:
+ *   # 1. Install OTel packages (if not already)
+ *   pnpm add -D @opentelemetry/api @opentelemetry/sdk-trace-node \
+ *     @opentelemetry/exporter-trace-otlp-http @opentelemetry/resources
+ *
+ *   # 2. Port-forward to Jaeger OTLP HTTP (if using in-cluster Jaeger)
+ *   kubectl port-forward svc/jaeger-otlp-http 4318:4318 -n event-store-team &
+ *
+ *   # 3. Run the script
+ *   OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 node scripts/verify-otel.js
+ *
+ *   # 4. Open Jaeger UI and search for service "harness-mcp-server"
+ */
+
+import { randomUUID } from "node:crypto";
+
+const endpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+if (!endpoint) {
+  console.error("ERROR: OTEL_EXPORTER_OTLP_ENDPOINT is not set.");
+  console.error("");
+  console.error("Usage:");
+  console.error("  OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 node scripts/verify-otel.js");
+  console.error("");
+  console.error("If your Jaeger is in-cluster, port-forward first:");
+  console.error("  kubectl port-forward svc/jaeger-otlp-http 4318:4318 -n <namespace>");
+  process.exit(1);
+}
+
+console.error(`[verify-otel] OTLP endpoint: ${endpoint}`);
+console.error("[verify-otel] Importing OTel sink...");
+
+const { OTelSink } = await import("../build/audit/sinks/otel.js");
+
+const sink = new OTelSink();
+
+// Wait for async initialization to complete
+await sink.flush();
+console.error("[verify-otel] OTel sink initialized");
+
+const sampleEvents = [
+  {
+    event_id: randomUUID(),
+    timestamp: new Date().toISOString(),
+    tool: "harness_list",
+    operation: "list",
+    resource_type: "pipeline",
+    account_id: "verify-test-account",
+    risk: "read",
+    outcome: "success",
+    duration_ms: 120,
+    http_method: "POST",
+    http_path: "/pipeline/api/pipelines/execution/summary",
+    org_id: "default",
+    project_id: "test-project",
+  },
+  {
+    event_id: randomUUID(),
+    timestamp: new Date().toISOString(),
+    tool: "harness_get",
+    operation: "get",
+    resource_type: "service",
+    resource_id: "my-backend-svc",
+    account_id: "verify-test-account",
+    risk: "read",
+    outcome: "success",
+    duration_ms: 85,
+    http_method: "GET",
+    http_path: "/ng/api/servicesV2/my-backend-svc",
+    org_id: "default",
+    project_id: "test-project",
+  },
+  {
+    event_id: randomUUID(),
+    timestamp: new Date().toISOString(),
+    tool: "harness_create",
+    operation: "create",
+    resource_type: "pipeline",
+    account_id: "verify-test-account",
+    risk: "medium_write",
+    confirmation: "elicited",
+    outcome: "success",
+    duration_ms: 340,
+    http_method: "POST",
+    http_path: "/pipeline/api/pipelines/v2",
+    http_status: 200,
+    org_id: "default",
+    project_id: "test-project",
+  },
+  {
+    event_id: randomUUID(),
+    timestamp: new Date().toISOString(),
+    tool: "harness_execute",
+    operation: "execute",
+    resource_type: "pipeline",
+    resource_id: "deploy-prod",
+    action: "run",
+    account_id: "verify-test-account",
+    risk: "high_write",
+    confirmation: "elicited",
+    outcome: "error",
+    error: "Pipeline input validation failed: missing required input 'tag'",
+    duration_ms: 1200,
+    http_method: "POST",
+    http_path: "/pipeline/api/pipeline/execute/deploy-prod",
+    http_status: 400,
+    org_id: "default",
+    project_id: "test-project",
+  },
+  {
+    event_id: randomUUID(),
+    timestamp: new Date().toISOString(),
+    tool: "harness_delete",
+    operation: "delete",
+    resource_type: "connector",
+    resource_id: "old-docker-hub",
+    account_id: "verify-test-account",
+    risk: "destructive",
+    confirmation: "elicited",
+    outcome: "success",
+    duration_ms: 210,
+    http_method: "DELETE",
+    http_path: "/ng/api/connectors/old-docker-hub",
+    http_status: 200,
+    org_id: "default",
+    project_id: "test-project",
+  },
+];
+
+console.error(`[verify-otel] Emitting ${sampleEvents.length} sample audit events...`);
+
+for (const event of sampleEvents) {
+  sink.emit(event);
+  console.error(`  -> ${event.tool} ${event.operation} ${event.resource_type} [${event.outcome}]`);
+}
+
+console.error("[verify-otel] Flushing spans...");
+await sink.flush();
+
+// Give the batch processor a moment to export
+await new Promise((r) => setTimeout(r, 3000));
+await sink.flush();
+
+console.error("[verify-otel] Shutting down...");
+await sink.close();
+
+console.error("");
+console.error("=== Verification Complete ===");
+console.error(`Sent ${sampleEvents.length} audit spans to ${endpoint}`);
+console.error("");
+console.error("Next steps:");
+console.error("  1. Open your Jaeger UI");
+console.error('  2. Search for service: "harness-mcp-server"');
+console.error("  3. You should see spans named like:");
+console.error("       audit.list.pipeline");
+console.error("       audit.get.service");
+console.error("       audit.create.pipeline");
+console.error("       audit.execute.pipeline (with error status)");
+console.error("       audit.delete.connector");
+console.error("  4. Click a span to see all audit attributes");

--- a/scripts/verify-otel.js
+++ b/scripts/verify-otel.js
@@ -18,6 +18,12 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const buildDir = join(__dirname, "..", "build");
 
 const endpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
 if (!endpoint) {
@@ -28,6 +34,13 @@ if (!endpoint) {
   console.error("");
   console.error("If your Jaeger is in-cluster, port-forward first:");
   console.error("  kubectl port-forward svc/jaeger-otlp-http 4318:4318 -n <namespace>");
+  process.exit(1);
+}
+
+if (!existsSync(join(buildDir, "audit", "sinks", "otel.js"))) {
+  console.error("ERROR: Build artifacts not found. Run `pnpm build` first.");
+  console.error("");
+  console.error("  pnpm build && node scripts/verify-otel.js");
   process.exit(1);
 }
 

--- a/specs/004-audit-sinks.md
+++ b/specs/004-audit-sinks.md
@@ -1,0 +1,89 @@
+# Spec 004: Enterprise Audit Sink Abstraction (P9)
+
+**Status**: Implementing  
+**Priority**: P9 — final quality review item  
+**Depends on**: P3/P4 (risk-based elicitation), P5 (retry policy), P11 (registry contract)
+
+---
+
+## Problem
+
+`logAudit()` in `src/utils/logger.ts` writes `AuditEntry` records to stderr. Limitations:
+
+- **Minimal schema**: Missing `event_id`, `risk`, `confirmation_method`, `duration_ms`, `account_id`, `timestamp`, HTTP status/method/path
+- **No pluggable sinks**: Only stderr; no file, webhook, or OTel destinations
+- **Scattered call sites**: Called from 4 tool handlers with inconsistent shapes
+- **No read audit**: List/get/describe/search leave no trail
+- **Internal repo gap**: `mcpServerInternal` has identical unused `logAudit()`; this design provides a plugin interface both repos can share
+
+## Design
+
+### AuditEvent (enriched)
+
+```typescript
+interface AuditEvent {
+  event_id: string;           // randomUUID()
+  timestamp: string;          // ISO 8601
+  tool: string;               // "harness_create" | "harness_list" | ...
+  operation: string;          // "create" | "list" | "get" | "delete" | "update" | "execute"
+  resource_type: string;
+  resource_id?: string;
+  action?: string;            // for execute actions
+  org_id?: string;
+  project_id?: string;
+  account_id: string;
+  risk: RiskLevel;
+  confirmation?: "auto_approved" | "elicited" | "skipped" | "blocked" | "not_required";
+  outcome: "success" | "error";
+  error?: string;
+  duration_ms: number;
+  http_status?: number;
+  http_method?: string;
+  http_path?: string;
+}
+```
+
+### AuditSink interface
+
+```typescript
+interface AuditSink {
+  name: string;
+  emit(event: AuditEvent): void | Promise<void>;
+  flush?(): Promise<void>;
+  close?(): Promise<void>;
+}
+```
+
+### Sinks
+
+1. **StderrSink** — always on, JSON to stderr via logger
+2. **JsonlFileSink** — append NDJSON to `HARNESS_AUDIT_FILE`, auto-mkdir
+3. **WebhookSink** — POST to `HARNESS_AUDIT_WEBHOOK_URL` with Bearer token, batched
+4. **OTelSink** — optional peer dep, dynamic `import("@opentelemetry/api")`, span events
+
+### AuditManager
+
+Fan-out orchestrator. Errors in sinks are logged but never propagate.
+
+### Emission point
+
+Wraps `executeSpec()` in `Registry` — captures ALL registry-mediated operations. Tool handlers pass `AuditContext` (tool name, confirmation method) through `dispatch`/`dispatchExecute`.
+
+### Config
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `HARNESS_AUDIT_FILE` | (none) | JSONL file path |
+| `HARNESS_AUDIT_WEBHOOK_URL` | (none) | Webhook endpoint |
+| `HARNESS_AUDIT_WEBHOOK_TOKEN` | (none) | Bearer token |
+| `HARNESS_AUDIT_WEBHOOK_BATCH_SIZE` | 10 | Batch size |
+| `HARNESS_AUDIT_WEBHOOK_FLUSH_MS` | 5000 | Flush interval |
+
+### Breaking changes
+
+- `logAudit()` and `AuditEntry` deprecated (still exported, delegate to AuditManager)
+- `dispatch`/`dispatchExecute` gain optional `AuditContext` parameter (backward compatible)
+
+### Internal repo integration
+
+Import `AuditManager` from `harness-mcp-v2`, add custom sinks. No monkey-patching.

--- a/specs/004-audit-sinks.md
+++ b/specs/004-audit-sinks.md
@@ -1,6 +1,6 @@
 # Spec 004: Enterprise Audit Sink Abstraction (P9)
 
-**Status**: Implementing  
+**Status**: Implemented  
 **Priority**: P9 — final quality review item  
 **Depends on**: P3/P4 (risk-based elicitation), P5 (retry policy), P11 (registry contract)
 
@@ -14,11 +14,34 @@
 - **No pluggable sinks**: Only stderr; no file, webhook, or OTel destinations
 - **Scattered call sites**: Called from 4 tool handlers with inconsistent shapes
 - **No read audit**: List/get/describe/search leave no trail
-- **Internal repo gap**: `mcpServerInternal` has identical unused `logAudit()`; this design provides a plugin interface both repos can share
+- **No extension point**: No way for downstream consumers to add custom sinks
 
-## Design
+---
 
-### AuditEvent (enriched)
+## Architecture
+
+### Data Flow
+
+```
+Tool Handler                    Registry                     AuditManager
+     |                             |                              |
+     |-- dispatch(AuditContext) -->|                              |
+     |                             |-- executeSpec() ----------->|
+     |                             |   (measures duration,        |
+     |                             |    captures outcome)         |
+     |                             |                              |-- emit() --> StderrSink
+     |                             |<-- result/error ------------|-- emit() --> JsonlFileSink
+     |<-- result/error ------------|                              |-- emit() --> WebhookSink
+     |                             |                              |-- emit() --> OTelSink
+```
+
+### Emission Point
+
+Audit events are emitted from `Registry.executeSpecWithAudit()` — a wrapper around `executeSpec()`. This guarantees 100% coverage of all registry-mediated operations without requiring individual tool handlers to emit events. Tool handlers pass an `AuditContext` (tool name, confirmation method, resource_id, action) through `dispatch`/`dispatchExecute`.
+
+---
+
+## AuditEvent Schema
 
 ```typescript
 interface AuditEvent {
@@ -33,7 +56,7 @@ interface AuditEvent {
   project_id?: string;
   account_id: string;
   risk: RiskLevel;
-  confirmation?: "auto_approved" | "elicited" | "skipped" | "blocked" | "not_required";
+  confirmation?: ConfirmationMethod;
   outcome: "success" | "error";
   error?: string;
   duration_ms: number;
@@ -41,49 +64,107 @@ interface AuditEvent {
   http_method?: string;
   http_path?: string;
 }
+
+type ConfirmationMethod = "auto_approved" | "elicited" | "skipped" | "blocked" | "not_required";
 ```
 
-### AuditSink interface
+## AuditSink Interface
 
 ```typescript
 interface AuditSink {
-  name: string;
+  readonly name: string;
   emit(event: AuditEvent): void | Promise<void>;
   flush?(): Promise<void>;
   close?(): Promise<void>;
 }
 ```
 
-### Sinks
+## AuditManager
 
-1. **StderrSink** — always on, JSON to stderr via logger
-2. **JsonlFileSink** — append NDJSON to `HARNESS_AUDIT_FILE`, auto-mkdir
-3. **WebhookSink** — POST to `HARNESS_AUDIT_WEBHOOK_URL` with Bearer token, batched
-4. **OTelSink** — optional peer dep, dynamic `import("@opentelemetry/api")`, span events
+Fan-out orchestrator. Errors in individual sinks are logged but **never propagate** to the tool handler — audit failures must not break tool execution.
 
-### AuditManager
+```typescript
+class AuditManager {
+  addSink(sink: AuditSink): void;
+  emit(event: AuditEvent): void;
+  flush(): Promise<void>;
+  close(): Promise<void>;
+}
+```
 
-Fan-out orchestrator. Errors in sinks are logged but never propagate.
+Created via `createAuditManager(config)` in `src/audit/index.ts`. Wired into the server lifecycle in `src/index.ts` — `close()` is called on SIGINT/SIGTERM (stdio) and session destruction (HTTP).
 
-### Emission point
+---
 
-Wraps `executeSpec()` in `Registry` — captures ALL registry-mediated operations. Tool handlers pass `AuditContext` (tool name, confirmation method) through `dispatch`/`dispatchExecute`.
+## Sinks
 
-### Config
+### 1. StderrSink (`src/audit/sinks/stderr.ts`)
 
-| Env Var | Default | Description |
-|---------|---------|-------------|
-| `HARNESS_AUDIT_FILE` | (none) | JSONL file path |
-| `HARNESS_AUDIT_WEBHOOK_URL` | (none) | Webhook endpoint |
-| `HARNESS_AUDIT_WEBHOOK_TOKEN` | (none) | Bearer token |
-| `HARNESS_AUDIT_WEBHOOK_BATCH_SIZE` | 10 | Batch size |
-| `HARNESS_AUDIT_WEBHOOK_FLUSH_MS` | 5000 | Flush interval |
+**Always active.** Writes each `AuditEvent` as a JSON object to stderr via the logger utility. Success events log at `info` level, error events at `warn`.
 
-### Breaking changes
+No configuration required.
 
-- `logAudit()` and `AuditEntry` deprecated (still exported, delegate to AuditManager)
-- `dispatch`/`dispatchExecute` gain optional `AuditContext` parameter (backward compatible)
+### 2. JsonlFileSink (`src/audit/sinks/jsonl-file.ts`)
 
-### Internal repo integration
+**Activates when `HARNESS_AUDIT_FILE` is set.** Appends each `AuditEvent` as a newline-delimited JSON (NDJSON) line to the specified file. Creates parent directories automatically. Write errors are logged but never thrown.
 
-Import `AuditManager` from `harness-mcp-v2`, add custom sinks. No monkey-patching.
+### 3. WebhookSink (`src/audit/sinks/webhook.ts`)
+
+**Activates when `HARNESS_AUDIT_WEBHOOK_URL` is set.** Batches `AuditEvent`s and POSTs them as `{ events: [...] }` to the configured URL. Supports optional Bearer token authentication via `HARNESS_AUDIT_WEBHOOK_TOKEN`.
+
+| Config | Default | Description |
+|--------|---------|-------------|
+| `HARNESS_AUDIT_WEBHOOK_URL` | (none) | Webhook endpoint URL |
+| `HARNESS_AUDIT_WEBHOOK_TOKEN` | (none) | Bearer token for Authorization header |
+| `HARNESS_AUDIT_WEBHOOK_BATCH_SIZE` | 10 | Events per batch before auto-flush |
+| `HARNESS_AUDIT_WEBHOOK_FLUSH_MS` | 5000 | Timer-based flush interval (ms) |
+
+### 4. OTelSink (`src/audit/sinks/otel.ts`)
+
+**Activates when `OTEL_EXPORTER_OTLP_ENDPOINT` is set and `@opentelemetry/api` is importable.**
+
+Self-bootstrapping sink that exports audit events as OpenTelemetry spans to any OTLP-compatible backend (Jaeger, Grafana Tempo, Datadog, etc.). Supports both standalone mode (bootstraps its own TracerProvider) and embedded mode (reuses an externally registered provider). All OTel packages are optional peer dependencies with zero bundle impact when not installed. Spans are exported asynchronously via `BatchSpanProcessor`.
+
+See **[Spec 005: OpenTelemetry Audit Sink](005-otel-audit-sink.md)** for full details: modes, configuration, span attributes, and verification.
+
+---
+
+## Configuration Summary
+
+| Env Var | Default | Sink | Description |
+|---------|---------|------|-------------|
+| *(none)* | always on | Stderr | JSON audit lines to stderr |
+| `HARNESS_AUDIT_FILE` | (none) | JSONL | File path for NDJSON audit log |
+| `HARNESS_AUDIT_WEBHOOK_URL` | (none) | Webhook | HTTP POST endpoint |
+| `HARNESS_AUDIT_WEBHOOK_TOKEN` | (none) | Webhook | Bearer token |
+| `HARNESS_AUDIT_WEBHOOK_BATCH_SIZE` | 10 | Webhook | Events per batch |
+| `HARNESS_AUDIT_WEBHOOK_FLUSH_MS` | 5000 | Webhook | Flush interval (ms) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | (none) | OTel | OTLP collector URL — see [Spec 005](005-otel-audit-sink.md) for all OTel env vars |
+
+---
+
+## Breaking Changes
+
+- `logAudit()` and `AuditEntry` in `src/utils/logger.ts` are deprecated (still exported for backward compatibility)
+- `dispatch`/`dispatchExecute` gain optional `AuditContext` parameter (backward compatible — `AbortSignal` still accepted in the same position)
+
+## Extensibility
+
+Downstream consumers can extend the audit system by:
+1. Importing `AuditManager` and calling `addSink()` with custom `AuditSink` implementations
+2. Registering their own `TracerProvider` before the MCP server starts — the OTel sink will detect it and use the existing tracing infrastructure
+
+No monkey-patching required.
+
+## Files
+
+| File | Role |
+|------|------|
+| `src/audit/types.ts` | `AuditEvent`, `AuditContext`, `AuditSink`, `ConfirmationMethod` |
+| `src/audit/manager.ts` | `AuditManager` orchestrator |
+| `src/audit/sinks/stderr.ts` | Stderr sink |
+| `src/audit/sinks/jsonl-file.ts` | JSONL file sink |
+| `src/audit/sinks/webhook.ts` | Webhook sink |
+| `src/audit/sinks/otel.ts` | OTel sink (self-bootstrapping) |
+| `src/audit/index.ts` | `createAuditManager()` factory |
+| `scripts/verify-otel.js` | OTel verification script |

--- a/specs/004-audit-sinks.md
+++ b/specs/004-audit-sinks.md
@@ -119,6 +119,8 @@ No configuration required.
 | `HARNESS_AUDIT_WEBHOOK_BATCH_SIZE` | 10 | Events per batch before auto-flush |
 | `HARNESS_AUDIT_WEBHOOK_FLUSH_MS` | 5000 | Timer-based flush interval (ms) |
 
+**Delivery guarantee**: Best-effort with bounded retry. Failed batches are re-enqueued for the next flush cycle, up to 5x the configured batch size. Events exceeding this capacity are dropped with a warning. This prevents unbounded memory growth while giving transient failures a second chance.
+
 ### 4. OTelSink (`src/audit/sinks/otel.ts`)
 
 **Activates when `OTEL_EXPORTER_OTLP_ENDPOINT` is set and `@opentelemetry/api` is importable.**

--- a/specs/005-otel-audit-sink.md
+++ b/specs/005-otel-audit-sink.md
@@ -1,0 +1,151 @@
+# Spec 005: OpenTelemetry Audit Sink
+
+**Status**: Implemented  
+**Depends on**: Spec 004 (Audit Sink Abstraction)
+
+---
+
+## Overview
+
+The OTel sink (`src/audit/sinks/otel.ts`) exports audit events as OpenTelemetry spans to any OTLP-compatible backend (Jaeger, Grafana Tempo, Datadog, etc.). It is self-bootstrapping — no external OTel setup is required beyond setting `OTEL_EXPORTER_OTLP_ENDPOINT` and installing the SDK packages.
+
+**Activates when** `OTEL_EXPORTER_OTLP_ENDPOINT` is set and `@opentelemetry/api` is importable.
+
+---
+
+## Modes
+
+The sink operates in one of two modes, determined at startup:
+
+### Mode A — External TracerProvider
+
+When a host application has already registered a `TracerProvider` before the MCP server starts (e.g. wrapping tool calls with OTel tracing), the sink detects it and reuses the existing provider. It does not bootstrap its own.
+
+At emit time:
+
+- **Active span exists** (per-request trace context from the host): the audit event is added as a **span event** on the active span. This preserves the trace hierarchy — audit data appears nested under the parent tool call trace.
+- **No active span**: a standalone root span is created via the external provider's tracer.
+
+### Mode B — Standalone (no external provider)
+
+When no external `TracerProvider` is registered, the sink dynamically imports the OTel SDK packages and bootstraps its own:
+
+- `NodeTracerProvider` with `BatchSpanProcessor` + `OTLPTraceExporter`
+- Resource attributes from `OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`, and `service.version`
+- Each audit event becomes a root span named `audit.{operation}.{resource_type}`
+- Error events set `otel.status_code=ERROR` with the error message
+
+### Emit Decision Flow
+
+```
+emit(event)
+  |
+  |-- active span exists? --> addEvent("audit", attributes) on active span
+  |
+  |-- no active span, tracer available? --> startSpan("audit.op.type", {attributes}), end()
+  |
+  |-- no tracer? --> no-op
+```
+
+---
+
+## Configuration
+
+The sink respects standard OpenTelemetry environment variables. No custom config variables are needed.
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | (none) | OTLP collector URL. **Required** to activate the sink. |
+| `OTEL_SERVICE_NAME` | `harness-mcp-server` | Override the `service.name` resource attribute |
+| `OTEL_RESOURCE_ATTRIBUTES` | (none) | Additional resource attributes as `key=val,key=val`. Example: `deployment.environment=prod,team=platform` |
+| `OTEL_EXPORTER_OTLP_HEADERS` | (none) | Custom headers on OTLP export requests. Example: `x-api-key=abc123` |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/protobuf` | Protocol: `http/protobuf`, `http/json`, or `grpc` |
+| `OTEL_BSP_SCHEDULE_DELAY` | `5000` | Batch export interval in ms |
+| `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` | `512` | Max spans per export batch |
+
+---
+
+## Required Packages
+
+All declared as optional `peerDependencies` in `package.json`. If the SDK packages are missing but `OTEL_EXPORTER_OTLP_ENDPOINT` is set, the sink logs a warning and degrades to no-op.
+
+| Package | Purpose |
+|---------|---------|
+| `@opentelemetry/api` | Trace API, active span detection |
+| `@opentelemetry/sdk-trace-node` | `NodeTracerProvider`, `BatchSpanProcessor` |
+| `@opentelemetry/exporter-trace-otlp-http` | `OTLPTraceExporter` for OTLP/HTTP |
+| `@opentelemetry/resources` | Service resource attributes |
+
+Install with:
+
+```bash
+pnpm add -D @opentelemetry/api @opentelemetry/sdk-trace-node \
+  @opentelemetry/exporter-trace-otlp-http @opentelemetry/resources
+```
+
+---
+
+## Span Attributes
+
+Every audit span carries these attributes:
+
+| Attribute | Source | Always present |
+|-----------|--------|----------------|
+| `audit.event_id` | `randomUUID()` | Yes |
+| `audit.timestamp` | ISO 8601 | Yes |
+| `audit.tool` | `harness_list`, `harness_create`, etc. | Yes |
+| `audit.operation` | `list`, `get`, `create`, `update`, `delete`, `execute` | Yes |
+| `audit.resource_type` | e.g. `pipeline`, `service`, `connector` | Yes |
+| `audit.outcome` | `success` or `error` | Yes |
+| `audit.risk` | `read`, `low_write`, `medium_write`, `high_write`, `destructive` | Yes |
+| `audit.duration_ms` | End-to-end API call duration | Yes |
+| `audit.account_id` | Harness account identifier | Yes |
+| `audit.resource_id` | Specific resource identifier | When available |
+| `audit.action` | Execute action (e.g. `run`, `stop`) | Execute operations |
+| `audit.confirmation` | `auto_approved`, `elicited`, `skipped`, `blocked`, `not_required` | Write operations |
+| `audit.error` | Error message | On failure |
+| `audit.http_method` | `GET`, `POST`, `PUT`, `DELETE` | When available |
+| `audit.http_path` | API path | When available |
+| `audit.http_status` | HTTP response status code | When available |
+| `audit.org_id` | Organization identifier | When available |
+| `audit.project_id` | Project identifier | When available |
+
+---
+
+## Dynamic Import Strategy
+
+All OTel packages are imported at runtime via a `Function("m", "return import(m)")` trick that prevents TypeScript from statically resolving the modules. This ensures zero bundle impact when OTel packages are not installed.
+
+---
+
+## Lifecycle
+
+- **Async init**: The constructor kicks off an async `init()` that resolves packages and bootstraps the provider. All methods await this before acting.
+- **`flush()`**: Awaits init, then calls `forceFlush()` on the self-bootstrapped provider (no-op if using external provider).
+- **`close()`**: Awaits init, then calls `shutdown()` on the self-bootstrapped provider. Called automatically during server shutdown.
+- **Span export**: `BatchSpanProcessor` exports spans asynchronously — zero impact on tool call latency.
+
+---
+
+## Verification
+
+```bash
+# Install OTel packages
+pnpm add -D @opentelemetry/api @opentelemetry/sdk-trace-node \
+  @opentelemetry/exporter-trace-otlp-http @opentelemetry/resources
+
+# Run verification script against any OTLP-compatible backend
+OTEL_EXPORTER_OTLP_ENDPOINT=https://your-collector/otlp node scripts/verify-otel.js
+
+# Check your tracing UI for service "harness-mcp-server"
+# You should see spans: audit.list.pipeline, audit.get.service, etc.
+```
+
+---
+
+## Files
+
+| File | Role |
+|------|------|
+| `src/audit/sinks/otel.ts` | OTel sink implementation |
+| `scripts/verify-otel.js` | Verification script |

--- a/src/audit/index.ts
+++ b/src/audit/index.ts
@@ -41,7 +41,12 @@ export function createAuditManager(config: Config): AuditManager {
       batchSize,
       flushIntervalMs: flushMs,
     }));
-    log.info("Webhook audit sink enabled", { url: webhookUrl });
+    try {
+      const origin = new URL(webhookUrl).origin;
+      log.info("Webhook audit sink enabled", { host: origin });
+    } catch {
+      log.info("Webhook audit sink enabled");
+    }
   }
 
   if (process.env.OTEL_EXPORTER_OTLP_ENDPOINT) {

--- a/src/audit/index.ts
+++ b/src/audit/index.ts
@@ -1,0 +1,53 @@
+import type { Config } from "../config.js";
+import { AuditManager } from "./manager.js";
+import { StderrSink } from "./sinks/stderr.js";
+import { JsonlFileSink } from "./sinks/jsonl-file.js";
+import { WebhookSink } from "./sinks/webhook.js";
+import { OTelSink } from "./sinks/otel.js";
+import { createLogger } from "../utils/logger.js";
+
+export { AuditManager } from "./manager.js";
+export type { AuditEvent, AuditContext, AuditSink, ConfirmationMethod } from "./types.js";
+
+const log = createLogger("audit");
+
+/**
+ * Create an AuditManager with sinks enabled based on configuration.
+ *
+ * - StderrSink is always active
+ * - JsonlFileSink activates when HARNESS_AUDIT_FILE is set
+ * - WebhookSink activates when HARNESS_AUDIT_WEBHOOK_URL is set
+ * - OTelSink activates when @opentelemetry/api is importable + OTEL endpoint is set
+ */
+export function createAuditManager(config: Config): AuditManager {
+  const manager = new AuditManager();
+
+  manager.addSink(new StderrSink());
+
+  const auditFile = (config as Record<string, unknown>).HARNESS_AUDIT_FILE as string | undefined;
+  if (auditFile) {
+    manager.addSink(new JsonlFileSink(auditFile));
+    log.info("JSONL audit file sink enabled", { path: auditFile });
+  }
+
+  const webhookUrl = (config as Record<string, unknown>).HARNESS_AUDIT_WEBHOOK_URL as string | undefined;
+  if (webhookUrl) {
+    const token = (config as Record<string, unknown>).HARNESS_AUDIT_WEBHOOK_TOKEN as string | undefined;
+    const batchSize = (config as Record<string, unknown>).HARNESS_AUDIT_WEBHOOK_BATCH_SIZE as number | undefined;
+    const flushMs = (config as Record<string, unknown>).HARNESS_AUDIT_WEBHOOK_FLUSH_MS as number | undefined;
+    manager.addSink(new WebhookSink({
+      url: webhookUrl,
+      token,
+      batchSize,
+      flushIntervalMs: flushMs,
+    }));
+    log.info("Webhook audit sink enabled", { url: webhookUrl });
+  }
+
+  if (process.env.OTEL_EXPORTER_OTLP_ENDPOINT) {
+    manager.addSink(new OTelSink());
+    log.info("OTel audit sink enabled (pending @opentelemetry/api availability)");
+  }
+
+  return manager;
+}

--- a/src/audit/manager.ts
+++ b/src/audit/manager.ts
@@ -1,0 +1,62 @@
+import type { AuditEvent, AuditSink } from "./types.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("audit-manager");
+
+/**
+ * Fan-out orchestrator for audit events.
+ * Distributes each event to all registered sinks. Sink failures are
+ * logged but never propagate — audit must never break tool execution.
+ */
+export class AuditManager {
+  private sinks: AuditSink[] = [];
+
+  addSink(sink: AuditSink): void {
+    this.sinks.push(sink);
+    log.debug(`Audit sink registered: ${sink.name}`);
+  }
+
+  emit(event: AuditEvent): void {
+    for (const sink of this.sinks) {
+      try {
+        const result = sink.emit(event);
+        if (result && typeof (result as Promise<void>).catch === "function") {
+          (result as Promise<void>).catch((err) => {
+            log.warn(`Audit sink "${sink.name}" async emit failed`, { error: String(err) });
+          });
+        }
+      } catch (err) {
+        log.warn(`Audit sink "${sink.name}" emit failed`, { error: String(err) });
+      }
+    }
+  }
+
+  async flush(): Promise<void> {
+    await Promise.allSettled(
+      this.sinks
+        .filter((s) => s.flush)
+        .map(async (s) => {
+          try {
+            await s.flush!();
+          } catch (err) {
+            log.warn(`Audit sink "${s.name}" flush failed`, { error: String(err) });
+          }
+        }),
+    );
+  }
+
+  async close(): Promise<void> {
+    await this.flush();
+    await Promise.allSettled(
+      this.sinks
+        .filter((s) => s.close)
+        .map(async (s) => {
+          try {
+            await s.close!();
+          } catch (err) {
+            log.warn(`Audit sink "${s.name}" close failed`, { error: String(err) });
+          }
+        }),
+    );
+  }
+}

--- a/src/audit/sinks/jsonl-file.ts
+++ b/src/audit/sinks/jsonl-file.ts
@@ -1,0 +1,37 @@
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import type { AuditEvent, AuditSink } from "../types.js";
+import { createLogger } from "../../utils/logger.js";
+
+const log = createLogger("audit-jsonl");
+
+/**
+ * Appends audit events as NDJSON (one JSON object per line) to a file.
+ * Enabled when HARNESS_AUDIT_FILE is set.
+ */
+export class JsonlFileSink implements AuditSink {
+  readonly name = "jsonl-file";
+  private dirEnsured = false;
+
+  constructor(private readonly filePath: string) {}
+
+  emit(event: AuditEvent): void {
+    if (!this.dirEnsured) {
+      try {
+        mkdirSync(dirname(this.filePath), { recursive: true });
+      } catch {
+        // Directory may already exist
+      }
+      this.dirEnsured = true;
+    }
+
+    try {
+      appendFileSync(this.filePath, JSON.stringify(event) + "\n");
+    } catch (err) {
+      log.warn("Failed to write audit event to file", {
+        path: this.filePath,
+        error: String(err),
+      });
+    }
+  }
+}

--- a/src/audit/sinks/otel.ts
+++ b/src/audit/sinks/otel.ts
@@ -67,6 +67,8 @@ export class OTelSink implements AuditSink {
   private provider: any = null;
   private ready = false;
   private initPromise: Promise<void>;
+  private pendingEvents: AuditEvent[] = [];
+  private static readonly MAX_PENDING = 100;
 
   constructor() {
     this.initPromise = this.init();
@@ -80,18 +82,17 @@ export class OTelSink implements AuditSink {
     }
     this.api = api;
 
-    // Check if a TracerProvider was already registered by a host application
-    // before the MCP server starts. The default no-op provider returns a
-    // ProxyTracerProvider — a real provider is anything else.
-    const existingProvider = api.trace?.getTracerProvider?.();
-    const hasExternalProvider = existingProvider
-      && existingProvider.constructor?.name !== "ProxyTracerProvider"
-      && existingProvider.constructor?.name !== "NoopTracerProvider";
+    // Detect if a host application already registered a real TracerProvider.
+    // In OTel JS, `trace.getTracerProvider()` always returns a ProxyTracerProvider.
+    // After `setGlobalTracerProvider()`, the proxy's delegate points to the real
+    // SDK provider. We check for a delegate to avoid constructor-name matching.
+    const globalProvider = api.trace?.getTracerProvider?.();
+    const delegate = globalProvider?.getDelegate?.();
+    const hasExternalProvider = delegate
+      && delegate !== globalProvider
+      && typeof delegate.getTracer === "function";
 
     if (hasExternalProvider) {
-      // Another system owns the TracerProvider — use it. At emit() time, if there's
-      // an active span (per-request), we attach as a span event; otherwise we create
-      // a child-less root span via this tracer.
       this.tracer = api.trace.getTracer("harness-mcp-audit");
       this.ready = true;
       log.debug("OTel audit sink using external TracerProvider");
@@ -151,10 +152,30 @@ export class OTelSink implements AuditSink {
     } catch (err) {
       log.error("Failed to bootstrap OTel TracerProvider", { error: String(err) });
     }
+
+    this.drainPending();
+  }
+
+  private drainPending(): void {
+    if (!this.ready || this.pendingEvents.length === 0) return;
+    const events = this.pendingEvents.splice(0);
+    for (const event of events) {
+      this.emitSpan(event);
+    }
   }
 
   emit(event: AuditEvent): void {
-    if (!this.ready || !this.api || !this.tracer) return;
+    if (!this.ready) {
+      if (this.pendingEvents.length < OTelSink.MAX_PENDING) {
+        this.pendingEvents.push(event);
+      }
+      return;
+    }
+    this.emitSpan(event);
+  }
+
+  private emitSpan(event: AuditEvent): void {
+    if (!this.api || !this.tracer) return;
 
     // Path 1: if there's an active span, add as a span event (embedded mode)
     const activeSpan = this.api.trace?.getActiveSpan?.();

--- a/src/audit/sinks/otel.ts
+++ b/src/audit/sinks/otel.ts
@@ -82,20 +82,20 @@ export class OTelSink implements AuditSink {
     }
     this.api = api;
 
-    // Detect if a host application already registered a real TracerProvider.
-    // In OTel JS, `trace.getTracerProvider()` always returns a ProxyTracerProvider.
-    // After `setGlobalTracerProvider()`, the proxy's delegate points to the real
-    // SDK provider. We check for a delegate to avoid constructor-name matching.
+    // Detect if a host application registered a real SDK TracerProvider.
+    // ProxyTracerProvider.getDelegate() returns NoopTracerProvider by default,
+    // which only has getTracer(). Real SDK providers also expose forceFlush().
     const globalProvider = api.trace?.getTracerProvider?.();
     const delegate = globalProvider?.getDelegate?.();
     const hasExternalProvider = delegate
-      && delegate !== globalProvider
-      && typeof delegate.getTracer === "function";
+      && typeof delegate.getTracer === "function"
+      && typeof delegate.forceFlush === "function";
 
     if (hasExternalProvider) {
       this.tracer = api.trace.getTracer("harness-mcp-audit");
       this.ready = true;
       log.debug("OTel audit sink using external TracerProvider");
+      this.drainPending();
       return;
     }
 

--- a/src/audit/sinks/otel.ts
+++ b/src/audit/sinks/otel.ts
@@ -1,0 +1,71 @@
+import type { AuditEvent, AuditSink } from "../types.js";
+import { createLogger } from "../../utils/logger.js";
+
+const log = createLogger("audit-otel");
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let otelApi: any = null;
+let otelResolved = false;
+
+async function resolveOtelApi(): Promise<unknown> {
+  if (otelResolved) return otelApi;
+  otelResolved = true;
+  try {
+    // Dynamic import with variable to prevent TS from resolving the module statically
+    const moduleName = "@opentelemetry/api";
+    otelApi = await (Function("m", "return import(m)")(moduleName) as Promise<unknown>);
+    return otelApi;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Emits audit events as span events on the active OpenTelemetry span.
+ * Activates only when @opentelemetry/api is importable AND
+ * OTEL_EXPORTER_OTLP_ENDPOINT is set. Zero footprint otherwise.
+ */
+export class OTelSink implements AuditSink {
+  readonly name = "otel";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private api: any = null;
+  private initPromise: Promise<void>;
+
+  constructor() {
+    this.initPromise = resolveOtelApi().then((api) => {
+      this.api = api;
+      if (api) {
+        log.debug("OTel audit sink activated");
+      } else {
+        log.debug("@opentelemetry/api not available, OTel audit sink inactive");
+      }
+    });
+  }
+
+  emit(event: AuditEvent): void {
+    if (!this.api) return;
+
+    const span = this.api.trace?.getActiveSpan?.();
+    if (!span) return;
+
+    span.addEvent("audit", {
+      "audit.event_id": event.event_id,
+      "audit.tool": event.tool,
+      "audit.operation": event.operation,
+      "audit.resource_type": event.resource_type,
+      "audit.outcome": event.outcome,
+      "audit.risk": event.risk,
+      "audit.duration_ms": event.duration_ms,
+      ...(event.resource_id ? { "audit.resource_id": event.resource_id } : {}),
+      ...(event.action ? { "audit.action": event.action } : {}),
+      ...(event.confirmation ? { "audit.confirmation": event.confirmation } : {}),
+      ...(event.error ? { "audit.error": event.error } : {}),
+      ...(event.http_status ? { "audit.http_status": event.http_status } : {}),
+      ...(event.http_method ? { "audit.http_method": event.http_method } : {}),
+    });
+  }
+
+  async flush(): Promise<void> {
+    await this.initPromise;
+  }
+}

--- a/src/audit/sinks/otel.ts
+++ b/src/audit/sinks/otel.ts
@@ -3,69 +3,187 @@ import { createLogger } from "../../utils/logger.js";
 
 const log = createLogger("audit-otel");
 
+/**
+ * Dynamically import a module by name, bypassing TypeScript static resolution.
+ * Returns null if the module is not installed.
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-let otelApi: any = null;
-let otelResolved = false;
-
-async function resolveOtelApi(): Promise<unknown> {
-  if (otelResolved) return otelApi;
-  otelResolved = true;
+async function tryImport(moduleName: string): Promise<any> {
   try {
-    // Dynamic import with variable to prevent TS from resolving the module statically
-    const moduleName = "@opentelemetry/api";
-    otelApi = await (Function("m", "return import(m)")(moduleName) as Promise<unknown>);
-    return otelApi;
+    return await (Function("m", "return import(m)")(moduleName) as Promise<unknown>);
   } catch {
     return null;
   }
 }
 
+function buildAttributes(event: AuditEvent): Record<string, string | number> {
+  const attrs: Record<string, string | number> = {
+    "audit.event_id": event.event_id,
+    "audit.tool": event.tool,
+    "audit.operation": event.operation,
+    "audit.resource_type": event.resource_type,
+    "audit.outcome": event.outcome,
+    "audit.risk": event.risk,
+    "audit.duration_ms": event.duration_ms,
+    "audit.account_id": event.account_id,
+    "audit.timestamp": event.timestamp,
+  };
+  if (event.resource_id) attrs["audit.resource_id"] = event.resource_id;
+  if (event.action) attrs["audit.action"] = event.action;
+  if (event.confirmation) attrs["audit.confirmation"] = event.confirmation;
+  if (event.error) attrs["audit.error"] = event.error;
+  if (event.http_status) attrs["audit.http_status"] = event.http_status;
+  if (event.http_method) attrs["audit.http_method"] = event.http_method;
+  if (event.http_path) attrs["audit.http_path"] = event.http_path;
+  if (event.org_id) attrs["audit.org_id"] = event.org_id;
+  if (event.project_id) attrs["audit.project_id"] = event.project_id;
+  return attrs;
+}
+
 /**
- * Emits audit events as span events on the active OpenTelemetry span.
- * Activates only when @opentelemetry/api is importable AND
- * OTEL_EXPORTER_OTLP_ENDPOINT is set. Zero footprint otherwise.
+ * Emits audit events as OpenTelemetry spans/events.
+ *
+ * Two modes:
+ * 1. **Active span** (host app with OTel tracing): adds audit as a span event
+ * 2. **Standalone**: bootstraps its own TracerProvider with an OTLP HTTP
+ *    exporter and creates a root span per audit event
+ *
+ * Requires `OTEL_EXPORTER_OTLP_ENDPOINT` to be set.
+ *
+ * Packages needed for standalone mode (all optional peer deps):
+ * - @opentelemetry/api
+ * - @opentelemetry/sdk-trace-node
+ * - @opentelemetry/exporter-trace-otlp-http
+ * - @opentelemetry/resources
  */
 export class OTelSink implements AuditSink {
   readonly name = "otel";
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private api: any = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private tracer: any = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private provider: any = null;
+  private ready = false;
   private initPromise: Promise<void>;
 
   constructor() {
-    this.initPromise = resolveOtelApi().then((api) => {
-      this.api = api;
-      if (api) {
-        log.debug("OTel audit sink activated");
-      } else {
-        log.debug("@opentelemetry/api not available, OTel audit sink inactive");
+    this.initPromise = this.init();
+  }
+
+  private async init(): Promise<void> {
+    const api = await tryImport("@opentelemetry/api");
+    if (!api) {
+      log.debug("@opentelemetry/api not available, OTel audit sink inactive");
+      return;
+    }
+    this.api = api;
+
+    // Check if a TracerProvider was already registered by a host application
+    // before the MCP server starts. The default no-op provider returns a
+    // ProxyTracerProvider — a real provider is anything else.
+    const existingProvider = api.trace?.getTracerProvider?.();
+    const hasExternalProvider = existingProvider
+      && existingProvider.constructor?.name !== "ProxyTracerProvider"
+      && existingProvider.constructor?.name !== "NoopTracerProvider";
+
+    if (hasExternalProvider) {
+      // Another system owns the TracerProvider — use it. At emit() time, if there's
+      // an active span (per-request), we attach as a span event; otherwise we create
+      // a child-less root span via this tracer.
+      this.tracer = api.trace.getTracer("harness-mcp-audit");
+      this.ready = true;
+      log.debug("OTel audit sink using external TracerProvider");
+      return;
+    }
+
+    // No external provider — try to bootstrap our own for standalone mode
+    const [sdkTrace, exporter, resources] = await Promise.all([
+      tryImport("@opentelemetry/sdk-trace-node"),
+      tryImport("@opentelemetry/exporter-trace-otlp-http"),
+      tryImport("@opentelemetry/resources"),
+    ]);
+
+    if (!sdkTrace || !exporter) {
+      log.warn(
+        "OTEL_EXPORTER_OTLP_ENDPOINT is set but OTel SDK packages are missing. " +
+        "Install @opentelemetry/sdk-trace-node and @opentelemetry/exporter-trace-otlp-http " +
+        "to enable the OTel audit sink.",
+      );
+      return;
+    }
+
+    try {
+      const serviceName = process.env.OTEL_SERVICE_NAME || "harness-mcp-server";
+      const resourceAttrs: Record<string, string> = {
+        "service.name": serviceName,
+        "service.version": process.env.npm_package_version || "unknown",
+      };
+
+      // OTEL_RESOURCE_ATTRIBUTES=key1=val1,key2=val2
+      const envAttrs = process.env.OTEL_RESOURCE_ATTRIBUTES;
+      if (envAttrs) {
+        for (const pair of envAttrs.split(",")) {
+          const eq = pair.indexOf("=");
+          if (eq > 0) {
+            resourceAttrs[pair.slice(0, eq).trim()] = pair.slice(eq + 1).trim();
+          }
+        }
       }
-    });
+
+      const resource = resources?.resourceFromAttributes
+        ? resources.resourceFromAttributes(resourceAttrs)
+        : undefined;
+
+      const otlpExporter = new exporter.OTLPTraceExporter();
+
+      this.provider = new sdkTrace.NodeTracerProvider({
+        resource,
+        spanProcessors: [new sdkTrace.BatchSpanProcessor(otlpExporter)],
+      });
+      this.provider.register();
+      this.tracer = this.provider.getTracer("harness-mcp-audit");
+      this.ready = true;
+      log.info("OTel audit sink bootstrapped standalone TracerProvider", {
+        endpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
+      });
+    } catch (err) {
+      log.error("Failed to bootstrap OTel TracerProvider", { error: String(err) });
+    }
   }
 
   emit(event: AuditEvent): void {
-    if (!this.api) return;
+    if (!this.ready || !this.api || !this.tracer) return;
 
-    const span = this.api.trace?.getActiveSpan?.();
-    if (!span) return;
+    // Path 1: if there's an active span, add as a span event (embedded mode)
+    const activeSpan = this.api.trace?.getActiveSpan?.();
+    if (activeSpan) {
+      activeSpan.addEvent("audit", buildAttributes(event));
+      return;
+    }
 
-    span.addEvent("audit", {
-      "audit.event_id": event.event_id,
-      "audit.tool": event.tool,
-      "audit.operation": event.operation,
-      "audit.resource_type": event.resource_type,
-      "audit.outcome": event.outcome,
-      "audit.risk": event.risk,
-      "audit.duration_ms": event.duration_ms,
-      ...(event.resource_id ? { "audit.resource_id": event.resource_id } : {}),
-      ...(event.action ? { "audit.action": event.action } : {}),
-      ...(event.confirmation ? { "audit.confirmation": event.confirmation } : {}),
-      ...(event.error ? { "audit.error": event.error } : {}),
-      ...(event.http_status ? { "audit.http_status": event.http_status } : {}),
-      ...(event.http_method ? { "audit.http_method": event.http_method } : {}),
+    // Path 2: create a standalone root span (OSS standalone mode)
+    const span = this.tracer.startSpan(`audit.${event.operation}.${event.resource_type}`, {
+      attributes: buildAttributes(event),
     });
+    if (event.outcome === "error") {
+      span.setStatus?.({ code: 2, message: event.error || "unknown error" });
+    }
+    span.end();
   }
 
   async flush(): Promise<void> {
     await this.initPromise;
+    if (this.provider?.forceFlush) {
+      await this.provider.forceFlush();
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.initPromise;
+    if (this.provider?.shutdown) {
+      await this.provider.shutdown();
+    }
   }
 }

--- a/src/audit/sinks/otel.ts
+++ b/src/audit/sinks/otel.ts
@@ -66,6 +66,7 @@ export class OTelSink implements AuditSink {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private provider: any = null;
   private ready = false;
+  private disabled = false;
   private initPromise: Promise<void>;
   private pendingEvents: AuditEvent[] = [];
   private static readonly MAX_PENDING = 100;
@@ -75,85 +76,93 @@ export class OTelSink implements AuditSink {
   }
 
   private async init(): Promise<void> {
-    const api = await tryImport("@opentelemetry/api");
-    if (!api) {
-      log.debug("@opentelemetry/api not available, OTel audit sink inactive");
-      return;
-    }
-    this.api = api;
-
-    // Detect if a host application registered a real SDK TracerProvider.
-    // ProxyTracerProvider.getDelegate() returns NoopTracerProvider by default,
-    // which only has getTracer(). Real SDK providers also expose forceFlush().
-    const globalProvider = api.trace?.getTracerProvider?.();
-    const delegate = globalProvider?.getDelegate?.();
-    const hasExternalProvider = delegate
-      && typeof delegate.getTracer === "function"
-      && typeof delegate.forceFlush === "function";
-
-    if (hasExternalProvider) {
-      this.tracer = api.trace.getTracer("harness-mcp-audit");
-      this.ready = true;
-      log.debug("OTel audit sink using external TracerProvider");
-      this.drainPending();
-      return;
-    }
-
-    // No external provider — try to bootstrap our own for standalone mode
-    const [sdkTrace, exporter, resources] = await Promise.all([
-      tryImport("@opentelemetry/sdk-trace-node"),
-      tryImport("@opentelemetry/exporter-trace-otlp-http"),
-      tryImport("@opentelemetry/resources"),
-    ]);
-
-    if (!sdkTrace || !exporter) {
-      log.warn(
-        "OTEL_EXPORTER_OTLP_ENDPOINT is set but OTel SDK packages are missing. " +
-        "Install @opentelemetry/sdk-trace-node and @opentelemetry/exporter-trace-otlp-http " +
-        "to enable the OTel audit sink.",
-      );
-      return;
-    }
-
     try {
-      const serviceName = process.env.OTEL_SERVICE_NAME || "harness-mcp-server";
-      const resourceAttrs: Record<string, string> = {
-        "service.name": serviceName,
-        "service.version": process.env.npm_package_version || "unknown",
-      };
+      const api = await tryImport("@opentelemetry/api");
+      if (!api) {
+        log.debug("@opentelemetry/api not available, OTel audit sink inactive");
+        return;
+      }
+      this.api = api;
 
-      // OTEL_RESOURCE_ATTRIBUTES=key1=val1,key2=val2
-      const envAttrs = process.env.OTEL_RESOURCE_ATTRIBUTES;
-      if (envAttrs) {
-        for (const pair of envAttrs.split(",")) {
-          const eq = pair.indexOf("=");
-          if (eq > 0) {
-            resourceAttrs[pair.slice(0, eq).trim()] = pair.slice(eq + 1).trim();
-          }
-        }
+      // Detect if a host application registered a real SDK TracerProvider.
+      // ProxyTracerProvider.getDelegate() returns NoopTracerProvider by default,
+      // which only has getTracer(). Real SDK providers also expose forceFlush().
+      const globalProvider = api.trace?.getTracerProvider?.();
+      const delegate = globalProvider?.getDelegate?.();
+      const hasExternalProvider = delegate
+        && typeof delegate.getTracer === "function"
+        && typeof delegate.forceFlush === "function";
+
+      if (hasExternalProvider) {
+        this.tracer = api.trace.getTracer("harness-mcp-audit");
+        this.ready = true;
+        log.debug("OTel audit sink using external TracerProvider");
+        return;
       }
 
-      const resource = resources?.resourceFromAttributes
-        ? resources.resourceFromAttributes(resourceAttrs)
-        : undefined;
+      // No external provider — try to bootstrap our own for standalone mode
+      const [sdkTrace, exporter, resources] = await Promise.all([
+        tryImport("@opentelemetry/sdk-trace-node"),
+        tryImport("@opentelemetry/exporter-trace-otlp-http"),
+        tryImport("@opentelemetry/resources"),
+      ]);
 
-      const otlpExporter = new exporter.OTLPTraceExporter();
+      if (!sdkTrace || !exporter) {
+        log.warn(
+          "OTEL_EXPORTER_OTLP_ENDPOINT is set but OTel SDK packages are missing. " +
+          "Install @opentelemetry/sdk-trace-node and @opentelemetry/exporter-trace-otlp-http " +
+          "to enable the OTel audit sink.",
+        );
+        return;
+      }
 
-      this.provider = new sdkTrace.NodeTracerProvider({
-        resource,
-        spanProcessors: [new sdkTrace.BatchSpanProcessor(otlpExporter)],
-      });
-      this.provider.register();
-      this.tracer = this.provider.getTracer("harness-mcp-audit");
-      this.ready = true;
-      log.info("OTel audit sink bootstrapped standalone TracerProvider", {
-        endpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
-      });
-    } catch (err) {
-      log.error("Failed to bootstrap OTel TracerProvider", { error: String(err) });
+      try {
+        const serviceName = process.env.OTEL_SERVICE_NAME || "harness-mcp-server";
+        const resourceAttrs: Record<string, string> = {
+          "service.name": serviceName,
+          "service.version": process.env.npm_package_version || "unknown",
+        };
+
+        // OTEL_RESOURCE_ATTRIBUTES=key1=val1,key2=val2
+        const envAttrs = process.env.OTEL_RESOURCE_ATTRIBUTES;
+        if (envAttrs) {
+          for (const pair of envAttrs.split(",")) {
+            const eq = pair.indexOf("=");
+            if (eq > 0) {
+              resourceAttrs[pair.slice(0, eq).trim()] = pair.slice(eq + 1).trim();
+            }
+          }
+        }
+
+        const resource = resources?.resourceFromAttributes
+          ? resources.resourceFromAttributes(resourceAttrs)
+          : undefined;
+
+        const otlpExporter = new exporter.OTLPTraceExporter();
+
+        this.provider = new sdkTrace.NodeTracerProvider({
+          resource,
+          spanProcessors: [new sdkTrace.BatchSpanProcessor(otlpExporter)],
+        });
+        this.provider.register();
+        this.tracer = this.provider.getTracer("harness-mcp-audit");
+        this.ready = true;
+        let endpointHost: string | undefined;
+        try { endpointHost = new URL(process.env.OTEL_EXPORTER_OTLP_ENDPOINT || "").origin; } catch { /* ignore */ }
+        log.info("OTel audit sink bootstrapped standalone TracerProvider", {
+          ...(endpointHost ? { endpoint: endpointHost } : {}),
+        });
+      } catch (err) {
+        log.error("Failed to bootstrap OTel TracerProvider", { error: String(err) });
+      }
+    } finally {
+      this.drainPending();
+      if (!this.ready) {
+        this.disabled = true;
+        this.pendingEvents = [];
+        log.debug("OTel audit sink disabled — init could not activate");
+      }
     }
-
-    this.drainPending();
   }
 
   private drainPending(): void {
@@ -165,6 +174,7 @@ export class OTelSink implements AuditSink {
   }
 
   emit(event: AuditEvent): void {
+    if (this.disabled) return;
     if (!this.ready) {
       if (this.pendingEvents.length < OTelSink.MAX_PENDING) {
         this.pendingEvents.push(event);

--- a/src/audit/sinks/stderr.ts
+++ b/src/audit/sinks/stderr.ts
@@ -1,0 +1,24 @@
+import type { AuditEvent, AuditSink } from "../types.js";
+import { createLogger } from "../../utils/logger.js";
+
+const auditLog = createLogger("audit");
+
+/**
+ * Emits audit events as structured JSON to stderr via the existing logger.
+ * Always active — this is the baseline audit trail.
+ */
+export class StderrSink implements AuditSink {
+  readonly name = "stderr";
+
+  emit(event: AuditEvent): void {
+    const { outcome, error, ...rest } = event;
+    const data: Record<string, unknown> = { ...rest, outcome };
+    if (error) data.error = error;
+
+    if (outcome === "error") {
+      auditLog.warn("audit", data);
+    } else {
+      auditLog.info("audit", data);
+    }
+  }
+}

--- a/src/audit/sinks/webhook.ts
+++ b/src/audit/sinks/webhook.ts
@@ -69,8 +69,10 @@ export class WebhookSink implements AuditSink {
         });
       }
     } catch (err) {
+      let host: string | undefined;
+      try { host = new URL(this.url).origin; } catch { /* ignore */ }
       log.warn("Webhook POST failed", {
-        url: this.url,
+        ...(host ? { host } : {}),
         eventCount: batch.length,
         error: String(err),
       });

--- a/src/audit/sinks/webhook.ts
+++ b/src/audit/sinks/webhook.ts
@@ -12,7 +12,9 @@ export interface WebhookSinkOptions {
 
 /**
  * POSTs audit events to an HTTP endpoint. Events are batched and flushed
- * periodically. Failures are logged but never block tool execution.
+ * periodically. Delivery is best-effort: failed batches are re-enqueued once
+ * (up to 5x batch capacity), then dropped with a warning. Failures never
+ * block tool execution.
  */
 export class WebhookSink implements AuditSink {
   readonly name = "webhook";
@@ -55,6 +57,7 @@ export class WebhookSink implements AuditSink {
     const headers: Record<string, string> = { "Content-Type": "application/json" };
     if (this.token) headers["Authorization"] = `Bearer ${this.token}`;
 
+    let delivered = false;
     try {
       const response = await fetch(this.url, {
         method: "POST",
@@ -62,6 +65,7 @@ export class WebhookSink implements AuditSink {
         body: JSON.stringify({ events: batch }),
         signal: AbortSignal.timeout(10_000),
       });
+      delivered = response.ok;
       if (!response.ok) {
         log.warn("Webhook returned non-OK status", {
           status: response.status,
@@ -76,6 +80,12 @@ export class WebhookSink implements AuditSink {
         eventCount: batch.length,
         error: String(err),
       });
+    }
+
+    if (!delivered && this.buffer.length + batch.length <= this.batchSize * 5) {
+      this.buffer.unshift(...batch);
+    } else if (!delivered) {
+      log.warn("Webhook buffer full, dropping failed batch", { eventCount: batch.length });
     }
   }
 

--- a/src/audit/sinks/webhook.ts
+++ b/src/audit/sinks/webhook.ts
@@ -1,0 +1,87 @@
+import type { AuditEvent, AuditSink } from "../types.js";
+import { createLogger } from "../../utils/logger.js";
+
+const log = createLogger("audit-webhook");
+
+export interface WebhookSinkOptions {
+  url: string;
+  token?: string;
+  batchSize?: number;
+  flushIntervalMs?: number;
+}
+
+/**
+ * POSTs audit events to an HTTP endpoint. Events are batched and flushed
+ * periodically. Failures are logged but never block tool execution.
+ */
+export class WebhookSink implements AuditSink {
+  readonly name = "webhook";
+
+  private buffer: AuditEvent[] = [];
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private readonly url: string;
+  private readonly token?: string;
+  private readonly batchSize: number;
+  private readonly flushIntervalMs: number;
+
+  constructor(options: WebhookSinkOptions) {
+    this.url = options.url;
+    this.token = options.token;
+    this.batchSize = options.batchSize ?? 10;
+    this.flushIntervalMs = options.flushIntervalMs ?? 5000;
+
+    this.timer = setInterval(() => {
+      this.flush().catch((err) => {
+        log.warn("Periodic webhook flush failed", { error: String(err) });
+      });
+    }, this.flushIntervalMs);
+
+    if (this.timer.unref) this.timer.unref();
+  }
+
+  emit(event: AuditEvent): void {
+    this.buffer.push(event);
+    if (this.buffer.length >= this.batchSize) {
+      this.flush().catch((err) => {
+        log.warn("Webhook batch flush failed", { error: String(err) });
+      });
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (this.buffer.length === 0) return;
+
+    const batch = this.buffer.splice(0);
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (this.token) headers["Authorization"] = `Bearer ${this.token}`;
+
+    try {
+      const response = await fetch(this.url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ events: batch }),
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!response.ok) {
+        log.warn("Webhook returned non-OK status", {
+          status: response.status,
+          eventCount: batch.length,
+        });
+      }
+    } catch (err) {
+      log.warn("Webhook POST failed", {
+        url: this.url,
+        eventCount: batch.length,
+        error: String(err),
+      });
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    await this.flush();
+  }
+}

--- a/src/audit/sinks/webhook.ts
+++ b/src/audit/sinks/webhook.ts
@@ -20,6 +20,7 @@ export class WebhookSink implements AuditSink {
   readonly name = "webhook";
 
   private buffer: AuditEvent[] = [];
+  private inflightFlush: Promise<void> | null = null;
   private timer: ReturnType<typeof setInterval> | null = null;
   private readonly url: string;
   private readonly token?: string;
@@ -52,7 +53,16 @@ export class WebhookSink implements AuditSink {
 
   async flush(): Promise<void> {
     if (this.buffer.length === 0) return;
+    const p = this.doFlush();
+    this.inflightFlush = p;
+    try {
+      await p;
+    } finally {
+      this.inflightFlush = null;
+    }
+  }
 
+  private async doFlush(): Promise<void> {
     const batch = this.buffer.splice(0);
     const headers: Record<string, string> = { "Content-Type": "application/json" };
     if (this.token) headers["Authorization"] = `Bearer ${this.token}`;
@@ -93,6 +103,9 @@ export class WebhookSink implements AuditSink {
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;
+    }
+    if (this.inflightFlush) {
+      await this.inflightFlush.catch(() => {});
     }
     await this.flush();
   }

--- a/src/audit/types.ts
+++ b/src/audit/types.ts
@@ -1,0 +1,56 @@
+import type { RiskLevel } from "../registry/types.js";
+
+/** How the user confirmation was resolved before the operation ran. */
+export type ConfirmationMethod =
+  | "auto_approved"
+  | "elicited"
+  | "skipped"
+  | "blocked"
+  | "not_required";
+
+/**
+ * Enriched audit event emitted for every registry-mediated API call.
+ * Sinks receive this and decide how to persist / forward it.
+ */
+export interface AuditEvent {
+  event_id: string;
+  timestamp: string;
+  tool: string;
+  operation: string;
+  resource_type: string;
+  resource_id?: string;
+  action?: string;
+  org_id?: string;
+  project_id?: string;
+  account_id: string;
+  risk: RiskLevel;
+  confirmation?: ConfirmationMethod;
+  outcome: "success" | "error";
+  error?: string;
+  duration_ms: number;
+  http_status?: number;
+  http_method?: string;
+  http_path?: string;
+}
+
+/**
+ * Context passed from tool handlers into registry dispatch so the
+ * audit layer can capture tool-level metadata it cannot derive itself.
+ */
+export interface AuditContext {
+  tool: string;
+  confirmation?: ConfirmationMethod;
+  resource_id?: string;
+  action?: string;
+}
+
+/**
+ * A destination for audit events. Implementations must be failure-isolated:
+ * errors during emit/flush/close are logged but never propagate.
+ */
+export interface AuditSink {
+  readonly name: string;
+  emit(event: AuditEvent): void | Promise<void>;
+  flush?(): Promise<void>;
+  close?(): Promise<void>;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -81,6 +81,11 @@ const RawConfigSchema = z.object({
   HARNESS_FME_BASE_URL: urlFromEnv("https://api.split.io"),
   HARNESS_LOG_UNSAFE_BODIES: booleanFromEnv.default(false),
   HARNESS_PIPELINE_VERSION: z.enum(["0", "1"]).optional(),
+  HARNESS_AUDIT_FILE: optionalStringFromEnv,
+  HARNESS_AUDIT_WEBHOOK_URL: z.preprocess(emptyStringAsUndefined, z.string().url().optional()),
+  HARNESS_AUDIT_WEBHOOK_TOKEN: optionalStringFromEnv,
+  HARNESS_AUDIT_WEBHOOK_BATCH_SIZE: z.coerce.number().default(10),
+  HARNESS_AUDIT_WEBHOOK_FLUSH_MS: z.coerce.number().default(5000),
 });
 
 export const ConfigSchema = RawConfigSchema.transform((data) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -84,8 +84,8 @@ const RawConfigSchema = z.object({
   HARNESS_AUDIT_FILE: optionalStringFromEnv,
   HARNESS_AUDIT_WEBHOOK_URL: z.preprocess(emptyStringAsUndefined, z.string().url().optional()),
   HARNESS_AUDIT_WEBHOOK_TOKEN: optionalStringFromEnv,
-  HARNESS_AUDIT_WEBHOOK_BATCH_SIZE: z.coerce.number().default(10),
-  HARNESS_AUDIT_WEBHOOK_FLUSH_MS: z.coerce.number().default(5000),
+  HARNESS_AUDIT_WEBHOOK_BATCH_SIZE: z.preprocess(emptyStringAsUndefined, z.coerce.number().min(1).default(10)),
+  HARNESS_AUDIT_WEBHOOK_FLUSH_MS: z.preprocess(emptyStringAsUndefined, z.coerce.number().min(1).default(5000)),
 });
 
 export const ConfigSchema = RawConfigSchema.transform((data) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,9 +43,10 @@ interface HarnessServerResult {
 
 /**
  * Create a fully-configured MCP server instance with all tools, resources, and prompts.
+ * @param sharedAuditManager When set (HTTP mode), reuse this manager instead of creating one per session.
  */
-function createHarnessServer(config: Config): HarnessServerResult {
-  const auditManager = createAuditManager(config);
+function createHarnessServer(config: Config, sharedAuditManager?: AuditManager): HarnessServerResult {
+  const auditManager = sharedAuditManager ?? createAuditManager(config);
   const client = new HarnessClient(config);
   const registry = new Registry(config, { auditManager });
 
@@ -185,7 +186,6 @@ async function startStdio(config: Config): Promise<void> {
 interface Session {
   server: McpServer;
   transport: StreamableHTTPServerTransport;
-  auditManager: AuditManager;
   lastActivity: number;
 }
 
@@ -245,12 +245,12 @@ async function startHttp(config: Config, port: number): Promise<void> {
 
   // ---- Session store ----
   const sessions = new Map<string, Session>();
+  const sharedAuditManager = createAuditManager(config);
 
   async function destroySession(sessionId: string): Promise<void> {
     const session = sessions.get(sessionId);
     if (!session) return;
     sessions.delete(sessionId);
-    await session.auditManager.close().catch(() => {});
     await session.transport.close().catch(() => {});
     await session.server.close().catch(() => {});
     log.info("Session destroyed", { sessionId, remaining: sessions.size });
@@ -315,16 +315,14 @@ async function startHttp(config: Config, port: number): Promise<void> {
     // No session header — must be an initialize request. Create a new session.
     let server: McpServer | undefined;
     let transport: StreamableHTTPServerTransport | undefined;
-    let sessionAuditManager: AuditManager | undefined;
     try {
       const sessionConfig = mergeConfigWithPipelineVersion(config, req);
-      const result = createHarnessServer(sessionConfig);
+      const result = createHarnessServer(sessionConfig, sharedAuditManager);
       server = result.server;
-      sessionAuditManager = result.auditManager;
       transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: () => randomUUID(),
         onsessioninitialized: (id) => {
-          sessions.set(id, { server: server!, transport: transport!, auditManager: sessionAuditManager!, lastActivity: Date.now() });
+          sessions.set(id, { server: server!, transport: transport!, lastActivity: Date.now() });
           log.info("Session created", { sessionId: id, total: sessions.size });
         },
       });
@@ -346,7 +344,6 @@ async function startHttp(config: Config, port: number): Promise<void> {
           id: null,
         });
       }
-      await sessionAuditManager?.close().catch(() => {});
       await transport?.close();
       await server?.close();
     }
@@ -454,6 +451,7 @@ async function startHttp(config: Config, port: number): Promise<void> {
     await Promise.allSettled(
       [...sessions.keys()].map((id) => destroySession(id)),
     );
+    await sharedAuditManager.close().catch(() => {});
 
     // 4. Allow in-flight responses to flush, then exit
     const DRAIN_TIMEOUT_MS = 10_000;

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,7 +149,7 @@ async function startStdio(config: Config): Promise<void> {
       uptime_s: Math.round(process.uptime()),
       memory_mb: Math.round(process.memoryUsage.rss() / 1024 / 1024),
     });
-    process.exit(0);
+    auditManager.close().catch(() => {}).finally(() => process.exit(0));
   });
 
   process.stdout.on("error", (err: NodeJS.ErrnoException) => {
@@ -159,7 +159,7 @@ async function startStdio(config: Config): Promise<void> {
       uptime_s: Math.round(process.uptime()),
     });
     if (err.code === "EPIPE" || err.code === "ERR_STREAM_DESTROYED") {
-      process.exit(0);
+      auditManager.close().catch(() => {}).finally(() => process.exit(0));
     }
   });
 
@@ -246,13 +246,13 @@ async function startHttp(config: Config, port: number): Promise<void> {
   // ---- Session store ----
   const sessions = new Map<string, Session>();
 
-  function destroySession(sessionId: string): void {
+  async function destroySession(sessionId: string): Promise<void> {
     const session = sessions.get(sessionId);
     if (!session) return;
     sessions.delete(sessionId);
-    session.auditManager.close().catch(() => {});
-    session.transport.close().catch(() => {});
-    session.server.close().catch(() => {});
+    await session.auditManager.close().catch(() => {});
+    await session.transport.close().catch(() => {});
+    await session.server.close().catch(() => {});
     log.info("Session destroyed", { sessionId, remaining: sessions.size });
   }
 
@@ -346,6 +346,7 @@ async function startHttp(config: Config, port: number): Promise<void> {
           id: null,
         });
       }
+      await sessionAuditManager?.close().catch(() => {});
       await transport?.close();
       await server?.close();
     }
@@ -429,7 +430,7 @@ async function startHttp(config: Config, port: number): Promise<void> {
 
   let draining = false;
 
-  const shutdown = (signal: string): void => {
+  const shutdown = async (signal: string): Promise<void> => {
     if (draining) return; // prevent double-shutdown
     draining = true;
     log.info(`Received ${signal}, draining...`);
@@ -450,9 +451,9 @@ async function startHttp(config: Config, port: number): Promise<void> {
 
     // 3. Close all sessions (terminates SSE streams, notifies transports)
     clearInterval(reaper);
-    for (const [id] of sessions) {
-      destroySession(id);
-    }
+    await Promise.allSettled(
+      [...sessions.keys()].map((id) => destroySession(id)),
+    );
 
     // 4. Allow in-flight responses to flush, then exit
     const DRAIN_TIMEOUT_MS = 10_000;

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { parseArgs, resolvePort, getVersion } from "./utils/cli.js";
 import { configureElicitation } from "./utils/elicitation.js";
 import { resolveHttpHostValidationOptions } from "./utils/http-hosts.js";
 import { loadEnvFile } from "./utils/env.js";
+import { createAuditManager, type AuditManager } from "./audit/index.js";
 
 const log = createLogger("main");
 
@@ -35,12 +36,18 @@ function mergeConfigWithPipelineVersion(baseConfig: Config, req: import("express
   return { ...baseConfig, HARNESS_PIPELINE_VERSION: pv };
 }
 
+interface HarnessServerResult {
+  server: McpServer;
+  auditManager: AuditManager;
+}
+
 /**
  * Create a fully-configured MCP server instance with all tools, resources, and prompts.
  */
-function createHarnessServer(config: Config): McpServer {
+function createHarnessServer(config: Config): HarnessServerResult {
+  const auditManager = createAuditManager(config);
   const client = new HarnessClient(config);
-  const registry = new Registry(config);
+  const registry = new Registry(config, { auditManager });
 
   const server = new McpServer(
     {
@@ -82,7 +89,7 @@ function createHarnessServer(config: Config): McpServer {
   registerAllResources(server, registry, client, config);
   registerAllPrompts(server);
 
-  return server;
+  return { server, auditManager };
 }
 
 /**
@@ -116,7 +123,7 @@ function logToFile(message: string, data?: Record<string, unknown>): void {
  * Start the server in stdio mode — single persistent connection.
  */
 async function startStdio(config: Config): Promise<void> {
-  const server = createHarnessServer(config);
+  const { server, auditManager } = createHarnessServer(config);
   const transport = new StdioServerTransport();
   await server.connect(transport);
   log.info("harness-mcp-server connected via stdio", {
@@ -161,6 +168,7 @@ async function startStdio(config: Config): Promise<void> {
       idle_ms: Date.now() - lastActivityTs,
       uptime_s: Math.round(process.uptime()),
     });
+    await auditManager.close();
     await transport.close();
     await server.close();
     log.info("Stdio server closed");
@@ -177,6 +185,7 @@ async function startStdio(config: Config): Promise<void> {
 interface Session {
   server: McpServer;
   transport: StreamableHTTPServerTransport;
+  auditManager: AuditManager;
   lastActivity: number;
 }
 
@@ -241,6 +250,7 @@ async function startHttp(config: Config, port: number): Promise<void> {
     const session = sessions.get(sessionId);
     if (!session) return;
     sessions.delete(sessionId);
+    session.auditManager.close().catch(() => {});
     session.transport.close().catch(() => {});
     session.server.close().catch(() => {});
     log.info("Session destroyed", { sessionId, remaining: sessions.size });
@@ -305,13 +315,16 @@ async function startHttp(config: Config, port: number): Promise<void> {
     // No session header — must be an initialize request. Create a new session.
     let server: McpServer | undefined;
     let transport: StreamableHTTPServerTransport | undefined;
+    let sessionAuditManager: AuditManager | undefined;
     try {
       const sessionConfig = mergeConfigWithPipelineVersion(config, req);
-      server = createHarnessServer(sessionConfig);
+      const result = createHarnessServer(sessionConfig);
+      server = result.server;
+      sessionAuditManager = result.auditManager;
       transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: () => randomUUID(),
         onsessioninitialized: (id) => {
-          sessions.set(id, { server: server!, transport: transport!, lastActivity: Date.now() });
+          sessions.set(id, { server: server!, transport: transport!, auditManager: sessionAuditManager!, lastActivity: Date.now() });
           log.info("Session created", { sessionId: id, total: sessions.size });
         },
       });

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -1,7 +1,10 @@
+import { randomUUID } from "node:crypto";
 import { type Config, resolveProductBaseUrl } from "../config.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import { HarnessApiError } from "../utils/errors.js";
 import type { ResourceDefinition, ToolsetDefinition, ToolsetName, OperationName, EndpointSpec, FilterFieldSpec } from "./types.js";
+import type { AuditManager } from "../audit/manager.js";
+import type { AuditContext, AuditEvent } from "../audit/types.js";
 import { createLogger } from "../utils/logger.js";
 import { buildDeepLink, appendStoreType } from "../utils/deep-links.js";
 
@@ -100,6 +103,8 @@ export interface RegistryOptions {
    * to `config.HARNESS_ACCOUNT_ID` if it returns `undefined`.
    */
   accountIdResolver?: () => string | undefined;
+  /** When provided, every dispatch emits an AuditEvent to all registered sinks. */
+  auditManager?: AuditManager;
 }
 
 /**
@@ -109,9 +114,11 @@ export class Registry {
   private resourceMap: Map<string, ResourceDefinition> = new Map();
   private toolsets: ToolsetDefinition[] = [];
   private accountIdResolver?: () => string | undefined;
+  private auditManager?: AuditManager;
 
   constructor(private config: Config, options: RegistryOptions = {}) {
     this.accountIdResolver = options.accountIdResolver;
+    this.auditManager = options.auditManager;
     const allToolsets = [...ALL_TOOLSETS, ...(options.additionalToolsets ?? [])];
     const enabledNames = this.parseToolsetFilter(allToolsets);
     this.toolsets = enabledNames
@@ -286,8 +293,12 @@ export class Registry {
     resourceType: string,
     operation: OperationName,
     input: Record<string, unknown>,
+    signalOrAudit?: AbortSignal | AuditContext,
     signal?: AbortSignal,
   ): Promise<unknown> {
+    const auditCtx = signalOrAudit instanceof AbortSignal ? undefined : signalOrAudit;
+    const abortSignal = signalOrAudit instanceof AbortSignal ? signalOrAudit : signal;
+
     if (this.config.HARNESS_READ_ONLY && !Registry.READ_OPERATIONS.has(operation)) {
       throw new Error(`Read-only mode is enabled (HARNESS_READ_ONLY=true). "${operation}" operations are not allowed.`);
     }
@@ -299,7 +310,6 @@ export class Registry {
       throw new Error(`Resource "${resourceType}" does not support "${operation}". Supported: ${supported}`);
     }
 
-    // Validate required listFilterFields for list operations before hitting the API
     if (operation === "list" && def.listFilterFields) {
       const missing = def.listFilterFields
         .filter(f => f.required && input[f.name] === undefined)
@@ -312,7 +322,7 @@ export class Registry {
       }
     }
 
-    return this.executeSpec(client, def, spec, input, signal);
+    return this.executeSpecWithAudit(client, def, spec, operation, resourceType, input, auditCtx, abortSignal);
   }
 
   /** Dispatch an execute action to the Harness API. */
@@ -321,8 +331,12 @@ export class Registry {
     resourceType: string,
     action: string,
     input: Record<string, unknown>,
+    signalOrAudit?: AbortSignal | AuditContext,
     signal?: AbortSignal,
   ): Promise<unknown> {
+    const auditCtx = signalOrAudit instanceof AbortSignal ? undefined : signalOrAudit;
+    const abortSignal = signalOrAudit instanceof AbortSignal ? signalOrAudit : signal;
+
     if (this.config.HARNESS_READ_ONLY) {
       throw new Error(`Read-only mode is enabled (HARNESS_READ_ONLY=true). Execute actions are not allowed.`);
     }
@@ -334,7 +348,73 @@ export class Registry {
       throw new Error(`Resource "${resourceType}" has no execute action "${action}". Available: ${available}`);
     }
 
-    return this.executeSpec(client, def, actionSpec, input, signal);
+    return this.executeSpecWithAudit(client, def, actionSpec, "execute", resourceType, input, { ...auditCtx, tool: auditCtx?.tool ?? "harness_execute", action }, abortSignal);
+  }
+
+  /**
+   * Wraps executeSpec with timing and audit event emission.
+   */
+  private async executeSpecWithAudit(
+    client: HarnessClient,
+    def: ResourceDefinition,
+    spec: EndpointSpec,
+    operation: string,
+    resourceType: string,
+    input: Record<string, unknown>,
+    auditCtx?: AuditContext,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
+    if (!this.auditManager) {
+      return this.executeSpec(client, def, spec, input, signal);
+    }
+
+    const startTime = Date.now();
+    try {
+      const result = await this.executeSpec(client, def, spec, input, signal);
+      this.emitAuditEvent(spec, operation, resourceType, input, auditCtx, "success", Date.now() - startTime);
+      return result;
+    } catch (err) {
+      const httpStatus = err instanceof HarnessApiError ? err.statusCode : undefined;
+      this.emitAuditEvent(spec, operation, resourceType, input, auditCtx, "error", Date.now() - startTime, String(err), httpStatus);
+      throw err;
+    }
+  }
+
+  private emitAuditEvent(
+    spec: EndpointSpec,
+    operation: string,
+    resourceType: string,
+    input: Record<string, unknown>,
+    auditCtx: AuditContext | undefined,
+    outcome: "success" | "error",
+    durationMs: number,
+    error?: string,
+    httpStatus?: number,
+  ): void {
+    if (!this.auditManager) return;
+
+    const event: AuditEvent = {
+      event_id: randomUUID(),
+      timestamp: new Date().toISOString(),
+      tool: auditCtx?.tool ?? `harness_${operation}`,
+      operation,
+      resource_type: resourceType,
+      resource_id: auditCtx?.resource_id ?? (input.resource_id as string | undefined),
+      action: auditCtx?.action,
+      org_id: (input.org_id as string | undefined) ?? this.config.HARNESS_ORG,
+      project_id: (input.project_id as string | undefined) ?? this.config.HARNESS_PROJECT,
+      account_id: this.getAccountId(),
+      risk: spec.operationPolicy?.risk ?? "read",
+      confirmation: auditCtx?.confirmation,
+      outcome,
+      duration_ms: durationMs,
+      http_method: spec.method,
+      http_path: spec.path,
+      ...(error ? { error } : {}),
+      ...(httpStatus ? { http_status: httpStatus } : {}),
+    };
+
+    this.auditManager.emit(event);
   }
 
   private async executeSpec(

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -371,16 +371,17 @@ export class Registry {
     const startTime = Date.now();
     try {
       const result = await this.executeSpec(client, def, spec, input, signal);
-      this.emitAuditEvent(spec, operation, resourceType, input, auditCtx, "success", Date.now() - startTime);
+      this.emitAuditEvent(def, spec, operation, resourceType, input, auditCtx, "success", Date.now() - startTime);
       return result;
     } catch (err) {
       const httpStatus = err instanceof HarnessApiError ? err.statusCode : undefined;
-      this.emitAuditEvent(spec, operation, resourceType, input, auditCtx, "error", Date.now() - startTime, String(err), httpStatus);
+      this.emitAuditEvent(def, spec, operation, resourceType, input, auditCtx, "error", Date.now() - startTime, String(err), httpStatus);
       throw err;
     }
   }
 
   private emitAuditEvent(
+    def: ResourceDefinition,
     spec: EndpointSpec,
     operation: string,
     resourceType: string,
@@ -401,8 +402,12 @@ export class Registry {
       resource_type: resourceType,
       resource_id: auditCtx?.resource_id ?? (input.resource_id as string | undefined),
       action: auditCtx?.action,
-      org_id: (input.org_id as string | undefined) ?? this.config.HARNESS_ORG,
-      project_id: (input.project_id as string | undefined) ?? this.config.HARNESS_PROJECT,
+      org_id: def.scopeOptional
+        ? (input.org_id as string | undefined)
+        : (input.org_id as string | undefined) ?? this.config.HARNESS_ORG,
+      project_id: def.scopeOptional
+        ? (input.project_id as string | undefined)
+        : (input.project_id as string | undefined) ?? this.config.HARNESS_PROJECT,
       account_id: this.getAccountId(),
       risk: spec.operationPolicy?.risk ?? "read",
       confirmation: auditCtx?.confirmation,

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -402,12 +402,12 @@ export class Registry {
       resource_type: resourceType,
       resource_id: auditCtx?.resource_id ?? (input.resource_id as string | undefined),
       action: auditCtx?.action,
-      org_id: def.scopeOptional
-        ? (input.org_id as string | undefined)
-        : (input.org_id as string | undefined) ?? this.config.HARNESS_ORG,
-      project_id: def.scopeOptional
-        ? (input.project_id as string | undefined)
-        : (input.project_id as string | undefined) ?? this.config.HARNESS_PROJECT,
+      org_id: def.scope === "account"
+        ? undefined
+        : (input.org_id as string | undefined) ?? (def.scopeOptional ? undefined : this.config.HARNESS_ORG),
+      project_id: def.scope === "account" || def.scope === "org"
+        ? undefined
+        : (input.project_id as string | undefined) ?? (def.scopeOptional ? undefined : this.config.HARNESS_PROJECT),
       account_id: this.getAccountId(),
       risk: spec.operationPolicy?.risk ?? "read",
       confirmation: auditCtx?.confirmation,

--- a/src/resources/execution-summary.ts
+++ b/src/resources/execution-summary.ts
@@ -24,7 +24,7 @@ export function registerExecutionSummaryResource(server: McpServer, registry: Re
           project_id: config.HARNESS_PROJECT ?? "",
           size: 10,
           page: 0,
-        });
+        }, { tool: "execution_summary_resource" });
 
         return {
           contents: [{

--- a/src/resources/pipeline-yaml.ts
+++ b/src/resources/pipeline-yaml.ts
@@ -18,7 +18,7 @@ export function registerPipelineYamlResource(server: McpServer, registry: Regist
           project_id: config.HARNESS_PROJECT ?? "",
           size: 20,
           page: 0,
-        });
+        }, { tool: "pipeline_yaml_resource" });
         const r = result as { items?: Array<{ identifier?: string; name?: string }> };
         return {
           resources: (r.items ?? [])
@@ -66,7 +66,7 @@ export function registerPipelineYamlResource(server: McpServer, registry: Regist
         pipeline_id: pipelineId,
         org_id: orgId,
         project_id: projectId,
-      });
+      }, { tool: "pipeline_yaml_resource" });
 
       const data = result as Record<string, unknown>;
       const yamlContent = data?.yamlPipeline ?? data?.yaml ?? JSON.stringify(data, null, 2);

--- a/src/tools/harness-create.ts
+++ b/src/tools/harness-create.ts
@@ -5,7 +5,6 @@ import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { isUserError, isUserFixableApiError, toMcpError } from "../utils/errors.js";
 import { confirmViaElicitation } from "../utils/elicitation.js";
-import type { ConfirmationMethod } from "../audit/types.js";
 import { applyUrlDefaults } from "../utils/url-parser.js";
 import { coerceRecord } from "../utils/type-guards.js";
 import { resourceTypeSchema } from "./input-schemas.js";
@@ -64,8 +63,7 @@ export function registerCreateTool(server: McpServer, registry: Registry, client
           return errorResult(`Operation ${elicit.reason} by user.`);
         }
 
-        const confirmation: ConfirmationMethod = elicit.proceed ? "elicited" : "blocked";
-        const result = await registry.dispatch(client, args.resource_type, "create", input, { tool: "harness_create", confirmation });
+        const result = await registry.dispatch(client, args.resource_type, "create", input, { tool: "harness_create", confirmation: elicit.method });
         return jsonResult(result);
       } catch (err) {
         if (isUserError(err)) return errorResult(err.message);

--- a/src/tools/harness-create.ts
+++ b/src/tools/harness-create.ts
@@ -4,8 +4,8 @@ import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { isUserError, isUserFixableApiError, toMcpError } from "../utils/errors.js";
-import { logAudit } from "../utils/logger.js";
 import { confirmViaElicitation } from "../utils/elicitation.js";
+import type { ConfirmationMethod } from "../audit/types.js";
 import { applyUrlDefaults } from "../utils/url-parser.js";
 import { coerceRecord } from "../utils/type-guards.js";
 import { resourceTypeSchema } from "./input-schemas.js";
@@ -64,11 +64,10 @@ export function registerCreateTool(server: McpServer, registry: Registry, client
           return errorResult(`Operation ${elicit.reason} by user.`);
         }
 
-        const result = await registry.dispatch(client, args.resource_type, "create", input);
-        logAudit({ operation: "create", resource_type: args.resource_type, org_id: input.org_id as string, project_id: input.project_id as string, outcome: "success" });
+        const confirmation: ConfirmationMethod = elicit.proceed ? "elicited" : "blocked";
+        const result = await registry.dispatch(client, args.resource_type, "create", input, { tool: "harness_create", confirmation });
         return jsonResult(result);
       } catch (err) {
-        logAudit({ operation: "create", resource_type: args.resource_type, outcome: "error", error: String(err) });
         if (isUserError(err)) return errorResult(err.message);
         if (isUserFixableApiError(err)) return errorResult(err.message);
         throw toMcpError(err);

--- a/src/tools/harness-delete.ts
+++ b/src/tools/harness-delete.ts
@@ -4,8 +4,8 @@ import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { isUserError, isUserFixableApiError, toMcpError } from "../utils/errors.js";
-import { logAudit } from "../utils/logger.js";
 import { confirmViaElicitation } from "../utils/elicitation.js";
+import type { ConfirmationMethod } from "../audit/types.js";
 import { applyUrlDefaults } from "../utils/url-parser.js";
 import { coerceRecord } from "../utils/type-guards.js";
 import { resourceTypeSchema } from "./input-schemas.js";
@@ -62,11 +62,10 @@ export function registerDeleteTool(server: McpServer, registry: Registry, client
           input[primaryField] = args.resource_id;
         }
 
-        const result = await registry.dispatch(client, args.resource_type, "delete", input);
-        logAudit({ operation: "delete", resource_type: args.resource_type, resource_id: args.resource_id, org_id: input.org_id as string, project_id: input.project_id as string, outcome: "success" });
+        const confirmation: ConfirmationMethod = "elicited";
+        const result = await registry.dispatch(client, args.resource_type, "delete", input, { tool: "harness_delete", confirmation, resource_id: args.resource_id });
         return jsonResult({ deleted: true, resource_type: args.resource_type, resource_id: args.resource_id, ...((typeof result === "object" && result !== null) ? result : {}) });
       } catch (err) {
-        logAudit({ operation: "delete", resource_type: args.resource_type, resource_id: args.resource_id, outcome: "error", error: String(err) });
         if (isUserError(err)) return errorResult(err.message);
         if (isUserFixableApiError(err)) return errorResult(err.message);
         throw toMcpError(err);

--- a/src/tools/harness-delete.ts
+++ b/src/tools/harness-delete.ts
@@ -5,7 +5,6 @@ import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { isUserError, isUserFixableApiError, toMcpError } from "../utils/errors.js";
 import { confirmViaElicitation } from "../utils/elicitation.js";
-import type { ConfirmationMethod } from "../audit/types.js";
 import { applyUrlDefaults } from "../utils/url-parser.js";
 import { coerceRecord } from "../utils/type-guards.js";
 import { resourceTypeSchema } from "./input-schemas.js";
@@ -62,8 +61,7 @@ export function registerDeleteTool(server: McpServer, registry: Registry, client
           input[primaryField] = args.resource_id;
         }
 
-        const confirmation: ConfirmationMethod = "elicited";
-        const result = await registry.dispatch(client, args.resource_type, "delete", input, { tool: "harness_delete", confirmation, resource_id: args.resource_id });
+        const result = await registry.dispatch(client, args.resource_type, "delete", input, { tool: "harness_delete", confirmation: elicit.method, resource_id: args.resource_id });
         return jsonResult({ deleted: true, resource_type: args.resource_type, resource_id: args.resource_id, ...((typeof result === "object" && result !== null) ? result : {}) });
       } catch (err) {
         if (isUserError(err)) return errorResult(err.message);

--- a/src/tools/harness-diagnose.ts
+++ b/src/tools/harness-diagnose.ts
@@ -100,7 +100,7 @@ export function registerDiagnoseTool(server: McpServer, registry: Registry, clie
               const pipelineId = asString(mergedArgs.pipeline_id) ?? asString(input.pipeline_id);
               if (pipelineId) {
                 try {
-                  const pipelineResp = await registry.dispatch(client, "pipeline", "get", { ...input, pipeline_id: pipelineId }, extra.signal);
+                  const pipelineResp = await registry.dispatch(client, "pipeline", "get", { ...input, pipeline_id: pipelineId }, { tool: "harness_diagnose" }, extra.signal);
                   const resp = asRecord(pipelineResp);
                   if (resp?.yamlPipeline && typeof resp.yamlPipeline === "string") {
                     const YAML = await import("yaml");

--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -6,7 +6,6 @@ import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { isUserError, isUserFixableApiError, toMcpError, HarnessApiError } from "../utils/errors.js";
 import { confirmViaElicitation } from "../utils/elicitation.js";
 import { createLogger } from "../utils/logger.js";
-import type { ConfirmationMethod } from "../audit/types.js";
 import { applyUrlDefaults } from "../utils/url-parser.js";
 import { asRecord, asString, coerceRecord } from "../utils/type-guards.js";
 import { isFlatKeyValueInputs, isResolvableInputs, flattenInputs, resolveRuntimeInputs, type ResolutionResult } from "../utils/runtime-input-resolver.js";
@@ -199,8 +198,7 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
           }
         }
 
-        const confirmation: ConfirmationMethod = "elicited";
-        const auditCtx = { tool: "harness_execute" as const, confirmation, resource_id: resourceId, action: args.action };
+        const auditCtx = { tool: "harness_execute" as const, confirmation: elicit.method, resource_id: resourceId, action: args.action };
 
         let result: unknown;
         try {

--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -5,7 +5,8 @@ import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { isUserError, isUserFixableApiError, toMcpError, HarnessApiError } from "../utils/errors.js";
 import { confirmViaElicitation } from "../utils/elicitation.js";
-import { createLogger, logAudit } from "../utils/logger.js";
+import { createLogger } from "../utils/logger.js";
+import type { ConfirmationMethod } from "../audit/types.js";
 import { applyUrlDefaults } from "../utils/url-parser.js";
 import { asRecord, asString, coerceRecord } from "../utils/type-guards.js";
 import { isFlatKeyValueInputs, isResolvableInputs, flattenInputs, resolveRuntimeInputs, type ResolutionResult } from "../utils/runtime-input-resolver.js";
@@ -198,13 +199,13 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
           }
         }
 
-        const auditBase = { operation: "execute", resource_type: resourceType, resource_id: resourceId, action: args.action, org_id: input.org_id as string, project_id: input.project_id as string };
+        const confirmation: ConfirmationMethod = "elicited";
+        const auditCtx = { tool: "harness_execute" as const, confirmation, resource_id: resourceId, action: args.action };
 
         let result: unknown;
         try {
-          result = await registry.dispatchExecute(client, resourceType, args.action, input);
+          result = await registry.dispatchExecute(client, resourceType, args.action, input, auditCtx);
         } catch (err) {
-          // If retry fails with 405, fall back to a fresh pipeline run
           if (
             args.action === "retry" &&
             resourceType === "pipeline" &&
@@ -229,14 +230,11 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
             }
 
             input.pipeline_id = pipelineId;
-            result = await registry.dispatchExecute(client, "pipeline", "run", input);
-            logAudit({ ...auditBase, action: "run (retry fallback)", outcome: "success" });
+            result = await registry.dispatchExecute(client, "pipeline", "run", input, { ...auditCtx, action: "run (retry fallback)" });
             return jsonResult({ ...(asRecord(result) ?? {}), _note: "Retry was not available (405). Executed a fresh pipeline run instead." });
           }
           throw err;
         }
-
-        logAudit({ ...auditBase, outcome: "success" });
 
         if (resolved) {
           return jsonResult({
@@ -251,7 +249,6 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
 
         return jsonResult(result);
       } catch (err) {
-        logAudit({ operation: "execute", resource_type: args.resource_type ?? "unknown", resource_id: args.resource_id, action: args.action, outcome: "error", error: String(err) });
         if (isUserError(err)) return errorResult(err.message);
         if (isUserFixableApiError(err)) return errorResult(err.message);
         throw toMcpError(err);

--- a/src/tools/harness-search.ts
+++ b/src/tools/harness-search.ts
@@ -93,7 +93,7 @@ export function registerSearchTool(server: McpServer, registry: Registry, client
                   size: args.max_per_type ?? 5,
                   limit: args.max_per_type ?? 5,
                   page: 0,
-                }, signal);
+                }, { tool: "harness_search" }, signal);
                 return { rt, result, error: null };
               } catch (err) {
                 log.debug(`Search failed for ${rt}`, { error: String(err) });

--- a/src/tools/harness-status.ts
+++ b/src/tools/harness-status.ts
@@ -109,15 +109,15 @@ export function registerStatusTool(
           registry.dispatch(client, "execution", "list", {
             ...baseInput,
             status: "Failed",
-          }, signal),
+          }, { tool: "harness_status" }, signal),
           registry.dispatch(client, "execution", "list", {
             ...baseInput,
             status: "Running",
-          }, signal),
+          }, { tool: "harness_status" }, signal),
           registry.dispatch(client, "execution", "list", {
             ...baseInput,
             size: Math.min(limit * 2, 20),
-          }, signal),
+          }, { tool: "harness_status" }, signal),
         ]);
 
         // Extract results with graceful degradation

--- a/src/tools/harness-update.ts
+++ b/src/tools/harness-update.ts
@@ -5,7 +5,6 @@ import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { isUserError, isUserFixableApiError, toMcpError } from "../utils/errors.js";
 import { confirmViaElicitation } from "../utils/elicitation.js";
-import type { ConfirmationMethod } from "../audit/types.js";
 import { applyUrlDefaults } from "../utils/url-parser.js";
 import { asString, isRecord, coerceRecord } from "../utils/type-guards.js";
 import { resourceTypeSchema } from "./input-schemas.js";
@@ -78,8 +77,7 @@ export function registerUpdateTool(server: McpServer, registry: Registry, client
           input.version_label = "v1";
         }
 
-        const confirmation: ConfirmationMethod = "elicited";
-        const result = await registry.dispatch(client, args.resource_type, "update", input, { tool: "harness_update", confirmation, resource_id: args.resource_id });
+        const result = await registry.dispatch(client, args.resource_type, "update", input, { tool: "harness_update", confirmation: elicit.method, resource_id: args.resource_id });
         return jsonResult(result);
       } catch (err) {
         if (isUserError(err)) return errorResult(err.message);

--- a/src/tools/harness-update.ts
+++ b/src/tools/harness-update.ts
@@ -4,8 +4,8 @@ import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { isUserError, isUserFixableApiError, toMcpError } from "../utils/errors.js";
-import { logAudit } from "../utils/logger.js";
 import { confirmViaElicitation } from "../utils/elicitation.js";
+import type { ConfirmationMethod } from "../audit/types.js";
 import { applyUrlDefaults } from "../utils/url-parser.js";
 import { asString, isRecord, coerceRecord } from "../utils/type-guards.js";
 import { resourceTypeSchema } from "./input-schemas.js";
@@ -78,11 +78,10 @@ export function registerUpdateTool(server: McpServer, registry: Registry, client
           input.version_label = "v1";
         }
 
-        const result = await registry.dispatch(client, args.resource_type, "update", input);
-        logAudit({ operation: "update", resource_type: args.resource_type, resource_id: args.resource_id, org_id: input.org_id as string, project_id: input.project_id as string, outcome: "success" });
+        const confirmation: ConfirmationMethod = "elicited";
+        const result = await registry.dispatch(client, args.resource_type, "update", input, { tool: "harness_update", confirmation, resource_id: args.resource_id });
         return jsonResult(result);
       } catch (err) {
-        logAudit({ operation: "update", resource_type: args.resource_type, resource_id: args.resource_id, outcome: "error", error: String(err) });
         if (isUserError(err)) return errorResult(err.message);
         if (isUserFixableApiError(err)) return errorResult(err.message);
         throw toMcpError(err);

--- a/src/utils/elicitation.ts
+++ b/src/utils/elicitation.ts
@@ -10,6 +10,8 @@ export interface ElicitationResult {
   proceed: boolean;
   /** Why the operation was stopped, if applicable. */
   reason?: "declined" | "cancelled";
+  /** How the confirmation was resolved — maps directly to ConfirmationMethod for audit. */
+  method: "elicited" | "auto_approved" | "not_required" | "blocked" | "skipped";
 }
 
 /** Module-level auto-approve threshold (set via HARNESS_AUTO_APPROVE_RISK). */
@@ -55,16 +57,16 @@ export async function confirmViaElicitation({
 }): Promise<ElicitationResult> {
   if (shouldAutoApprove(risk, _autoApproveRisk)) {
     log.debug("Auto-approved (risk within autonomous threshold)", { toolName, risk, threshold: _autoApproveRisk });
-    return { proceed: true };
+    return { proceed: true, method: "auto_approved" };
   }
 
   if (!clientSupportsElicitation(server.server)) {
     if (requiresConfirmation(risk)) {
       log.warn("Client does not support elicitation, blocking operation", { toolName, risk });
-      return { proceed: false, reason: "declined" };
+      return { proceed: false, reason: "declined", method: "blocked" };
     }
     log.debug("Client does not support elicitation, proceeding (low risk)", { toolName, risk });
-    return { proceed: true };
+    return { proceed: true, method: "not_required" };
   }
 
   try {
@@ -80,12 +82,12 @@ export async function confirmViaElicitation({
     log.info("Elicitation response", { toolName, action: result.action });
 
     if (result.action === "accept") {
-      return { proceed: true };
+      return { proceed: true, method: "elicited" };
     }
     if (result.action === "decline") {
-      return { proceed: false, reason: "declined" };
+      return { proceed: false, reason: "declined", method: "elicited" };
     }
-    return { proceed: false, reason: "cancelled" };
+    return { proceed: false, reason: "cancelled", method: "elicited" };
   } catch (err) {
     if (requiresConfirmation(risk)) {
       log.warn("Elicitation failed, blocking operation", {
@@ -93,13 +95,13 @@ export async function confirmViaElicitation({
         risk,
         error: String(err),
       });
-      return { proceed: false, reason: "cancelled" };
+      return { proceed: false, reason: "cancelled", method: "blocked" };
     }
     log.warn("Elicitation failed, proceeding without confirmation (low risk)", {
       toolName,
       risk,
       error: String(err),
     });
-    return { proceed: true };
+    return { proceed: true, method: "skipped" };
   }
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -25,6 +25,10 @@ export interface Logger {
   error: (msg: string, data?: Record<string, unknown>) => void;
 }
 
+/**
+ * @deprecated Use `AuditEvent` from `../audit/types.js` instead.
+ * Kept for backward compatibility with external consumers.
+ */
 export interface AuditEntry {
   operation: string;
   resource_type: string;
@@ -44,6 +48,11 @@ const auditLogger = {
   },
 };
 
+/**
+ * @deprecated Use `AuditManager` from `../audit/index.js` instead.
+ * This function writes directly to stderr and does not fan out to
+ * configured audit sinks. Kept for backward compatibility.
+ */
 export function logAudit(entry: AuditEntry): void {
   const { outcome, error, ...rest } = entry;
   const data: Record<string, unknown> = { ...rest, outcome };

--- a/tests/audit/manager.test.ts
+++ b/tests/audit/manager.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from "vitest";
+import { AuditManager } from "../../src/audit/manager.js";
+import type { AuditEvent, AuditSink } from "../../src/audit/types.js";
+
+function makeEvent(overrides: Partial<AuditEvent> = {}): AuditEvent {
+  return {
+    event_id: "test-id",
+    timestamp: "2026-01-01T00:00:00.000Z",
+    tool: "harness_create",
+    operation: "create",
+    resource_type: "pipeline",
+    account_id: "acct1",
+    risk: "low_write",
+    outcome: "success",
+    duration_ms: 42,
+    http_method: "POST",
+    http_path: "/pipeline/api/pipelines/v2",
+    ...overrides,
+  };
+}
+
+function makeSink(name: string): AuditSink & { events: AuditEvent[]; flushCount: number; closeCount: number } {
+  const sink = {
+    name,
+    events: [] as AuditEvent[],
+    flushCount: 0,
+    closeCount: 0,
+    emit(event: AuditEvent) {
+      sink.events.push(event);
+    },
+    async flush() {
+      sink.flushCount++;
+    },
+    async close() {
+      sink.closeCount++;
+    },
+  };
+  return sink;
+}
+
+describe("AuditManager", () => {
+  it("fans out events to all registered sinks", () => {
+    const mgr = new AuditManager();
+    const s1 = makeSink("s1");
+    const s2 = makeSink("s2");
+    mgr.addSink(s1);
+    mgr.addSink(s2);
+
+    const event = makeEvent();
+    mgr.emit(event);
+
+    expect(s1.events).toHaveLength(1);
+    expect(s2.events).toHaveLength(1);
+    expect(s1.events[0]).toEqual(event);
+  });
+
+  it("swallows sync errors from sinks", () => {
+    const mgr = new AuditManager();
+    const badSink: AuditSink = {
+      name: "bad",
+      emit() { throw new Error("boom"); },
+    };
+    const goodSink = makeSink("good");
+    mgr.addSink(badSink);
+    mgr.addSink(goodSink);
+
+    mgr.emit(makeEvent());
+    expect(goodSink.events).toHaveLength(1);
+  });
+
+  it("swallows async errors from sinks", () => {
+    const mgr = new AuditManager();
+    const asyncBadSink: AuditSink = {
+      name: "async-bad",
+      emit() { return Promise.reject(new Error("async boom")); },
+    };
+    const goodSink = makeSink("good");
+    mgr.addSink(asyncBadSink);
+    mgr.addSink(goodSink);
+
+    expect(() => mgr.emit(makeEvent())).not.toThrow();
+    expect(goodSink.events).toHaveLength(1);
+  });
+
+  it("flush() calls flush on all sinks", async () => {
+    const mgr = new AuditManager();
+    const s1 = makeSink("s1");
+    const s2 = makeSink("s2");
+    mgr.addSink(s1);
+    mgr.addSink(s2);
+
+    await mgr.flush();
+    expect(s1.flushCount).toBe(1);
+    expect(s2.flushCount).toBe(1);
+  });
+
+  it("close() calls flush then close on all sinks", async () => {
+    const mgr = new AuditManager();
+    const s1 = makeSink("s1");
+    mgr.addSink(s1);
+
+    await mgr.close();
+    expect(s1.flushCount).toBe(1);
+    expect(s1.closeCount).toBe(1);
+  });
+
+  it("close() swallows errors from failing sinks", async () => {
+    const mgr = new AuditManager();
+    const failSink: AuditSink = {
+      name: "fail",
+      emit() {},
+      async flush() { throw new Error("flush fail"); },
+      async close() { throw new Error("close fail"); },
+    };
+    mgr.addSink(failSink);
+
+    await expect(mgr.close()).resolves.toBeUndefined();
+  });
+
+  it("works with zero sinks", () => {
+    const mgr = new AuditManager();
+    expect(() => mgr.emit(makeEvent())).not.toThrow();
+  });
+});

--- a/tests/audit/registry-audit.test.ts
+++ b/tests/audit/registry-audit.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi } from "vitest";
+import { Registry } from "../../src/registry/index.js";
+import { AuditManager } from "../../src/audit/manager.js";
+import type { AuditEvent, AuditSink } from "../../src/audit/types.js";
+
+function makeConfig(overrides = {}) {
+  return {
+    HARNESS_API_KEY: "pat.acct1.token.secret",
+    HARNESS_ACCOUNT_ID: "acct1",
+    HARNESS_BASE_URL: "https://app.harness.io",
+    HARNESS_ORG: "default",
+    HARNESS_PROJECT: "proj1",
+    HARNESS_API_TIMEOUT_MS: 30000,
+    HARNESS_MAX_RETRIES: 3,
+    LOG_LEVEL: "info" as const,
+    HARNESS_TOOLSETS: "pipelines",
+    HARNESS_MAX_BODY_SIZE_MB: 10,
+    HARNESS_RATE_LIMIT_RPS: 10,
+    HARNESS_READ_ONLY: false,
+    HARNESS_SKIP_ELICITATION: false,
+    HARNESS_AUTO_APPROVE_RISK: "none",
+    HARNESS_ALLOW_HTTP: false,
+    HARNESS_FME_BASE_URL: "https://api.split.io",
+    HARNESS_LOG_UNSAFE_BODIES: false,
+    HARNESS_AUDIT_WEBHOOK_BATCH_SIZE: 10,
+    HARNESS_AUDIT_WEBHOOK_FLUSH_MS: 5000,
+    ...overrides,
+  };
+}
+
+function collectingSink(): AuditSink & { events: AuditEvent[] } {
+  const events: AuditEvent[] = [];
+  return {
+    name: "test-collector",
+    events,
+    emit(event: AuditEvent) { events.push(event); },
+  };
+}
+
+describe("Registry audit emission", () => {
+  it("emits an audit event on successful dispatch", async () => {
+    const sink = collectingSink();
+    const auditManager = new AuditManager();
+    auditManager.addSink(sink);
+
+    const config = makeConfig();
+    const registry = new Registry(config as any, { auditManager });
+
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ status: "SUCCESS", data: { identifier: "p1" } }),
+      account: "acct1",
+    };
+
+    await registry.dispatch(mockClient as any, "pipeline", "list", {}, { tool: "harness_list", confirmation: "not_required" });
+
+    expect(sink.events).toHaveLength(1);
+    const event = sink.events[0]!;
+    expect(event.tool).toBe("harness_list");
+    expect(event.operation).toBe("list");
+    expect(event.resource_type).toBe("pipeline");
+    expect(event.outcome).toBe("success");
+    expect(event.account_id).toBe("acct1");
+    expect(event.confirmation).toBe("not_required");
+    expect(event.duration_ms).toBeGreaterThanOrEqual(0);
+    expect(event.http_method).toBeDefined();
+    expect(event.event_id).toBeDefined();
+    expect(event.timestamp).toBeDefined();
+  });
+
+  it("emits an audit event on failed dispatch", async () => {
+    const sink = collectingSink();
+    const auditManager = new AuditManager();
+    auditManager.addSink(sink);
+
+    const config = makeConfig();
+    const registry = new Registry(config as any, { auditManager });
+
+    const mockClient = {
+      request: vi.fn().mockRejectedValue(new Error("API timeout")),
+      account: "acct1",
+    };
+
+    await expect(
+      registry.dispatch(mockClient as any, "pipeline", "list", {}, { tool: "harness_list" }),
+    ).rejects.toThrow("API timeout");
+
+    expect(sink.events).toHaveLength(1);
+    const event = sink.events[0]!;
+    expect(event.outcome).toBe("error");
+    expect(event.error).toContain("API timeout");
+  });
+
+  it("does not emit audit events when auditManager is not configured", async () => {
+    const config = makeConfig();
+    const registry = new Registry(config as any);
+
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ status: "SUCCESS", data: {} }),
+      account: "acct1",
+    };
+
+    // Should not throw — just operates without audit
+    await registry.dispatch(mockClient as any, "pipeline", "list", {});
+  });
+
+  it("emits audit event for dispatchExecute", async () => {
+    const sink = collectingSink();
+    const auditManager = new AuditManager();
+    auditManager.addSink(sink);
+
+    const config = makeConfig();
+    const registry = new Registry(config as any, { auditManager });
+
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ status: "SUCCESS", data: { planExecution: { uuid: "ex1" } } }),
+      account: "acct1",
+    };
+
+    await registry.dispatchExecute(mockClient as any, "pipeline", "run", { pipeline_id: "p1" }, { tool: "harness_execute", confirmation: "elicited", action: "run" });
+
+    expect(sink.events).toHaveLength(1);
+    const event = sink.events[0]!;
+    expect(event.tool).toBe("harness_execute");
+    expect(event.operation).toBe("execute");
+    expect(event.action).toBe("run");
+    expect(event.confirmation).toBe("elicited");
+  });
+
+  it("backward compatible — dispatch still works with AbortSignal", async () => {
+    const sink = collectingSink();
+    const auditManager = new AuditManager();
+    auditManager.addSink(sink);
+
+    const config = makeConfig();
+    const registry = new Registry(config as any, { auditManager });
+
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ status: "SUCCESS", data: {} }),
+      account: "acct1",
+    };
+
+    const controller = new AbortController();
+    await registry.dispatch(mockClient as any, "pipeline", "list", {}, controller.signal);
+
+    expect(sink.events).toHaveLength(1);
+    expect(sink.events[0]!.tool).toBe("harness_list");
+  });
+});

--- a/tests/audit/sinks.test.ts
+++ b/tests/audit/sinks.test.ts
@@ -179,4 +179,14 @@ describe("OTelSink", () => {
     const sink = new OTelSink();
     await expect(sink.flush()).resolves.toBeUndefined();
   });
+
+  it("close resolves without error", async () => {
+    const sink = new OTelSink();
+    await expect(sink.close()).resolves.toBeUndefined();
+  });
+
+  it("has the correct name", () => {
+    const sink = new OTelSink();
+    expect(sink.name).toBe("otel");
+  });
 });

--- a/tests/audit/sinks.test.ts
+++ b/tests/audit/sinks.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { readFileSync, existsSync, unlinkSync, mkdirSync, rmdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import type { AuditEvent } from "../../src/audit/types.js";
+import { StderrSink } from "../../src/audit/sinks/stderr.js";
+import { JsonlFileSink } from "../../src/audit/sinks/jsonl-file.js";
+import { WebhookSink } from "../../src/audit/sinks/webhook.js";
+import { OTelSink } from "../../src/audit/sinks/otel.js";
+
+function makeEvent(overrides: Partial<AuditEvent> = {}): AuditEvent {
+  return {
+    event_id: "evt-1",
+    timestamp: "2026-01-01T00:00:00.000Z",
+    tool: "harness_create",
+    operation: "create",
+    resource_type: "pipeline",
+    account_id: "acct1",
+    risk: "low_write",
+    outcome: "success",
+    duration_ms: 42,
+    http_method: "POST",
+    http_path: "/pipeline/api/pipelines/v2",
+    ...overrides,
+  };
+}
+
+describe("StderrSink", () => {
+  it("writes success events via info log", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const sink = new StderrSink();
+    sink.emit(makeEvent());
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const logged = JSON.parse(spy.mock.calls[0]![0] as string);
+    expect(logged.module).toBe("audit");
+    expect(logged.level).toBe("info");
+    expect(logged.event_id).toBe("evt-1");
+    expect(logged.outcome).toBe("success");
+    spy.mockRestore();
+  });
+
+  it("writes error events via warn log", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const sink = new StderrSink();
+    sink.emit(makeEvent({ outcome: "error", error: "something failed" }));
+
+    const logged = JSON.parse(spy.mock.calls[0]![0] as string);
+    expect(logged.level).toBe("warn");
+    expect(logged.error).toBe("something failed");
+    spy.mockRestore();
+  });
+});
+
+describe("JsonlFileSink", () => {
+  let testDir: string;
+  let testFile: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `audit-test-${randomUUID()}`);
+    testFile = join(testDir, "audit.jsonl");
+  });
+
+  afterEach(() => {
+    try { unlinkSync(testFile); } catch {}
+    try { rmdirSync(testDir); } catch {}
+  });
+
+  it("creates directory and appends NDJSON", () => {
+    const sink = new JsonlFileSink(testFile);
+    sink.emit(makeEvent({ event_id: "e1" }));
+    sink.emit(makeEvent({ event_id: "e2" }));
+
+    expect(existsSync(testFile)).toBe(true);
+    const lines = readFileSync(testFile, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]!).event_id).toBe("e1");
+    expect(JSON.parse(lines[1]!).event_id).toBe("e2");
+  });
+
+  it("handles write errors gracefully", () => {
+    const sink = new JsonlFileSink("/nonexistent/path/that/should/fail/audit.jsonl");
+    expect(() => sink.emit(makeEvent())).not.toThrow();
+  });
+});
+
+describe("WebhookSink", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("batches events and flushes when batch size is reached", async () => {
+    const sink = new WebhookSink({
+      url: "https://example.com/audit",
+      token: "test-token",
+      batchSize: 2,
+      flushIntervalMs: 60000,
+    });
+
+    sink.emit(makeEvent({ event_id: "e1" }));
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    sink.emit(makeEvent({ event_id: "e2" }));
+
+    // Give the async flush a tick
+    await new Promise((r) => setTimeout(r, 10));
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    const [url, opts] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("https://example.com/audit");
+    expect(opts.headers["Authorization"]).toBe("Bearer test-token");
+
+    const body = JSON.parse(opts.body);
+    expect(body.events).toHaveLength(2);
+
+    await sink.close();
+  });
+
+  it("flush sends partial batch", async () => {
+    const sink = new WebhookSink({
+      url: "https://example.com/audit",
+      batchSize: 100,
+      flushIntervalMs: 60000,
+    });
+
+    sink.emit(makeEvent({ event_id: "e1" }));
+    await sink.flush();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1].body);
+    expect(body.events).toHaveLength(1);
+
+    await sink.close();
+  });
+
+  it("handles fetch errors gracefully", async () => {
+    fetchSpy.mockRejectedValue(new Error("network error"));
+    const sink = new WebhookSink({
+      url: "https://example.com/audit",
+      batchSize: 1,
+      flushIntervalMs: 60000,
+    });
+
+    sink.emit(makeEvent());
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Should not throw
+    await sink.close();
+  });
+
+  it("flush is a no-op when buffer is empty", async () => {
+    const sink = new WebhookSink({
+      url: "https://example.com/audit",
+      flushIntervalMs: 60000,
+    });
+
+    await sink.flush();
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    await sink.close();
+  });
+});
+
+describe("OTelSink", () => {
+  it("emit is a no-op when @opentelemetry/api is not available", () => {
+    const sink = new OTelSink();
+    expect(() => sink.emit(makeEvent())).not.toThrow();
+  });
+
+  it("flush resolves without error", async () => {
+    const sink = new OTelSink();
+    await expect(sink.flush()).resolves.toBeUndefined();
+  });
+});

--- a/tests/utils/elicitation.test.ts
+++ b/tests/utils/elicitation.test.ts
@@ -94,7 +94,7 @@ describe("confirmViaElicitation", () => {
       message: "Create pipeline?",
       risk: "low_write",
     });
-    expect(result).toEqual({ proceed: true });
+    expect(result).toEqual({ proceed: true, method: "not_required" });
     expect(mcpServer.server.elicitInput).not.toHaveBeenCalled();
   });
 
@@ -106,7 +106,7 @@ describe("confirmViaElicitation", () => {
       message: "Delete pipeline?",
       risk: "destructive",
     });
-    expect(result).toEqual({ proceed: false, reason: "declined" });
+    expect(result).toEqual({ proceed: false, reason: "declined", method: "blocked" });
     expect(mcpServer.server.elicitInput).not.toHaveBeenCalled();
   });
 
@@ -118,7 +118,7 @@ describe("confirmViaElicitation", () => {
       message: "Create repo rule?",
       risk: "medium_write",
     });
-    expect(result).toEqual({ proceed: false, reason: "declined" });
+    expect(result).toEqual({ proceed: false, reason: "declined", method: "blocked" });
   });
 
   it("proceeds when user accepts", async () => {
@@ -132,7 +132,7 @@ describe("confirmViaElicitation", () => {
       message: "Create service?",
       risk: "low_write",
     });
-    expect(result).toEqual({ proceed: true });
+    expect(result).toEqual({ proceed: true, method: "elicited" });
     expect(mcpServer.server.elicitInput).toHaveBeenCalledOnce();
   });
 
@@ -147,7 +147,7 @@ describe("confirmViaElicitation", () => {
       message: "Delete connector?",
       risk: "destructive",
     });
-    expect(result).toEqual({ proceed: false, reason: "declined" });
+    expect(result).toEqual({ proceed: false, reason: "declined", method: "elicited" });
   });
 
   it("returns cancelled when user cancels", async () => {
@@ -161,7 +161,7 @@ describe("confirmViaElicitation", () => {
       message: "Run pipeline?",
       risk: "high_write",
     });
-    expect(result).toEqual({ proceed: false, reason: "cancelled" });
+    expect(result).toEqual({ proceed: false, reason: "cancelled", method: "elicited" });
   });
 
   it("proceeds when elicitInput throws (low_write)", async () => {
@@ -173,7 +173,7 @@ describe("confirmViaElicitation", () => {
       message: "Create service?",
       risk: "low_write",
     });
-    expect(result).toEqual({ proceed: true });
+    expect(result).toEqual({ proceed: true, method: "skipped" });
   });
 
   it("blocks when elicitInput throws (destructive)", async () => {
@@ -185,7 +185,7 @@ describe("confirmViaElicitation", () => {
       message: "Delete service?",
       risk: "destructive",
     });
-    expect(result).toEqual({ proceed: false, reason: "cancelled" });
+    expect(result).toEqual({ proceed: false, reason: "cancelled", method: "blocked" });
   });
 
   it("blocks when elicitInput throws (medium_write)", async () => {
@@ -197,7 +197,7 @@ describe("confirmViaElicitation", () => {
       message: "Create repo rule?",
       risk: "medium_write",
     });
-    expect(result).toEqual({ proceed: false, reason: "cancelled" });
+    expect(result).toEqual({ proceed: false, reason: "cancelled", method: "blocked" });
   });
 
   it("passes message to elicitInput with empty schema", async () => {
@@ -229,7 +229,7 @@ describe("confirmViaElicitation", () => {
       message: "Delete pipeline?",
       risk: "destructive",
     });
-    expect(result).toEqual({ proceed: true });
+    expect(result).toEqual({ proceed: true, method: "auto_approved" });
     expect(mcpServer.server.elicitInput).not.toHaveBeenCalled();
   });
 
@@ -242,7 +242,7 @@ describe("confirmViaElicitation", () => {
       message: "Create service?",
       risk: "low_write",
     });
-    expect(result).toEqual({ proceed: true });
+    expect(result).toEqual({ proceed: true, method: "auto_approved" });
   });
 
   it("does not auto-approve high_write when threshold is low_write", async () => {
@@ -254,7 +254,7 @@ describe("confirmViaElicitation", () => {
       message: "Run pipeline?",
       risk: "high_write",
     });
-    expect(result).toEqual({ proceed: false, reason: "declined" });
+    expect(result).toEqual({ proceed: false, reason: "declined", method: "blocked" });
   });
 
   it("skips elicitation for non-destructive ops when auto-approve is 'all'", async () => {
@@ -266,7 +266,7 @@ describe("confirmViaElicitation", () => {
       message: "Create service?",
       risk: "low_write",
     });
-    expect(result).toEqual({ proceed: true });
+    expect(result).toEqual({ proceed: true, method: "auto_approved" });
     expect(mcpServer.server.elicitInput).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- **Pluggable audit sink system**: Replaces scattered `logAudit()` calls in 4 tool handlers with centralized `AuditManager` that emits enriched `AuditEvent` records from the registry dispatch layer
- **Four sink implementations**: StderrSink (always on), JsonlFileSink (`HARNESS_AUDIT_FILE`), WebhookSink (batched POST with Bearer auth), OTelSink (optional `@opentelemetry/api` peer dep)
- **Enriched audit events**: Every registry-mediated API call produces an event with `event_id`, `risk`, `confirmation` method, `duration_ms`, HTTP method/path/status, and full scope identifiers
- **Internal repo integration**: `AuditManager` is exposed via `RegistryOptions` so `mcpServerInternal` can add custom sinks (e.g. Harness Platform Audit Service) without monkey-patching

### New files
- `src/audit/types.ts` — `AuditEvent`, `AuditContext`, `AuditSink` interfaces
- `src/audit/manager.ts` — Fan-out orchestrator with error isolation
- `src/audit/sinks/stderr.ts` — StderrSink
- `src/audit/sinks/jsonl-file.ts` — JsonlFileSink
- `src/audit/sinks/webhook.ts` — WebhookSink (batched, configurable)
- `src/audit/sinks/otel.ts` — OTelSink (dynamic import)
- `src/audit/index.ts` — `createAuditManager(config)` factory
- `specs/004-audit-sinks.md` — Design spec

### Modified files
- `src/registry/index.ts` — `auditManager` in `RegistryOptions`, `AuditContext` param on dispatch, `executeSpecWithAudit` wrapper
- `src/tools/harness-{create,update,delete,execute}.ts` — Remove `logAudit` calls, pass `AuditContext`
- `src/config.ts` — Audit env vars
- `src/index.ts` — Wire `AuditManager` lifecycle (creation + shutdown)
- `src/utils/logger.ts` — Deprecate `logAudit()` / `AuditEntry`
- `package.json` — `@opentelemetry/api` optional peer dep

## Test plan

- [x] Typecheck passes
- [x] All 1126 tests pass (22 new: 7 manager, 10 sinks, 5 registry integration)
- [x] AuditManager fan-out, error isolation, flush/close
- [x] StderrSink info/warn routing
- [x] JsonlFileSink file creation, NDJSON append, error handling
- [x] WebhookSink batching, Bearer auth, fetch error resilience
- [x] OTelSink graceful no-op when @opentelemetry/api unavailable
- [x] Registry emits audit events on success and failure
- [x] Backward compat: dispatch still works with AbortSignal (no AuditContext)
- [x] No audit events when AuditManager not configured


Made with [Cursor](https://cursor.com)