### PR TITLE
feat: dual pipeline version support + progressive-discovery examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Harness MCP Server 2.0
 
-An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 167 resource types.
+An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 168 resource types.
 
 ## Why Use This MCP Server
 
@@ -8,7 +8,7 @@ Most MCP servers map one tool per API endpoint. For a platform as broad as Harne
 
 This server is built differently:
 
-- **11 tools, 167 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
+- **11 tools, 168 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
 - **Full platform coverage.** 31 toolsets spanning CI/CD, GitOps, Feature Flags, Cloud Cost Management, Security Testing, Chaos Engineering, Database DevOps, Internal Developer Portal, Software Supply Chain, Governance, Service Overrides, Visualizations, and more. Not just pipelines — the entire Harness platform.
 - **Multi-project workflows out of the box.** Agents discover organizations and projects dynamically — no hardcoded env vars needed. Ask "show failed executions across all projects" and the agent can navigate the full account hierarchy.
 - **30 prompt templates.** Pre-built prompts for common workflows: build & deploy apps end-to-end, debug failed pipelines, review DORA metrics, triage vulnerabilities, optimize cloud costs, audit access control, plan feature flag rollouts, review pull requests, approve pending pipelines, and more.
@@ -954,7 +954,7 @@ Harness pipelines can be stored in three ways:
 
 ## Resource Types
 
-167 resource types organized across 31 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
+168 resource types organized across 31 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
 
 ### Platform
 
@@ -1491,7 +1491,7 @@ Available toolset names:
                  +--------v---------+
                 |    Registry       |  <-- Declarative resource definitions
                 |  32 Toolsets      |      (data files, not code)
-                |  167 Resource Types|
+                |  168 Resource Types|
                  +--------+---------+
                           |
                  +--------v---------+

--- a/src/data/examples/index.ts
+++ b/src/data/examples/index.ts
@@ -2,8 +2,13 @@ import type { ResourceExample } from "./types.js";
 
 const ALL_EXAMPLES: ResourceExample[] = [];
 
-/** Register examples from a module. Called by each example file. */
+/** Register examples from a module. Called by each example file. Names must be globally unique. */
 export function registerExamples(examples: ResourceExample[]): void {
+  for (const ex of examples) {
+    if (ALL_EXAMPLES.some((e) => e.name === ex.name)) {
+      throw new Error(`Duplicate example name: '${ex.name}'. Example names must be globally unique.`);
+    }
+  }
   ALL_EXAMPLES.push(...examples);
 }
 

--- a/src/data/examples/index.ts
+++ b/src/data/examples/index.ts
@@ -1,0 +1,37 @@
+import type { ResourceExample } from "./types.js";
+
+const ALL_EXAMPLES: ResourceExample[] = [];
+
+/** Register examples from a module. Called by each example file. */
+export function registerExamples(examples: ResourceExample[]): void {
+  ALL_EXAMPLES.push(...examples);
+}
+
+/** Fetch a single example by exact name. */
+export function getExample(name: string): ResourceExample | undefined {
+  return ALL_EXAMPLES.find((e) => e.name === name);
+}
+
+/** Search examples by keyword. Matches against name, description, tags, and resourceType. */
+export function searchExamples(query: string, resourceType?: string): ResourceExample[] {
+  const q = query.toLowerCase();
+  return ALL_EXAMPLES.filter((e) => {
+    if (resourceType && e.resourceType !== resourceType) return false;
+    return (
+      e.name.toLowerCase().includes(q) ||
+      e.description.toLowerCase().includes(q) ||
+      e.resourceType.toLowerCase().includes(q) ||
+      e.tags.some((t) => t.toLowerCase().includes(q))
+    );
+  });
+}
+
+/** Get all example names for a specific resource type. */
+export function getExamplesForResource(resourceType: string): ResourceExample[] {
+  return ALL_EXAMPLES.filter((e) => e.resourceType === resourceType);
+}
+
+/** Get all unique resource types that have examples. */
+export function getResourceTypesWithExamples(): string[] {
+  return [...new Set(ALL_EXAMPLES.map((e) => e.resourceType))];
+}

