### PR TITLE
fix: redact YAML block scalar secrets

### DIFF
--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -1,5 +1,5 @@
 const SENSITIVE_KEYS =
-  "token|secret|password|authorization|bearer|credentials?|webhook|webhook[_-]?url|callback[_-]?url|endpoint[_-]?url|private[_-]?key|client[_-]?secret|api[_-]?key|secret[_-]?key|access[_-]?key|ssh[_-]?key|passphrase|encrypted|access[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?token|cookie";
+  "webhook[_-]?url|callback[_-]?url|endpoint[_-]?url|private[_-]?key|privateKey|client[_-]?secret|clientSecret|api[_-]?key|apiKey|secret[_-]?key|secretKey|access[_-]?key|accessKey|ssh[_-]?key|sshKey|access[_-]?token|accessToken|refresh[_-]?token|refreshToken|id[_-]?token|idToken|session[_-]?token|sessionToken|authorization|bearer|credentials?|passphrase|encrypted|password|webhook|secret|cookie|token";
 
 const SENSITIVE_KEY_PATTERN = new RegExp(`^(${SENSITIVE_KEYS})$`, "i");
 
@@ -39,8 +39,13 @@ export function redactSensitiveFields(obj: unknown, depth = 0): unknown {
  * Value capture handles quoted strings (double or single) and unquoted values up to the next delimiter.
  */
 const INLINE_SECRET_PATTERN = new RegExp(
-  `(["']?(?:${SENSITIVE_KEYS})["']?)\\s*[:=]\\s*("[^"]*"|'[^']*'|[^,\\n}{\\]]+)`,
+  `(["']?(?:${SENSITIVE_KEYS})(?![A-Za-z0-9_-])["']?)[ \\t]*[:=][ \\t]*(?![|>](?:\\s|$))("[^"]*"|'[^']*'|[^,\\n}{\\]]+)`,
   "gi",
+);
+
+const YAML_BLOCK_SECRET_PATTERN = new RegExp(
+  `(^[ \\t]*["']?(?:${SENSITIVE_KEYS})["']?[ \\t]*:[ \\t]*[|>][^\\n]*\\n)(?:[ \\t]+.*(?:\\n|$))+`,
+  "gim",
 );
 
 /**
@@ -54,7 +59,9 @@ export function redactJsonString(jsonStr: string, maxLen = 1000): string {
     const out = JSON.stringify(redacted);
     return out.length > maxLen ? out.slice(0, maxLen) + "..." : out;
   } catch {
-    const scrubbed = jsonStr.replace(INLINE_SECRET_PATTERN, `$1: ${REDACTED}`);
+    const scrubbed = jsonStr
+      .replace(YAML_BLOCK_SECRET_PATTERN, `$1  ${REDACTED}\n`)
+      .replace(INLINE_SECRET_PATTERN, `$1: ${REDACTED}`);
     return scrubbed.length > maxLen ? scrubbed.slice(0, maxLen) + "..." : scrubbed;
   }
 }

--- a/tests/utils/redact.test.ts
+++ b/tests/utils/redact.test.ts
@@ -220,6 +220,22 @@ describe("redactJsonString", () => {
     expect(result).toContain("[REDACTED]");
   });
 
+  it("redacts YAML block scalars in non-JSON text", () => {
+    const raw = `name: deploy
+privateKey: |
+  line-one-secret
+  line-two-secret
+command: echo safe`;
+
+    const result = redactJsonString(raw);
+
+    expect(result).toContain("name: deploy");
+    expect(result).toContain("[REDACTED]");
+    expect(result).toContain("command: echo safe");
+    expect(result).not.toContain("line-one-secret");
+    expect(result).not.toContain("line-two-secret");
+  });
+
   it("redacts kebab-case keys in JSON objects", () => {
     const json = JSON.stringify({ "private-key": "secret_value", name: "safe" });
     const result = redactJsonString(json);


### PR DESCRIPTION
## Summary
- redact YAML `|`/`>` block scalar values for sensitive keys in the non-JSON fallback path
- keep inline non-JSON redaction intact while avoiding YAML block indicators
- add regression coverage for YAML block scalar scrubbing

Fixes #118

## Test Plan
- `pnpm exec vitest run tests/utils/redact.test.ts`
- `pnpm build`
