### PR TITLE
feat: per-call scope_level override for account/org-level queries

### DIFF
--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -390,6 +390,13 @@ export class Registry {
   ): void {
     if (!this.auditManager) return;
 
+    // Determine effective scope for audit based on scope_level override
+    const auditScopeLevel = (input.scope_level as string | undefined);
+    const effectiveAccountScope = def.scope === "account" ||
+      (auditScopeLevel === "account" && def.supportedScopeLevels?.includes("account"));
+    const effectiveOrgScope = def.scope === "org" ||
+      (auditScopeLevel === "org" && def.supportedScopeLevels?.includes("org"));
+
     const event: AuditEvent = {
       event_id: randomUUID(),
       timestamp: new Date().toISOString(),
@@ -398,10 +405,10 @@ export class Registry {
       resource_type: resourceType,
       resource_id: auditCtx?.resource_id ?? (input.resource_id as string | undefined),
       action: auditCtx?.action,
-      org_id: def.scope === "account"
+      org_id: effectiveAccountScope
         ? undefined
         : (input.org_id as string | undefined) ?? (def.scopeOptional ? undefined : this.config.HARNESS_ORG),
-      project_id: def.scope === "account" || def.scope === "org"
+      project_id: effectiveAccountScope || effectiveOrgScope
         ? undefined
         : (input.project_id as string | undefined) ?? (def.scopeOptional ? undefined : this.config.HARNESS_PROJECT),
       account_id: this.getAccountId(),

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -474,9 +474,13 @@ export class Registry {
     //   "account" → suppress both org and project injection (account-wide query)
     //   "org"     → inject org (from input or config fallback), suppress project
     //   undefined → use resource's default scoping behavior
+    // Only honored when the resource declares supportedScopeLevels.
     const orgParam = def.scopeParams?.org ?? "orgIdentifier";
     const projectParam = def.scopeParams?.project ?? "projectIdentifier";
-    const scopeLevel = input.scope_level as string | undefined;
+    const rawScopeLevel = input.scope_level as string | undefined;
+    const scopeLevel = rawScopeLevel && def.supportedScopeLevels?.includes(rawScopeLevel as "account" | "org")
+      ? rawScopeLevel
+      : undefined;
     if (scopeLevel === "account") {
       // Account-level: no org or project injected
     } else if (scopeLevel === "org") {

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -469,9 +469,20 @@ export class Registry {
     // Add scope params (allow per-resource override of query param names)
     // When scopeOptional is true, only add org/project if explicitly provided in input.
     // Otherwise, fall back to config defaults based on the resource's scope level.
+    //
+    // Per-call scope override via input.scope_level:
+    //   "account" → suppress both org and project injection (account-wide query)
+    //   "org"     → inject org (from input or config fallback), suppress project
+    //   undefined → use resource's default scoping behavior
     const orgParam = def.scopeParams?.org ?? "orgIdentifier";
     const projectParam = def.scopeParams?.project ?? "projectIdentifier";
-    if (def.scopeOptional) {
+    const scopeLevel = input.scope_level as string | undefined;
+    if (scopeLevel === "account") {
+      // Account-level: no org or project injected
+    } else if (scopeLevel === "org") {
+      // Org-level: inject org (explicit or config default), no project
+      params[orgParam] = (input.org_id as string) ?? this.config.HARNESS_ORG;
+    } else if (def.scopeOptional) {
       // Dynamic scoping: only inject when caller explicitly provides them
       if (input.org_id) {
         params[orgParam] = input.org_id as string;

--- a/src/registry/toolsets/access-control.ts
+++ b/src/registry/toolsets/access-control.ts
@@ -136,9 +136,10 @@ export const accessControlToolset: ToolsetDefinition = {
     {
       resourceType: "service_account",
       displayName: "Service Account",
-      description: "Service account for API access. Supports list, get, create, and delete.",
+      description: "Service account for API access. Supports list, get, create, and delete. Pass scope_level='account' to list all account-level service accounts.",
       toolset: "access_control",
       scope: "project",
+      supportedScopeLevels: ["account", "org"],
       identifierFields: ["service_account_id"],
       listFilterFields: [
         { name: "search_term", description: "Filter service accounts by name or keyword" },

--- a/src/registry/toolsets/connectors.ts
+++ b/src/registry/toolsets/connectors.ts
@@ -34,9 +34,10 @@ export const connectorsToolset: ToolsetDefinition = {
     {
       resourceType: "connector",
       displayName: "Connector",
-      description: "External integration connector. Supports full CRUD and test_connection.",
+      description: "External integration connector. Supports full CRUD and test_connection. Pass scope_level='account' to list all account-level connectors.",
       toolset: "connectors",
       scope: "project",
+      supportedScopeLevels: ["account", "org"],
       identifierFields: ["connector_id"],
       diagnosticHint: "Use harness_diagnose with resource_id set to the connector identifier to run a live connectivity test and get auth method, status history, and error details.",
       listFilterFields: [

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -322,6 +322,13 @@ export interface ResourceDefinition {
    */
   scopeOptional?: boolean;
   /**
+   * When set, the resource honors the per-call `scope_level` input parameter
+   * for the listed levels. E.g. ["account", "org"] means callers can pass
+   * scope_level="account" or "org" to widen beyond the resource's default scope.
+   * Resources without this field ignore `scope_level` entirely.
+   */
+  supportedScopeLevels?: Array<"account" | "org">;
+  /**
    * Override default scope query parameter names.
    * Standard NG API uses orgIdentifier / projectIdentifier.
    * Some APIs (e.g., Chaos) use organizationIdentifier instead.

--- a/src/tools/harness-describe.ts
+++ b/src/tools/harness-describe.ts
@@ -34,6 +34,7 @@ export function registerDescribeTool(server: McpServer, registry: Registry): voi
             description: def.description,
             toolset: def.toolset,
             scope: def.scope,
+            supportedScopeLevels: def.supportedScopeLevels ?? undefined,
             identifierFields: def.identifierFields,
             listFilterFields: def.listFilterFields,
             operations: Object.entries(def.operations).map(([op, spec]) => ({

--- a/src/tools/harness-get.ts
+++ b/src/tools/harness-get.ts
@@ -23,6 +23,7 @@ export function registerGetTool(server: McpServer, registry: Registry, client: H
         url: z.string().describe("Harness UI URL — auto-extracts org, project, type, and ID").optional(),
         org_id: z.string().describe("Organization identifier (overrides default)").optional(),
         project_id: z.string().describe("Project identifier (overrides default)").optional(),
+        scope_level: z.enum(["account", "org", "project"]).describe("Override scope for this call. 'account' retrieves at account level (ignores default org/project).").optional(),
         params: z.record(z.string(), z.unknown()).describe("Additional identifiers for nested resources. Call harness_describe for fields per resource_type.").optional(),
       },
       annotations: {

--- a/src/tools/harness-list.ts
+++ b/src/tools/harness-list.ts
@@ -32,6 +32,7 @@ export function registerListTool(server: McpServer, registry: Registry, client: 
         url: z.string().describe("Harness UI URL — auto-extracts org, project, and type").optional(),
         org_id: z.string().describe("Organization identifier (overrides default)").optional(),
         project_id: z.string().describe("Project identifier (overrides default)").optional(),
+        scope_level: z.enum(["account", "org", "project"]).describe("Override scope for this call. 'account' lists across the entire account (ignores default org/project). 'org' lists within the org only.").optional(),
         page: z.number().describe("Page number, 0-indexed").default(0).optional(),
         size: z.number().min(1).max(100).describe("Page size (1–100)").default(20).optional(),
         search_term: z.string().describe("Filter results by name or keyword").optional(),

--- a/tests/audit/registry-audit.test.ts
+++ b/tests/audit/registry-audit.test.ts
@@ -145,4 +145,67 @@ describe("Registry audit emission", () => {
     expect(sink.events).toHaveLength(1);
     expect(sink.events[0]!.tool).toBe("harness_list");
   });
+
+  it("audit event reflects scope_level=account override for supported resources", async () => {
+    const sink = collectingSink();
+    const auditManager = new AuditManager();
+    auditManager.addSink(sink);
+
+    const config = makeConfig({ HARNESS_TOOLSETS: "connectors" });
+    const registry = new Registry(config as any, { auditManager });
+
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ data: { content: [], totalElements: 0 } }),
+      account: "acct1",
+    };
+
+    await registry.dispatch(mockClient as any, "connector", "list", { scope_level: "account" }, { tool: "harness_list" });
+
+    expect(sink.events).toHaveLength(1);
+    const event = sink.events[0]!;
+    expect(event.org_id).toBeUndefined();
+    expect(event.project_id).toBeUndefined();
+  });
+
+  it("audit event reflects scope_level=org override (org present, no project)", async () => {
+    const sink = collectingSink();
+    const auditManager = new AuditManager();
+    auditManager.addSink(sink);
+
+    const config = makeConfig({ HARNESS_TOOLSETS: "connectors" });
+    const registry = new Registry(config as any, { auditManager });
+
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ data: { content: [], totalElements: 0 } }),
+      account: "acct1",
+    };
+
+    await registry.dispatch(mockClient as any, "connector", "list", { scope_level: "org", org_id: "my-org" }, { tool: "harness_list" });
+
+    expect(sink.events).toHaveLength(1);
+    const event = sink.events[0]!;
+    expect(event.org_id).toBe("my-org");
+    expect(event.project_id).toBeUndefined();
+  });
+
+  it("audit event uses default scope when scope_level is not supported by resource", async () => {
+    const sink = collectingSink();
+    const auditManager = new AuditManager();
+    auditManager.addSink(sink);
+
+    const config = makeConfig({ HARNESS_TOOLSETS: "pipelines" });
+    const registry = new Registry(config as any, { auditManager });
+
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ status: "SUCCESS", data: {} }),
+      account: "acct1",
+    };
+
+    await registry.dispatch(mockClient as any, "pipeline", "list", { scope_level: "account" }, { tool: "harness_list" });
+
+    expect(sink.events).toHaveLength(1);
+    const event = sink.events[0]!;
+    expect(event.org_id).toBe("default");
+    expect(event.project_id).toBe("proj1");
+  });
 });

--- a/tests/registry/registry.test.ts
+++ b/tests/registry/registry.test.ts
@@ -657,6 +657,62 @@ describe("Registry", () => {
     });
   });
 
+  describe("scope_level override", () => {
+    let registry: Registry;
+    beforeEach(() => {
+      registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "connectors" }));
+    });
+
+    it("default: injects org and project from config for project-scoped resources", async () => {
+      const mockRequest = vi.fn().mockResolvedValue({ data: { content: [], totalElements: 0 } });
+      const client = makeClient(mockRequest);
+      await registry.dispatch(client, "connector", "list", {});
+      const call = mockRequest.mock.calls[0][0];
+      expect(call.params.orgIdentifier).toBe("default");
+      expect(call.params.projectIdentifier).toBe("test-project");
+    });
+
+    it("scope_level=account suppresses org and project injection", async () => {
+      const mockRequest = vi.fn().mockResolvedValue({ data: { content: [], totalElements: 0 } });
+      const client = makeClient(mockRequest);
+      await registry.dispatch(client, "connector", "list", { scope_level: "account" });
+      const call = mockRequest.mock.calls[0][0];
+      expect(call.params.orgIdentifier).toBeUndefined();
+      expect(call.params.projectIdentifier).toBeUndefined();
+    });
+
+    it("scope_level=org injects org from config but suppresses project", async () => {
+      const mockRequest = vi.fn().mockResolvedValue({ data: { content: [], totalElements: 0 } });
+      const client = makeClient(mockRequest);
+      await registry.dispatch(client, "connector", "list", { scope_level: "org" });
+      const call = mockRequest.mock.calls[0][0];
+      expect(call.params.orgIdentifier).toBe("default");
+      expect(call.params.projectIdentifier).toBeUndefined();
+    });
+
+    it("scope_level=org uses explicit org_id over config default", async () => {
+      const mockRequest = vi.fn().mockResolvedValue({ data: { content: [], totalElements: 0 } });
+      const client = makeClient(mockRequest);
+      await registry.dispatch(client, "connector", "list", { scope_level: "org", org_id: "custom-org" });
+      const call = mockRequest.mock.calls[0][0];
+      expect(call.params.orgIdentifier).toBe("custom-org");
+      expect(call.params.projectIdentifier).toBeUndefined();
+    });
+
+    it("scope_level=account ignores explicit org_id and project_id", async () => {
+      const mockRequest = vi.fn().mockResolvedValue({ data: { content: [], totalElements: 0 } });
+      const client = makeClient(mockRequest);
+      await registry.dispatch(client, "connector", "list", {
+        scope_level: "account",
+        org_id: "should-be-ignored",
+        project_id: "should-be-ignored",
+      });
+      const call = mockRequest.mock.calls[0][0];
+      expect(call.params.orgIdentifier).toBeUndefined();
+      expect(call.params.projectIdentifier).toBeUndefined();
+    });
+  });
+
   describe("trigger pipelineIdentifier extraction", () => {
     let registry: Registry;
 

--- a/tests/registry/registry.test.ts
+++ b/tests/registry/registry.test.ts
@@ -711,6 +711,16 @@ describe("Registry", () => {
       expect(call.params.orgIdentifier).toBeUndefined();
       expect(call.params.projectIdentifier).toBeUndefined();
     });
+
+    it("scope_level is ignored for resources without supportedScopeLevels", async () => {
+      const pipelineRegistry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines" }));
+      const mockRequest = vi.fn().mockResolvedValue({ data: { content: [], totalElements: 0 } });
+      const client = makeClient(mockRequest);
+      await pipelineRegistry.dispatch(client, "pipeline", "list", { scope_level: "account" });
+      const call = mockRequest.mock.calls[0][0];
+      expect(call.params.orgIdentifier).toBe("default");
+      expect(call.params.projectIdentifier).toBe("test-project");
+    });
   });
 
   describe("trigger pipelineIdentifier extraction", () => {

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -938,6 +938,24 @@ describe("harness_describe", () => {
     const data = parseResult(result) as { total_results: number; resource_types: unknown[] };
     expect(data.total_results).toBeGreaterThan(0);
   });
+
+  it("surfaces supportedScopeLevels for connector resource", async () => {
+    const connectorRegistry = new Registry(makeConfig({ HARNESS_TOOLSETS: "connectors" }));
+    const { registerDescribeTool } = await import("../../src/tools/harness-describe.js");
+    const connectorServer = makeMcpServer();
+    registerDescribeTool(connectorServer, connectorRegistry);
+    const result = await connectorServer.call("harness_describe", { resource_type: "connector" });
+    expect(result.isError).toBeUndefined();
+    const data = parseResult(result) as { supportedScopeLevels?: string[] };
+    expect(data.supportedScopeLevels).toEqual(["account", "org"]);
+  });
+
+  it("does not include supportedScopeLevels for resources without it", async () => {
+    const result = await server.call("harness_describe", { resource_type: "pipeline" });
+    expect(result.isError).toBeUndefined();
+    const data = parseResult(result) as { supportedScopeLevels?: string[] };
+    expect(data.supportedScopeLevels).toBeUndefined();
+  });
 });
 
 describe("harness_search", () => {


### PR DESCRIPTION
## Summary

Adds a `scope_level` parameter to `harness_list` and `harness_get` that lets callers explicitly widen scope on a per-call basis without changing resource defaults.

**Problem:** Connector listing returns 1/22 and service_account listing returns 0/14 at account level because the registry always injects `orgIdentifier`/`projectIdentifier` from config defaults. The previous fix (`scopeOptional: true`) silently widened ALL calls to account scope, breaking the default-scoping contract.

**Solution:** A per-call opt-in parameter:

| `scope_level` | Behavior |
|---|---|
| omitted | Preserves existing default scoping (org+project from config) |
| `"account"` | Suppresses both org and project injection — account-wide query |
| `"org"` | Injects org (from input or config fallback), suppresses project |

**Example usage:**
```
harness_list(resource_type='connector', scope_level='account')  → all 22 account connectors
harness_list(resource_type='service_account', scope_level='account')  → all 14 service accounts
harness_list(resource_type='connector')  → default project-scoped (unchanged behavior)
```

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] 1182 tests pass (5 new scope_level assertions added)
- [ ] Verify `harness_list(resource_type='connector', scope_level='account')` returns full account connector set
- [ ] Verify `harness_list(resource_type='service_account', scope_level='account')` returns all service accounts
- [ ] Verify default behavior (no scope_level) is unchanged — still scopes to config org/project

🤖 Generated with [Claude Code](https://claude.com/claude-code)