### PR TITLE
fix: resolve 6 issues from Takeda user feedback

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -54,8 +54,9 @@ export interface RequestOptions {
   timeoutMs?: number;
   /** Return raw ArrayBuffer instead of parsing JSON. Used for binary endpoints (ZIP downloads). */
   responseType?: "json" | "buffer";
-  /** Product backend — when "fme", skips Harness-specific auth/headers/params. */
-  product?: "harness" | "fme";
+  /** Product backend — when "fme", skips Harness-specific auth/headers/params.
+   *  When "idp", routes to the IDP Backstage API at idp.harness.io. */
+  product?: "harness" | "fme" | "idp";
   /** When true, omit the automatic `accountIdentifier` query param.
    *  Some APIs (e.g. SEI) use only the `Harness-Account` header for account scoping. */
   headerBasedScoping?: boolean;

--- a/src/config.ts
+++ b/src/config.ts
@@ -79,6 +79,7 @@ const RawConfigSchema = z.object({
   HARNESS_ALLOW_HTTP: booleanFromEnv.default(false),
   HARNESS_MCP_ALLOWED_HOSTS: optionalStringFromEnv.transform(validateAllowedHosts),
   HARNESS_FME_BASE_URL: urlFromEnv("https://api.split.io"),
+  HARNESS_IDP_BASE_URL: urlFromEnv("https://idp.harness.io"),
   HARNESS_LOG_UNSAFE_BODIES: booleanFromEnv.default(false),
   HARNESS_PIPELINE_VERSION: z.enum(["0", "1"]).optional(),
   HARNESS_AUDIT_FILE: optionalStringFromEnv,
@@ -106,6 +107,13 @@ export const ConfigSchema = RawConfigSchema.transform((data) => {
   if (data.HARNESS_FME_BASE_URL && !data.HARNESS_FME_BASE_URL.startsWith("https://") && !data.HARNESS_ALLOW_HTTP) {
     throw new Error(
       `HARNESS_FME_BASE_URL must use HTTPS (got "${data.HARNESS_FME_BASE_URL}"). ` +
+      "If you need HTTP for local development, set HARNESS_ALLOW_HTTP=true.",
+    );
+  }
+
+  if (data.HARNESS_IDP_BASE_URL && !data.HARNESS_IDP_BASE_URL.startsWith("https://") && !data.HARNESS_ALLOW_HTTP) {
+    throw new Error(
+      `HARNESS_IDP_BASE_URL must use HTTPS (got "${data.HARNESS_IDP_BASE_URL}"). ` +
       "If you need HTTP for local development, set HARNESS_ALLOW_HTTP=true.",
     );
   }
@@ -149,9 +157,11 @@ export type Config = z.infer<typeof ConfigSchema>;
  * Resolve the base URL for a given product backend.
  * - "harness" → undefined (uses the default client base URL)
  * - "fme"     → HARNESS_FME_BASE_URL from config (defaults to https://api.split.io)
+ * - "idp"     → HARNESS_IDP_BASE_URL from config (defaults to https://idp.harness.io)
  */
-export function resolveProductBaseUrl(config: Config, product: "harness" | "fme"): string | undefined {
+export function resolveProductBaseUrl(config: Config, product: "harness" | "fme" | "idp"): string | undefined {
   if (product === "fme") return config.HARNESS_FME_BASE_URL;
+  if (product === "idp") return config.HARNESS_IDP_BASE_URL;
   return undefined;
 }
 

--- a/src/registry/toolsets/access-control.ts
+++ b/src/registry/toolsets/access-control.ts
@@ -139,6 +139,7 @@ export const accessControlToolset: ToolsetDefinition = {
       description: "Service account for API access. Supports list, get, create, and delete.",
       toolset: "access_control",
       scope: "project",
+      scopeOptional: true,
       identifierFields: ["service_account_id"],
       listFilterFields: [
         { name: "search_term", description: "Filter service accounts by name or keyword" },

--- a/src/registry/toolsets/audit.ts
+++ b/src/registry/toolsets/audit.ts
@@ -28,7 +28,7 @@ export const auditToolset: ToolsetDefinition = {
       scope: "account",
       identifierFields: ["audit_id"],
       listFilterFields: [
-        { name: "resource_type", description: "Filter audit logs by resource type", enum: ["ORGANIZATION", "PROJECT", "USER_GROUP", "SECRET", "PIPELINE", "TRIGGER", "TEMPLATE", "INPUT_SET", "DELEGATE_CONFIGURATION", "DELEGATE_GROUPS", "SERVICE", "ENVIRONMENT", "ENVIRONMENT_GROUP", "DELEGATE", "SERVICE_ACCOUNT", "CONNECTOR", "ROLE", "RESOURCE_GROUP", "DASHBOARD", "GOVERNANCE_POLICY", "GOVERNANCE_POLICY_SET", "VARIABLE", "MONITORED_SERVICE", "FEATURE_FLAG", "CHAOS_HUB", "CHAOS_INFRASTRUCTURE", "CHAOS_EXPERIMENT", "GITOPS_AGENT", "GITOPS_APPLICATION", "CODE_REPOSITORY", "SETTING", "DEPLOYMENT_FREEZE"] },
+        { name: "audit_resource_type", description: "Filter audit logs by resource type (renamed from resource_type to avoid conflict with MCP parameter)", enum: ["ORGANIZATION", "PROJECT", "USER_GROUP", "SECRET", "PIPELINE", "TRIGGER", "TEMPLATE", "INPUT_SET", "DELEGATE_CONFIGURATION", "DELEGATE_GROUPS", "SERVICE", "ENVIRONMENT", "ENVIRONMENT_GROUP", "DELEGATE", "SERVICE_ACCOUNT", "CONNECTOR", "ROLE", "RESOURCE_GROUP", "DASHBOARD", "GOVERNANCE_POLICY", "GOVERNANCE_POLICY_SET", "VARIABLE", "MONITORED_SERVICE", "FEATURE_FLAG", "CHAOS_HUB", "CHAOS_INFRASTRUCTURE", "CHAOS_EXPERIMENT", "GITOPS_AGENT", "GITOPS_APPLICATION", "CODE_REPOSITORY", "SETTING", "DEPLOYMENT_FREEZE"] },
         { name: "action", description: "Filter audit logs by action type", enum: ["CREATE", "UPDATE", "RESTORE", "DELETE", "FORCE_DELETE", "UPSERT", "INVITE", "RESEND_INVITE", "REVOKE_INVITE", "ADD_COLLABORATOR", "REMOVE_COLLABORATOR", "CREATE_TOKEN", "REVOKE_TOKEN", "LOGIN", "LOGIN2FA", "UNSUCCESSFUL_LOGIN", "ADD_MEMBERSHIP", "REMOVE_MEMBERSHIP", "START", "END", "PAUSE", "RESUME", "ABORT", "TIMEOUT", "ROLE_ASSIGNMENT_CREATED", "ROLE_ASSIGNMENT_UPDATED", "ROLE_ASSIGNMENT_DELETED", "ENABLED", "DISABLED", "RERUN", "BYPASS"] },
         { name: "start_time", description: "Start time in ISO 8601 format (e.g. 2025-07-10T08:00:00Z). Default: 7 days ago." },
         { name: "end_time", description: "End time in ISO 8601 format (e.g. 2025-07-10T23:59:59Z). Default: now." },
@@ -52,6 +52,7 @@ export const auditToolset: ToolsetDefinition = {
               filterType: "Audit",
               modules: input.module ? [input.module] : undefined,
               actions: input.action ? [input.action] : undefined,
+              resources: input.audit_resource_type ? [{ type: input.audit_resource_type }] : undefined,
               startTime,
               endTime,
             };

--- a/src/registry/toolsets/connectors.ts
+++ b/src/registry/toolsets/connectors.ts
@@ -37,6 +37,7 @@ export const connectorsToolset: ToolsetDefinition = {
       description: "External integration connector. Supports full CRUD and test_connection.",
       toolset: "connectors",
       scope: "project",
+      scopeOptional: true,
       identifierFields: ["connector_id"],
       diagnosticHint: "Use harness_diagnose with resource_id set to the connector identifier to run a live connectivity test and get auth method, status history, and error details.",
       listFilterFields: [

--- a/src/registry/toolsets/gitops.ts
+++ b/src/registry/toolsets/gitops.ts
@@ -229,9 +229,13 @@ export const gitopsToolset: ToolsetDefinition = {
         "IDENTIFIERS: agent_id is scope-prefixed:\n" +
         "- Account-scoped agent: 'account.myagent'\n" +
         "- Org-scoped agent: 'org.myagent'\n" +
-        "- Project-scoped agent: 'myagent' (no prefix)",
+        "- Project-scoped agent: 'myagent' (no prefix)\n" +
+        "SCOPE BEHAVIOR for list/search:\n" +
+        "- Pass org_id and project_id explicitly for project-scoped results\n" +
+        "- Omitting them searches at account level only",
       toolset: "gitops",
       scope: "project",
+      scopeOptional: true,
       diagnosticHint: "Use harness_diagnose with resource_type='gitops_application', agent_id, and resource_id (app name) to analyze sync failures, health issues, and unhealthy K8s resources. Combines app status, resource tree, and recent events.",
       executeHint:
         "SYNC: action='sync' for single app, action='bulk_sync' for multiple. " +

--- a/src/registry/toolsets/idp.ts
+++ b/src/registry/toolsets/idp.ts
@@ -1,5 +1,37 @@
-import type { ToolsetDefinition } from "../types.js";
+import type { ToolsetDefinition, BodySchema } from "../types.js";
 import { ngExtract, pageExtract, v1ListExtract } from "../extractors.js";
+
+const idpEntityCreateSchema: BodySchema = {
+  description: "IDP catalog entity definition (Backstage catalog-info format)",
+  fields: [
+    { name: "kind", type: "string", required: true, description: "Entity kind (e.g. Component, API, System, Resource, Group, User)" },
+    { name: "metadata", type: "object", required: true, description: "Entity metadata (name, namespace, annotations, labels, tags)", fields: [
+      { name: "name", type: "string", required: true, description: "Entity name (unique within namespace+kind)" },
+      { name: "namespace", type: "string", required: false, description: "Namespace (defaults to 'default')" },
+      { name: "description", type: "string", required: false, description: "Entity description" },
+      { name: "annotations", type: "object", required: false, description: "Key-value annotations" },
+      { name: "labels", type: "object", required: false, description: "Key-value labels" },
+      { name: "tags", type: "array", required: false, description: "Tags", itemType: "string" },
+    ]},
+    { name: "spec", type: "object", required: true, description: "Kind-specific specification (varies by entity kind)" },
+  ],
+};
+
+const idpEntityUpdateSchema: BodySchema = {
+  description: "IDP catalog entity update definition (full entity replacement)",
+  fields: [
+    { name: "kind", type: "string", required: true, description: "Entity kind" },
+    { name: "metadata", type: "object", required: true, description: "Entity metadata (name, namespace, annotations, labels, tags)", fields: [
+      { name: "name", type: "string", required: true, description: "Entity name" },
+      { name: "namespace", type: "string", required: false, description: "Namespace (defaults to 'default')" },
+      { name: "description", type: "string", required: false, description: "Entity description" },
+      { name: "annotations", type: "object", required: false, description: "Key-value annotations" },
+      { name: "labels", type: "object", required: false, description: "Key-value labels" },
+      { name: "tags", type: "array", required: false, description: "Tags", itemType: "string" },
+    ]},
+    { name: "spec", type: "object", required: true, description: "Kind-specific specification" },
+  ],
+};
 
 export const idpToolset: ToolsetDefinition = {
   name: "idp",
@@ -9,9 +41,10 @@ export const idpToolset: ToolsetDefinition = {
     {
       resourceType: "idp_entity",
       displayName: "IDP Entity",
-      description: "Internal Developer Portal catalog entity. Supports list and get.",
+      description: "Internal Developer Portal catalog entity. Supports list, get, create, update, and delete.",
       toolset: "idp",
       scope: "account",
+      product: "idp",
       identifierFields: ["entity_id", "kind"],
       listFilterFields: [
         { name: "kind", description: "Catalog entity kind filter", enum: ["api", "component", "environment", "environmentblueprint", "group", "resource", "user", "workflow"] },
@@ -56,6 +89,46 @@ export const idpToolset: ToolsetDefinition = {
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           responseExtractor: ngExtract,
           description: "Get IDP catalog entity details by scope, kind, namespace, and name (entity_ref format: kind:namespace/name)",
+        },
+        create: {
+          method: "POST",
+          path: "/v1/entities",
+          operationPolicy: { risk: "low_write", retryPolicy: "do_not_retry" },
+          bodyBuilder: (input) => input.body ?? {},
+          responseExtractor: ngExtract,
+          description: "Create (register) an IDP catalog entity",
+          bodySchema: idpEntityCreateSchema,
+        },
+        update: {
+          method: "PUT",
+          path: "/v1/entities",
+          operationPolicy: { risk: "low_write", retryPolicy: "safe" },
+          bodyBuilder: (input) => input.body ?? {},
+          responseExtractor: ngExtract,
+          description: "Update (replace) an IDP catalog entity",
+          bodySchema: idpEntityUpdateSchema,
+        },
+        delete: {
+          method: "DELETE",
+          path: "/v1/entities/{scope}/{kind}/{namespace}/{entityId}",
+          pathBuilder: (input) => {
+            let scope = "account";
+            const orgId = input.org_id as string | undefined;
+            const projectId = input.project_id as string | undefined;
+            if (orgId) {
+              scope += `.${orgId}`;
+              if (projectId) {
+                scope += `.${projectId}`;
+              }
+            }
+            const kind = (input.kind as string) || "component";
+            const namespace = (input.namespace as string) || scope;
+            const entityId = input.entity_id as string;
+            return `/v1/entities/${encodeURIComponent(scope)}/${encodeURIComponent(kind)}/${encodeURIComponent(namespace)}/${encodeURIComponent(entityId)}`;
+          },
+          operationPolicy: { risk: "destructive", retryPolicy: "do_not_retry" },
+          responseExtractor: ngExtract,
+          description: "Delete (unregister) an IDP catalog entity by scope, kind, namespace, and name",
         },
       },
     },

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -139,7 +139,7 @@ export type ToolsetName =
   | "overrides"
   | "ai-evals";
 
-export type ProductName = "harness" | "fme";
+export type ProductName = "harness" | "fme" | "idp";
 
 export type OperationName = "list" | "get" | "create" | "update" | "delete";
 


### PR DESCRIPTION
## Summary

Addresses 6 broken/missing capabilities reported by Takeda users:

- **connector + service_account account-level listing**: Added `scopeOptional: true` so listing without org/project returns all account-level resources instead of filtering to the configured default scope
- **idp_entity get (wrong domain)**: Added `product: "idp"` and `HARNESS_IDP_BASE_URL` config (defaults to `https://idp.harness.io`) so IDP catalog API calls hit the correct Backstage endpoint
- **idp_entity create/update/delete (missing)**: Added full CUD operations with body schemas against the `/v1/entities` Backstage catalog API
- **GitOps search returns 0**: Added `scopeOptional: true` so users must pass `org_id`/`project_id` explicitly for project-scoped search results
- **audit_event resource_type filter conflict**: Renamed filter key from `resource_type` to `audit_resource_type` to prevent `Object.assign` shadowing the MCP parameter name, and implemented the filter in the bodyBuilder (was silently ignored before)

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 1177 unit tests pass
- [ ] Verify `harness_list(resource_type='connector')` without org/project returns full account-level connector set
- [ ] Verify `harness_list(resource_type='service_account')` without org/project returns all service accounts
- [ ] Verify `harness_get(resource_type='idp_entity', ...)` hits `idp.harness.io` not `app.harness.io`
- [ ] Verify `harness_create/update/delete(resource_type='idp_entity', ...)` works against IDP catalog
- [ ] Verify `harness_list(resource_type='gitops_application', org_id='x', project_id='y', search_term='foo')` returns results
- [ ] Verify `harness_list(resource_type='audit_event', filters={audit_resource_type:'PIPELINE'})` filters correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)