--- a/src/data/examples/load-all.ts
+++ b/src/data/examples/load-all.ts
@@ -1,0 +1,4 @@
+// Side-effect imports that register all examples into the registry.
+// Import this file once at startup to ensure examples are available.
+import "./pipeline.js";
+import "./pipeline-v1.js";

--- a/src/data/examples/pipeline-v1.ts
+++ b/src/data/examples/pipeline-v1.ts
@@ -1,0 +1,52 @@
+import { registerExamples } from "./index.js";
+import type { ResourceExample } from "./types.js";
+
+const examples: ResourceExample[] = [
+  {
+    name: "minimal-v1",
+    resourceType: "pipeline_v1",
+    description: "Minimal v1 pipeline with a single run step",
+    tags: ["v1", "minimal", "starter", "ci", "simplified"],
+    yaml: `pipeline:
+  name: Simple Build
+  identifier: simple_build
+  stages:
+    - name: build
+      steps:
+        - type: run
+          spec:
+            shell: sh
+            command: |
+              echo "Building..."
+              npm install
+              npm test`,
+  },
+  {
+    name: "agent-pipeline",
+    resourceType: "pipeline_v1",
+    description: "AI agent pipeline with tools, MCP servers, and skills",
+    tags: ["v1", "agent", "ai", "mcp", "tools", "agentic"],
+    yaml: `pipeline:
+  name: Code Review Agent
+  identifier: code_review_agent
+  version: 1
+  stages:
+    - name: review
+      steps:
+        - type: agent
+          spec:
+            model: claude-sonnet-4-6
+            prompt: "Review the PR for correctness, security, and performance issues"
+            tools:
+              - name: read_file
+              - name: search_code
+            mcp_servers:
+              - url: https://mcp.harness.io
+            rules:
+              - "Focus on security vulnerabilities"
+              - "Check for breaking API changes"`,
+  },
+];
+
+registerExamples(examples);
+export default examples;

--- a/src/data/examples/pipeline.ts
+++ b/src/data/examples/pipeline.ts
@@ -1,0 +1,106 @@
+import { registerExamples } from "./index.js";
+import type { ResourceExample } from "./types.js";
+
+const examples: ResourceExample[] = [
+  {
+    name: "minimal-ci",
+    resourceType: "pipeline",
+    description: "Minimal CI pipeline with a single build stage running tests",
+    tags: ["ci", "build", "test", "minimal", "starter"],
+    yaml: `pipeline:
+  name: Build and Test
+  identifier: build_and_test
+  projectIdentifier: <+input>
+  orgIdentifier: <+input>
+  stages:
+    - stage:
+        name: Build
+        identifier: build
+        type: CI
+        spec:
+          cloneCodebase: true
+          execution:
+            steps:
+              - step:
+                  type: Run
+                  name: Run Tests
+                  identifier: run_tests
+                  spec:
+                    shell: Sh
+                    command: |
+                      npm install
+                      npm test`,
+  },
+  {
+    name: "deploy-k8s",
+    resourceType: "pipeline",
+    description: "Deploy to Kubernetes with rolling update strategy",
+    tags: ["cd", "deploy", "kubernetes", "k8s", "rolling"],
+    yaml: `pipeline:
+  name: Deploy to K8s
+  identifier: deploy_k8s
+  projectIdentifier: <+input>
+  orgIdentifier: <+input>
+  stages:
+    - stage:
+        name: Deploy
+        identifier: deploy
+        type: Deployment
+        spec:
+          deploymentType: Kubernetes
+          service:
+            serviceRef: <+input>
+          environment:
+            environmentRef: <+input>
+            infrastructureDefinitions:
+              - identifier: <+input>
+          execution:
+            steps:
+              - step:
+                  type: K8sRollingDeploy
+                  name: Rolling Deploy
+                  identifier: rolling_deploy
+                  spec:
+                    skipDryRun: false
+            rollbackSteps:
+              - step:
+                  type: K8sRollingRollback
+                  name: Rollback
+                  identifier: rollback
+                  spec: {}`,
+  },
+  {
+    name: "docker-build",
+    resourceType: "pipeline",
+    description: "Build and push Docker image to a container registry",
+    tags: ["ci", "docker", "build", "push", "image", "container"],
+    yaml: `pipeline:
+  name: Docker Build and Push
+  identifier: docker_build_push
+  projectIdentifier: <+input>
+  orgIdentifier: <+input>
+  stages:
+    - stage:
+        name: Build Image
+        identifier: build_image
+        type: CI
+        spec:
+          cloneCodebase: true
+          execution:
+            steps:
+              - step:
+                  type: BuildAndPushDockerRegistry
+                  name: Build and Push
+                  identifier: build_and_push
+                  spec:
+                    connectorRef: <+input>
+                    repo: <+input>
+                    tags:
+                      - latest
+                      - <+pipeline.sequenceId>
+                    caching: true`,
+  },
+];
+
+registerExamples(examples);
+export default examples;

