### PR TITLE
fix: remove hardcoded 'default' fallback for HARNESS_ORG

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -124,7 +124,7 @@ export const ConfigSchema = RawConfigSchema.transform((data) => {
   if (!data.HARNESS_PROJECT && data.HARNESS_DEFAULT_PROJECT_ID) {
     console.error('[DEPRECATION] HARNESS_DEFAULT_PROJECT_ID is deprecated. Use HARNESS_PROJECT instead.');
   }
-  const HARNESS_ORG = data.HARNESS_ORG ?? data.HARNESS_DEFAULT_ORG_ID ?? "default";
+  const HARNESS_ORG = data.HARNESS_ORG ?? data.HARNESS_DEFAULT_ORG_ID;
   const HARNESS_PROJECT = data.HARNESS_PROJECT ?? data.HARNESS_DEFAULT_PROJECT_ID;
 
   // Resolve auto-approve risk: prefer new name, fall back to deprecated SKIP_ELICITATION


### PR DESCRIPTION
## Summary
- Removes the hardcoded `'default'` fallback in `HARNESS_ORG` resolution
- Ensures org context remains `undefined` when neither `HARNESS_ORG` nor `HARNESS_DEFAULT_ORG_ID` is provided
- Fixes incorrect org context injection for account-level API calls (e.g., global templates listing)

## Changes
**src/config.ts**:
- Line 127: Changed `data.HARNESS_ORG ?? data.HARNESS_DEFAULT_ORG_ID ?? "default"` to `data.HARNESS_ORG ?? data.HARNESS_DEFAULT_ORG_ID`

## Why
The hardcoded `'default'` fallback was causing issues when listing global templates at the account scope. API calls that should operate at the account level were incorrectly receiving an org context, leading to permission errors or missing data.

## Test plan
- [ ] Verify `harness_list template` works without `HARNESS_ORG` set (should list global templates)
- [ ] Verify `harness_list template` works with `HARNESS_ORG=specific-org` (should list org-scoped templates)
- [ ] Verify existing org/project-scoped operations continue to work with explicit org values
- [ ] Confirm no regression in backward compatibility with `HARNESS_DEFAULT_ORG_ID`

🤖 Generated with [Claude Code](https://claude.com/claude-code)