### PR TITLE
fix: resource_scope fail-loud dispatch, search type filtering, Zod descriptions

### DIFF
--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -959,6 +959,7 @@ export class Registry {
           displayName: r.displayName,
           description: r.description,
           scope: r.scope,
+          supportedScopes: getSupportedScopes(r).length > 1 ? getSupportedScopes(r) : undefined,
           operations: Object.keys(r.operations),
           executeActions: r.executeActions ? Object.keys(r.executeActions) : undefined,
           identifierFields: r.identifierFields,

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { type Config, resolveProductBaseUrl } from "../config.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import { HarnessApiError } from "../utils/errors.js";
-import type { ResourceDefinition, ToolsetDefinition, ToolsetName, OperationName, EndpointSpec, FilterFieldSpec } from "./types.js";
+import type { ResourceDefinition, ToolsetDefinition, ToolsetName, OperationName, EndpointSpec, FilterFieldSpec, ResourceScope } from "./types.js";
 import type { AuditManager } from "../audit/manager.js";
 import type { AuditContext, AuditEvent } from "../audit/types.js";
 import { createLogger } from "../utils/logger.js";
@@ -47,11 +47,51 @@ const log = createLogger("registry");
 
 /** Keys under which different Harness APIs return list arrays. */
 const LIST_ARRAY_KEYS = ["items", "features", "content", "data", "objects"];
+const RESOURCE_SCOPES: readonly ResourceScope[] = ["account", "org", "project"];
 
 /** Backward-compatible aliases for renamed public toolset names. */
 const TOOLSET_ALIASES: Record<string, string> = {
   "agent-pipelines": "agents",
 };
+
+function isResourceScope(value: unknown): value is ResourceScope {
+  return typeof value === "string" && RESOURCE_SCOPES.includes(value as ResourceScope);
+}
+
+function getSupportedScopes(def: ResourceDefinition): readonly ResourceScope[] {
+  if (def.supportedScopes?.length) {
+    return def.supportedScopes;
+  }
+  if (def.scopeOptional) {
+    return RESOURCE_SCOPES;
+  }
+  return [def.scope];
+}
+
+function getRequestedScope(def: ResourceDefinition, input: Record<string, unknown>): ResourceScope | undefined {
+  const value = input.scope;
+  if (value === undefined || value === "") {
+    return undefined;
+  }
+  if (!isResourceScope(value)) {
+    throw new Error(`Invalid scope "${String(value)}". Expected one of: ${RESOURCE_SCOPES.join(", ")}`);
+  }
+  const supported = getSupportedScopes(def);
+  if (!supported.includes(value)) {
+    throw new Error(
+      `${def.resourceType} does not support ${value} scope. Supported scopes: ${supported.join(", ")}`,
+    );
+  }
+  return value;
+}
+
+function shouldUseOrg(scope: ResourceScope): boolean {
+  return scope === "org" || scope === "project";
+}
+
+function shouldUseProject(scope: ResourceScope): boolean {
+  return scope === "project";
+}
 
 const ALL_TOOLSETS: ToolsetDefinition[] = [
   pipelinesToolset,
@@ -389,6 +429,7 @@ export class Registry {
     httpStatus?: number,
   ): void {
     if (!this.auditManager) return;
+    const auditScope = isResourceScope(input.scope) ? input.scope : undefined;
 
     // Resolve path using pathBuilder if present, otherwise use static path
     const resolvedPath = spec.pathBuilder
@@ -403,12 +444,20 @@ export class Registry {
       resource_type: resourceType,
       resource_id: auditCtx?.resource_id ?? (input.resource_id as string | undefined),
       action: auditCtx?.action,
-      org_id: def.scope === "account"
-        ? undefined
-        : (input.org_id as string | undefined) ?? (def.scopeOptional ? undefined : this.config.HARNESS_ORG),
-      project_id: def.scope === "account" || def.scope === "org"
-        ? undefined
-        : (input.project_id as string | undefined) ?? (def.scopeOptional ? undefined : this.config.HARNESS_PROJECT),
+      org_id: auditScope
+        ? shouldUseOrg(auditScope)
+          ? (input.org_id as string | undefined) ?? this.config.HARNESS_ORG
+          : undefined
+        : def.scope === "account"
+          ? undefined
+          : (input.org_id as string | undefined) ?? (def.scopeOptional ? undefined : this.config.HARNESS_ORG),
+      project_id: auditScope
+        ? shouldUseProject(auditScope)
+          ? (input.project_id as string | undefined) ?? this.config.HARNESS_PROJECT
+          : undefined
+        : def.scope === "account" || def.scope === "org"
+          ? undefined
+          : (input.project_id as string | undefined) ?? (def.scopeOptional ? undefined : this.config.HARNESS_PROJECT),
       account_id: this.getAccountId(),
       risk: spec.operationPolicy?.risk ?? "read",
       confirmation: auditCtx?.confirmation,
@@ -432,6 +481,8 @@ export class Registry {
   ): Promise<unknown> {
     const resolvedAccountId = this.getAccountId();
     const resolvedConfig: Config = { ...this.config, HARNESS_ACCOUNT_ID: resolvedAccountId };
+    const requestedScope = getRequestedScope(def, input);
+    const pathDefaultScope = requestedScope ?? def.scope;
 
     // Run preflight hook (e.g. duplicate-check before create) before hitting the API.
     if (spec.preflight) {
@@ -449,15 +500,16 @@ export class Registry {
           let value = input[inputKey];
           if (value === undefined || value === "") {
             // Default scope placeholders from config for project/org-scoped resources
-            if (pathPlaceholder === "org" && (def.scope === "project" || def.scope === "org")) {
+            if (pathPlaceholder === "org" && shouldUseOrg(pathDefaultScope)) {
               value = this.config.HARNESS_ORG;
-            } else if (pathPlaceholder === "project" && def.scope === "project") {
+            } else if (pathPlaceholder === "project" && shouldUseProject(pathDefaultScope)) {
               value = this.config.HARNESS_PROJECT;
             }
           }
           if (value === undefined || value === "") {
-            const scopeHint = def.scopeOptional
-              ? ` This resource supports account/org/project scope — pass "${inputKey}" via params, or use a Harness URL.`
+            const supportedScopes = getSupportedScopes(def);
+            const scopeHint = supportedScopes.length > 1
+              ? ` This resource supports ${supportedScopes.join("/")} scope — pass "${inputKey}" via params, set scope appropriately, or use a Harness URL.`
               : "";
             throw new Error(
               `Missing required field "${inputKey}" for ${def.resourceType}.${scopeHint}`,
@@ -476,8 +528,16 @@ export class Registry {
     // Otherwise, fall back to config defaults based on the resource's scope level.
     const orgParam = def.scopeParams?.org ?? "orgIdentifier";
     const projectParam = def.scopeParams?.project ?? "projectIdentifier";
-    if (def.scopeOptional) {
-      // Dynamic scoping: only inject when caller explicitly provides them
+    if (requestedScope) {
+      // Explicit scoping: account omits org/project, org injects org only, project injects both.
+      if (shouldUseOrg(requestedScope)) {
+        params[orgParam] = (input.org_id as string) ?? this.config.HARNESS_ORG;
+      }
+      if (shouldUseProject(requestedScope)) {
+        params[projectParam] = (input.project_id as string) ?? this.config.HARNESS_PROJECT;
+      }
+    } else if (def.scopeOptional) {
+      // Dynamic scoping: only inject when caller explicitly provides them.
       if (input.org_id) {
         params[orgParam] = input.org_id as string;
       }

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -93,6 +93,10 @@ function shouldUseProject(scope: ResourceScope): boolean {
   return scope === "project";
 }
 
+function hasResolvedScopeIdentifier(value: string | undefined): boolean {
+  return value !== undefined && value !== null && String(value).trim() !== "";
+}
+
 const ALL_TOOLSETS: ToolsetDefinition[] = [
   pipelinesToolset,
   agentsToolset,
@@ -315,6 +319,16 @@ export class Registry {
     return def?.operations[operation] !== undefined;
   }
 
+  /**
+   * True when the resource type accepts the given dispatcher `resource_scope`
+   * (account / org / project) for list/get/execute calls.
+   */
+  supportsResourceScope(resourceType: string, scope: ResourceScope): boolean {
+    const def = this.resourceMap.get(resourceType);
+    if (!def) return false;
+    return getSupportedScopes(def).includes(scope);
+  }
+
   /** Check if a resource type has execute actions. */
   getExecuteActions(resourceType: string): Record<string, EndpointSpec & { actionDescription: string }> | undefined {
     const def = this.resourceMap.get(resourceType);
@@ -483,6 +497,22 @@ export class Registry {
     const resolvedConfig: Config = { ...this.config, HARNESS_ACCOUNT_ID: resolvedAccountId };
     const requestedScope = getRequestedScope(def, input);
     const pathDefaultScope = requestedScope ?? def.scope;
+
+    // Explicit resource_scope must not widen when org/project identifiers are missing.
+    if (requestedScope) {
+      const orgResolved = (input.org_id as string | undefined) ?? this.config.HARNESS_ORG;
+      const projectResolved = (input.project_id as string | undefined) ?? this.config.HARNESS_PROJECT;
+      if (shouldUseOrg(requestedScope) && !hasResolvedScopeIdentifier(orgResolved)) {
+        throw new Error(
+          `resource_scope "${requestedScope}" requires an organization identifier. Pass org_id or configure HARNESS_ORG.`,
+        );
+      }
+      if (shouldUseProject(requestedScope) && !hasResolvedScopeIdentifier(projectResolved)) {
+        throw new Error(
+          `resource_scope "project" requires a project identifier. Pass project_id or configure HARNESS_PROJECT.`,
+        );
+      }
+    }
 
     // Run preflight hook (e.g. duplicate-check before create) before hitting the API.
     if (spec.preflight) {

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -69,12 +69,12 @@ function getSupportedScopes(def: ResourceDefinition): readonly ResourceScope[] {
 }
 
 function getRequestedScope(def: ResourceDefinition, input: Record<string, unknown>): ResourceScope | undefined {
-  const value = input.scope;
+  const value = input.resource_scope;
   if (value === undefined || value === "") {
     return undefined;
   }
   if (!isResourceScope(value)) {
-    throw new Error(`Invalid scope "${String(value)}". Expected one of: ${RESOURCE_SCOPES.join(", ")}`);
+    throw new Error(`Invalid resource_scope "${String(value)}". Expected one of: ${RESOURCE_SCOPES.join(", ")}`);
   }
   const supported = getSupportedScopes(def);
   if (!supported.includes(value)) {
@@ -429,7 +429,7 @@ export class Registry {
     httpStatus?: number,
   ): void {
     if (!this.auditManager) return;
-    const auditScope = isResourceScope(input.scope) ? input.scope : undefined;
+    const auditScope = isResourceScope(input.resource_scope) ? input.resource_scope : undefined;
 
     // Resolve path using pathBuilder if present, otherwise use static path
     const resolvedPath = spec.pathBuilder
@@ -509,7 +509,7 @@ export class Registry {
           if (value === undefined || value === "") {
             const supportedScopes = getSupportedScopes(def);
             const scopeHint = supportedScopes.length > 1
-              ? ` This resource supports ${supportedScopes.join("/")} scope — pass "${inputKey}" via params, set scope appropriately, or use a Harness URL.`
+              ? ` This resource supports ${supportedScopes.join("/")} scope — pass "${inputKey}" via params, set resource_scope appropriately, or use a Harness URL.`
               : "";
             throw new Error(
               `Missing required field "${inputKey}" for ${def.resourceType}.${scopeHint}`,
@@ -529,7 +529,7 @@ export class Registry {
     const orgParam = def.scopeParams?.org ?? "orgIdentifier";
     const projectParam = def.scopeParams?.project ?? "projectIdentifier";
     if (requestedScope) {
-      // Explicit scoping: account omits org/project, org injects org only, project injects both.
+      // Explicit resource scoping: account omits org/project, org injects org only, project injects both.
       if (shouldUseOrg(requestedScope)) {
         params[orgParam] = (input.org_id as string) ?? this.config.HARNESS_ORG;
       }

--- a/src/registry/toolsets/connectors.ts
+++ b/src/registry/toolsets/connectors.ts
@@ -34,7 +34,7 @@ export const connectorsToolset: ToolsetDefinition = {
     {
       resourceType: "connector",
       displayName: "Connector",
-      description: "External integration connector. Supports full CRUD and test_connection. Use scope='account' to list or get account-level connectors.",
+      description: "External integration connector. Supports full CRUD and test_connection. Use resource_scope='account' to list or get account-level connectors.",
       toolset: "connectors",
       scope: "project",
       supportedScopes: ["account", "org", "project"],

--- a/src/registry/toolsets/connectors.ts
+++ b/src/registry/toolsets/connectors.ts
@@ -34,9 +34,10 @@ export const connectorsToolset: ToolsetDefinition = {
     {
       resourceType: "connector",
       displayName: "Connector",
-      description: "External integration connector. Supports full CRUD and test_connection.",
+      description: "External integration connector. Supports full CRUD and test_connection. Use scope='account' to list or get account-level connectors.",
       toolset: "connectors",
       scope: "project",
+      supportedScopes: ["account", "org", "project"],
       identifierFields: ["connector_id"],
       diagnosticHint: "Use harness_diagnose with resource_id set to the connector identifier to run a live connectivity test and get auth method, status history, and error details.",
       listFilterFields: [

--- a/src/registry/toolsets/environments.ts
+++ b/src/registry/toolsets/environments.ts
@@ -33,7 +33,7 @@ export const environmentsToolset: ToolsetDefinition = {
     {
       resourceType: "environment",
       displayName: "Environment",
-      description: "Deployment target environment. Supports full CRUD. Use scope='account' to list or get account-level environments.",
+      description: "Deployment target environment. Supports full CRUD. Use resource_scope='account' to list or get account-level environments.",
       toolset: "environments",
       scope: "project",
       supportedScopes: ["account", "org", "project"],

--- a/src/registry/toolsets/environments.ts
+++ b/src/registry/toolsets/environments.ts
@@ -33,9 +33,10 @@ export const environmentsToolset: ToolsetDefinition = {
     {
       resourceType: "environment",
       displayName: "Environment",
-      description: "Deployment target environment. Supports full CRUD.",
+      description: "Deployment target environment. Supports full CRUD. Use scope='account' to list or get account-level environments.",
       toolset: "environments",
       scope: "project",
+      supportedScopes: ["account", "org", "project"],
       identifierFields: ["environment_id"],
       listFilterFields: [
         { name: "search_term", description: "Filter environments by name or keyword" },

--- a/src/registry/toolsets/infrastructure.ts
+++ b/src/registry/toolsets/infrastructure.ts
@@ -9,7 +9,7 @@ export const infrastructureToolset: ToolsetDefinition = {
     {
       resourceType: "infrastructure",
       displayName: "Infrastructure Definition",
-      description: "Infrastructure definition within an environment. Supports full CRUD. Use scope='account' to list or get account-level infrastructure definitions.",
+      description: "Infrastructure definition within an environment. Supports full CRUD. Use resource_scope='account' to list or get account-level infrastructure definitions.",
       toolset: "infrastructure",
       scope: "project",
       supportedScopes: ["account", "org", "project"],

--- a/src/registry/toolsets/infrastructure.ts
+++ b/src/registry/toolsets/infrastructure.ts
@@ -9,9 +9,10 @@ export const infrastructureToolset: ToolsetDefinition = {
     {
       resourceType: "infrastructure",
       displayName: "Infrastructure Definition",
-      description: "Infrastructure definition within an environment. Supports full CRUD.",
+      description: "Infrastructure definition within an environment. Supports full CRUD. Use scope='account' to list or get account-level infrastructure definitions.",
       toolset: "infrastructure",
       scope: "project",
+      supportedScopes: ["account", "org", "project"],
       identifierFields: ["infrastructure_id"],
       listFilterFields: [
         { name: "environment_id", description: "**Required.** Environment identifier — infrastructure is always scoped to an environment" },

--- a/src/registry/toolsets/secrets.ts
+++ b/src/registry/toolsets/secrets.ts
@@ -9,7 +9,7 @@ export const secretsToolset: ToolsetDefinition = {
     {
       resourceType: "secret",
       displayName: "Secret",
-      description: "Secret metadata (name, type, scope). Values are NEVER returned. Read-only. Use scope='account' to list or get account-level secret metadata.",
+      description: "Secret metadata (name, type, scope). Values are NEVER returned. Read-only. Use resource_scope='account' to list or get account-level secret metadata.",
       toolset: "secrets",
       scope: "project",
       supportedScopes: ["account", "org", "project"],

--- a/src/registry/toolsets/secrets.ts
+++ b/src/registry/toolsets/secrets.ts
@@ -9,9 +9,10 @@ export const secretsToolset: ToolsetDefinition = {
     {
       resourceType: "secret",
       displayName: "Secret",
-      description: "Secret metadata (name, type, scope). Values are NEVER returned. Read-only.",
+      description: "Secret metadata (name, type, scope). Values are NEVER returned. Read-only. Use scope='account' to list or get account-level secret metadata.",
       toolset: "secrets",
       scope: "project",
+      supportedScopes: ["account", "org", "project"],
       identifierFields: ["secret_id"],
       listFilterFields: [
         { name: "search_term", description: "Filter secrets by name or keyword" },

--- a/src/registry/toolsets/services.ts
+++ b/src/registry/toolsets/services.ts
@@ -31,9 +31,10 @@ export const servicesToolset: ToolsetDefinition = {
     {
       resourceType: "service",
       displayName: "Service",
-      description: "Deployable service/workload definition. Supports full CRUD.",
+      description: "Deployable service/workload definition. Supports full CRUD. Use scope='account' to list or get account-level services.",
       toolset: "services",
       scope: "project",
+      supportedScopes: ["account", "org", "project"],
       identifierFields: ["service_id"],
       listFilterFields: [
         { name: "search_term", description: "Filter services by name or keyword" },

--- a/src/registry/toolsets/services.ts
+++ b/src/registry/toolsets/services.ts
@@ -31,7 +31,7 @@ export const servicesToolset: ToolsetDefinition = {
     {
       resourceType: "service",
       displayName: "Service",
-      description: "Deployable service/workload definition. Supports full CRUD. Use scope='account' to list or get account-level services.",
+      description: "Deployable service/workload definition. Supports full CRUD. Use resource_scope='account' to list or get account-level services.",
       toolset: "services",
       scope: "project",
       supportedScopes: ["account", "org", "project"],

--- a/src/registry/toolsets/templates.ts
+++ b/src/registry/toolsets/templates.ts
@@ -9,9 +9,10 @@ export const templatesToolset: ToolsetDefinition = {
     {
       resourceType: "template",
       displayName: "Template",
-      description: "Reusable template definition. Supports list, get, create, update, and delete.",
+      description: "Reusable template definition. Supports list, get, create, update, and delete. Use scope='account' to list or get account-level templates.",
       toolset: "templates",
       scope: "project",
+      supportedScopes: ["account", "org", "project"],
       identifierFields: ["template_id"],
       listFilterFields: [
         { name: "search_term", description: "Filter templates by name or keyword" },

--- a/src/registry/toolsets/templates.ts
+++ b/src/registry/toolsets/templates.ts
@@ -9,7 +9,7 @@ export const templatesToolset: ToolsetDefinition = {
     {
       resourceType: "template",
       displayName: "Template",
-      description: "Reusable template definition. Supports list, get, create, update, and delete. Use scope='account' to list or get account-level templates.",
+      description: "Reusable template definition. Supports list, get, create, update, and delete. Use resource_scope='account' to list or get account-level templates.",
       toolset: "templates",
       scope: "project",
       supportedScopes: ["account", "org", "project"],

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -142,6 +142,7 @@ export type ToolsetName =
 export type ProductName = "harness" | "fme";
 
 export type OperationName = "list" | "get" | "create" | "update" | "delete";
+export type ResourceScope = "project" | "org" | "account";
 
 /**
  * Lightweight field descriptor for body schemas.
@@ -312,8 +313,13 @@ export interface ResourceDefinition {
   description: string;
   /** Which toolset this resource belongs to (for HARNESS_TOOLSETS filtering) */
   toolset: string;
-  /** Scope level: "project" | "org" | "account" */
-  scope: "project" | "org" | "account";
+  /** Default scope level: "project" | "org" | "account" */
+  scope: ResourceScope;
+  /**
+   * Scopes this resource can query when the caller passes `scope`.
+   * If omitted, the resource supports only its default `scope`.
+   */
+  supportedScopes?: readonly ResourceScope[];
   /**
    * When true, org/project params are only added if explicitly provided in input.
    * Use for resources that support multiple scopes (e.g., Harness Code repos/PRs

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -316,7 +316,7 @@ export interface ResourceDefinition {
   /** Default scope level: "project" | "org" | "account" */
   scope: ResourceScope;
   /**
-   * Scopes this resource can query when the caller passes `scope`.
+   * Scopes this resource can query when the caller passes `resource_scope`.
    * If omitted, the resource supports only its default `scope`.
    */
   supportedScopes?: readonly ResourceScope[];

--- a/src/tools/harness-describe.ts
+++ b/src/tools/harness-describe.ts
@@ -39,7 +39,7 @@ export function registerDescribeTool(server: McpServer, registry: Registry): voi
             scope: def.scope,
             supportedScopes,
             scopeHint: supportedScopes && supportedScopes.length > 1
-              ? "Set scope='account' for account-level data, scope='org' for org-level data, or scope='project' for project-level data. If scope is omitted, the resource uses its default scope and configured defaults."
+              ? "Set resource_scope='account' for account-level data, resource_scope='org' for org-level data, or resource_scope='project' for project-level data. If resource_scope is omitted, the resource uses its default scope and configured defaults."
               : undefined,
             identifierFields: def.identifierFields,
             listFilterFields: def.listFilterFields,

--- a/src/tools/harness-describe.ts
+++ b/src/tools/harness-describe.ts
@@ -28,12 +28,19 @@ export function registerDescribeTool(server: McpServer, registry: Registry): voi
       if (args.resource_type) {
         try {
           const def = registry.getResource(args.resource_type);
+          const supportedScopes = def.supportedScopes ?? (
+            def.scopeOptional ? ["account", "org", "project"] : undefined
+          );
           return jsonResult({
             resource_type: def.resourceType,
             displayName: def.displayName,
             description: def.description,
             toolset: def.toolset,
             scope: def.scope,
+            supportedScopes,
+            scopeHint: supportedScopes && supportedScopes.length > 1
+              ? "Set scope='account' for account-level data, scope='org' for org-level data, or scope='project' for project-level data. If scope is omitted, the resource uses its default scope and configured defaults."
+              : undefined,
             identifierFields: def.identifierFields,
             listFilterFields: def.listFilterFields,
             operations: Object.entries(def.operations).map(([op, spec]) => ({

--- a/src/tools/harness-get.ts
+++ b/src/tools/harness-get.ts
@@ -21,6 +21,7 @@ export function registerGetTool(server: McpServer, registry: Registry, client: H
         resource_type: resourceTypeSchema(gettableTypes).optional().describe("Resource type to retrieve. Auto-detected from url."),
         resource_id: z.string().describe("Primary resource identifier. Auto-detected from url.").optional(),
         url: z.string().describe("Harness UI URL — auto-extracts org, project, type, and ID").optional(),
+        scope: z.enum(["account", "org", "project"]).describe("Scope to query. Use account for account-level resources and to omit org/project defaults; org injects only org; project injects org+project. Auto-detected from url.").optional(),
         org_id: z.string().describe("Organization identifier (overrides default)").optional(),
         project_id: z.string().describe("Project identifier (overrides default)").optional(),
         params: z.record(z.string(), z.unknown()).describe("Additional identifiers for nested resources. Call harness_describe for fields per resource_type.").optional(),

--- a/src/tools/harness-get.ts
+++ b/src/tools/harness-get.ts
@@ -21,7 +21,7 @@ export function registerGetTool(server: McpServer, registry: Registry, client: H
         resource_type: resourceTypeSchema(gettableTypes).optional().describe("Resource type to retrieve. Auto-detected from url."),
         resource_id: z.string().describe("Primary resource identifier. Auto-detected from url.").optional(),
         url: z.string().describe("Harness UI URL — auto-extracts org, project, type, and ID").optional(),
-        resource_scope: z.enum(["account", "org", "project"]).describe("Scope to query. Use account for account-level resources and to omit org/project defaults; org injects only org; project injects org+project. Auto-detected from url.").optional(),
+        resource_scope: z.enum(["account", "org", "project"]).optional().describe("Scope to query. Use account for account-level resources and to omit org/project defaults; org injects only org; project injects org+project. Auto-detected from url."),
         org_id: z.string().describe("Organization identifier (overrides default)").optional(),
         project_id: z.string().describe("Project identifier (overrides default)").optional(),
         params: z.record(z.string(), z.unknown()).describe("Additional identifiers for nested resources. Call harness_describe for fields per resource_type.").optional(),

--- a/src/tools/harness-get.ts
+++ b/src/tools/harness-get.ts
@@ -21,7 +21,7 @@ export function registerGetTool(server: McpServer, registry: Registry, client: H
         resource_type: resourceTypeSchema(gettableTypes).optional().describe("Resource type to retrieve. Auto-detected from url."),
         resource_id: z.string().describe("Primary resource identifier. Auto-detected from url.").optional(),
         url: z.string().describe("Harness UI URL — auto-extracts org, project, type, and ID").optional(),
-        scope: z.enum(["account", "org", "project"]).describe("Scope to query. Use account for account-level resources and to omit org/project defaults; org injects only org; project injects org+project. Auto-detected from url.").optional(),
+        resource_scope: z.enum(["account", "org", "project"]).describe("Scope to query. Use account for account-level resources and to omit org/project defaults; org injects only org; project injects org+project. Auto-detected from url.").optional(),
         org_id: z.string().describe("Organization identifier (overrides default)").optional(),
         project_id: z.string().describe("Project identifier (overrides default)").optional(),
         params: z.record(z.string(), z.unknown()).describe("Additional identifiers for nested resources. Call harness_describe for fields per resource_type.").optional(),

--- a/src/tools/harness-list.ts
+++ b/src/tools/harness-list.ts
@@ -30,7 +30,7 @@ export function registerListTool(server: McpServer, registry: Registry, client: 
       inputSchema: {
         resource_type: resourceTypeSchema(listableTypes).optional().describe("Resource type to list. Auto-detected from url."),
         url: z.string().describe("Harness UI URL — auto-extracts org, project, and type").optional(),
-        resource_scope: z.enum(["account", "org", "project"]).describe("Scope to query. Use account for account-level resources and to omit org/project defaults; org injects only org; project injects org+project. Auto-detected from url.").optional(),
+        resource_scope: z.enum(["account", "org", "project"]).optional().describe("Scope to query. Use account for account-level resources and to omit org/project defaults; org injects only org; project injects org+project. Auto-detected from url."),
         org_id: z.string().describe("Organization identifier (overrides default)").optional(),
         project_id: z.string().describe("Project identifier (overrides default)").optional(),
         page: z.number().describe("Page number, 0-indexed").default(0).optional(),

--- a/src/tools/harness-list.ts
+++ b/src/tools/harness-list.ts
@@ -30,6 +30,7 @@ export function registerListTool(server: McpServer, registry: Registry, client: 
       inputSchema: {
         resource_type: resourceTypeSchema(listableTypes).optional().describe("Resource type to list. Auto-detected from url."),
         url: z.string().describe("Harness UI URL — auto-extracts org, project, and type").optional(),
+        scope: z.enum(["account", "org", "project"]).describe("Scope to query. Use account for account-level resources and to omit org/project defaults; org injects only org; project injects org+project. Auto-detected from url.").optional(),
         org_id: z.string().describe("Organization identifier (overrides default)").optional(),
         project_id: z.string().describe("Project identifier (overrides default)").optional(),
         page: z.number().describe("Page number, 0-indexed").default(0).optional(),

--- a/src/tools/harness-list.ts
+++ b/src/tools/harness-list.ts
@@ -30,7 +30,7 @@ export function registerListTool(server: McpServer, registry: Registry, client: 
       inputSchema: {
         resource_type: resourceTypeSchema(listableTypes).optional().describe("Resource type to list. Auto-detected from url."),
         url: z.string().describe("Harness UI URL — auto-extracts org, project, and type").optional(),
-        scope: z.enum(["account", "org", "project"]).describe("Scope to query. Use account for account-level resources and to omit org/project defaults; org injects only org; project injects org+project. Auto-detected from url.").optional(),
+        resource_scope: z.enum(["account", "org", "project"]).describe("Scope to query. Use account for account-level resources and to omit org/project defaults; org injects only org; project injects org+project. Auto-detected from url.").optional(),
         org_id: z.string().describe("Organization identifier (overrides default)").optional(),
         project_id: z.string().describe("Project identifier (overrides default)").optional(),
         page: z.number().describe("Page number, 0-indexed").default(0).optional(),

--- a/src/tools/harness-search.ts
+++ b/src/tools/harness-search.ts
@@ -46,6 +46,7 @@ export function registerSearchTool(server: McpServer, registry: Registry, client
         query: z.string().describe("Search term"),
         resource_types: z.array(z.enum(listableTypes)).describe("Types to search (defaults to all listable)").optional(),
         url: z.string().describe("Harness UI URL — auto-extracts org and project").optional(),
+        resource_scope: z.enum(["account", "org", "project"]).describe("Scope to search. Use account for account-level resources and to omit org/project defaults; org injects only org; project injects org+project. Auto-detected from url.").optional(),
         org_id: z.string().describe("Organization identifier (overrides default)").optional(),
         project_id: z.string().describe("Project identifier (overrides default)").optional(),
         max_per_type: z.number().describe("Max results per type").default(5).optional(),

--- a/src/tools/harness-search.ts
+++ b/src/tools/harness-search.ts
@@ -1,6 +1,7 @@
 import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
+import type { ResourceScope } from "../registry/types.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { isUserError, isUserFixableApiError, toMcpError } from "../utils/errors.js";
@@ -26,6 +27,12 @@ function getTier(resourceType: string): number {
   return RELEVANCE_TIERS[resourceType] ?? 3;
 }
 
+function parseResourceScope(value: unknown): ResourceScope | undefined {
+  if (value === undefined || value === "") return undefined;
+  if (value === "account" || value === "org" || value === "project") return value;
+  return undefined;
+}
+
 interface SearchResultEntry {
   resource_type: string;
   tier: number;
@@ -46,7 +53,7 @@ export function registerSearchTool(server: McpServer, registry: Registry, client
         query: z.string().describe("Search term"),
         resource_types: z.array(z.enum(listableTypes)).describe("Types to search (defaults to all listable)").optional(),
         url: z.string().describe("Harness UI URL — auto-extracts org and project").optional(),
-        resource_scope: z.enum(["account", "org", "project"]).describe("Scope to search. Use account for account-level resources and to omit org/project defaults; org injects only org; project injects org+project. Auto-detected from url.").optional(),
+        resource_scope: z.enum(["account", "org", "project"]).optional().describe("Scope to search. Use account for account-level resources and to omit org/project defaults; org injects only org; project injects org+project. Auto-detected from url."),
         org_id: z.string().describe("Organization identifier (overrides default)").optional(),
         project_id: z.string().describe("Project identifier (overrides default)").optional(),
         max_per_type: z.number().describe("Max results per type").default(5).optional(),
@@ -67,6 +74,16 @@ export function registerSearchTool(server: McpServer, registry: Registry, client
         if (targetTypes.length === 0) {
           // Search all types that support list
           targetTypes = registry.getAllResourceTypes().filter((rt) => registry.supportsOperation(rt, "list"));
+        }
+
+        const requestedSearchScope = parseResourceScope(mergedArgs.resource_scope);
+        if (requestedSearchScope) {
+          targetTypes = targetTypes.filter((rt) => registry.supportsResourceScope(rt, requestedSearchScope));
+          if (targetTypes.length === 0) {
+            return errorResult(
+              `No listable resource types support resource_scope "${requestedSearchScope}" with the enabled toolsets. Omit resource_scope, pass resource_types that support this scope, or use a Harness URL.`,
+            );
+          }
         }
 
         const entries: SearchResultEntry[] = [];

--- a/src/utils/url-parser.ts
+++ b/src/utils/url-parser.ts
@@ -5,7 +5,7 @@
 
 export interface ParsedHarnessUrl {
   account_id: string;
-  scope?: "account" | "org" | "project";
+  resource_scope?: "account" | "org" | "project";
   org_id?: string;
   project_id?: string;
   module?: string;
@@ -53,6 +53,8 @@ const RESOURCE_SEGMENTS: Record<string, { type: string; contextField: ContextFie
   "input-sets":       { type: "input_set",           contextField: "resource_id" },
   "services":         { type: "service",             contextField: "resource_id" },
   "environments":     { type: "environment",         contextField: "environment_id" },
+  "infrastructures":  { type: "infrastructure",      contextField: "resource_id" },
+  "infrastructure-definitions": { type: "infrastructure", contextField: "resource_id" },
   "connectors":       { type: "connector",           contextField: "resource_id" },
   "templates":        { type: "template",            contextField: "resource_id" },
   "secrets":          { type: "secret",              contextField: "resource_id" },
@@ -179,11 +181,11 @@ export function parseHarnessUrl(urlStr: string): ParsedHarnessUrl {
     }
 
     if (result.project_id) {
-      result.scope = "project";
+      result.resource_scope = "project";
     } else if (result.org_id) {
-      result.scope = "org";
+      result.resource_scope = "org";
     } else {
-      result.scope = "account";
+      result.resource_scope = "account";
     }
   }
 
@@ -204,7 +206,7 @@ export function parseHarnessUrl(urlStr: string): ParsedHarnessUrl {
 
 /** Fields that applyUrlDefaults will merge */
 const MERGEABLE_FIELDS: (keyof ParsedHarnessUrl)[] = [
-  "scope",
+  "resource_scope",
   "org_id",
   "project_id",
   "module",

--- a/src/utils/url-parser.ts
+++ b/src/utils/url-parser.ts
@@ -86,6 +86,15 @@ const RESOURCE_SEGMENTS: Record<string, { type: string; contextField: ContextFie
   "conversation":     { type: "pr_activity",          contextField: "comment_id" },
 };
 
+const URL_RESOURCE_SCOPE_TYPES = new Set([
+  "connector",
+  "service",
+  "environment",
+  "infrastructure",
+  "secret",
+  "template",
+]);
+
 /** Structural segments that should never be treated as resource IDs */
 const STRUCTURAL = new Set([
   "ng", "all", "account", "module", "orgs", "projects", "organizations",
@@ -180,12 +189,14 @@ export function parseHarnessUrl(urlStr: string): ParsedHarnessUrl {
       result.resource_id = primary.id;
     }
 
-    if (result.project_id) {
-      result.resource_scope = "project";
-    } else if (result.org_id) {
-      result.resource_scope = "org";
-    } else {
-      result.resource_scope = "account";
+    if (URL_RESOURCE_SCOPE_TYPES.has(primary.type)) {
+      if (result.project_id) {
+        result.resource_scope = "project";
+      } else if (result.org_id) {
+        result.resource_scope = "org";
+      } else {
+        result.resource_scope = "account";
+      }
     }
   }
 

--- a/src/utils/url-parser.ts
+++ b/src/utils/url-parser.ts
@@ -5,6 +5,7 @@
 
 export interface ParsedHarnessUrl {
   account_id: string;
+  scope?: "account" | "org" | "project";
   org_id?: string;
   project_id?: string;
   module?: string;
@@ -176,6 +177,14 @@ export function parseHarnessUrl(urlStr: string): ParsedHarnessUrl {
     if (primary.id) {
       result.resource_id = primary.id;
     }
+
+    if (result.project_id) {
+      result.scope = "project";
+    } else if (result.org_id) {
+      result.scope = "org";
+    } else {
+      result.scope = "account";
+    }
   }
 
   const stepId = url.searchParams.get("step") ?? url.searchParams.get("stepId");
@@ -195,6 +204,7 @@ export function parseHarnessUrl(urlStr: string): ParsedHarnessUrl {
 
 /** Fields that applyUrlDefaults will merge */
 const MERGEABLE_FIELDS: (keyof ParsedHarnessUrl)[] = [
+  "scope",
   "org_id",
   "project_id",
   "module",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -263,3 +263,17 @@
 - Clarified in README that hosted `https://mcp.harness.io/mcp` is managed and cannot be pointed at Harness0 from Claude/Cursor/Cowork client config; Support must configure hosted MCP for that target environment.
 - Updated MCPB manifest descriptions so `HARNESS_BASE_URL` covers private SaaS hosts such as `https://harness0.harness.io`, not just self-managed installs.
 - Verified with `pnpm build` and `pnpm docs:check`.
+
+## Slack Bug Triage: Account-Scope Resource Queries (2026-05-13)
+- [x] Trace current scope injection and URL parsing for account-level resources
+- [ ] Add failing tests for explicit/account URL scope behavior
+- [ ] Implement explicit account/org/project scope handling and describe metadata
+- [ ] Mark connectors, services, environments, infrastructure, secrets, and templates as multi-scope queryable
+- [ ] Run focused tests, typecheck, and broader verification
+- [ ] Commit, push, and open/update PR
+
+### Plan
+- Preserve existing default behavior for project-scoped calls with no explicit scope so current users with `HARNESS_ORG`/`HARNESS_PROJECT` keep getting default project results.
+- Add a generic `scope` selector accepted by `harness_list` and `harness_get`: `account` omits org/project, `org` injects only org, and `project` injects org+project.
+- Teach account-level Harness URLs (for example `/all/settings/connectors`) to set `scope: "account"` so pasted account URLs do not get config defaults re-injected.
+- Surface multi-scope capability in `harness_describe` so agents know that account-level connectors, services, environments, infrastructure, secrets, and templates can be requested with `scope: "account"`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -282,4 +282,5 @@
 - Added explicit `resource_scope` support for list/get requests: account scope omits org/project query params, org scope omits project, and project/default behavior continues to use configured defaults.
 - Account-level Harness URLs now propagate `resource_scope: "account"` through `applyUrlDefaults`, preventing account settings URLs from being narrowed by `HARNESS_ORG`/`HARNESS_PROJECT`.
 - Marked connectors, services, environments, infrastructure, secrets, and templates as supporting `account`, `org`, and `project` scopes and surfaced that guidance through `harness_describe`.
-- Verified with focused red/green coverage, `pnpm typecheck`, full `pnpm test` (52 files / 1201 tests), and `pnpm build`.
+- Kept resource-specific `scope` filters available for APIs such as GitOps cluster links by reserving `resource_scope` for dispatcher-level scoping.
+- Verified with focused red/green coverage, `pnpm typecheck`, full `pnpm test` (52 files / 1203 tests), and `pnpm build`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -284,4 +284,5 @@
 - Marked connectors, services, environments, infrastructure, secrets, and templates as supporting `account`, `org`, and `project` scopes and surfaced that guidance through `harness_describe`.
 - Kept resource-specific `scope` filters available for APIs such as GitOps cluster links by reserving `resource_scope` for dispatcher-level scoping.
 - Added coverage that each supported entity resource can list at account, org, and project scope, and that `harness_search` forwards explicit and URL-derived `resource_scope`.
-- Verified with focused red/green coverage, `pnpm typecheck`, full `pnpm test` (52 files / 1211 tests), and `pnpm build`.
+- Limited URL-derived `resource_scope` to known multi-scope entity URLs so account-scoped APIs with org/project UI paths, such as FME feature flags, are not rejected as unsupported project scope.
+- Verified with focused red/green coverage, `pnpm typecheck`, full `pnpm test` (52 files / 1213 tests), and `pnpm build`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -283,4 +283,5 @@
 - Account-level Harness URLs now propagate `resource_scope: "account"` through `applyUrlDefaults`, preventing account settings URLs from being narrowed by `HARNESS_ORG`/`HARNESS_PROJECT`.
 - Marked connectors, services, environments, infrastructure, secrets, and templates as supporting `account`, `org`, and `project` scopes and surfaced that guidance through `harness_describe`.
 - Kept resource-specific `scope` filters available for APIs such as GitOps cluster links by reserving `resource_scope` for dispatcher-level scoping.
-- Verified with focused red/green coverage, `pnpm typecheck`, full `pnpm test` (52 files / 1203 tests), and `pnpm build`.
+- Added coverage that each supported entity resource can list at account, org, and project scope, and that `harness_search` forwards explicit and URL-derived `resource_scope`.
+- Verified with focused red/green coverage, `pnpm typecheck`, full `pnpm test` (52 files / 1211 tests), and `pnpm build`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -266,14 +266,20 @@
 
 ## Slack Bug Triage: Account-Scope Resource Queries (2026-05-13)
 - [x] Trace current scope injection and URL parsing for account-level resources
-- [ ] Add failing tests for explicit/account URL scope behavior
-- [ ] Implement explicit account/org/project scope handling and describe metadata
-- [ ] Mark connectors, services, environments, infrastructure, secrets, and templates as multi-scope queryable
-- [ ] Run focused tests, typecheck, and broader verification
-- [ ] Commit, push, and open/update PR
+- [x] Add failing tests for explicit/account URL scope behavior
+- [x] Implement explicit account/org/project scope handling and describe metadata
+- [x] Mark connectors, services, environments, infrastructure, secrets, and templates as multi-scope queryable
+- [x] Run focused tests, typecheck, and broader verification
+- [x] Commit, push, and open/update PR
 
 ### Plan
 - Preserve existing default behavior for project-scoped calls with no explicit scope so current users with `HARNESS_ORG`/`HARNESS_PROJECT` keep getting default project results.
 - Add a generic `scope` selector accepted by `harness_list` and `harness_get`: `account` omits org/project, `org` injects only org, and `project` injects org+project.
 - Teach account-level Harness URLs (for example `/all/settings/connectors`) to set `scope: "account"` so pasted account URLs do not get config defaults re-injected.
 - Surface multi-scope capability in `harness_describe` so agents know that account-level connectors, services, environments, infrastructure, secrets, and templates can be requested with `scope: "account"`.
+
+### Review
+- Added explicit `scope` support for list/get requests: account scope omits org/project query params, org scope omits project, and project/default behavior continues to use configured defaults.
+- Account-level Harness URLs now propagate `scope: "account"` through `applyUrlDefaults`, preventing account settings URLs from being narrowed by `HARNESS_ORG`/`HARNESS_PROJECT`.
+- Marked connectors, services, environments, infrastructure, secrets, and templates as supporting `account`, `org`, and `project` scopes and surfaced that guidance through `harness_describe`.
+- Verified with focused red/green coverage, `pnpm typecheck`, full `pnpm test` (52 files / 1201 tests), and `pnpm build`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -273,13 +273,13 @@
 - [x] Commit, push, and open/update PR
 
 ### Plan
-- Preserve existing default behavior for project-scoped calls with no explicit scope so current users with `HARNESS_ORG`/`HARNESS_PROJECT` keep getting default project results.
-- Add a generic `scope` selector accepted by `harness_list` and `harness_get`: `account` omits org/project, `org` injects only org, and `project` injects org+project.
-- Teach account-level Harness URLs (for example `/all/settings/connectors`) to set `scope: "account"` so pasted account URLs do not get config defaults re-injected.
-- Surface multi-scope capability in `harness_describe` so agents know that account-level connectors, services, environments, infrastructure, secrets, and templates can be requested with `scope: "account"`.
+- Preserve existing default behavior for project-scoped calls with no explicit resource scope so current users with `HARNESS_ORG`/`HARNESS_PROJECT` keep getting default project results.
+- Add a generic `resource_scope` selector accepted by `harness_list` and `harness_get`: `account` omits org/project, `org` injects only org, and `project` injects org+project.
+- Teach account-level Harness URLs (for example `/all/settings/connectors`) to set `resource_scope: "account"` so pasted account URLs do not get config defaults re-injected.
+- Surface multi-scope capability in `harness_describe` so agents know that account-level connectors, services, environments, infrastructure, secrets, and templates can be requested with `resource_scope: "account"`.
 
 ### Review
-- Added explicit `scope` support for list/get requests: account scope omits org/project query params, org scope omits project, and project/default behavior continues to use configured defaults.
-- Account-level Harness URLs now propagate `scope: "account"` through `applyUrlDefaults`, preventing account settings URLs from being narrowed by `HARNESS_ORG`/`HARNESS_PROJECT`.
+- Added explicit `resource_scope` support for list/get requests: account scope omits org/project query params, org scope omits project, and project/default behavior continues to use configured defaults.
+- Account-level Harness URLs now propagate `resource_scope: "account"` through `applyUrlDefaults`, preventing account settings URLs from being narrowed by `HARNESS_ORG`/`HARNESS_PROJECT`.
 - Marked connectors, services, environments, infrastructure, secrets, and templates as supporting `account`, `org`, and `project` scopes and surfaced that guidance through `harness_describe`.
 - Verified with focused red/green coverage, `pnpm typecheck`, full `pnpm test` (52 files / 1201 tests), and `pnpm build`.

--- a/tests/registry/registry.test.ts
+++ b/tests/registry/registry.test.ts
@@ -234,6 +234,21 @@ describe("Registry", () => {
         expect(registry.getResource(resourceType).supportedScopes).toEqual(["account", "org", "project"]);
       }
     });
+
+    it("includes supportedScopes in toolset-level describe metadata", () => {
+      const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "connectors" }));
+      const desc = registry.describe() as {
+        toolsets: {
+          connectors: {
+            resources: Array<{ resource_type: string; supportedScopes?: string[] }>;
+          };
+        };
+      };
+
+      const connector = desc.toolsets.connectors.resources.find((r) => r.resource_type === "connector");
+
+      expect(connector?.supportedScopes).toEqual(["account", "org", "project"]);
+    });
   });
 
   describe("getAllFilterFields", () => {

--- a/tests/registry/registry.test.ts
+++ b/tests/registry/registry.test.ts
@@ -453,7 +453,7 @@ describe("Registry", () => {
       const client = makeClient(mockRequest);
 
       await accountRegistry.dispatch(client, "connector", "list", {
-        scope: "account",
+        resource_scope: "account",
         type: "Bitbucket",
         page: 0,
         size: 100,
@@ -477,7 +477,7 @@ describe("Registry", () => {
       const client = makeClient(mockRequest);
 
       await accountRegistry.dispatch(client, "connector", "list", {
-        scope: "org",
+        resource_scope: "org",
         org_id: "platform",
       });
 
@@ -506,7 +506,7 @@ describe("Registry", () => {
       const client = makeClient(mockRequest);
 
       await accountRegistry.dispatch(client, "secret", "get", {
-        scope: "account",
+        resource_scope: "account",
         secret_id: "acctSecret",
       });
 
@@ -514,6 +514,27 @@ describe("Registry", () => {
       expect(call.path).toBe("/ng/api/v2/secrets/acctSecret");
       expect(call.params.orgIdentifier).toBeUndefined();
       expect(call.params.projectIdentifier).toBeUndefined();
+    });
+
+    it("does not treat resource-specific scope filters as dispatcher scope", async () => {
+      const gitopsRegistry = new Registry(makeConfig({ HARNESS_TOOLSETS: "gitops" }));
+      const mockRequest = vi.fn().mockResolvedValue({
+        data: { content: [], totalElements: 0 },
+      });
+      const client = makeClient(mockRequest);
+
+      await gitopsRegistry.dispatch(client, "gitops_cluster_link", "list", {
+        environment_id: "prod",
+        scope: "ACCOUNT",
+      });
+
+      const call = mockRequest.mock.calls[0][0];
+      expect(call.params).toMatchObject({
+        orgIdentifier: "default",
+        projectIdentifier: "test-project",
+        environmentIdentifier: "prod",
+        scope: "ACCOUNT",
+      });
     });
 
     it("builds correct path with path params for a get operation", async () => {

--- a/tests/registry/registry.test.ts
+++ b/tests/registry/registry.test.ts
@@ -501,6 +501,37 @@ describe("Registry", () => {
       expect(call.params.projectIdentifier).toBeUndefined();
     });
 
+    it("throws when explicit org resource_scope lacks org_id and HARNESS_ORG", async () => {
+      const accountRegistry = new Registry(
+        makeConfig({ HARNESS_TOOLSETS: "connectors", HARNESS_ORG: undefined, HARNESS_PROJECT: undefined }),
+      );
+      const client = makeClient(vi.fn());
+
+      await expect(
+        accountRegistry.dispatch(client, "connector", "list", {
+          resource_scope: "org",
+        }),
+      ).rejects.toThrow(/resource_scope "org" requires an organization identifier/);
+    });
+
+    it("throws when explicit project resource_scope lacks project_id and HARNESS_PROJECT", async () => {
+      const accountRegistry = new Registry(
+        makeConfig({
+          HARNESS_TOOLSETS: "connectors",
+          HARNESS_ORG: "has-org",
+          HARNESS_PROJECT: undefined,
+        }),
+      );
+      const client = makeClient(vi.fn());
+
+      await expect(
+        accountRegistry.dispatch(client, "connector", "list", {
+          resource_scope: "project",
+          org_id: "has-org",
+        }),
+      ).rejects.toThrow(/resource_scope "project" requires a project identifier/);
+    });
+
     it("keeps default project scope when scope is omitted", async () => {
       const accountRegistry = new Registry(makeConfig({ HARNESS_TOOLSETS: "connectors" }));
       const mockRequest = vi.fn().mockResolvedValue({

--- a/tests/registry/registry.test.ts
+++ b/tests/registry/registry.test.ts
@@ -500,6 +500,45 @@ describe("Registry", () => {
       expect(call.params.projectIdentifier).toBe("test-project");
     });
 
+    it.each([
+      ["connectors", "connector"],
+      ["services", "service"],
+      ["environments", "environment"],
+      ["infrastructure", "infrastructure"],
+      ["secrets", "secret"],
+      ["templates", "template"],
+    ])("supports account/org/project list scoping for %s", async (toolset, resourceType) => {
+      const scopedRegistry = new Registry(makeConfig({ HARNESS_TOOLSETS: toolset }));
+      const mockRequest = vi.fn().mockResolvedValue({
+        data: { content: [], totalElements: 0 },
+      });
+      const client = makeClient(mockRequest);
+
+      await scopedRegistry.dispatch(client, resourceType, "list", {
+        resource_scope: "account",
+      });
+      await scopedRegistry.dispatch(client, resourceType, "list", {
+        resource_scope: "org",
+        org_id: "org-level",
+      });
+      await scopedRegistry.dispatch(client, resourceType, "list", {
+        resource_scope: "project",
+        org_id: "proj-org",
+        project_id: "proj-level",
+      });
+
+      const accountCall = mockRequest.mock.calls[0][0];
+      const orgCall = mockRequest.mock.calls[1][0];
+      const projectCall = mockRequest.mock.calls[2][0];
+
+      expect(accountCall.params.orgIdentifier).toBeUndefined();
+      expect(accountCall.params.projectIdentifier).toBeUndefined();
+      expect(orgCall.params.orgIdentifier).toBe("org-level");
+      expect(orgCall.params.projectIdentifier).toBeUndefined();
+      expect(projectCall.params.orgIdentifier).toBe("proj-org");
+      expect(projectCall.params.projectIdentifier).toBe("proj-level");
+    });
+
     it("omits default org/project query params for explicit account-scope secret get", async () => {
       const accountRegistry = new Registry(makeConfig({ HARNESS_TOOLSETS: "secrets" }));
       const mockRequest = vi.fn().mockResolvedValue({ data: { identifier: "acctSecret" } });

--- a/tests/registry/registry.test.ts
+++ b/tests/registry/registry.test.ts
@@ -224,6 +224,16 @@ describe("Registry", () => {
       expect(desc.total_resource_types).toBeGreaterThan(0);
       expect(desc.toolsets).toHaveProperty("pipelines");
     });
+
+    it("marks account-queryable settings resources as multi-scope", () => {
+      const registry = new Registry(makeConfig({
+        HARNESS_TOOLSETS: "connectors,services,environments,infrastructure,secrets,templates",
+      }));
+
+      for (const resourceType of ["connector", "service", "environment", "infrastructure", "secret", "template"]) {
+        expect(registry.getResource(resourceType).supportedScopes).toEqual(["account", "org", "project"]);
+      }
+    });
   });
 
   describe("getAllFilterFields", () => {
@@ -433,6 +443,77 @@ describe("Registry", () => {
         page: 0,
         size: 10,
       });
+    });
+
+    it("omits default org/project query params for explicit account-scope connector list", async () => {
+      const accountRegistry = new Registry(makeConfig({ HARNESS_TOOLSETS: "connectors" }));
+      const mockRequest = vi.fn().mockResolvedValue({
+        data: { content: [], totalElements: 0 },
+      });
+      const client = makeClient(mockRequest);
+
+      await accountRegistry.dispatch(client, "connector", "list", {
+        scope: "account",
+        type: "Bitbucket",
+        page: 0,
+        size: 100,
+      });
+
+      const call = mockRequest.mock.calls[0][0];
+      expect(call.path).toBe("/ng/api/connectors/listV2");
+      expect(call.params.orgIdentifier).toBeUndefined();
+      expect(call.params.projectIdentifier).toBeUndefined();
+      expect(call.body).toMatchObject({
+        filterType: "Connector",
+        types: ["Bitbucket"],
+      });
+    });
+
+    it("injects only org query params for explicit org-scope connector list", async () => {
+      const accountRegistry = new Registry(makeConfig({ HARNESS_TOOLSETS: "connectors" }));
+      const mockRequest = vi.fn().mockResolvedValue({
+        data: { content: [], totalElements: 0 },
+      });
+      const client = makeClient(mockRequest);
+
+      await accountRegistry.dispatch(client, "connector", "list", {
+        scope: "org",
+        org_id: "platform",
+      });
+
+      const call = mockRequest.mock.calls[0][0];
+      expect(call.params.orgIdentifier).toBe("platform");
+      expect(call.params.projectIdentifier).toBeUndefined();
+    });
+
+    it("keeps default project scope when scope is omitted", async () => {
+      const accountRegistry = new Registry(makeConfig({ HARNESS_TOOLSETS: "connectors" }));
+      const mockRequest = vi.fn().mockResolvedValue({
+        data: { content: [], totalElements: 0 },
+      });
+      const client = makeClient(mockRequest);
+
+      await accountRegistry.dispatch(client, "connector", "list", {});
+
+      const call = mockRequest.mock.calls[0][0];
+      expect(call.params.orgIdentifier).toBe("default");
+      expect(call.params.projectIdentifier).toBe("test-project");
+    });
+
+    it("omits default org/project query params for explicit account-scope secret get", async () => {
+      const accountRegistry = new Registry(makeConfig({ HARNESS_TOOLSETS: "secrets" }));
+      const mockRequest = vi.fn().mockResolvedValue({ data: { identifier: "acctSecret" } });
+      const client = makeClient(mockRequest);
+
+      await accountRegistry.dispatch(client, "secret", "get", {
+        scope: "account",
+        secret_id: "acctSecret",
+      });
+
+      const call = mockRequest.mock.calls[0][0];
+      expect(call.path).toBe("/ng/api/v2/secrets/acctSecret");
+      expect(call.params.orgIdentifier).toBeUndefined();
+      expect(call.params.projectIdentifier).toBeUndefined();
     });
 
     it("builds correct path with path params for a get operation", async () => {

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -960,7 +960,7 @@ describe("harness_describe", () => {
     expect(result.isError).toBeUndefined();
     const data = parseResult(result) as { supportedScopes?: string[]; scopeHint?: string };
     expect(data.supportedScopes).toEqual(["account", "org", "project"]);
-    expect(data.scopeHint).toContain("scope='account'");
+    expect(data.scopeHint).toContain("resource_scope='account'");
   });
 
   it("returns error hint for unknown resource_type", async () => {

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -108,6 +108,24 @@ describe("harness_list", () => {
     expect(data.items).toBeDefined();
   });
 
+  it("uses account scope from account-level connector URLs instead of config defaults", async () => {
+    registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "connectors" }));
+    mockRequest = vi.fn().mockResolvedValue({ data: { content: [], totalElements: 0 } });
+    client = makeClient(mockRequest);
+    const connectorServer = makeMcpServer();
+    const { registerListTool } = await import("../../src/tools/harness-list.js");
+    registerListTool(connectorServer, registry, client);
+
+    const result = await connectorServer.call("harness_list", {
+      url: "https://app.harness.io/ng/account/test-account/all/settings/connectors",
+    });
+
+    expect(result.isError).toBeUndefined();
+    const call = mockRequest.mock.calls[0]![0] as { params: Record<string, unknown> };
+    expect(call.params.orgIdentifier).toBeUndefined();
+    expect(call.params.projectIdentifier).toBeUndefined();
+  });
+
   it("propagates user-fixable API errors as errorResult", async () => {
     mockRequest.mockRejectedValueOnce(new HarnessApiError("Not found", 404));
     const result = await server.call("harness_list", { resource_type: "pipeline" });
@@ -929,6 +947,20 @@ describe("harness_describe", () => {
     const data = parseResult(result) as { resource_type: string; operations: unknown[] };
     expect(data.resource_type).toBe("pipeline");
     expect(data.operations.length).toBeGreaterThan(0);
+  });
+
+  it("describes account/org/project scope support for multi-scope resources", async () => {
+    registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "connectors" }));
+    const connectorServer = makeMcpServer();
+    const { registerDescribeTool } = await import("../../src/tools/harness-describe.js");
+    registerDescribeTool(connectorServer, registry);
+
+    const result = await connectorServer.call("harness_describe", { resource_type: "connector" });
+
+    expect(result.isError).toBeUndefined();
+    const data = parseResult(result) as { supportedScopes?: string[]; scopeHint?: string };
+    expect(data.supportedScopes).toEqual(["account", "org", "project"]);
+    expect(data.scopeHint).toContain("scope='account'");
   });
 
   it("returns error hint for unknown resource_type", async () => {

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -1025,6 +1025,50 @@ describe("harness_search", () => {
     expect(data.searched_types).toBe(1);
   });
 
+  it("passes explicit account resource_scope through to searched resources", async () => {
+    registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "connectors" }));
+    mockRequest = vi.fn().mockResolvedValue({
+      data: { content: [{ identifier: "bitbucket" }], totalElements: 1 },
+    });
+    client = makeClient(mockRequest);
+    const searchServer = makeMcpServer();
+    const { registerSearchTool } = await import("../../src/tools/harness-search.js");
+    registerSearchTool(searchServer, registry, client);
+
+    const result = await searchServer.call("harness_search", {
+      query: "bitbucket",
+      resource_types: ["connector"],
+      resource_scope: "account",
+    });
+
+    expect(result.isError).toBeUndefined();
+    const call = mockRequest.mock.calls[0]![0] as { params: Record<string, unknown> };
+    expect(call.params.orgIdentifier).toBeUndefined();
+    expect(call.params.projectIdentifier).toBeUndefined();
+  });
+
+  it("uses account resource_scope from account-level URLs during search", async () => {
+    registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "connectors" }));
+    mockRequest = vi.fn().mockResolvedValue({
+      data: { content: [{ identifier: "github" }], totalElements: 1 },
+    });
+    client = makeClient(mockRequest);
+    const searchServer = makeMcpServer();
+    const { registerSearchTool } = await import("../../src/tools/harness-search.js");
+    registerSearchTool(searchServer, registry, client);
+
+    const result = await searchServer.call("harness_search", {
+      query: "github",
+      resource_types: ["connector"],
+      url: "https://app.harness.io/ng/account/test-account/all/settings/connectors",
+    });
+
+    expect(result.isError).toBeUndefined();
+    const call = mockRequest.mock.calls[0]![0] as { params: Record<string, unknown> };
+    expect(call.params.orgIdentifier).toBeUndefined();
+    expect(call.params.projectIdentifier).toBeUndefined();
+  });
+
   it("gracefully handles search failures for individual types", async () => {
     // First call fails, second succeeds
     mockRequest

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -197,6 +197,26 @@ describe("harness_get", () => {
     expect(call.params.accountIdentifier).toBe("__GLOBAL_TEMPLATES_ACCOUNT_ID__");
     expect(call.params.versionLabel).toBe("1.0.8");
   });
+
+  it("does not infer resource_scope for account APIs with org/project UI URLs", async () => {
+    registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "feature-flags" }));
+    mockRequest = vi.fn().mockResolvedValue({ id: "my_flag" });
+    client = makeClient(mockRequest);
+    const fmeServer = makeMcpServer();
+    const { registerGetTool } = await import("../../src/tools/harness-get.js");
+    registerGetTool(fmeServer, registry, client);
+
+    const result = await fmeServer.call("harness_get", {
+      url: "https://app.harness.io/ng/account/abc123/cf/orgs/default/projects/myProject/feature-flags/my_flag",
+      params: { workspace_id: "workspace-1" },
+    });
+
+    expect(result.isError).toBeUndefined();
+    const call = mockRequest.mock.calls[0]![0] as { path: string; params: Record<string, unknown> };
+    expect(call.path).toBe("/internal/api/v2/splits/ws/workspace-1/my_flag");
+    expect(call.params.orgIdentifier).toBeUndefined();
+    expect(call.params.projectIdentifier).toBeUndefined();
+  });
 });
 
 describe("harness_get — execution_log", () => {

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -1089,6 +1089,29 @@ describe("harness_search", () => {
     expect(call.params.projectIdentifier).toBeUndefined();
   });
 
+  it("narrows broad harness_search to resource types compatible with resource_scope", async () => {
+    registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines,connectors" }));
+    mockRequest = vi.fn().mockResolvedValue({
+      data: { content: [], totalElements: 0 },
+    });
+    client = makeClient(mockRequest);
+    const searchServer = makeMcpServer();
+    const { registerSearchTool } = await import("../../src/tools/harness-search.js");
+    registerSearchTool(searchServer, registry, client);
+
+    const result = await searchServer.call("harness_search", {
+      query: "x",
+      resource_scope: "account",
+    });
+
+    expect(result.isError).toBeUndefined();
+    const data = parseResult(result) as { errors?: Record<string, string>; searched_types: number };
+    expect(data.errors).toBeUndefined();
+    expect(data.searched_types).toBeGreaterThan(0);
+    const paths = mockRequest.mock.calls.map((c) => (c[0] as { path: string }).path);
+    expect(paths.some((p) => p.includes("/pipelines/list"))).toBe(false);
+  });
+
   it("gracefully handles search failures for individual types", async () => {
     // First call fails, second succeeds
     mockRequest

--- a/tests/utils/url-parser.test.ts
+++ b/tests/utils/url-parser.test.ts
@@ -148,6 +148,7 @@ describe("parseHarnessUrl", () => {
     expect(result.resource_type).toBe("environment");
     expect(result.resource_id).toBe("prod");
     expect(result.environment_id).toBe("prod");
+    expect(result.resource_scope).toBe("project");
   });
 
   it("handles gitops agents URL", () => {
@@ -165,6 +166,7 @@ describe("parseHarnessUrl", () => {
     );
     expect(result.resource_type).toBe("fme_feature_flag");
     expect(result.resource_id).toBe("my_flag");
+    expect(result.resource_scope).toBeUndefined();
   });
 
   it("extracts repo_id and pr_number from Harness Code PR URL", () => {

--- a/tests/utils/url-parser.test.ts
+++ b/tests/utils/url-parser.test.ts
@@ -59,7 +59,7 @@ describe("parseHarnessUrl", () => {
     expect(result.account_id).toBe("lnFZRF6jQO6tQnB9znMALw");
     expect(result.resource_type).toBe("connector");
     expect(result.resource_id).toBeUndefined();
-    expect(result.scope).toBe("account");
+    expect(result.resource_scope).toBe("account");
     expect(result.org_id).toBeUndefined();
     expect(result.project_id).toBeUndefined();
   });
@@ -70,7 +70,7 @@ describe("parseHarnessUrl", () => {
     );
     expect(result.resource_type).toBe("connector");
     expect(result.resource_id).toBe("test");
-    expect(result.scope).toBe("account");
+    expect(result.resource_scope).toBe("account");
     expect(result.org_id).toBeUndefined();
   });
 
@@ -80,9 +80,20 @@ describe("parseHarnessUrl", () => {
     );
     expect(result.org_id).toBe("default");
     expect(result.project_id).toBe("GitX_Test");
-    expect(result.scope).toBe("project");
+    expect(result.resource_scope).toBe("project");
     expect(result.resource_type).toBe("connector");
     expect(result.resource_id).toBe("harnessSecretManager");
+  });
+
+  it("handles account-level settings infrastructure list", () => {
+    const result = parseHarnessUrl(
+      "https://app.harness.io/ng/account/lnFZRF6jQO6tQnB9znMALw/all/settings/infrastructures",
+    );
+    expect(result.account_id).toBe("lnFZRF6jQO6tQnB9znMALw");
+    expect(result.resource_type).toBe("infrastructure");
+    expect(result.resource_scope).toBe("account");
+    expect(result.org_id).toBeUndefined();
+    expect(result.project_id).toBeUndefined();
   });
 
   it("extracts execution ID and pipeline ID from execution URL", () => {

--- a/tests/utils/url-parser.test.ts
+++ b/tests/utils/url-parser.test.ts
@@ -59,6 +59,7 @@ describe("parseHarnessUrl", () => {
     expect(result.account_id).toBe("lnFZRF6jQO6tQnB9znMALw");
     expect(result.resource_type).toBe("connector");
     expect(result.resource_id).toBeUndefined();
+    expect(result.scope).toBe("account");
     expect(result.org_id).toBeUndefined();
     expect(result.project_id).toBeUndefined();
   });
@@ -69,6 +70,7 @@ describe("parseHarnessUrl", () => {
     );
     expect(result.resource_type).toBe("connector");
     expect(result.resource_id).toBe("test");
+    expect(result.scope).toBe("account");
     expect(result.org_id).toBeUndefined();
   });
 
@@ -78,6 +80,7 @@ describe("parseHarnessUrl", () => {
     );
     expect(result.org_id).toBe("default");
     expect(result.project_id).toBe("GitX_Test");
+    expect(result.scope).toBe("project");
     expect(result.resource_type).toBe("connector");
     expect(result.resource_id).toBe("harnessSecretManager");
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Addresses the three architecture-review items raised on PR #182 (explicit `resource_scope` fail-open behavior, broad `harness_search` fan-out, and Zod 4 `.describe()` ordering).

- **Registry dispatch**: When callers set `resource_scope` to `org` or `project`, require a resolved organization (from `org_id` or `HARNESS_ORG`) and, for project scope, a resolved project (`project_id` or `HARNESS_PROJECT`) before building the request. This prevents empty scope params from widening the API call.
- **`harness_search`**: After URL defaults merge, filter list targets to resource types where `supportsResourceScope` includes the requested scope. Return a clear user-facing error if nothing remains. Added `Registry.supportsResourceScope()` for reuse.
- **Zod inputs**: `resource_scope` on `harness_list`, `harness_get`, and `harness_search` now uses `.optional().describe(...)` so descriptions are preserved for agents (Zod 4).

Tests: new registry cases for missing org/project under explicit scope; new search case for `pipelines,connectors` + `resource_scope: account` ensuring no pipeline list calls.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] Tests pass (`pnpm test` on touched suites; `pnpm typecheck`; `pnpm build`)
- [x] Typecheck passes

Note: This branch is based on the current head of PR #182 so the review fixes stack cleanly; it can be merged after #182 or the commits can be cherry-picked onto that PR branch as preferred by maintainers.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://harness.slack.com/archives/C0AKBK5UF0A/p1778649463638269?thread_ts=1778649463.638269&cid=C0AKBK5UF0A)

<div><a href="https://cursor.com/agents/bc-b403c92e-c8cb-5c0b-9c79-c0e5216ace19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b403c92e-c8cb-5c0b-9c79-c0e5216ace19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

