### PR TITLE
feat: support additional schemas via additionalSchemas parameter

### DIFF
--- a/src/data/schemas/index.ts
+++ b/src/data/schemas/index.ts
@@ -34,5 +34,12 @@ export const SCHEMAS: Record<AllSchemaKeys, Record<string, any>> = {
 export const VALID_SCHEMAS: AllSchemaKeys[] = Object.keys(SCHEMAS) as AllSchemaKeys[];
 export type SchemaName = AllSchemaKeys;
 
+/** Metadata-wrapped schema entry. All registered schemas must provide description and group. */
+export type SchemaEntry = {
+  schema: Record<string, any>;
+  description: string;
+  group: string;
+};
+
 export const V0_SCHEMA_KEYS: V0SchemaKey[] = ["pipeline", "template", "trigger"];
 export const V1_SCHEMA_KEYS: V1SchemaKey[] = ["pipeline_v1", "template_v1", "trigger_v1", "inputSet_v1", "overlayInputSet_v1", "service_v1", "infra_v1"];

--- a/src/data/schemas/index.ts
+++ b/src/data/schemas/index.ts
@@ -17,7 +17,7 @@ type V1SchemaKey = "pipeline_v1" | "template_v1" | "trigger_v1" | "inputSet_v1" 
 type LocalSchemaKey = "agent-pipeline";
 type AllSchemaKeys = V0SchemaKey | V1SchemaKey | LocalSchemaKey;
 
-export const SCHEMAS: Record<AllSchemaKeys, Record<string, any>> = {
+export const SCHEMAS: Record<string, Record<string, any>> = {
   "pipeline": pipeline,
   "template": template,
   "trigger": trigger,
@@ -31,8 +31,21 @@ export const SCHEMAS: Record<AllSchemaKeys, Record<string, any>> = {
   "agent-pipeline": agentPipeline,
 };
 
-export const VALID_SCHEMAS = Object.keys(SCHEMAS) as AllSchemaKeys[];
-export type SchemaName = AllSchemaKeys;
+export const VALID_SCHEMAS: string[] = Object.keys(SCHEMAS);
+export type SchemaName = AllSchemaKeys | string;
+
+/**
+ * Register an additional schema at runtime.
+ * Used by internal/extension servers to add schemas without modifying the OSS package.
+ * Must be called before the schema tool is registered (i.e., at startup).
+ */
+export function registerSchema(name: string, schema: Record<string, any>): void {
+  if (SCHEMAS[name]) {
+    throw new Error(`Schema '${name}' already registered.`);
+  }
+  SCHEMAS[name] = schema;
+  VALID_SCHEMAS.push(name);
+}
 
 export const V0_SCHEMA_KEYS: V0SchemaKey[] = ["pipeline", "template", "trigger"];
 export const V1_SCHEMA_KEYS: V1SchemaKey[] = ["pipeline_v1", "template_v1", "trigger_v1", "inputSet_v1", "overlayInputSet_v1", "service_v1", "infra_v1"];

--- a/src/data/schemas/index.ts
+++ b/src/data/schemas/index.ts
@@ -15,9 +15,9 @@ import agentPipeline from "./local/agent-pipeline.js";
 type V0SchemaKey = "pipeline" | "template" | "trigger";
 type V1SchemaKey = "pipeline_v1" | "template_v1" | "trigger_v1" | "inputSet_v1" | "overlayInputSet_v1" | "service_v1" | "infra_v1";
 type LocalSchemaKey = "agent-pipeline";
-type AllSchemaKeys = V0SchemaKey | V1SchemaKey | LocalSchemaKey;
+export type AllSchemaKeys = V0SchemaKey | V1SchemaKey | LocalSchemaKey;
 
-export const SCHEMAS: Record<string, Record<string, any>> = {
+export const SCHEMAS: Record<AllSchemaKeys, Record<string, any>> = {
   "pipeline": pipeline,
   "template": template,
   "trigger": trigger,
@@ -31,21 +31,8 @@ export const SCHEMAS: Record<string, Record<string, any>> = {
   "agent-pipeline": agentPipeline,
 };
 
-export const VALID_SCHEMAS: string[] = Object.keys(SCHEMAS);
-export type SchemaName = AllSchemaKeys | string;
-
-/**
- * Register an additional schema at runtime.
- * Used by internal/extension servers to add schemas without modifying the OSS package.
- * Must be called before the schema tool is registered (i.e., at startup).
- */
-export function registerSchema(name: string, schema: Record<string, any>): void {
-  if (SCHEMAS[name]) {
-    throw new Error(`Schema '${name}' already registered.`);
-  }
-  SCHEMAS[name] = schema;
-  VALID_SCHEMAS.push(name);
-}
+export const VALID_SCHEMAS: AllSchemaKeys[] = Object.keys(SCHEMAS) as AllSchemaKeys[];
+export type SchemaName = AllSchemaKeys;
 
 export const V0_SCHEMA_KEYS: V0SchemaKey[] = ["pipeline", "template", "trigger"];
 export const V1_SCHEMA_KEYS: V1SchemaKey[] = ["pipeline_v1", "template_v1", "trigger_v1", "inputSet_v1", "overlayInputSet_v1", "service_v1", "infra_v1"];

--- a/src/resources/harness-schema.ts
+++ b/src/resources/harness-schema.ts
@@ -13,6 +13,13 @@ export function registerHarnessSchemaResource(
   server: McpServer,
   additionalSchemas?: Record<string, Record<string, any>>,
 ): void {
+  if (additionalSchemas) {
+    for (const key of Object.keys(additionalSchemas)) {
+      if (key in SCHEMAS) {
+        log.warn(`additionalSchemas key '${key}' overrides a built-in schema`);
+      }
+    }
+  }
   const allSchemas: Record<string, Record<string, any>> = additionalSchemas
     ? { ...SCHEMAS, ...additionalSchemas }
     : { ...SCHEMAS };

--- a/src/resources/harness-schema.ts
+++ b/src/resources/harness-schema.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createLogger } from "../utils/logger.js";
-import { SCHEMAS, VALID_SCHEMAS, type SchemaName } from "../data/schemas/index.js";
+import { SCHEMAS, VALID_SCHEMAS, type SchemaName, type SchemaEntry } from "../data/schemas/index.js";
 
 const log = createLogger("resource:harness-schema");
 
@@ -11,7 +11,7 @@ export function isValidSchemaName(name: string, validNames: readonly string[] = 
 
 export function registerHarnessSchemaResource(
   server: McpServer,
-  additionalSchemas?: Record<string, Record<string, any>>,
+  additionalSchemas?: Record<string, SchemaEntry>,
 ): void {
   if (additionalSchemas) {
     for (const key of Object.keys(additionalSchemas)) {
@@ -21,7 +21,7 @@ export function registerHarnessSchemaResource(
     }
   }
   const allSchemas: Record<string, Record<string, any>> = additionalSchemas
-    ? { ...SCHEMAS, ...additionalSchemas }
+    ? { ...SCHEMAS, ...Object.fromEntries(Object.entries(additionalSchemas).map(([k, v]) => [k, v.schema])) }
     : { ...SCHEMAS };
   const allSchemaNames = Object.keys(allSchemas);
 

--- a/src/resources/harness-schema.ts
+++ b/src/resources/harness-schema.ts
@@ -16,7 +16,7 @@ export function registerHarnessSchemaResource(
   if (additionalSchemas) {
     for (const key of Object.keys(additionalSchemas)) {
       if (key in SCHEMAS) {
-        log.warn(`additionalSchemas key '${key}' overrides a built-in schema`);
+        throw new Error(`additionalSchemas key '${key}' conflicts with a built-in schema name`);
       }
     }
   }

--- a/src/resources/harness-schema.ts
+++ b/src/resources/harness-schema.ts
@@ -5,21 +5,29 @@ import { SCHEMAS, VALID_SCHEMAS, type SchemaName } from "../data/schemas/index.j
 
 const log = createLogger("resource:harness-schema");
 
-function isValidSchemaName(name: string): name is SchemaName {
-  return (VALID_SCHEMAS as readonly string[]).includes(name);
+export function isValidSchemaName(name: string, validNames: readonly string[] = VALID_SCHEMAS): name is SchemaName {
+  return validNames.includes(name);
 }
 
-export function registerHarnessSchemaResource(server: McpServer): void {
+export function registerHarnessSchemaResource(
+  server: McpServer,
+  additionalSchemas?: Record<string, Record<string, any>>,
+): void {
+  const allSchemas: Record<string, Record<string, any>> = additionalSchemas
+    ? { ...SCHEMAS, ...additionalSchemas }
+    : { ...SCHEMAS };
+  const allSchemaNames = Object.keys(allSchemas);
+
   const template = new ResourceTemplate("schema:///{schemaName}", {
     list: async () => ({
-      resources: VALID_SCHEMAS.map((name) => ({
+      resources: allSchemaNames.map((name) => ({
         uri: `schema:///${name}`,
         name: `${name} schema`,
       })),
     }),
     complete: {
       schemaName: (value) =>
-        VALID_SCHEMAS.filter((s) => s.startsWith(value)),
+        allSchemaNames.filter((s) => s.startsWith(value)),
     },
   });
 
@@ -28,19 +36,19 @@ export function registerHarnessSchemaResource(server: McpServer): void {
     template,
     {
       title: "Harness Schema",
-      description: `Harness JSON Schema definitions. Valid schema names: ${VALID_SCHEMAS.join(", ")}. Use these to understand the required body format for harness_create.`,
+      description: `Harness JSON Schema definitions. Valid schema names: ${allSchemaNames.join(", ")}. Use these to understand the required body format for harness_create.`,
       mimeType: "application/schema+json",
     },
     async (uri) => {
       const schemaName = uri.pathname.replace(/^\/+/, "");
 
-      if (!isValidSchemaName(schemaName)) {
+      if (!isValidSchemaName(schemaName, allSchemaNames)) {
         throw new Error(
-          `Unknown schema '${schemaName}'. Valid schemas: ${VALID_SCHEMAS.join(", ")}`,
+          `Unknown schema '${schemaName}'. Valid schemas: ${allSchemaNames.join(", ")}`,
         );
       }
 
-      const schema = SCHEMAS[schemaName];
+      const schema = allSchemas[schemaName];
 
       return {
         contents: [
@@ -55,5 +63,3 @@ export function registerHarnessSchemaResource(server: McpServer): void {
   );
 }
 
-// Exported for testing
-export { isValidSchemaName };

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -7,8 +7,8 @@ import { registerPipelineYamlResource } from "./pipeline-yaml.js";
 import { registerExecutionSummaryResource } from "./execution-summary.js";
 import { registerHarnessSchemaResource } from "./harness-schema.js";
 
-export function registerAllResources(server: McpServer, registry: Registry, client: HarnessClient, config: Config): void {
+export function registerAllResources(server: McpServer, registry: Registry, client: HarnessClient, config: Config, additionalSchemas?: Record<string, Record<string, any>>): void {
   registerPipelineYamlResource(server, registry, client, config);
   registerExecutionSummaryResource(server, registry, client, config);
-  registerHarnessSchemaResource(server);
+  registerHarnessSchemaResource(server, additionalSchemas);
 }

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -6,8 +6,9 @@ import type { Config } from "../config.js";
 import { registerPipelineYamlResource } from "./pipeline-yaml.js";
 import { registerExecutionSummaryResource } from "./execution-summary.js";
 import { registerHarnessSchemaResource } from "./harness-schema.js";
+import type { SchemaEntry } from "../data/schemas/index.js";
 
-export function registerAllResources(server: McpServer, registry: Registry, client: HarnessClient, config: Config, additionalSchemas?: Record<string, Record<string, any>>): void {
+export function registerAllResources(server: McpServer, registry: Registry, client: HarnessClient, config: Config, additionalSchemas?: Record<string, SchemaEntry>): void {
   registerPipelineYamlResource(server, registry, client, config);
   registerExecutionSummaryResource(server, registry, client, config);
   registerHarnessSchemaResource(server, additionalSchemas);

--- a/src/tools/harness-schema.ts
+++ b/src/tools/harness-schema.ts
@@ -124,8 +124,14 @@ function getSummary(schema: Record<string, unknown>, resourceType: string): Reco
   };
 }
 
-export function registerSchemaTool(server: McpServer): void {
-  const availableSchemas = VALID_SCHEMAS;
+export function registerSchemaTool(
+  server: McpServer,
+  additionalSchemas?: Record<string, Record<string, any>>,
+): void {
+  const allSchemas: Record<string, Record<string, any>> = additionalSchemas
+    ? { ...SCHEMAS, ...additionalSchemas }
+    : { ...SCHEMAS };
+  const availableSchemas = Object.keys(allSchemas);
 
   server.registerTool(
     "harness_schema",
@@ -213,7 +219,7 @@ export function registerSchemaTool(server: McpServer): void {
           return errorResult("resource_type is required for schema lookups. Use example_search to search examples without specifying a resource type.");
         }
 
-        const schema = SCHEMAS[args.resource_type as keyof typeof SCHEMAS] as Record<string, unknown>;
+        const schema = allSchemas[args.resource_type] as Record<string, unknown>;
 
         // No path → return summary with available examples
         if (!args.path) {

--- a/src/tools/harness-schema.ts
+++ b/src/tools/harness-schema.ts
@@ -128,6 +128,13 @@ export function registerSchemaTool(
   server: McpServer,
   additionalSchemas?: Record<string, Record<string, any>>,
 ): void {
+  if (additionalSchemas) {
+    for (const key of Object.keys(additionalSchemas)) {
+      if (key in SCHEMAS) {
+        log.warn(`additionalSchemas key '${key}' overrides a built-in schema`);
+      }
+    }
+  }
   const allSchemas: Record<string, Record<string, any>> = additionalSchemas
     ? { ...SCHEMAS, ...additionalSchemas }
     : { ...SCHEMAS };

--- a/src/tools/harness-schema.ts
+++ b/src/tools/harness-schema.ts
@@ -2,7 +2,7 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { createLogger } from "../utils/logger.js";
-import { SCHEMAS, VALID_SCHEMAS } from "../data/schemas/index.js";
+import { SCHEMAS, VALID_SCHEMAS, type SchemaEntry } from "../data/schemas/index.js";
 import { getExample, searchExamples, getExamplesForResource } from "../data/examples/index.js";
 
 const log = createLogger("tool:harness-schema");
@@ -129,7 +129,7 @@ function getSummary(schema: Record<string, unknown>, resourceType: string): Reco
 
 export function registerSchemaTool(
   server: McpServer,
-  additionalSchemas?: Record<string, Record<string, any>>,
+  additionalSchemas?: Record<string, SchemaEntry>,
 ): void {
   if (additionalSchemas) {
     for (const key of Object.keys(additionalSchemas)) {
@@ -139,7 +139,7 @@ export function registerSchemaTool(
     }
   }
   const allSchemas: Record<string, Record<string, any>> = additionalSchemas
-    ? { ...SCHEMAS, ...additionalSchemas }
+    ? { ...SCHEMAS, ...Object.fromEntries(Object.entries(additionalSchemas).map(([k, v]) => [k, v.schema])) }
     : { ...SCHEMAS };
   const availableSchemas = Object.keys(allSchemas);
 

--- a/src/tools/harness-schema.ts
+++ b/src/tools/harness-schema.ts
@@ -96,10 +96,13 @@ function navigateToPath(
  */
 function getSummary(schema: Record<string, unknown>, resourceType: string): Record<string, unknown> {
   const definitions = schema.definitions as Record<string, Record<string, unknown>> | undefined;
-  const sections = definitions ? Object.keys(definitions[resourceType] ?? {}) : [];
 
-  // Get the root resource definition
-  const rootDef = definitions?.[resourceType]?.[resourceType] as Record<string, unknown> | undefined;
+  // Harness-generated schemas nest the root definition under definitions[type][type].
+  // Plain JSON Schemas (extension schemas) place properties at the root level.
+  const harnessRootDef = definitions?.[resourceType]?.[resourceType] as Record<string, unknown> | undefined;
+  const rootDef = harnessRootDef ?? (schema.properties ? schema : undefined) as Record<string, unknown> | undefined;
+
+  const sections = definitions ? Object.keys(definitions[resourceType] ?? {}) : [];
   const properties = rootDef?.properties as Record<string, unknown> | undefined;
   const required = rootDef?.required as string[] | undefined;
 
@@ -131,7 +134,7 @@ export function registerSchemaTool(
   if (additionalSchemas) {
     for (const key of Object.keys(additionalSchemas)) {
       if (key in SCHEMAS) {
-        log.warn(`additionalSchemas key '${key}' overrides a built-in schema`);
+        throw new Error(`additionalSchemas key '${key}' conflicts with a built-in schema name`);
       }
     }
   }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -17,7 +17,7 @@ import { registerSchemaTool } from "./harness-schema.js";
 import "../data/examples/load-all.js";
 
 
-export function registerAllTools(server: McpServer, registry: Registry, client: HarnessClient, config: Config): void {
+export function registerAllTools(server: McpServer, registry: Registry, client: HarnessClient, config: Config, additionalSchemas?: Record<string, Record<string, any>>): void {
   registerListTool(server, registry, client);
   registerGetTool(server, registry, client);
   registerCreateTool(server, registry, client);
@@ -28,5 +28,5 @@ export function registerAllTools(server: McpServer, registry: Registry, client: 
   registerSearchTool(server, registry, client);
   registerDescribeTool(server, registry);
   registerStatusTool(server, registry, client, config);
-  registerSchemaTool(server);
+  registerSchemaTool(server, additionalSchemas);
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -14,10 +14,11 @@ import { registerSearchTool } from "./harness-search.js";
 import { registerDescribeTool } from "./harness-describe.js";
 import { registerStatusTool } from "./harness-status.js";
 import { registerSchemaTool } from "./harness-schema.js";
+import type { SchemaEntry } from "../data/schemas/index.js";
 import "../data/examples/load-all.js";
 
 
-export function registerAllTools(server: McpServer, registry: Registry, client: HarnessClient, config: Config, additionalSchemas?: Record<string, Record<string, any>>): void {
+export function registerAllTools(server: McpServer, registry: Registry, client: HarnessClient, config: Config, additionalSchemas?: Record<string, SchemaEntry>): void {
   registerListTool(server, registry, client);
   registerGetTool(server, registry, client);
   registerCreateTool(server, registry, client);

--- a/tests/resources/harness-schema.test.ts
+++ b/tests/resources/harness-schema.test.ts
@@ -1,5 +1,16 @@
-import { describe, it, expect } from "vitest";
-import { isValidSchemaName } from "../../src/resources/harness-schema.js";
+import { describe, it, expect, vi } from "vitest";
+import { isValidSchemaName, registerHarnessSchemaResource } from "../../src/resources/harness-schema.js";
+
+describe("registerHarnessSchemaResource collision guard", () => {
+  it("throws when additionalSchemas key collides with a built-in schema name", () => {
+    const server = {
+      registerResource: vi.fn(),
+    } as any;
+    expect(() =>
+      registerHarnessSchemaResource(server, { pipeline: { type: "object" } }),
+    ).toThrow("conflicts with a built-in schema name");
+  });
+});
 
 describe("isValidSchemaName with extension schemas", () => {
   it("returns false for an extension schema name when no extensions passed", () => {

--- a/tests/resources/harness-schema.test.ts
+++ b/tests/resources/harness-schema.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi } from "vitest";
 import { isValidSchemaName, registerHarnessSchemaResource } from "../../src/resources/harness-schema.js";
+import type { SchemaEntry } from "../../src/data/schemas/index.js";
 
 describe("registerHarnessSchemaResource collision guard", () => {
   it("throws when additionalSchemas key collides with a built-in schema name", () => {
-    const server = {
-      registerResource: vi.fn(),
-    } as any;
+    const server = { registerResource: vi.fn() } as any;
+    const e: SchemaEntry = { schema: { type: "object" }, description: "test", group: "test" };
     expect(() =>
-      registerHarnessSchemaResource(server, { pipeline: { type: "object" } }),
+      registerHarnessSchemaResource(server, { pipeline: e }),
     ).toThrow("conflicts with a built-in schema name");
   });
 });

--- a/tests/resources/harness-schema.test.ts
+++ b/tests/resources/harness-schema.test.ts
@@ -1,6 +1,22 @@
 import { describe, it, expect } from "vitest";
 import { isValidSchemaName } from "../../src/resources/harness-schema.js";
 
+describe("isValidSchemaName with extension schemas", () => {
+  it("returns false for an extension schema name when no extensions passed", () => {
+    expect(isValidSchemaName("DashboardContract")).toBe(false);
+  });
+
+  it("returns true for an extension schema name when passed in merged set", () => {
+    const mergedNames = ["pipeline", "DashboardContract"];
+    expect(isValidSchemaName("DashboardContract", mergedNames)).toBe(true);
+  });
+
+  it("returns false for unknown name even with merged set", () => {
+    const mergedNames = ["pipeline", "DashboardContract"];
+    expect(isValidSchemaName("unknown", mergedNames)).toBe(false);
+  });
+});
+
 describe("harness-schema resource", () => {
   describe("isValidSchemaName", () => {
     it("returns true for v0 schema names", () => {

--- a/tests/tools/harness-schema-tool.test.ts
+++ b/tests/tools/harness-schema-tool.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerSchemaTool } from "../../src/tools/harness-schema.js";
+
+function makeServer() {
+  return new McpServer({ name: "test", version: "0.0.0" });
+}
+
+describe("registerSchemaTool additionalSchemas", () => {
+  it("accepts additionalSchemas without throwing", () => {
+    const server = makeServer();
+    const extra = {
+      DashboardContract: { type: "object", properties: { id: { type: "string" } } },
+    };
+    expect(() => registerSchemaTool(server, extra)).not.toThrow();
+  });
+
+  it("registers without additionalSchemas (backwards compat)", () => {
+    const server = makeServer();
+    expect(() => registerSchemaTool(server)).not.toThrow();
+  });
+});

--- a/tests/tools/harness-schema-tool.test.ts
+++ b/tests/tools/harness-schema-tool.test.ts
@@ -35,7 +35,14 @@ describe("registerSchemaTool additionalSchemas", () => {
     expect(() => registerSchemaTool(server)).not.toThrow();
   });
 
-  it("handler returns extension schema content when resource_type matches additionalSchemas key", async () => {
+  it("throws when additionalSchemas key collides with a built-in schema name", () => {
+    const server = makeMcpServer();
+    expect(() =>
+      registerSchemaTool(server, { pipeline: { type: "object" } }),
+    ).toThrow("conflicts with a built-in schema name");
+  });
+
+  it("handler returns fields from a Harness-layout extension schema (definitions[type][type])", async () => {
     const server = makeMcpServer();
     const dashboardSchema = {
       definitions: {
@@ -54,7 +61,29 @@ describe("registerSchemaTool additionalSchemas", () => {
     const parsed = parseResult(result) as Record<string, unknown>;
 
     expect(parsed.resource_type).toBe("DashboardContract");
-    expect(parsed.fields).toBeDefined();
+    expect(parsed.fields).toEqual([
+      { name: "title", type: "string", required: true },
+      { name: "widgets", type: "array", required: false },
+    ]);
+  });
+
+  it("handler returns fields from a plain JSON Schema extension schema (root-level properties)", async () => {
+    const server = makeMcpServer();
+    const plainSchema = {
+      type: "object",
+      properties: { name: { type: "string" }, count: { type: "number" } },
+      required: ["name"],
+    };
+    registerSchemaTool(server, { MyExtension: plainSchema });
+
+    const result = await server.call("harness_schema", { resource_type: "MyExtension" });
+    const parsed = parseResult(result) as Record<string, unknown>;
+
+    expect(parsed.resource_type).toBe("MyExtension");
+    expect(parsed.fields).toEqual([
+      { name: "name", type: "string", required: true },
+      { name: "count", type: "number", required: false },
+    ]);
   });
 
   it("handler still returns built-in schema content when no additionalSchemas", async () => {
@@ -65,5 +94,6 @@ describe("registerSchemaTool additionalSchemas", () => {
     const parsed = parseResult(result) as Record<string, unknown>;
 
     expect(parsed.resource_type).toBe("pipeline");
+    expect(Array.isArray(parsed.fields)).toBe(true);
   });
 });

--- a/tests/tools/harness-schema-tool.test.ts
+++ b/tests/tools/harness-schema-tool.test.ts
@@ -1,14 +1,29 @@
-import { describe, it, expect } from "vitest";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { describe, it, expect, vi } from "vitest";
+import type { ToolResult } from "../../src/utils/response-formatter.js";
 import { registerSchemaTool } from "../../src/tools/harness-schema.js";
 
-function makeServer() {
-  return new McpServer({ name: "test", version: "0.0.0" });
+function makeMcpServer() {
+  const tools = new Map<string, { handler: (...args: unknown[]) => Promise<ToolResult> }>();
+  return {
+    registerTool: vi.fn((name: string, _schema: unknown, handler: (...args: unknown[]) => Promise<ToolResult>) => {
+      tools.set(name, { handler });
+    }),
+    async call(name: string, args: Record<string, unknown>): Promise<ToolResult> {
+      const tool = tools.get(name);
+      if (!tool) throw new Error(`Tool "${name}" not registered`);
+      const extra = { signal: new AbortController().signal, sendNotification: vi.fn(), _meta: {} };
+      return tool.handler(args, extra) as Promise<ToolResult>;
+    },
+  } as any;
+}
+
+function parseResult(result: ToolResult): unknown {
+  return JSON.parse(result.content[0]!.text);
 }
 
 describe("registerSchemaTool additionalSchemas", () => {
   it("accepts additionalSchemas without throwing", () => {
-    const server = makeServer();
+    const server = makeMcpServer();
     const extra = {
       DashboardContract: { type: "object", properties: { id: { type: "string" } } },
     };
@@ -16,7 +31,39 @@ describe("registerSchemaTool additionalSchemas", () => {
   });
 
   it("registers without additionalSchemas (backwards compat)", () => {
-    const server = makeServer();
+    const server = makeMcpServer();
     expect(() => registerSchemaTool(server)).not.toThrow();
+  });
+
+  it("handler returns extension schema content when resource_type matches additionalSchemas key", async () => {
+    const server = makeMcpServer();
+    const dashboardSchema = {
+      definitions: {
+        DashboardContract: {
+          DashboardContract: {
+            type: "object",
+            properties: { title: { type: "string" }, widgets: { type: "array" } },
+            required: ["title"],
+          },
+        },
+      },
+    };
+    registerSchemaTool(server, { DashboardContract: dashboardSchema });
+
+    const result = await server.call("harness_schema", { resource_type: "DashboardContract" });
+    const parsed = parseResult(result) as Record<string, unknown>;
+
+    expect(parsed.resource_type).toBe("DashboardContract");
+    expect(parsed.fields).toBeDefined();
+  });
+
+  it("handler still returns built-in schema content when no additionalSchemas", async () => {
+    const server = makeMcpServer();
+    registerSchemaTool(server);
+
+    const result = await server.call("harness_schema", { resource_type: "pipeline" });
+    const parsed = parseResult(result) as Record<string, unknown>;
+
+    expect(parsed.resource_type).toBe("pipeline");
   });
 });

--- a/tests/tools/harness-schema-tool.test.ts
+++ b/tests/tools/harness-schema-tool.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 import type { ToolResult } from "../../src/utils/response-formatter.js";
+import type { SchemaEntry } from "../../src/data/schemas/index.js";
 import { registerSchemaTool } from "../../src/tools/harness-schema.js";
+
+function entry(schema: Record<string, any>): SchemaEntry {
+  return { schema, description: "test", group: "test" };
+}
 
 function makeMcpServer() {
   const tools = new Map<string, { handler: (...args: unknown[]) => Promise<ToolResult> }>();
@@ -24,10 +29,9 @@ function parseResult(result: ToolResult): unknown {
 describe("registerSchemaTool additionalSchemas", () => {
   it("accepts additionalSchemas without throwing", () => {
     const server = makeMcpServer();
-    const extra = {
-      DashboardContract: { type: "object", properties: { id: { type: "string" } } },
-    };
-    expect(() => registerSchemaTool(server, extra)).not.toThrow();
+    expect(() =>
+      registerSchemaTool(server, { DashboardContract: entry({ type: "object", properties: { id: { type: "string" } } }) })
+    ).not.toThrow();
   });
 
   it("registers without additionalSchemas (backwards compat)", () => {
@@ -38,13 +42,13 @@ describe("registerSchemaTool additionalSchemas", () => {
   it("throws when additionalSchemas key collides with a built-in schema name", () => {
     const server = makeMcpServer();
     expect(() =>
-      registerSchemaTool(server, { pipeline: { type: "object" } }),
+      registerSchemaTool(server, { pipeline: entry({ type: "object" }) }),
     ).toThrow("conflicts with a built-in schema name");
   });
 
   it("handler returns fields from a Harness-layout extension schema (definitions[type][type])", async () => {
     const server = makeMcpServer();
-    const dashboardSchema = {
+    const dashboardSchema = entry({
       definitions: {
         DashboardContract: {
           DashboardContract: {
@@ -54,7 +58,7 @@ describe("registerSchemaTool additionalSchemas", () => {
           },
         },
       },
-    };
+    });
     registerSchemaTool(server, { DashboardContract: dashboardSchema });
 
     const result = await server.call("harness_schema", { resource_type: "DashboardContract" });
@@ -69,12 +73,13 @@ describe("registerSchemaTool additionalSchemas", () => {
 
   it("handler returns fields from a plain JSON Schema extension schema (root-level properties)", async () => {
     const server = makeMcpServer();
-    const plainSchema = {
-      type: "object",
-      properties: { name: { type: "string" }, count: { type: "number" } },
-      required: ["name"],
-    };
-    registerSchemaTool(server, { MyExtension: plainSchema });
+    registerSchemaTool(server, {
+      MyExtension: entry({
+        type: "object",
+        properties: { name: { type: "string" }, count: { type: "number" } },
+        required: ["name"],
+      }),
+    });
 
     const result = await server.call("harness_schema", { resource_type: "MyExtension" });
     const parsed = parseResult(result) as Record<string, unknown>;


### PR DESCRIPTION
## Summary

- Add optional `additionalSchemas` parameter to `registerSchemaTool()` and `registerHarnessSchemaResource()`, allowing extension servers to inject extra JSON schemas at registration time
- Add `SchemaEntry` type (`{ schema, description, group }`) as the extension API surface — typed for future use, no migration required
- Collision guard: throws if an extension schema key matches a built-in schema name (fail-loud)
- `getSummary` falls back to root-level `properties` for plain JSON Schemas, in addition to the existing Harness nested-definition layout
- `isValidSchemaName` now accepts an optional `validNames` parameter so callers with a merged schema set can validate without re-reading global state

## Motivation

The OSS package is used as a dependency by extension servers that need to surface additional JSON schemas to agents (e.g. domain-specific resource contracts). The previous global-mutation approach (`registerSchema()`) had ordering hazards and no collision protection. Parameter injection is explicit, testable, and isolated per registration.

## Test plan

- [x] `registerSchemaTool(server, { MyExt: entry({...}) })` registers without throwing
- [x] Collision with built-in name throws `"conflicts with a built-in schema name"`
- [x] Handler returns correct fields for Harness-layout extension schema (`definitions[type][type]`)
- [x] Handler returns correct fields for plain JSON Schema (root-level `properties`)
- [x] Built-in schemas (`pipeline`, etc.) still work when no `additionalSchemas` passed
- [x] `isValidSchemaName` correctly validates extension names when merged set is passed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)