### PR TITLE
fix: improve v1 pipeline generation quality

### DIFF
--- a/src/data/schemas/index.ts
+++ b/src/data/schemas/index.ts
@@ -11,10 +11,11 @@ import overlayInputSetV1 from "./v1/overlayInputSet.js";
 import serviceV1 from "./v1/service.js";
 import infraV1 from "./v1/infra.js";
 import agentPipeline from "./local/agent-pipeline.js";
+import pipelineV1Examples from "./local/pipeline-v1-examples.js";
 
 type V0SchemaKey = "pipeline" | "template" | "trigger";
 type V1SchemaKey = "pipeline_v1" | "template_v1" | "trigger_v1" | "inputSet_v1" | "overlayInputSet_v1" | "service_v1" | "infra_v1";
-type LocalSchemaKey = "agent-pipeline";
+type LocalSchemaKey = "agent-pipeline" | "pipeline_v1_examples";
 type AllSchemaKeys = V0SchemaKey | V1SchemaKey | LocalSchemaKey;
 
 export const SCHEMAS: Record<AllSchemaKeys, Record<string, any>> = {
@@ -29,10 +30,11 @@ export const SCHEMAS: Record<AllSchemaKeys, Record<string, any>> = {
   "service_v1": serviceV1,
   "infra_v1": infraV1,
   "agent-pipeline": agentPipeline,
+  "pipeline_v1_examples": pipelineV1Examples,
 };
 
 export const VALID_SCHEMAS = Object.keys(SCHEMAS) as AllSchemaKeys[];
 export type SchemaName = AllSchemaKeys;
 
 export const V0_SCHEMA_KEYS: V0SchemaKey[] = ["pipeline", "template", "trigger"];
-export const V1_SCHEMA_KEYS: V1SchemaKey[] = ["pipeline_v1", "template_v1", "trigger_v1", "inputSet_v1", "overlayInputSet_v1", "service_v1", "infra_v1"];
+export const V1_SCHEMA_KEYS: (V1SchemaKey | "pipeline_v1_examples")[] = ["pipeline_v1", "template_v1", "trigger_v1", "inputSet_v1", "overlayInputSet_v1", "service_v1", "infra_v1", "pipeline_v1_examples"];

--- a/src/data/schemas/local/agent-pipeline.ts
+++ b/src/data/schemas/local/agent-pipeline.ts
@@ -3758,7 +3758,7 @@ const schema: Record<string, any> = {
                 "$ref": "#/definitions/pipeline/Clone"
               },
               "action": {
-                "description": "Action step configuration.",
+                "description": "Drone/Harness plugin step. Prefer 'template: uses:' for Harness built-in steps instead.",
                 "$ref": "#/definitions/pipeline/steps/unified/ActionStepInfoV1"
               },
               "background": {
@@ -4210,15 +4210,15 @@ const schema: Record<string, any> = {
           },
           "ActionStepInfoV1": {
             "title": "ActionStepInfoV1",
-            "description": "Action step configuration for running GitHub-style actions.",
+            "description": "Action step using a Harness plugin or Drone plugin. IMPORTANT: Prefer 'template: uses:' for Harness built-in steps (e.g., k8sRollingDeployStep, buildAndPushToECR, TerraformPlan). Only use 'action:' for Drone/Harness plugins from the plugin registry. Do NOT use GitHub Actions marketplace references here.",
             "type": "object",
             "properties": {
               "uses": {
-                "description": "Action reference (e.g., actions/checkout@v3). Supports expressions.",
+                "description": "Plugin reference from the Harness/Drone plugin registry (e.g., plugins/docker, plugins/s3). Do NOT use GitHub Actions references like 'actions/checkout@v3'.",
                 "type": "string"
               },
               "with": {
-                "description": "Action inputs. Supports expressions.",
+                "description": "Plugin inputs as key-value pairs. Supports expressions.",
                 "$ref": "#/definitions/pipeline/common/ObjectOrExpression"
               },
               "env": {

--- a/src/data/schemas/local/pipeline-v1-examples.ts
+++ b/src/data/schemas/local/pipeline-v1-examples.ts
@@ -1,0 +1,426 @@
+// Curated v1 pipeline examples extracted from real customer pipelines.
+// These demonstrate correct v1 syntax and best practices.
+// Served via schema:///pipeline_v1_examples
+// @ts-nocheck
+
+const schema: Record<string, any> = {
+  "title": "pipeline_v1_examples",
+  "description": "Curated Harness v1 pipeline YAML examples. Use these as reference when generating v1 pipelines. IMPORTANT: Always prefer 'template: uses:' for Harness built-in steps. Never use GitHub Actions syntax or v0 patterns.",
+  "examples": {
+    "ci_build_and_push": {
+      "title": "CI Pipeline — Build, Test, and Push to ECR",
+      "description": "A CI pipeline that clones a repo, runs tests in parallel with linting, then builds and pushes a Docker image to ECR.",
+      "yaml": `pipeline:
+  id: ci_build_push
+  name: CI Build and Push
+  clone:
+    connector: account.github
+    enabled: true
+    ref:
+      type: branch
+      name: <+trigger.targetBranch>
+    repo: org/my-app
+  stages:
+    - id: Build_and_Test
+      name: Build and Test
+      clone:
+        enabled: true
+      runtime:
+        kubernetes:
+          connector: account.k8s_build
+          namespace: harness-build
+          os: Linux
+      steps:
+        - parallel:
+            steps:
+              - id: run_tests
+                name: Run Tests
+                run:
+                  container:
+                    connector: account.dockerhub
+                    image: node:20
+                  script: |
+                    npm ci
+                    npm test
+                  shell: bash
+                timeout: 10m
+              - id: lint
+                name: Lint
+                run:
+                  container:
+                    connector: account.dockerhub
+                    image: node:20
+                  script: |
+                    npm ci
+                    npm run lint
+                  shell: bash
+                timeout: 5m
+        - id: build_push
+          name: Build and Push
+          template:
+            uses: buildAndPushToECR
+            with:
+              connector: account.aws_connector
+              region: us-east-1
+              registry: 123456789.dkr.ecr.us-east-1.amazonaws.com
+              repo: my-app
+              tags:
+                - <+pipeline.sequenceId>
+                - latest
+`
+    },
+    "k8s_rolling_deploy": {
+      "title": "CD Pipeline — Kubernetes Rolling Deployment",
+      "description": "A CD pipeline that deploys a service to Kubernetes using a rolling strategy with rollback on failure.",
+      "yaml": `pipeline:
+  id: k8s_deploy
+  name: Deploy to Kubernetes
+  clone:
+    enabled: false
+  stages:
+    - id: deploy_dev
+      name: Deploy to Dev
+      environment:
+        id: dev
+        name: dev
+        deploy-to: dev_k8s_cluster
+      service: my_service
+      on-failure:
+        - action: stage-rollback
+          errors:
+            - all
+      rollback:
+        - id: rollback
+          name: Rollback Deployment
+          template:
+            uses: k8sRollingRollbackStep
+            with:
+              pruning: false
+          timeout: 10m
+      steps:
+        - id: deploy
+          name: Rolling Deploy
+          template:
+            uses: k8sRollingDeployStep
+            with:
+              skip_dry_run: false
+              pruning: false
+          timeout: 10m
+        - id: verify
+          name: Verify Deployment
+          template:
+            uses: Verify
+          timeout: 15m
+`
+    },
+    "terraform_infra": {
+      "title": "Infrastructure Pipeline — Terraform Plan/Approve/Apply",
+      "description": "An infrastructure pipeline with Terraform plan, manual approval, and apply steps with automatic rollback on failure.",
+      "yaml": `pipeline:
+  id: terraform_infra
+  name: Terraform Infrastructure
+  clone:
+    connector: account.github
+    enabled: true
+    ref:
+      type: branch
+      name: main
+    repo: org/infrastructure
+  stages:
+    - id: Terraform
+      name: Terraform
+      runtime:
+        shell: true
+      steps:
+        - id: tf_plan
+          name: Terraform Plan
+          template:
+            uses: TerraformPlan
+          timeout: 20m
+        - approval:
+            uses: harness
+            with:
+              approvers-min-count: 1
+              auto-approve: false
+              message: "Review the Terraform plan and approve to apply changes."
+              user-groups:
+                - infra_admins
+          id: approve_apply
+          name: Approve Apply
+          timeout: 2d
+        - id: tf_apply
+          name: Terraform Apply
+          template:
+            uses: TerraformApply
+          timeout: 20m
+        - id: tf_rollback
+          if: <+OnStageFailure>
+          name: Terraform Rollback
+          template:
+            uses: TerraformRollback
+          timeout: 20m
+`
+    },
+    "helm_deploy": {
+      "title": "CD Pipeline — Helm Deployment with Rollback",
+      "description": "A Helm-based deployment pipeline for Kubernetes services.",
+      "yaml": `pipeline:
+  id: helm_deploy
+  name: Helm Deploy
+  clone:
+    enabled: false
+  stages:
+    - id: Helm_Deploy
+      name: Helm Deploy
+      environment:
+        id: prod
+        name: prod
+        deploy-to: prod_cluster
+      service: my_helm_service
+      on-failure:
+        - action: stage-rollback
+          errors:
+            - all
+      rollback:
+        - id: helm_rollback
+          name: Helm Rollback
+          template:
+            uses: helmRollbackStep
+            with: {}
+          timeout: 10m
+      steps:
+        - id: helm_deploy
+          name: Helm Deployment
+          template:
+            uses: helmDeployBasicStep
+            with:
+              ignore_failed_release: false
+          timeout: 10m
+        - id: fetch_instances
+          name: Fetch Instances
+          template:
+            uses: FetchInstanceScript
+          timeout: 1m
+`
+    },
+    "ecs_blue_green": {
+      "title": "CD Pipeline — ECS Blue/Green Deployment",
+      "description": "An ECS pipeline using blue/green deployment strategy with target group swap.",
+      "yaml": `pipeline:
+  id: ecs_blue_green
+  name: ECS Blue Green Deploy
+  clone:
+    enabled: false
+  stages:
+    - id: Deploy_ECS
+      name: Deploy ECS
+      environment:
+        id: prod
+        name: prod
+        deploy-to: ecs_prod
+      service: my_ecs_service
+      on-failure:
+        - action: stage-rollback
+          errors:
+            - all
+      rollback:
+        - id: ecs_rollback
+          name: ECS Rollback
+          template:
+            uses: EcsBlueGreenRollback
+          timeout: 10m
+      steps:
+        - id: create_service
+          name: Create Service
+          template:
+            uses: EcsBlueGreenCreateService
+          timeout: 10m
+        - id: swap_targets
+          name: Swap Target Groups
+          template:
+            uses: EcsBlueGreenSwapTargetGroups
+          timeout: 10m
+`
+    },
+    "multi_env_with_approvals": {
+      "title": "Multi-Environment Pipeline with Approvals and Notifications",
+      "description": "A production pipeline deploying through dev → staging → prod with approvals, notifications, and matrix-based infrastructure selection.",
+      "yaml": `pipeline:
+  id: service_deploy
+  name: Service Deployment
+  clone:
+    enabled: false
+  inputs:
+    environment:
+      type: string
+      enum:
+        - dev
+        - staging
+        - prod
+      value: dev
+    image_tag:
+      type: string
+      value: latest
+  notifications:
+    - id: slack_notify
+      name: Pipeline Notifications
+      "on":
+        - pipeline:
+            - success
+            - failed
+      uses: slack
+      with:
+        webhook: <+variable.slack_webhook>
+  stages:
+    - id: deploy_dev
+      name: Deploy Dev
+      environment:
+        id: dev
+        name: dev
+        deploy-to: dev_k8s
+      service: my_service
+      on-failure:
+        - action: stage-rollback
+          errors:
+            - all
+      rollback:
+        - id: rollback
+          name: Rollback
+          template:
+            uses: k8sRollingRollbackStep
+            with:
+              pruning: false
+          timeout: 10m
+      steps:
+        - id: deploy
+          name: Deploy
+          template:
+            uses: k8sRollingDeployStep
+            with:
+              skip_dry_run: false
+          timeout: 10m
+    - id: approve_staging
+      name: Approve Staging
+      steps:
+        - approval:
+            uses: harness
+            with:
+              approvers-min-count: 1
+              auto-approve: false
+              message: "Dev deployment succeeded. Approve promotion to staging?"
+              user-groups:
+                - dev_leads
+          id: approve
+          name: Approve
+          timeout: 1d
+    - id: deploy_staging
+      name: Deploy Staging
+      if: <+OnPipelineSuccess>
+      environment:
+        id: staging
+        name: staging
+        deploy-to: staging_k8s
+      service: my_service
+      on-failure:
+        - action: stage-rollback
+          errors:
+            - all
+      rollback:
+        - id: rollback
+          name: Rollback
+          template:
+            uses: k8sRollingRollbackStep
+            with:
+              pruning: false
+          timeout: 10m
+      steps:
+        - id: deploy
+          name: Deploy
+          template:
+            uses: k8sRollingDeployStep
+            with:
+              skip_dry_run: false
+          timeout: 10m
+    - id: approve_prod
+      name: Approve Production
+      steps:
+        - approval:
+            uses: harness
+            with:
+              approvers-min-count: 2
+              auto-approve: false
+              message: "Staging verified. Approve production deployment?"
+              user-groups:
+                - prod_approvers
+          id: approve
+          name: Approve
+          timeout: 2d
+    - id: deploy_prod
+      name: Deploy Production
+      if: <+OnPipelineSuccess>
+      environment:
+        id: prod
+        name: prod
+        deploy-to: prod_k8s
+      service: my_service
+      on-failure:
+        - action: stage-rollback
+          errors:
+            - all
+      rollback:
+        - id: rollback
+          name: Rollback
+          template:
+            uses: k8sRollingRollbackStep
+            with:
+              pruning: false
+          timeout: 10m
+      steps:
+        - id: deploy
+          name: Deploy
+          template:
+            uses: k8sRollingDeployStep
+            with:
+              skip_dry_run: false
+          timeout: 10m
+`
+    }
+  },
+  "step_reference": {
+    "description": "Quick reference of available v1 step types and their syntax. Use 'template: uses:' as the default for any Harness built-in operation.",
+    "template_step": {
+      "syntax": "template:\\n  uses: <templateName>\\n  with:\\n    key: value",
+      "when_to_use": "ALL Harness built-in steps — deployments, builds, Terraform, cache, artifact uploads, etc.",
+      "common_templates": [
+        "k8sRollingDeployStep", "k8sRollingRollbackStep", "k8sCanaryDeployStep",
+        "k8sCanaryDeleteStep", "k8sScaleStep", "k8sDeleteStep", "k8sDryRunStep",
+        "k8sBlueGreenDeployStep", "k8sBlueGreenSwapServicesSelectorsStep",
+        "helmDeployBasicStep", "helmRollbackStep",
+        "buildAndPushToECR", "buildAndPushToDocker", "buildAndPushToGCR", "buildAndPushToACR",
+        "TerraformPlan", "TerraformApply", "TerraformRollback", "TerraformCloudRun",
+        "EcsRollingDeploy", "EcsRollingRollback",
+        "EcsBlueGreenCreateService", "EcsBlueGreenSwapTargetGroups", "EcsBlueGreenRollback",
+        "uploadArtifactsToS3", "uploadArtifactsToJfrogArtifactory",
+        "saveCacheToS3", "restoreCacheFromS3", "saveCacheToGCS", "restoreCacheFromGCS",
+        "FetchInstanceScript", "Command", "Verify", "Container",
+        "JenkinsBuild", "Sonarqube", "Security", "Wiz",
+        "gitCloneStep", "jiraCreate", "jiraUpdate", "ShellScriptProvision"
+      ]
+    },
+    "run_step": {
+      "syntax": "run:\\n  script: |\\n    commands here\\n  shell: bash\\n  container:\\n    connector: account.dockerhub\\n    image: node:20",
+      "when_to_use": "Custom shell scripts with no corresponding Harness template"
+    },
+    "approval_step": {
+      "syntax": "approval:\\n  uses: harness\\n  with:\\n    approvers-min-count: 1\\n    message: 'Approve?'\\n    user-groups:\\n      - group_name",
+      "when_to_use": "Manual approval gates between stages"
+    },
+    "do_not_use": {
+      "github_actions": "NEVER use 'actions/checkout@v3', 'docker/build-push-action', or any GitHub Actions marketplace reference. These are NOT valid in Harness v1.",
+      "v0_syntax": "NEVER use 'step.type:', 'spec:', 'identifier:', 'connectorRef:' at step level. These are v0 patterns.",
+      "action_step": "'action:' is ONLY for Drone/Harness plugins (e.g., plugins/docker). Prefer 'template: uses:' for all Harness built-in operations."
+    }
+  }
+};
+
+export default schema;

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ function createHarnessServer(config: Config, sharedAuditManager?: AuditManager):
         "",
         "PR RESOURCES: pull_request, pr_comment, pr_activity, pr_reviewer, pr_check — all accept URL or explicit repo_id + pr_number.",
         ...(config.HARNESS_PIPELINE_VERSION === "1"
-          ? ["", "PIPELINE VERSION: This account uses v1 pipelines. Use resource_type='pipeline_v1' for all pipeline operations."]
+          ? ["", "PIPELINE VERSION: This account uses v1 pipelines. Use resource_type='pipeline_v1' for all pipeline operations. When generating pipeline YAML, use 'template: uses: <stepName>' for Harness built-in steps (e.g., k8sRollingDeployStep, buildAndPushToECR, TerraformPlan). Do NOT use GitHub Actions syntax."]
           : ["", "PIPELINE VERSION: This account uses v0 pipelines. Use resource_type='pipeline' for all pipeline operations."]),
       ].join("\n"),
     },

--- a/src/prompts/build-deploy-app.ts
+++ b/src/prompts/build-deploy-app.ts
@@ -73,9 +73,11 @@ Generate a Harness CI pipeline that:
 - Builds the Docker image from the Dockerfile found in Step 1
 - Tags the image with \`latest\` and \`<+pipeline.sequenceId>\`
 - Includes a build test step if the repo has tests (e.g. npm test, go test, pytest)
-- Uses a \`BuildAndPushDockerRegistry\` step. CRITICAL: The step spec differs based on the registry type. Use EXACTLY one of the two templates below — do not mix fields between them.
+- Uses the appropriate build-and-push step for the pipeline version (check server instructions for v0 vs v1)
 
-**TEMPLATE A — Harness Artifact Registry (default when user says "Harness Artifact Registry" or "HAR"):**
+**If v0 pipelines** — use a \`BuildAndPushDockerRegistry\` step:
+
+TEMPLATE A — Harness Artifact Registry (HAR):
 \`\`\`yaml
 - step:
     type: BuildAndPushDockerRegistry
@@ -89,9 +91,9 @@ Generate a Harness CI pipeline that:
       caching: true
       registryRef: <+input>
 \`\`\`
-Key: uses \`registryRef\`. Does NOT have \`connectorRef\`. No Docker connector needed.
+Key: uses \`registryRef\`. Does NOT have \`connectorRef\`.
 
-**TEMPLATE B — Third-party registry (DockerHub, ECR, GCR, ACR, etc.):**
+TEMPLATE B — Third-party registry (DockerHub, ECR, GCR, ACR):
 \`\`\`yaml
 - step:
     type: BuildAndPushDockerRegistry
@@ -106,6 +108,55 @@ Key: uses \`registryRef\`. Does NOT have \`connectorRef\`. No Docker connector n
       caching: true
 \`\`\`
 Key: uses \`connectorRef\`. Does NOT have \`registryRef\`.
+
+**If v1 pipelines** — use \`template: uses:\` syntax (NEVER use v0 \`step.type\`/\`spec:\` or GitHub Actions):
+
+TEMPLATE A — Build and push to ECR:
+\`\`\`yaml
+- id: build_push
+  name: Build and Push
+  template:
+    uses: buildAndPushToECR
+    with:
+      connector: account.aws_connector
+      region: us-east-1
+      registry: 123456789.dkr.ecr.us-east-1.amazonaws.com
+      repo: my-app
+      tags:
+        - <+pipeline.sequenceId>
+        - latest
+\`\`\`
+
+TEMPLATE B — Build and push to Docker registry:
+\`\`\`yaml
+- id: build_push
+  name: Build and Push
+  template:
+    uses: buildAndPushToDocker
+    with:
+      connector: account.dockerhub
+      repo: myorg/myapp
+      tags:
+        - <+pipeline.sequenceId>
+        - latest
+\`\`\`
+
+Other available templates: \`buildAndPushToGCR\`, \`buildAndPushToACR\`, \`buildAndPushToECR\`
+
+For v1 test steps use \`run:\`:
+\`\`\`yaml
+- id: run_tests
+  name: Run Tests
+  run:
+    container:
+      connector: account.dockerhub
+      image: node:20
+    script: |
+      npm ci
+      npm test
+    shell: bash
+  timeout: 10m
+\`\`\`
 
 Present the full pipeline YAML for review. Do NOT create it yet.
 
@@ -170,6 +221,37 @@ Generate a Harness CD pipeline that:
 - Uses a Rolling deployment strategy
 - Includes infrastructure definition targeting the ${namespace || "default"} namespace
 - Includes a Verify step or health check after deployment
+
+**If v1 pipelines** — use \`template: uses:\` for deploy steps:
+\`\`\`yaml
+- id: deploy_app
+  name: Deploy
+  environment:
+    id: dev
+    name: dev
+    deploy-to: ${namespace || "default"}
+  service: <service_id>
+  on-failure:
+    - action: stage-rollback
+      errors:
+        - all
+  rollback:
+    - id: rollback
+      name: Rollback
+      template:
+        uses: k8sRollingRollbackStep
+        with:
+          pruning: false
+      timeout: 10m
+  steps:
+    - id: deploy
+      name: Rolling Deploy
+      template:
+        uses: k8sRollingDeployStep
+        with:
+          skip_dry_run: false
+      timeout: 10m
+\`\`\`
 
 Present the full pipeline YAML for review. Do NOT create it yet.
 

--- a/src/prompts/create-pipeline.ts
+++ b/src/prompts/create-pipeline.ts
@@ -21,52 +21,19 @@ export function registerCreatePipelinePrompt(server: McpServer): void {
 ${description}
 
 Steps:
-1. Read the pipeline JSON Schema resource (schema:///pipeline) to understand the required pipeline structure and fields
-2. Call harness_describe with resource_type="pipeline" to understand available operations
-3. If helpful, call harness_list with resource_type="pipeline"${projectId ? ` and project_id="${projectId}"` : ""} to see existing pipeline patterns
+1. Read the pipeline JSON Schema resource (schema:///pipeline or schema:///pipeline_v1 depending on version) to understand the required pipeline structure and fields
+2. Call harness_describe with resource_type="pipeline" (or "pipeline_v1") to understand available operations
+3. If helpful, call harness_list with resource_type="pipeline" (or "pipeline_v1")${projectId ? ` and project_id="${projectId}"` : ""} to see existing pipeline patterns
 4. Also check available connectors (harness_list resource_type="connector"), services (harness_list resource_type="service"), and environments (harness_list resource_type="environment")
 5. If the pipeline involves building/pushing Docker images, determine the registry type:
-   - If the user says "Harness Artifact Registry" or "HAR" → use TEMPLATE A below
-   - If the user says DockerHub, ECR, GCR, ACR, or any other provider → use TEMPLATE B below
+   - If the user says "Harness Artifact Registry" or "HAR" → use the HAR template for your version
+   - If the user says DockerHub, ECR, GCR, ACR, or any other provider → use the third-party template
    - Call harness_list with resource_type="registry"${projectId ? ` and project_id="${projectId}"` : ""} to discover existing HAR registries
-
-   **TEMPLATE A — Harness Artifact Registry (use when user says "Harness Artifact Registry" or "HAR"):**
-   \`\`\`yaml
-   - step:
-       type: BuildAndPushDockerRegistry
-       name: Build and Push to Harness Artifact Registry
-       identifier: build_and_push_har
-       spec:
-         repo: <+input>
-         tags:
-           - latest
-           - <+pipeline.sequenceId>
-         caching: true
-         registryRef: <+input>
-   \`\`\`
-   Key: uses \`registryRef\`. Does NOT have \`connectorRef\`. No Docker connector needed.
-
-   **TEMPLATE B — Third-party registry (DockerHub, ECR, GCR, ACR, etc.):**
-   \`\`\`yaml
-   - step:
-       type: BuildAndPushDockerRegistry
-       name: Build and Push Docker Image
-       identifier: build_and_push_docker
-       spec:
-         connectorRef: <+input>
-         repo: <+input>
-         tags:
-           - latest
-           - <+pipeline.sequenceId>
-         caching: true
-   \`\`\`
-   Key: uses \`connectorRef\`. Does NOT have \`registryRef\`.
-
-6. Generate the pipeline YAML conforming to the schema, using the correct template from step 5
+6. Generate the pipeline YAML conforming to the schema for the correct version
 7. **Choose storage mode** — ask the user where to store the pipeline:
-   - **Inline (default)**: Stored in Harness. Simplest setup, no Git required. Just call harness_create with resource_type="pipeline" and the YAML body.
-   - **Remote (External Git)**: Stored in GitHub/GitLab/Bitbucket. Pass \`params: { store_type: "REMOTE", connector_ref: "<git_connector>", repo_name: "<repo>", branch: "main", file_path: ".harness/<pipeline_id>.yaml", commit_msg: "Add pipeline via MCP" }\`
-   - **Remote (Harness Code)**: Stored in a Harness Code repo. Pass \`params: { store_type: "REMOTE", is_harness_code_repo: true, repo_name: "<repo>", branch: "main", file_path: ".harness/<pipeline_id>.yaml", commit_msg: "Add pipeline via MCP" }\`
+   - **Inline (default)**: Stored in Harness. Call harness_create with the appropriate resource_type and YAML body.
+   - **Remote (External Git)**: Pass \`params: { store_type: "REMOTE", connector_ref: "<git_connector>", repo_name: "<repo>", branch: "main", file_path: ".harness/<pipeline_id>.yaml", commit_msg: "Add pipeline via MCP" }\`
+   - **Remote (Harness Code)**: Pass \`params: { store_type: "REMOTE", is_harness_code_repo: true, repo_name: "<repo>", branch: "main", file_path: ".harness/<pipeline_id>.yaml", commit_msg: "Add pipeline via MCP" }\`
 8. Present the YAML for review before creating
 
 Do NOT create the pipeline until I confirm — just show me the YAML first.
@@ -75,20 +42,256 @@ After the pipeline is created, if it contains \`<+input>\` runtime placeholders:
 9. **Suggest creating input sets** to save common configurations for future runs:
    - Call harness_get with resource_type="runtime_input_template" and resource_id=<pipeline_id> to discover all \`<+input>\` placeholders
    - Propose input sets for common scenarios (e.g., "dev-defaults", "prod-defaults") that pre-fill values
-   - Create using harness_create with resource_type="input_set", pipeline_id=<pipeline_id>, and a YAML body like:
-     \`\`\`yaml
-     inputSet:
-       name: Dev Defaults
-       identifier: dev_defaults
-       pipeline:
-         identifier: <pipeline_id>
-         variables:
-           - name: env
-             type: String
-             value: dev
-     \`\`\`
-   - This lets future runs use \`input_set_ids: ["dev_defaults"]\` instead of manual input each time
-   - This step is optional — only create if the user wants reusable run configurations`,
+   - Create using harness_create with resource_type="input_set", pipeline_id=<pipeline_id>, and appropriate YAML body
+   - This step is optional — only create if the user wants reusable run configurations
+
+---
+
+## V0 PIPELINE SYNTAX (use when server instructions say "v0 pipelines")
+
+### Build & Push Docker — HAR (Harness Artifact Registry):
+\`\`\`yaml
+- step:
+    type: BuildAndPushDockerRegistry
+    name: Build and Push to Harness Artifact Registry
+    identifier: build_and_push_har
+    spec:
+      repo: <+input>
+      tags:
+        - latest
+        - <+pipeline.sequenceId>
+      caching: true
+      registryRef: <+input>
+\`\`\`
+Key: uses \`registryRef\`. Does NOT have \`connectorRef\`. No Docker connector needed.
+
+### Build & Push Docker — Third-party (DockerHub, ECR, GCR, ACR):
+\`\`\`yaml
+- step:
+    type: BuildAndPushDockerRegistry
+    name: Build and Push Docker Image
+    identifier: build_and_push_docker
+    spec:
+      connectorRef: <+input>
+      repo: <+input>
+      tags:
+        - latest
+        - <+pipeline.sequenceId>
+      caching: true
+\`\`\`
+Key: uses \`connectorRef\`. Does NOT have \`registryRef\`.
+
+---
+
+## V1 PIPELINE SYNTAX (use when server instructions say "v1 pipelines")
+
+Harness v1 pipelines use a flat, simplified YAML syntax. Do NOT use v0 patterns (\`step.type\`, \`spec:\`, \`identifier:\`).
+
+### Top-Level Structure
+\`\`\`yaml
+pipeline:
+  id: my_pipeline
+  name: My Pipeline
+  clone:
+    enabled: true
+    connector: account.github
+    repo: org/repo
+    ref:
+      type: branch
+      name: main
+  stages:
+    - id: build
+      name: Build
+      runtime:
+        kubernetes:
+          connector: account.k8s_connector
+          namespace: harness-build
+          os: Linux
+      steps:
+        - ...
+\`\`\`
+
+### Step Types — Use These (in priority order):
+
+**1. \`template: uses:\` — For ALL Harness built-in steps (PREFERRED)**
+This is the primary mechanism for Harness platform steps. Always prefer this over \`action:\`.
+\`\`\`yaml
+# Kubernetes deploy
+- id: rollout
+  name: Rollout Deployment
+  template:
+    uses: k8sRollingDeployStep
+    with:
+      skip_dry_run: false
+      pruning: false
+  timeout: 10m
+
+# Build and push to ECR
+- id: build_push
+  name: Build and Push
+  template:
+    uses: buildAndPushToECR
+    with:
+      connector: account.aws_connector
+      region: us-east-1
+      registry: 123456789.dkr.ecr.us-east-1.amazonaws.com
+      repo: my-app
+      tags:
+        - <+pipeline.sequenceId>
+        - latest
+
+# Terraform
+- id: tf_plan
+  name: Terraform Plan
+  template:
+    uses: TerraformPlan
+  timeout: 20m
+
+- id: tf_apply
+  name: Terraform Apply
+  template:
+    uses: TerraformApply
+  timeout: 20m
+\`\`\`
+
+Common template names: \`k8sRollingDeployStep\`, \`k8sRollingRollbackStep\`, \`k8sCanaryDeployStep\`, \`k8sCanaryDeleteStep\`, \`k8sScaleStep\`, \`k8sDeleteStep\`, \`k8sDryRunStep\`, \`k8sBlueGreenDeployStep\`, \`k8sBlueGreenSwapServicesSelectorsStep\`, \`helmDeployBasicStep\`, \`helmRollbackStep\`, \`buildAndPushToECR\`, \`buildAndPushToDocker\`, \`buildAndPushToGCR\`, \`buildAndPushToACR\`, \`TerraformPlan\`, \`TerraformApply\`, \`TerraformRollback\`, \`EcsRollingDeploy\`, \`EcsRollingRollback\`, \`EcsBlueGreenCreateService\`, \`EcsBlueGreenSwapTargetGroups\`, \`EcsBlueGreenRollback\`, \`uploadArtifactsToS3\`, \`uploadArtifactsToJfrogArtifactory\`, \`saveCacheToS3\`, \`restoreCacheFromS3\`, \`saveCacheToGCS\`, \`restoreCacheFromGCS\`, \`FetchInstanceScript\`, \`Command\`, \`Verify\`, \`Container\`, \`JenkinsBuild\`, \`Sonarqube\`, \`Security\`
+
+**2. \`run:\` — For shell scripts**
+\`\`\`yaml
+- id: run_tests
+  name: Run Tests
+  run:
+    container:
+      connector: account.dockerhub
+      image: node:20
+    script: |
+      npm ci
+      npm test
+    shell: bash
+    output:
+      - name: TEST_RESULT
+        alias: TEST_RESULT
+  timeout: 10m
+\`\`\`
+
+**3. \`approval:\` — For gates**
+\`\`\`yaml
+- id: approve_prod
+  name: Approve Production
+  approval:
+    uses: harness
+    with:
+      approvers-min-count: 1
+      auto-approve: false
+      message: "Please approve deployment to production"
+      user-groups:
+        - project_admins
+  timeout: 2d
+\`\`\`
+
+**4. \`parallel:\` — For parallel execution**
+\`\`\`yaml
+- parallel:
+    steps:
+      - id: unit_tests
+        name: Unit Tests
+        run:
+          script: npm test
+          shell: bash
+      - id: lint
+        name: Lint
+        run:
+          script: npm run lint
+          shell: bash
+\`\`\`
+
+**5. \`group:\` — For step groups with shared inputs**
+\`\`\`yaml
+- group:
+    inputs:
+      IMAGE_TAG:
+        type: string
+        value: <+pipeline.sequenceId>
+    steps:
+      - id: build
+        name: Build
+        run:
+          script: docker build -t app:<+group.variables.IMAGE_TAG> .
+          shell: bash
+  id: build_group
+  name: Build Group
+\`\`\`
+
+### CD Stage Pattern (with environment + service)
+\`\`\`yaml
+- id: deploy_dev
+  name: Deploy to Dev
+  environment:
+    id: dev
+    name: dev
+    deploy-to: dev_k8s
+  service: my_service
+  on-failure:
+    - action: stage-rollback
+      errors:
+        - all
+  rollback:
+    - id: rollback
+      name: Rollback
+      template:
+        uses: k8sRollingRollbackStep
+        with:
+          pruning: false
+      timeout: 10m
+  steps:
+    - id: deploy
+      name: Deploy
+      template:
+        uses: k8sRollingDeployStep
+        with:
+          skip_dry_run: false
+      timeout: 10m
+\`\`\`
+
+### Notifications
+\`\`\`yaml
+pipeline:
+  notifications:
+    - id: slack_notify
+      name: Slack Notification
+      "on":
+        - pipeline:
+            - success
+            - failed
+      uses: slack
+      with:
+        webhook: <+variable.slack_webhook>
+\`\`\`
+
+### Pipeline Inputs (runtime variables)
+\`\`\`yaml
+pipeline:
+  inputs:
+    environment:
+      type: string
+      enum:
+        - dev
+        - staging
+        - prod
+      value: dev
+    image_tag:
+      type: string
+      value: latest
+\`\`\`
+
+### V1 CRITICAL RULES:
+- **NEVER use GitHub Actions syntax** (e.g., \`actions/checkout@v3\`, \`docker/build-push-action@v5\`). These are NOT valid in Harness v1.
+- **NEVER use v0 syntax** (e.g., \`step.type:\`, \`spec:\`, \`identifier:\`, \`connectorRef:\` at step level).
+- **Always prefer \`template: uses:\`** for Harness built-in operations over \`action:\` or inline scripts.
+- Use \`run:\` only for custom shell logic that has no corresponding Harness template.
+- \`id\` uses snake_case. \`name\` is human-readable.
+- \`timeout\` goes at step level, not inside the step type.
+- Use \`<+expression>\` syntax for Harness expressions (not \${{ }}).`,
         },
       }],
     }),

