### PR TITLE
fix: add routingId parameter to API requests

### DIFF
--- a/src/client/harness-client.ts
+++ b/src/client/harness-client.ts
@@ -467,6 +467,7 @@ export class HarnessClient {
     if (!options.headerBasedScoping && options.product !== "fme") {
       const accountId = this.resolveAccountId();
       params.set("accountIdentifier", accountId);
+      params.set("routingId", accountId);
 
       // Log-service gateway expects accountID (capital ID) in query params
       if (path.includes("/log-service/")) {

--- a/tests/client/harness-client.test.ts
+++ b/tests/client/harness-client.test.ts
@@ -55,6 +55,7 @@ describe("HarnessClient", () => {
       expect(url.origin).toBe("https://app.harness.io");
       expect(url.pathname).toBe("/ng/api/projects");
       expect(url.searchParams.get("accountIdentifier")).toBe("test-account");
+      expect(url.searchParams.get("routingId")).toBe("test-account");
       expect(url.searchParams.get("orgIdentifier")).toBe("myorg");
     });
 
@@ -67,6 +68,7 @@ describe("HarnessClient", () => {
       const url = new URL(fetchSpy.mock.calls[0][0] as string);
       expect(url.searchParams.get("accountID")).toBe("test-account");
       expect(url.searchParams.get("accountIdentifier")).toBe("test-account");
+      expect(url.searchParams.get("routingId")).toBe("test-account");
     });
 
     it("encodes query param for multi-word params", async () => {
@@ -164,6 +166,40 @@ describe("HarnessClient", () => {
       const url = new URL(fetchSpy.mock.calls[0][0] as string);
       expect(url.searchParams.getAll("inputSetIdentifiers")).toEqual(["set-a", "set-b"]);
       expect(url.searchParams.get("orgIdentifier")).toBe("o");
+    });
+
+    it("omits routingId when headerBasedScoping is true", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      const client = new HarnessClient(makeConfig());
+
+      await client.request({ path: "/sei/api/v1/users", headerBasedScoping: true });
+
+      const url = new URL(fetchSpy.mock.calls[0][0] as string);
+      expect(url.searchParams.has("accountIdentifier")).toBe(false);
+      expect(url.searchParams.has("routingId")).toBe(false);
+    });
+
+    it("omits routingId for FME product requests", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      const client = new HarnessClient(makeConfig());
+
+      await client.request({ path: "/internal/api/v2/splits", product: "fme" });
+
+      const url = new URL(fetchSpy.mock.calls[0][0] as string);
+      expect(url.searchParams.has("accountIdentifier")).toBe(false);
+      expect(url.searchParams.has("routingId")).toBe(false);
+    });
+
+    it("uses resolved account ID for routingId", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      const client = new HarnessClient(makeConfig());
+      client.setAccountIdResolver(() => "resolved-account-123");
+
+      await client.request({ path: "/ng/api/projects" });
+
+      const url = new URL(fetchSpy.mock.calls[0][0] as string);
+      expect(url.searchParams.get("accountIdentifier")).toBe("resolved-account-123");
+      expect(url.searchParams.get("routingId")).toBe("resolved-account-123");
     });
   });
 


### PR DESCRIPTION
## Summary
Adds `routingId` query parameter to all Harness API requests to fix cluster routing issues when `accountIdentifier` needs to be overridden for global entities.

## What Changed
- Added `routingId` parameter alongside `accountIdentifier` in HarnessClient request method
- `routingId` is always set to the actual account ID for proper routing
- Applied to all non-header-based-scoping API calls (excluding FME product)

## Why
Some Harness APIs require `accountIdentifier` to be set to a different value than the actual account ID (e.g., when accessing global entities like templates). However, changing `accountIdentifier` breaks cluster routing because the gateway uses it to route requests to the correct backend cluster.

By adding `routingId` set to the actual account ID, we maintain correct cluster routing while allowing `accountIdentifier` to be overridden as needed by specific APIs.

**Before:** Changing `accountIdentifier` for global entities → routing failures
**After:** `routingId` handles routing, `accountIdentifier` can be safely overridden

🤖 Generated with [Claude Code](https://claude.com/claude-code)