--- a/src/data/examples/types.ts
+++ b/src/data/examples/types.ts
@@ -1,0 +1,12 @@
+export interface ResourceExample {
+  /** Unique name for this example, used to fetch it (e.g. 'minimal-ci') */
+  name: string;
+  /** Which resource_type this example belongs to (e.g. 'pipeline', 'pipeline_v1') */
+  resourceType: string;
+  /** One-line human description shown in search results */
+  description: string;
+  /** Searchable tags — matched during example_search */
+  tags: string[];
+  /** The actual YAML content */
+  yaml: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,8 +79,8 @@ function createHarnessServer(config: Config, sharedAuditManager?: AuditManager):
         "",
         "PR RESOURCES: pull_request, pr_comment, pr_activity, pr_reviewer, pr_check — all accept URL or explicit repo_id + pr_number.",
         ...(config.HARNESS_PIPELINE_VERSION === "1"
-          ? ["", "PIPELINES: Both v0 (resource_type='pipeline') and v1 (resource_type='pipeline_v1') are available. Default to 'pipeline_v1' (v1) unless the user explicitly requests v0 or provides v0-style YAML (camelCase keys, nested stage/step wrappers). If unsure, ask."]
-          : ["", "PIPELINES: Both v0 (resource_type='pipeline') and v1 (resource_type='pipeline_v1') are available. Default to 'pipeline' (v0) unless the user explicitly requests v1, mentions 'agent pipeline', or provides YAML with v1 indicators (kebab-case keys, top-level run/agent/action/approval steps). If unsure, ask."]),
+          ? ["", "PIPELINES: Both v0 ('pipeline') and v1 ('pipeline_v1') are available. Default to v1. Use harness_describe for version detection hints."]
+          : ["", "PIPELINES: Both v0 ('pipeline') and v1 ('pipeline_v1') are available. Default to v0 unless user explicitly requests v1 or 'agent pipeline'. Use harness_describe for version detection hints."]),
       ].join("\n"),
     },
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,8 +79,8 @@ function createHarnessServer(config: Config, sharedAuditManager?: AuditManager):
         "",
         "PR RESOURCES: pull_request, pr_comment, pr_activity, pr_reviewer, pr_check — all accept URL or explicit repo_id + pr_number.",
         ...(config.HARNESS_PIPELINE_VERSION === "1"
-          ? ["", "PIPELINE VERSION: This account uses v1 pipelines. Use resource_type='pipeline_v1' for all pipeline operations."]
-          : ["", "PIPELINE VERSION: This account uses v0 pipelines. Use resource_type='pipeline' for all pipeline operations."]),
+          ? ["", "PIPELINES: Both v0 (resource_type='pipeline') and v1 (resource_type='pipeline_v1') are available. Default to 'pipeline_v1' (v1) unless the user explicitly requests v0 or provides v0-style YAML (camelCase keys, nested stage/step wrappers). If unsure, ask."]
+          : ["", "PIPELINES: Both v0 (resource_type='pipeline') and v1 (resource_type='pipeline_v1') are available. Default to 'pipeline' (v0) unless the user explicitly requests v1, mentions 'agent pipeline', or provides YAML with v1 indicators (kebab-case keys, top-level run/agent/action/approval steps). If unsure, ask."]),
       ].join("\n"),
     },
   );

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -127,20 +127,14 @@ export class Registry {
       ? allToolsets.filter((t) => enabledNames.has(t.name))
       : allToolsets.filter((t) => !t.optIn);
 
-    const excludedPipelineType =
-      (this.config.HARNESS_PIPELINE_VERSION ?? "0") === "0"
-        ? "pipeline_v1"
-        : "pipeline";
-
     for (const toolset of this.toolsets) {
       for (const resource of toolset.resources) {
-        if (resource.resourceType === excludedPipelineType) continue;
         this.resourceMap.set(resource.resourceType, resource);
       }
     }
 
     log.info(`Registry loaded: ${this.resourceMap.size} resource types from ${this.toolsets.length} toolsets`, {
-      pipelineVersion: this.config.HARNESS_PIPELINE_VERSION ?? "0",
+      defaultPipelineVersion: this.config.HARNESS_PIPELINE_VERSION ?? "0",
     });
   }
 

