### PR TITLE
Fix global templates account id override

### DIFF
--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -494,6 +494,12 @@ export class Registry {
       params[def.scopeParams.account] = resolvedAccountId;
     }
 
+    // Allow the global templates sentinel to override accountIdentifier.
+    // Only this specific value is permitted — arbitrary account overrides are not supported.
+    if (input.account_id === "__GLOBAL_TEMPLATES_ACCOUNT_ID__") {
+      params["accountIdentifier"] = "__GLOBAL_TEMPLATES_ACCOUNT_ID__";
+    }
+
     // Account-scoped resources sometimes still need orgIdentifier in query params (NG /ng/api/projects).
     if (spec.injectOrgQueryFallback) {
       const orgKey = def.scopeParams?.org ?? "orgIdentifier";

--- a/tests/registry/registry.test.ts
+++ b/tests/registry/registry.test.ts
@@ -606,6 +606,40 @@ describe("Registry", () => {
       const call = mockRequest.mock.calls[0][0];
       expect(call.body.accountIdentifier).toBe("resolved-account");
     });
+
+    it("overrides accountIdentifier with __GLOBAL_TEMPLATES_ACCOUNT_ID__ sentinel", async () => {
+      const mockRequest = vi.fn().mockResolvedValue({ data: { content: [], totalElements: 0 } });
+      const client = makeClient(mockRequest);
+      const registry = new Registry(
+        makeConfig({ HARNESS_TOOLSETS: "templates", HARNESS_ACCOUNT_ID: "static-account" }),
+      );
+
+      await registry.dispatch(client, "template", "list", {
+        org_id: "org1",
+        project_id: "proj1",
+        account_id: "__GLOBAL_TEMPLATES_ACCOUNT_ID__",
+      });
+
+      const call = mockRequest.mock.calls[0][0];
+      expect(call.params.accountIdentifier).toBe("__GLOBAL_TEMPLATES_ACCOUNT_ID__");
+    });
+
+    it("does not override accountIdentifier for arbitrary account_id values", async () => {
+      const mockRequest = vi.fn().mockResolvedValue({ data: { content: [], totalElements: 0 } });
+      const client = makeClient(mockRequest);
+      const registry = new Registry(
+        makeConfig({ HARNESS_TOOLSETS: "templates", HARNESS_ACCOUNT_ID: "static-account" }),
+      );
+
+      await registry.dispatch(client, "template", "list", {
+        org_id: "org1",
+        project_id: "proj1",
+        account_id: "some-other-account",
+      });
+
+      const call = mockRequest.mock.calls[0][0];
+      expect(call.params.accountIdentifier).toBeUndefined();
+    });
   });
 
   describe("read-only mode", () => {


### PR DESCRIPTION
## Summary
Fixes template listing when using the `__GLOBAL_TEMPLATES_ACCOUNT_ID__` sentinel. Previously, passing `account_id: "__GLOBAL_TEMPLATES_ACCOUNT_ID__"` via params was silently ignored and the request always used the account ID from config.

## What Changed
- `src/registry/index.ts`: When `input.account_id` equals `__GLOBAL_TEMPLATES_ACCOUNT_ID__`, the registry now injects it as `accountIdentifier` in the outgoing query params, overriding the client default
- `tests/registry/registry.test.ts`: Two new tests — one verifying the sentinel passes through, one verifying arbitrary `account_id` values are still ignored

## Why
Harness global/account-level templates live under a special account scope (`__GLOBAL_TEMPLATES_ACCOUNT_ID__`). Agents need to pass this sentinel to list templates not scoped to any org/project. The fix is deliberately narrow — only this one sentinel value is allowed through, preventing arbitrary account ID overrides.
