### PR TITLE
fix: Updating resource group tools with the Access-Control(authz) API

### DIFF
--- a/src/registry/toolsets/access-control.ts
+++ b/src/registry/toolsets/access-control.ts
@@ -323,7 +323,7 @@ export const accessControlToolset: ToolsetDefinition = {
       operations: {
         list: {
           method: "GET",
-          path: "/resourcegroup/api/v2/resourcegroup",
+          path: "/authz/api/v2/resourcegroup",
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           queryParams: {
             search_term: "searchTerm",
@@ -335,7 +335,7 @@ export const accessControlToolset: ToolsetDefinition = {
         },
         get: {
           method: "GET",
-          path: "/resourcegroup/api/v2/resourcegroup/{resourceGroupIdentifier}",
+          path: "/authz/api/v2/resourcegroup/{resourceGroupIdentifier}",
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           pathParams: { resource_group_id: "resourceGroupIdentifier" },
           responseExtractor: ngExtract,
@@ -343,9 +343,26 @@ export const accessControlToolset: ToolsetDefinition = {
         },
         create: {
           method: "POST",
-          path: "/resourcegroup/api/v2/resourcegroup",
+          path: "/authz/api/v2/resourcegroup",
           operationPolicy: { risk: "low_write", retryPolicy: "do_not_retry" },
-          bodyBuilder: (input) => input.body,
+          /** POST body must be `{ resourceGroup: { ... } }` per Harness authz API. */
+          bodyBuilder: (input) => {
+            const b = input.body;
+            if (b === undefined || b === null) return b;
+            if (typeof b !== "object" || Array.isArray(b)) return b;
+            const rec = b as Record<string, unknown>;
+            if (
+              "resourceGroup" in rec &&
+              typeof rec.resourceGroup === "object" &&
+              rec.resourceGroup !== null &&
+              !Array.isArray(rec.resourceGroup)
+            ) {
+              return { resourceGroup: rec.resourceGroup };
+            }
+            return { resourceGroup: rec };
+          },
+          bodyWrapperKey: "resourceGroup",
+          injectAccountInBody: true,
           responseExtractor: ngExtract,
           description: "Create a resource group",
           bodySchema: {
@@ -361,7 +378,7 @@ export const accessControlToolset: ToolsetDefinition = {
         },
         delete: {
           method: "DELETE",
-          path: "/resourcegroup/api/v2/resourcegroup/{resourceGroupIdentifier}",
+          path: "/authz/api/v2/resourcegroup/{resourceGroupIdentifier}",
           operationPolicy: { risk: "destructive", retryPolicy: "do_not_retry" },
           pathParams: { resource_group_id: "resourceGroupIdentifier" },
           responseExtractor: ngExtract,


### PR DESCRIPTION
## Description

- Updated the ResourceGroup tools to use /authz/api/v2/resourcegroup instead of /resourcegroup/api/v2/resourcegroup.
- Updated the Create tool to now send the payload under the top-level resourceGroup key.


<img width="617" height="644" alt="Screenshot 2026-05-05 at 11 00 15 PM" src="https://github.com/user-attachments/assets/9fdfca6a-b92d-48d2-b42d-b6153dcf0b7a" />



<img width="640" height="254" alt="Screenshot 2026-05-05 at 10 46 08 PM" src="https://github.com/user-attachments/assets/4a204004-bf9f-4fd4-8898-c7e6c0da7131" />


<img width="640" height="220" alt="Screenshot 2026-05-05 at 10 47 12 PM" src="https://github.com/user-attachments/assets/873f7176-5090-4a92-b47e-8a9708d73ad6" />



<img width="1728" height="1117" alt="Screenshot 2026-05-05 at 10 49 32 PM" src="https://github.com/user-attachments/assets/dc8d53f4-3908-4ce8-aec9-0dbcc5b32837" />


## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [ ] Tests pass
- [ ] Typecheck passes
