### PR TITLE
fix: upgrade postcss to >=8.5.10 (XSS vulnerability)

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
       "path-to-regexp": ">=8.4.0",
       "@hono/node-server": ">=1.19.10",
       "express-rate-limit": ">=8.2.2",
-      "vite": "^7.3.2"
+      "vite": "^7.3.2",
+      "postcss": ">=8.5.10"
     }
   },
   "packageManager": "pnpm@10.18.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   '@hono/node-server': '>=1.19.10'
   express-rate-limit: '>=8.2.2'
   vite: ^7.3.2
+  postcss: '>=8.5.10'
 
 importers:
 
@@ -1073,8 +1074,8 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
-  postcss@8.5.9:
-    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   protobufjs@8.0.1:
@@ -2179,7 +2180,7 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
-  postcss@8.5.9:
+  postcss@8.5.14:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -2399,7 +2400,7 @@ snapshots:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.9
+      postcss: 8.5.14
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Adds `postcss: ">=8.5.10"` to `pnpm.overrides` to force the patched version (resolves to 8.5.14)
- Fixes Dependabot alert for PostCSS XSS via unescaped `</style>` in CSS stringify output (affects postcss < 8.5.10)
- Transitive dependency introduced via `vitest` → `vite` → `postcss`

## Test plan
- [x] `pnpm install` succeeds
- [x] Lockfile resolves postcss to 8.5.14
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)