--- a/src/registry/toolsets/pipelines.ts
+++ b/src/registry/toolsets/pipelines.ts
@@ -406,7 +406,7 @@ export const pipelinesToolset: ToolsetDefinition = {
     {
       resourceType: "pipeline_v1",
       displayName: "Pipeline (V1)",
-      description: "V1 pipeline definition using simplified YAML format. Use for agent pipelines and v1 YAML schema. Supports list, get, create, update, delete, and execute (run). V1 pipelines use a flatter YAML structure with direct step types (run, agent, action, approval) instead of v0's nested stage/step wrappers.",
+      description: "V1 pipeline definition using simplified YAML format. Use ONLY when user explicitly requests v1, says 'agent pipeline', or provides YAML with v1 indicators: kebab-case keys (allow-stage-executions, fixed-inputs-on-rerun), top-level step types (run, agent, action, approval) without nested stage/step wrappers. Supports list, get, create, update, delete, and execute (run).",
       toolset: "pipelines",
       scope: "project",
       headerBasedScoping: true,

--- a/src/tools/harness-describe.ts
+++ b/src/tools/harness-describe.ts
@@ -4,7 +4,6 @@ import type { Registry } from "../registry/index.js";
 import type { InputExpansionRule } from "../registry/types.js";
 import { jsonResult } from "../utils/response-formatter.js";
 import { getExamplesForResource } from "../data/examples/index.js";
-import "../data/examples/load-all.js";
 
 export function registerDescribeTool(server: McpServer, registry: Registry): void {
   const allTypes = registry.getAllResourceTypes() as [string, ...string[]];

--- a/src/tools/harness-describe.ts
+++ b/src/tools/harness-describe.ts
@@ -3,6 +3,8 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { InputExpansionRule } from "../registry/types.js";
 import { jsonResult } from "../utils/response-formatter.js";
+import { getExamplesForResource } from "../data/examples/index.js";
+import "../data/examples/load-all.js";
 
 export function registerDescribeTool(server: McpServer, registry: Registry): void {
   const allTypes = registry.getAllResourceTypes() as [string, ...string[]];
@@ -55,6 +57,15 @@ export function registerDescribeTool(server: McpServer, registry: Registry): voi
             diagnosticHint: def.diagnosticHint ?? undefined,
             relatedResources: def.relatedResources ?? undefined,
             executeHint: def.executeHint ?? undefined,
+            ...(() => {
+              const examples = getExamplesForResource(def.resourceType);
+              return examples.length > 0
+                ? {
+                    examples_available: examples.map((e) => ({ name: e.name, description: e.description })),
+                    examples_hint: `Use harness_schema(resource_type='${def.resourceType}', example='<name>') to fetch full YAML.`,
+                  }
+                : {};
+            })(),
           });
         } catch (err) {
           // Resource type not found — return the compact summary with an error hint

--- a/src/tools/harness-schema.ts
+++ b/src/tools/harness-schema.ts
@@ -3,12 +3,12 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { createLogger } from "../utils/logger.js";
-import { SCHEMAS, VALID_SCHEMAS, V0_SCHEMA_KEYS, V1_SCHEMA_KEYS } from "../data/schemas/index.js";
+import { SCHEMAS, VALID_SCHEMAS } from "../data/schemas/index.js";
+import { getExample, searchExamples, getExamplesForResource } from "../data/examples/index.js";
+import "../data/examples/load-all.js";
 
 const log = createLogger("tool:harness-schema");
 
-const V0_ONLY = new Set<string>(V0_SCHEMA_KEYS);
-const V1_ONLY = new Set<string>(V1_SCHEMA_KEYS);
 
 /**
  * Resolve a $ref pointer within the schema.
@@ -127,33 +127,23 @@ function getSummary(schema: Record<string, unknown>, resourceType: string): Reco
 }
 
 export function registerSchemaTool(server: McpServer, registry?: Registry): void {
-  const registeredTypes = registry ? new Set(registry.getAllResourceTypes()) : undefined;
-
-  // Determine which version set to exclude based on registry's pipeline version.
-  // If pipeline_v1 is registered → v1 account → hide v0-only schemas.
-  // If pipeline is registered → v0 account → hide v1-only schemas.
-  // Local schemas (agent-pipeline) are always available.
-  const excludeSet = registeredTypes?.has("pipeline_v1") ? V0_ONLY : V1_ONLY;
-
-  const availableSchemas = VALID_SCHEMAS.filter((s) => {
-    if (!registeredTypes) return true;
-    if (V0_ONLY.has(s) || V1_ONLY.has(s)) return !excludeSet.has(s);
-    return true; // local schemas always pass
-  });
+  const availableSchemas = VALID_SCHEMAS;
 
   server.registerTool(
     "harness_schema",
     {
       description:
-        "Fetch Harness YAML schema for a resource type. Returns the JSON Schema definition " +
-        "so you know the exact body structure for harness_create/harness_update. " +
+        "Fetch Harness YAML schema or examples for a resource type. " +
         "Use without path for a summary of fields and available sections. " +
         "Use with path to drill into a specific section. " +
+        "Use with example to fetch a named example YAML snippet. " +
+        "Use with example_search to find examples by keyword. " +
         `Available schemas: ${availableSchemas.join(", ")}.`,
       inputSchema: {
         resource_type: z
           .enum(availableSchemas as [string, ...string[]])
-          .describe(`Schema to fetch. Available: ${availableSchemas.join(", ")}`),
+          .describe(`Schema to fetch. Available: ${availableSchemas.join(", ")}. Required for schema/path lookups, optional for example_search.`)
+          .optional(),
         path: z
           .string()
           .optional()
@@ -161,6 +151,14 @@ export function registerSchemaTool(server: McpServer, registry?: Registry): void
             "Dot-separated path to drill into a specific definition section. " +
             "Omit for a top-level summary showing all available sections.",
           ),
+        example: z
+          .string()
+          .optional()
+          .describe("Fetch a specific example by name (e.g. 'minimal-ci'). Returns the full YAML snippet and description."),
+        example_search: z
+          .string()
+          .optional()
+          .describe("Search examples by keyword. Returns matching example names and descriptions. Optionally combine with resource_type to filter."),
       },
       annotations: {
         title: "Harness YAML Schema",
@@ -170,11 +168,62 @@ export function registerSchemaTool(server: McpServer, registry?: Registry): void
     },
     async (args) => {
       try {
+        // --- Example fetch mode ---
+        if (args.example) {
+          const ex = getExample(args.example);
+          if (!ex) {
+            const available = args.resource_type
+              ? getExamplesForResource(args.resource_type).map((e) => e.name)
+              : [];
+            return jsonResult({
+              error: `Example '${args.example}' not found.` +
+                (available.length ? ` Available for ${args.resource_type}: ${available.join(", ")}` : " Use example_search to find examples."),
+              available_examples: available,
+            });
+          }
+          return jsonResult({
+            name: ex.name,
+            resourceType: ex.resourceType,
+            description: ex.description,
+            tags: ex.tags,
+            yaml: ex.yaml,
+          });
+        }
+
+        // --- Example search mode ---
+        if (args.example_search) {
+          const results = searchExamples(args.example_search, args.resource_type);
+          return jsonResult({
+            search: args.example_search,
+            ...(args.resource_type ? { resource_type: args.resource_type } : {}),
+            total: results.length,
+            results: results.map((e) => ({
+              name: e.name,
+              resourceType: e.resourceType,
+              description: e.description,
+              tags: e.tags,
+            })),
+            hint: results.length > 0
+              ? "Use example='<name>' to fetch the full YAML for any result."
+              : "No matches. Try a broader keyword or omit resource_type to search globally.",
+          });
+        }
+
+        // --- Schema mode (existing behavior) ---
+        if (!args.resource_type) {
+          return errorResult("resource_type is required for schema lookups. Use example_search to search examples without specifying a resource type.");
+        }
+
         const schema = SCHEMAS[args.resource_type as keyof typeof SCHEMAS] as Record<string, unknown>;
 
-        // No path → return summary
+        // No path → return summary with available examples
         if (!args.path) {
-          return jsonResult(getSummary(schema, args.resource_type));
+          const summary = getSummary(schema, args.resource_type);
+          const examples = getExamplesForResource(args.resource_type);
+          if (examples.length > 0) {
+            (summary as Record<string, unknown>).examples_available = examples.map((e) => e.name);
+          }
+          return jsonResult(summary);
         }
 
         // Navigate to the requested path

--- a/src/tools/harness-schema.ts
+++ b/src/tools/harness-schema.ts
@@ -1,6 +1,5 @@
 import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { Registry } from "../registry/index.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { createLogger } from "../utils/logger.js";
 import { SCHEMAS, VALID_SCHEMAS } from "../data/schemas/index.js";
@@ -125,7 +124,7 @@ function getSummary(schema: Record<string, unknown>, resourceType: string): Reco
   };
 }
 
-export function registerSchemaTool(server: McpServer, registry?: Registry): void {
+export function registerSchemaTool(server: McpServer): void {
   const availableSchemas = VALID_SCHEMAS;
 
   server.registerTool(

--- a/src/tools/harness-schema.ts
+++ b/src/tools/harness-schema.ts
@@ -5,7 +5,6 @@ import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { createLogger } from "../utils/logger.js";
 import { SCHEMAS, VALID_SCHEMAS } from "../data/schemas/index.js";
 import { getExample, searchExamples, getExamplesForResource } from "../data/examples/index.js";
-import "../data/examples/load-all.js";
 
 const log = createLogger("tool:harness-schema");
 
@@ -138,6 +137,7 @@ export function registerSchemaTool(server: McpServer, registry?: Registry): void
         "Use with path to drill into a specific section. " +
         "Use with example to fetch a named example YAML snippet. " +
         "Use with example_search to find examples by keyword. " +
+        "Precedence: example > example_search > path > summary. " +
         `Available schemas: ${availableSchemas.join(", ")}.`,
       inputSchema: {
         resource_type: z

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -14,6 +14,7 @@ import { registerSearchTool } from "./harness-search.js";
 import { registerDescribeTool } from "./harness-describe.js";
 import { registerStatusTool } from "./harness-status.js";
 import { registerSchemaTool } from "./harness-schema.js";
+import "../data/examples/load-all.js";
 
 
 export function registerAllTools(server: McpServer, registry: Registry, client: HarnessClient, config: Config): void {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -28,5 +28,5 @@ export function registerAllTools(server: McpServer, registry: Registry, client: 
   registerSearchTool(server, registry, client);
   registerDescribeTool(server, registry);
   registerStatusTool(server, registry, client, config);
-  registerSchemaTool(server, registry);
+  registerSchemaTool(server);
 }

--- a/tests/tools/harness-schema-examples.test.ts
+++ b/tests/tools/harness-schema-examples.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { getExample, searchExamples, getExamplesForResource } from "../../src/data/examples/index.js";
-import "../../src/data/examples/pipeline.js";
-import "../../src/data/examples/pipeline-v1.js";
+import "../../src/data/examples/load-all.js";
 
 describe("example registry", () => {
   it("getExample returns undefined for non-existent example", () => {

--- a/tests/tools/harness-schema-examples.test.ts
+++ b/tests/tools/harness-schema-examples.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { getExample, searchExamples, getExamplesForResource } from "../../src/data/examples/index.js";
+import "../../src/data/examples/pipeline.js";
+import "../../src/data/examples/pipeline-v1.js";
 
 describe("example registry", () => {
   it("getExample returns undefined for non-existent example", () => {
@@ -12,5 +14,52 @@ describe("example registry", () => {
 
   it("getExamplesForResource returns empty array for unknown resource type", () => {
     expect(getExamplesForResource("unknown_type")).toEqual([]);
+  });
+});
+
+describe("pipeline v0 examples", () => {
+  it("getExample('minimal-ci') returns a valid example", () => {
+    const ex = getExample("minimal-ci");
+    expect(ex).toBeDefined();
+    expect(ex!.resourceType).toBe("pipeline");
+    expect(ex!.yaml).toContain("pipeline:");
+  });
+
+  it("searchExamples('docker') finds docker-build example", () => {
+    const results = searchExamples("docker");
+    expect(results.some((r) => r.name === "docker-build")).toBe(true);
+  });
+
+  it("getExamplesForResource('pipeline') returns all v0 examples", () => {
+    const results = getExamplesForResource("pipeline");
+    expect(results.length).toBeGreaterThanOrEqual(3);
+    expect(results.every((r) => r.resourceType === "pipeline")).toBe(true);
+  });
+});
+
+describe("pipeline v1 examples", () => {
+  it("getExample('minimal-v1') returns a valid v1 example", () => {
+    const ex = getExample("minimal-v1");
+    expect(ex).toBeDefined();
+    expect(ex!.resourceType).toBe("pipeline_v1");
+    expect(ex!.yaml).toContain("pipeline:");
+  });
+
+  it("getExample('agent-pipeline') returns an agent pipeline example", () => {
+    const ex = getExample("agent-pipeline");
+    expect(ex).toBeDefined();
+    expect(ex!.resourceType).toBe("pipeline_v1");
+    expect(ex!.tags).toContain("agent");
+  });
+
+  it("searchExamples('agent') finds agent-pipeline", () => {
+    const results = searchExamples("agent");
+    expect(results.some((r) => r.name === "agent-pipeline")).toBe(true);
+  });
+
+  it("getExamplesForResource('pipeline_v1') returns only v1 examples", () => {
+    const results = getExamplesForResource("pipeline_v1");
+    expect(results.length).toBeGreaterThanOrEqual(2);
+    expect(results.every((r) => r.resourceType === "pipeline_v1")).toBe(true);
   });
 });

--- a/tests/tools/harness-schema-examples.test.ts
+++ b/tests/tools/harness-schema-examples.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { getExample, searchExamples, getExamplesForResource } from "../../src/data/examples/index.js";
+
+describe("example registry", () => {
+  it("getExample returns undefined for non-existent example", () => {
+    expect(getExample("nonexistent")).toBeUndefined();
+  });
+
+  it("searchExamples returns empty array for no matches", () => {
+    expect(searchExamples("zzz_no_match_zzz")).toEqual([]);
+  });
+
+  it("getExamplesForResource returns empty array for unknown resource type", () => {
+    expect(getExamplesForResource("unknown_type")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- **Both v0 and v1 pipelines are now always available.** `HARNESS_PIPELINE_VERSION` env var controls the default version (v0 when unset or `"0"`, v1 when `"1"`). Both `pipeline` and `pipeline_v1` resource types are always registered regardless of the setting.
- **Progressive-discovery examples** added to `harness_schema` tool. Agents can browse, search, and fetch annotated YAML snippets for any resource type.
- **`harness_describe`** now surfaces `examples_available` when a resource type has examples.

### New agent interaction flow:
```
harness_describe(resource_type='pipeline')        → sees example names
harness_schema(example_search='docker')           → finds matching examples  
harness_schema(example='docker-build')            → gets the full YAML snippet
harness_schema(example_search='agent')            → global search across all types
```

### Adding examples for new resource types:
1. Create `src/data/examples/<resource-type>.ts`
2. Export array of `ResourceExample` objects, call `registerExamples()`
3. Add import to `src/data/examples/load-all.ts`

## Test plan

- [x] All 1177 tests pass
- [x] Typecheck clean
- [x] Build succeeds
- [x] Runtime verification: examples load and search works
- [ ] Smoke test with MCP Inspector (highest-value manual gate for optional resource_type + example modes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)