--- a/src/prompts/onboard-service.ts
+++ b/src/prompts/onboard-service.ts
@@ -25,10 +25,21 @@ Steps:
 4. **Connectors**: Call harness_list with resource_type="connector"${projectId ? ` and project_id="${projectId}"` : ""} to see available infrastructure connectors
 5. **Check existing input sets**: Call harness_list with resource_type="input_set"${projectId ? ` and project_id="${projectId}"` : ""} to see if the project already uses input sets for parameterized deployments
 6. **Create service**: Generate the service YAML definition following existing patterns
-7. **Create pipeline**: Generate a deployment pipeline YAML for the service with:
+7. **Create pipeline**: Generate a deployment pipeline YAML for the service. Check the server instructions for which pipeline version this account uses (v0 or v1), then:
    - Build stage (if applicable)
    - Deploy to dev/staging/prod environments using \`<+input>\` for environment-specific values (infrastructure, namespace, replicas, image tag)
    - Approval gates between staging and prod
+
+   **If v1 pipelines**: Use v1 syntax — \`template: uses:\` for Harness built-in steps (e.g., \`k8sRollingDeployStep\`, \`helmDeployBasicStep\`, \`buildAndPushToECR\`), \`run:\` for scripts, \`approval: uses: harness\` for approvals. Do NOT use v0 patterns (\`step.type\`, \`spec:\`, \`identifier:\`) or GitHub Actions syntax. Example CD step:
+   \`\`\`yaml
+   - id: deploy
+     name: Deploy
+     template:
+       uses: k8sRollingDeployStep
+       with:
+         skip_dry_run: false
+     timeout: 10m
+   \`\`\`
 8. **Choose storage mode** — ask where to store the pipeline:
    - **Inline (default)**: Stored in Harness — simplest setup
    - **Remote (External Git)**: Stored in GitHub/GitLab/Bitbucket via a Git connector

--- a/src/registry/toolsets/pipelines.ts
+++ b/src/registry/toolsets/pipelines.ts
@@ -406,13 +406,13 @@ export const pipelinesToolset: ToolsetDefinition = {
     {
       resourceType: "pipeline_v1",
       displayName: "Pipeline (V1)",
-      description: "V1 pipeline definition using simplified YAML format. Use for agent pipelines and v1 YAML schema. Supports list, get, create, update, delete, and execute (run). V1 pipelines use a flatter YAML structure with direct step types (run, agent, action, approval) instead of v0's nested stage/step wrappers.",
+      description: "V1 pipeline definition using simplified YAML format. Use for agent pipelines and v1 YAML schema. Supports list, get, create, update, delete, and execute (run). V1 pipelines use a flatter YAML structure with direct step types (run, approval, template) instead of v0's nested stage/step wrappers. IMPORTANT: When generating v1 pipeline YAML, prefer 'template: uses: <stepName>' for Harness built-in steps (e.g., k8sRollingDeployStep, buildAndPushToECR, TerraformPlan). Use 'run:' for custom scripts. Do NOT use GitHub Actions references.",
       toolset: "pipelines",
       scope: "project",
       headerBasedScoping: true,
       identifierFields: ["pipeline_id"],
       searchAliases: ["v1 pipeline", "agent pipeline", "v1"],
-      diagnosticHint: "Use harness_diagnose with pipeline_id or execution_id to analyze failures. V1 pipelines use the same execution engine as v0.",
+      diagnosticHint: "Use harness_diagnose with pipeline_id or execution_id to analyze failures. V1 pipelines use the same execution engine as v0. If YAML validation fails, check: (1) Are you using v0 syntax like 'step.type' or 'spec:'? V1 uses 'template: uses:' and 'run:' directly. (2) Are you referencing GitHub Actions like 'actions/checkout@v3'? Use Harness templates instead.",
       deepLinkTemplate: "/ng/account/{accountId}/all/orgs/{orgIdentifier}/projects/{projectIdentifier}/pipelines/{pipelineIdentifier}/pipeline-studio",
       operations: {
         list: {
@@ -447,7 +447,7 @@ export const pipelinesToolset: ToolsetDefinition = {
           pathParams: { org_id: "org", project_id: "project" },
           bodyBuilder: buildV1PipelineBody,
           responseExtractor: passthrough,
-          description: "Create a new v1 pipeline. Pass pipeline_yaml (YAML string), identifier, name. Version defaults to '1'. Alternatively pass a raw YAML string as body.",
+          description: "Create a new v1 pipeline. Pass pipeline_yaml (YAML string), identifier, name. Version defaults to '1'. Alternatively pass a raw YAML string as body. V1 YAML must use: 'template: uses: <stepName>' for built-in steps, 'run:' for scripts, 'approval: uses: harness' for gates. Never use v0 syntax (step.type, spec:, identifier:) or GitHub Actions.",
           bodySchema: pipelineV1CreateSchema,
         },
         update: {

--- a/src/tools/harness-schema.ts
+++ b/src/tools/harness-schema.ts
@@ -92,6 +92,33 @@ function navigateToPath(
   return current;
 }
 
+const V1_STEP_GUIDANCE = "STEP PRIORITY for v1 pipelines: (1) 'template: uses: <stepName>' for Harness built-in steps — this is the preferred approach. (2) 'run:' for custom shell scripts. (3) 'approval:' for gates. (4) 'action:' ONLY for Drone/Harness plugins — do NOT use GitHub Actions references. Common template names: k8sRollingDeployStep, k8sRollingRollbackStep, helmDeployBasicStep, buildAndPushToECR, buildAndPushToDocker, TerraformPlan, TerraformApply, EcsRollingDeploy, EcsBlueGreenCreateService.";
+
+/**
+ * For v1 pipeline schemas, annotate step-type results with guidance
+ * that steers agents toward template: uses: over action:.
+ */
+function annotateV1StepTypes(resourceType: string, path: string | undefined, result: Record<string, unknown>): Record<string, unknown> {
+  if (!resourceType.includes("v1") && resourceType !== "agent-pipeline") return result;
+
+  // Always include guidance on the summary (no path) so agents see it early
+  if (!path) {
+    return { ...result, _guidance: V1_STEP_GUIDANCE };
+  }
+
+  const pathLower = path.toLowerCase();
+  const resultStr = JSON.stringify(result);
+  const isStepRelated = pathLower.includes("step") ||
+    pathLower.includes("action") ||
+    resultStr.includes("ActionStepInfoV1") ||
+    resultStr.includes("StepItems");
+
+  if (isStepRelated) {
+    return { ...result, _guidance: V1_STEP_GUIDANCE };
+  }
+  return result;
+}
+
 /**
  * Get a compact summary of the top-level structure: property names, types,
  * required fields, and available definition sections.
@@ -174,7 +201,7 @@ export function registerSchemaTool(server: McpServer, registry?: Registry): void
 
         // No path → return summary
         if (!args.path) {
-          return jsonResult(getSummary(schema, args.resource_type));
+          return jsonResult(annotateV1StepTypes(args.resource_type, undefined, getSummary(schema, args.resource_type)));
         }
 
         // Navigate to the requested path
@@ -191,11 +218,11 @@ export function registerSchemaTool(server: McpServer, registry?: Registry): void
         // Inline $ref references so the result is self-contained
         const resolved = inlineRefs(schema, node);
 
-        return jsonResult({
+        return jsonResult(annotateV1StepTypes(args.resource_type, args.path, {
           resource_type: args.resource_type,
           path: args.path,
           schema: resolved,
-        });
+        }));
       } catch (err) {
         return errorResult(err instanceof Error ? err.message : String(err));
       }


### PR DESCRIPTION
## Summary
- Fixes AI agents drifting toward GitHub Actions syntax (`actions/checkout@v3`, `docker/build-push-action`) when generating v1 pipelines
- Prioritizes `template: uses: <stepName>` as the primary step mechanism for v1 pipeline YAML generation
- Adds curated v1 pipeline examples resource (`schema:///pipeline_v1_examples`) with 6 real-world patterns

