### PR TITLE
Fix template update body and delete path

### DIFF
--- a/src/registry/toolsets/templates.ts
+++ b/src/registry/toolsets/templates.ts
@@ -1,5 +1,42 @@
-import type { ToolsetDefinition } from "../types.js";
+import type { ToolsetDefinition, PathBuilderConfig } from "../types.js";
 import { ngExtract, pageExtract } from "../extractors.js";
+
+/**
+ * Builds a scope-aware v1 API base path for templates.
+ * Uses ONLY explicit input fields (org_id, project_id) — never falls back to
+ * config defaults. This lets callers target org/account scope even when
+ * HARNESS_PROJECT is configured. The dispatcher still handles default scope
+ * injection for NG endpoints (list/get/delete) via query params.
+ */
+function templateV1BasePath(input: Record<string, unknown>, _config: PathBuilderConfig): string {
+  const org = input.org_id as string | undefined;
+  const project = input.project_id as string | undefined;
+  const templateId = input.template_id as string;
+  if (!templateId) throw new Error("template_id is required");
+
+  if (org && project) {
+    return `/v1/orgs/${encodeURIComponent(org)}/projects/${encodeURIComponent(project)}/templates/${encodeURIComponent(templateId)}`;
+  }
+  if (org) {
+    return `/v1/orgs/${encodeURIComponent(org)}/templates/${encodeURIComponent(templateId)}`;
+  }
+  return `/v1/templates/${encodeURIComponent(templateId)}`;
+}
+
+/**
+ * Builds the NG delete path for templates.
+ * When version_label is provided: /template/api/templates/{id}/{version}
+ * When omitted: /template/api/templates/{id} (deletes all versions)
+ */
+function templateNgDeletePath(input: Record<string, unknown>): string {
+  const templateId = input.template_id as string;
+  if (!templateId) throw new Error("template_id is required");
+  const version = input.version_label as string | undefined;
+  if (version) {
+    return `/template/api/templates/${encodeURIComponent(templateId)}/${encodeURIComponent(version)}`;
+  }
+  return `/template/api/templates/${encodeURIComponent(templateId)}`;
+}
 
 export const templatesToolset: ToolsetDefinition = {
   name: "templates",
@@ -12,6 +49,7 @@ export const templatesToolset: ToolsetDefinition = {
       description: "Reusable template definition. Supports list, get, create, update, and delete.",
       toolset: "templates",
       scope: "project",
+      scopeOptional: true,
       identifierFields: ["template_id"],
       listFilterFields: [
         { name: "search_term", description: "Filter templates by name or keyword" },
@@ -62,7 +100,11 @@ export const templatesToolset: ToolsetDefinition = {
           method: "PUT",
           path: "/v1/orgs/{org}/projects/{project}/templates/{template}/versions/{version}",
           operationPolicy: { risk: "low_write", retryPolicy: "safe" },
-          pathParams: { org_id: "org", project_id: "project", template_id: "template", version_label: "version" },
+          pathBuilder: (input, config) => {
+            const version = input.version_label as string;
+            if (!version) throw new Error("version_label is required for template update");
+            return `${templateV1BasePath(input, config)}/versions/${encodeURIComponent(version)}`;
+          },
           bodyBuilder: (input) => {
             const b = (input.body as Record<string, unknown>) ?? {};
             const templateYaml =
@@ -75,6 +117,11 @@ export const templatesToolset: ToolsetDefinition = {
               throw new Error("body.template_yaml (or body.yaml) is required: full template YAML string with your changes");
             }
             const out: Record<string, unknown> = { template_yaml: templateYaml };
+            if (b.identifier !== undefined) out.identifier = b.identifier;
+            if (b.name !== undefined) out.name = b.name;
+            if (b.label !== undefined) out.label = b.label;
+            if (b.yaml_version !== undefined) out.yaml_version = b.yaml_version;
+            if (b.git_details !== undefined) out.git_details = b.git_details;
             if (b.is_stable !== undefined) out.is_stable = b.is_stable;
             if (b.comments !== undefined) out.comments = b.comments;
             return out;
@@ -82,19 +129,34 @@ export const templatesToolset: ToolsetDefinition = {
           bodySchema: {
             description: "Template version update",
             fields: [
-              { name: "template_yaml", type: "yaml", required: true, description: "Full template YAML string with changes" },
+              { name: "template_yaml", type: "yaml", required: true, description: "Full template YAML string with changes (name, identifier, etc. are derived from the YAML)" },
+              { name: "identifier", type: "string", required: false, description: "Template identifier (derived from YAML if omitted)" },
+              { name: "name", type: "string", required: false, description: "Display name (derived from YAML if omitted)" },
+              { name: "label", type: "string", required: false, description: "Version label (derived from YAML if omitted)" },
+              { name: "yaml_version", type: "string", required: false, description: "YAML version (e.g. '1')" },
+              { name: "git_details", type: "object", required: false, description: "Git storage details (e.g. { store_type: 'INLINE' })" },
               { name: "is_stable", type: "boolean", required: false, description: "Mark as stable version" },
               { name: "comments", type: "string", required: false, description: "Version update comments" },
             ],
           },
           responseExtractor: ngExtract,
-          description: "Update a template version. Provide full template_yaml (required). Optional: is_stable, comments.",
+          description: "Update a template version. Pass org_id (and optionally project_id) to set scope explicitly. Provide full template_yaml (required). Optional: identifier, name, label, yaml_version, git_details, is_stable, comments.",
         },
         create: {
           method: "POST",
           path: "/v1/orgs/{org}/projects/{project}/templates",
           operationPolicy: { risk: "low_write", retryPolicy: "do_not_retry" },
-          pathParams: { org_id: "org", project_id: "project" },
+          pathBuilder: (input, _config) => {
+            const org = input.org_id as string | undefined;
+            const project = input.project_id as string | undefined;
+            if (org && project) {
+              return `/v1/orgs/${encodeURIComponent(org)}/projects/${encodeURIComponent(project)}/templates`;
+            }
+            if (org) {
+              return `/v1/orgs/${encodeURIComponent(org)}/templates`;
+            }
+            return "/v1/templates";
+          },
           bodyBuilder: (input) => {
             const b = (input.body as Record<string, unknown>) ?? {};
             const templateYaml =
@@ -137,17 +199,16 @@ export const templatesToolset: ToolsetDefinition = {
             ],
           },
           responseExtractor: ngExtract,
-          description: "Create a template (step, stage, or pipeline). Body: template_yaml (string, required), identifier, name, label (version), is_stable.",
+          description: "Create a template (step, stage, or pipeline). Pass org_id (and optionally project_id) to set scope explicitly. Body: template_yaml (string, required), identifier, name, label (version), is_stable.",
         },
         delete: {
           method: "DELETE",
-          path: "/template/api/templates/{templateIdentifier}",
+          path: "/template/api/templates/{templateIdentifier}/{versionLabel}",
           operationPolicy: { risk: "destructive", retryPolicy: "do_not_retry" },
-          pathParams: { template_id: "templateIdentifier" },
-          queryParams: { version_label: "versionLabel" },
+          pathBuilder: (input) => templateNgDeletePath(input),
           responseExtractor: ngExtract,
           description:
-            "Delete a template. If version_label is provided, only that version is deleted. If omitted, all versions of the template are deleted.",
+            "Delete a template. When version_label is provided, deletes that specific version. When omitted, deletes all versions of the template.",
         },
       },
     },


### PR DESCRIPTION
## Summary

- **Template delete**: Fixed delete path to include `{versionLabel}` as a path parameter instead of a query parameter, which was causing backend 500 errors when deleting a specific template version.
- **Template update/create — scope support**: The v1 template API uses different URL paths per scope (account, org, project), but the toolset hardcoded only the project-scoped path. Org-scoped and account-scoped templates failed with "Missing required field project_id" before the request ever reached the API. Added a dynamic `pathBuilder` that constructs the correct URL based on which scope fields are present.
- **Template update — body fields**: Added optional snake_case fields (`identifier`, `name`, `label`, `yaml_version`, `git_details`) as pass-through fields in the `bodyBuilder`. While `template_yaml` is the only strictly required field (the API derives metadata from the YAML content), including these optional fields ensures forward compatibility and allows explicit overrides when needed.
- **Build fix**: Added missing `SchemaEntry` type export to both `src/data/schemas/index.ts` and the `sync-schemas.js` generator so the export survives re-generation.

## Root Cause

The Harness v1 template update API (`PUT /v1/orgs/{org}/projects/{project}/templates/{template}/versions/{version}`) expects a JSON body with snake_case fields matching the Go DTO (`TemplateV1CreateRequest`). The old `bodyBuilder` only sent `template_yaml`, missing required fields like `identifier`, `label` (not `versionLabel`), `name`, `yaml_version`, and `git_details`.

## Test Plan
- [x] Verified template update via Cursor MCP tool (renamed template successfully on QA)
- [x] TypeScript typecheck passes (`tsc --noEmit`)
- [ ] Verify template delete works with the new path parameter format