## Problem
The v1 schema described `ActionStepInfoV1` as "GitHub-style actions" with `actions/checkout@v3` as the example. Prompts used v0 syntax exclusively. This caused models to generate invalid pipelines mixing GitHub Actions and v0 patterns into v1 YAML.

## Changes
- **Schema**: Remove GHA language from `agent-pipeline.ts` ActionStepInfoV1 description
- **Prompts**: Add v1 syntax sections to `create-pipeline`, `build-deploy-app`, `onboard-service` (v0 still supported)
- **Examples**: New `pipeline-v1-examples.ts` with CI, K8s CD, Terraform, Helm, ECS, multi-env patterns
- **Schema tool**: Annotate v1 schema drill-down responses with step-priority guidance
- **Registry**: Update `pipeline_v1` resource description and `diagnosticHint` on EndpointSpec
- **Instructions**: Add template-first guidance to v1 server instructions

## Test plan
- [ ] Verify `harness_schema(resource_type="pipeline_v1")` summary includes `_guidance` field
- [ ] Verify `schema:///pipeline_v1_examples` returns curated examples for v1 accounts
- [ ] Verify v0 accounts do NOT see `pipeline_v1_examples` in available schemas
- [ ] Test create-pipeline prompt generates correct v1 YAML with `template: uses:` syntax
- [ ] Test build-deploy-app prompt branches correctly for v1 vs v0

🤖 Generated with [Claude Code](https://claude.com/claude-code)