### PR TITLE
Add Harness Code PR close action

### DIFF
--- a/src/registry/toolsets/pull-requests.ts
+++ b/src/registry/toolsets/pull-requests.ts
@@ -11,7 +11,7 @@ export const pullRequestsToolset: ToolsetDefinition = {
       resourceType: "pull_request",
       displayName: "Pull Request",
       description:
-        "Code pull request. Supports list, get, create, and update. Use execute actions for merge.",
+        "Code pull request. Supports list, get, create, and update. Use execute actions for close and merge.",
       toolset: "pull-requests",
       scope: "account",
       scopeOptional: true,
@@ -90,6 +90,23 @@ export const pullRequestsToolset: ToolsetDefinition = {
         },
       },
       executeActions: {
+        close: {
+          method: "PATCH",
+          path: "/code/api/v1/repos/{repoIdentifier}/pullreq/{prNumber}",
+          operationPolicy: { risk: "medium_write", retryPolicy: "do_not_retry" },
+          pathParams: {
+            repo_id: "repoIdentifier",
+            pr_number: "prNumber",
+          },
+          bodyBuilder: () => ({ state: "closed" }),
+          responseExtractor: passthrough,
+          actionDescription:
+            "Close a pull request without merging it. Sends state='closed' to the pull request update endpoint.",
+          bodySchema: {
+            description: "No body required. The action sends { state: 'closed' } automatically.",
+            fields: [],
+          },
+        },
         merge: {
           method: "POST",
           path: "/code/api/v1/repos/{repoIdentifier}/pullreq/{prNumber}/merge",

--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -75,11 +75,24 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
           return errorResult(`Operation ${elicit.reason} by user.`);
         }
 
-        // Map resource_id to the first unresolved identifier field. URL and params
-        // may already provide parent IDs for nested resources such as PRs.
-        const resourceIdField = getResourceIdField(def.identifierFields, input);
-        if (resourceIdField && resourceId && (input[resourceIdField] === undefined || input[resourceIdField] === "")) {
-          input[resourceIdField] = resourceId;
+        // Map resource_id → identifierFields[0] (the documented primary field).
+        // For multi-identifier resources where the primary field is already
+        // populated with a DIFFERENT value (e.g. URL filled repo_id while
+        // resource_id is the pr_number), fall through to the child (last)
+        // identifier field instead — preserving the parent context.
+        // When the primary field holds the SAME value as resource_id (e.g.
+        // GitOps agent_id supplied via both resource_id and params), just
+        // overwrite — no fallthrough.
+        const primaryField = def.identifierFields[0];
+        if (primaryField && resourceId) {
+          const existing = input[primaryField];
+          const primaryAlreadySet = existing !== undefined && existing !== "" && existing !== resourceId;
+          if (primaryAlreadySet && def.identifierFields.length > 1) {
+            const childField = def.identifierFields[def.identifierFields.length - 1]!;
+            input[childField] = resourceId;
+          } else {
+            input[primaryField] = resourceId;
+          }
         }
 
         // Pass input_set_ids as string[] so HarnessClient emits repeated `inputSetIdentifiers=` query keys
@@ -265,11 +278,6 @@ const STRUCTURAL_FIELDS = new Set([
   "infrastructure", "execution", "spec", "template",
   "templateinputs", "servicedefinition", "artifacts", "manifests",
 ]);
-
-function getResourceIdField(identifierFields: string[], input: Record<string, unknown>): string | undefined {
-  if (identifierFields.length === 0) return undefined;
-  return identifierFields.find((field) => input[field] === undefined || input[field] === "") ?? identifierFields[0];
-}
 
 function isStructuralField(fieldName: string): boolean {
   return STRUCTURAL_FIELDS.has(fieldName.toLowerCase());

--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -75,10 +75,11 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
           return errorResult(`Operation ${elicit.reason} by user.`);
         }
 
-        // Map resource_id to the primary identifier field
-        const primaryField = def.identifierFields[0];
-        if (primaryField && resourceId) {
-          input[primaryField] = resourceId;
+        // Map resource_id to the first unresolved identifier field. URL and params
+        // may already provide parent IDs for nested resources such as PRs.
+        const resourceIdField = getResourceIdField(def.identifierFields, input);
+        if (resourceIdField && resourceId && (input[resourceIdField] === undefined || input[resourceIdField] === "")) {
+          input[resourceIdField] = resourceId;
         }
 
         // Pass input_set_ids as string[] so HarnessClient emits repeated `inputSetIdentifiers=` query keys
@@ -264,6 +265,11 @@ const STRUCTURAL_FIELDS = new Set([
   "infrastructure", "execution", "spec", "template",
   "templateinputs", "servicedefinition", "artifacts", "manifests",
 ]);
+
+function getResourceIdField(identifierFields: string[], input: Record<string, unknown>): string | undefined {
+  if (identifierFields.length === 0) return undefined;
+  return identifierFields.find((field) => input[field] === undefined || input[field] === "") ?? identifierFields[0];
+}
 
 function isStructuralField(fieldName: string): boolean {
   return STRUCTURAL_FIELDS.has(fieldName.toLowerCase());

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -359,4 +359,4 @@
 - Added `pull_request.close` as a medium-risk execute action that PATCHes the PR update endpoint with `{ state: "closed" }`.
 - Added registry coverage for the close action and MCP-handler coverage for closing directly from a Harness PR URL.
 - Fixed `harness_execute` resource-id mapping so URL-derived parent identifiers like `repo_id` are preserved instead of being overwritten by the URL's `resource_id`.
-- Verified with `pnpm test tests/registry/registry.test.ts tests/tools/tool-handlers.test.ts`, `pnpm typecheck`, `pnpm build`, and full `pnpm test` (53 files / 1308 tests).
+- Verified with `pnpm test tests/registry/registry.test.ts tests/tools/tool-handlers.test.ts`, `pnpm typecheck`, `pnpm build`, and full `pnpm test` (53 files / 1309 tests).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -342,14 +342,21 @@
 - Verified with `pnpm test tests/client/harness-client.test.ts`, `pnpm typecheck`, `pnpm build`, and full `pnpm test`.
 
 ## Slack Bug Triage: Pull Request Close Support (2026-05-14)
-- [ ] Confirm whether PR close is available by design or missing from MCP v2 metadata
-- [ ] Add a failing registry test for a first-class pull request close action
-- [ ] Implement the minimal pull request close action against the existing Harness Code PR update endpoint
-- [ ] Run focused tests, typecheck, build, and relevant broader verification
-- [ ] Commit, push, and open/update PR
+- [x] Confirm whether PR close is available by design or missing from MCP v2 metadata
+- [x] Add a failing registry test for a first-class pull request close action
+- [x] Implement the minimal pull request close action against the existing Harness Code PR update endpoint
+- [x] Run focused tests, typecheck, build, and relevant broader verification
+- [x] Commit, push, and open/update PR
 
 ### Plan
 - Keep the change scoped to the existing `pull_request` resource in `src/registry/toolsets/pull-requests.ts`.
 - Preserve the already-supported generic update path (`harness_update` with `body.state = "closed"`) and add a more discoverable `harness_execute` action named `close`.
 - Map `close` to the existing Harness Code PATCH endpoint `/code/api/v1/repos/{repoIdentifier}/pullreq/{prNumber}` with a fixed `{ state: "closed" }` body.
 - Mark the action as `medium_write` and `do_not_retry`, matching a non-idempotent PR state transition that requires confirmation in clients with elicitation.
+
+### Review
+- Confirmed PR close was not blocked by MCP design: generic `harness_update` already documented `state: open/closed`, but no first-class `harness_execute` close action existed, so agents asking to "close a PR" saw only `merge`.
+- Added `pull_request.close` as a medium-risk execute action that PATCHes the PR update endpoint with `{ state: "closed" }`.
+- Added registry coverage for the close action and MCP-handler coverage for closing directly from a Harness PR URL.
+- Fixed `harness_execute` resource-id mapping so URL-derived parent identifiers like `repo_id` are preserved instead of being overwritten by the URL's `resource_id`.
+- Verified with `pnpm test tests/registry/registry.test.ts tests/tools/tool-handlers.test.ts`, `pnpm typecheck`, `pnpm build`, and full `pnpm test` (53 files / 1308 tests).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -340,3 +340,16 @@
 - Split query strings out of `RequestOptions.path` before base-path de-duplication and query assembly.
 - Merged path query params into the generated `URLSearchParams` before applying `options.params`, preserving explicit override behavior.
 - Verified with `pnpm test tests/client/harness-client.test.ts`, `pnpm typecheck`, `pnpm build`, and full `pnpm test`.
+
+## Slack Bug Triage: Pull Request Close Support (2026-05-14)
+- [ ] Confirm whether PR close is available by design or missing from MCP v2 metadata
+- [ ] Add a failing registry test for a first-class pull request close action
+- [ ] Implement the minimal pull request close action against the existing Harness Code PR update endpoint
+- [ ] Run focused tests, typecheck, build, and relevant broader verification
+- [ ] Commit, push, and open/update PR
+
+### Plan
+- Keep the change scoped to the existing `pull_request` resource in `src/registry/toolsets/pull-requests.ts`.
+- Preserve the already-supported generic update path (`harness_update` with `body.state = "closed"`) and add a more discoverable `harness_execute` action named `close`.
+- Map `close` to the existing Harness Code PATCH endpoint `/code/api/v1/repos/{repoIdentifier}/pullreq/{prNumber}` with a fixed `{ state: "closed" }` body.
+- Mark the action as `medium_write` and `do_not_retry`, matching a non-idempotent PR state transition that requires confirmation in clients with elicitation.

--- a/tests/registry/registry.test.ts
+++ b/tests/registry/registry.test.ts
@@ -733,6 +733,23 @@ describe("Registry", () => {
       ).rejects.toThrow(/Missing required field/);
     });
 
+    it("closes a Harness Code pull request via execute action", async () => {
+      const prRegistry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pull-requests" }));
+      const mockRequest = vi.fn().mockResolvedValue({ number: 42, state: "closed" });
+      const client = makeClient(mockRequest);
+
+      await prRegistry.dispatchExecute(client, "pull_request", "close", {
+        repo_id: "my-repo",
+        pr_number: "42",
+      });
+
+      expect(mockRequest).toHaveBeenCalledOnce();
+      const call = mockRequest.mock.calls[0][0];
+      expect(call.method).toBe("PATCH");
+      expect(call.path).toBe("/code/api/v1/repos/my-repo/pullreq/42");
+      expect(call.body).toEqual({ state: "closed" });
+    });
+
     it("pipeline update with yamlPipeline sends raw YAML string as body with Content-Type header and returns openInHarness", async () => {
       const yaml = "pipeline:\n  name: Test\n  identifier: test_pipeline\n  stages: []";
       const mockRequest = vi.fn().mockResolvedValue({

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -771,6 +771,26 @@ describe("harness_execute", () => {
     expect(call.body).toEqual({ state: "closed" });
   });
 
+  it("uses resource_id for the missing child identifier when parent params are provided", async () => {
+    const prServer = makeMcpServer("accept");
+    const prRegistry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pull-requests" }));
+    const prRequest = vi.fn().mockResolvedValue({ number: 42, state: "closed" });
+    const prClient = makeClient(prRequest);
+    const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
+    registerExecuteTool(prServer, prRegistry, prClient);
+
+    const result = await prServer.call("harness_execute", {
+      resource_type: "pull_request",
+      action: "close",
+      resource_id: "42",
+      params: { repo_id: "my-repo" },
+    });
+
+    expect(result.isError).toBeUndefined();
+    const call = prRequest.mock.calls[0]![0] as { path?: string };
+    expect(call.path).toBe("/code/api/v1/repos/my-repo/pullreq/42");
+  });
+
   it("materializes input_set_ids by GETting each input set then POSTing merged pipeline YAML", async () => {
     const inputSetYaml = `inputSet:\n  pipeline:\n    identifier: mat_pipe\n    variables:\n      - name: x\n        type: String\n        value: "1"\n`;
     mockRequest

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -750,6 +750,27 @@ describe("harness_execute", () => {
     expect(mockRequest).toHaveBeenCalled();
   });
 
+  it("closes a pull request from a Harness PR URL", async () => {
+    const prServer = makeMcpServer("accept");
+    const prRegistry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pull-requests" }));
+    const prRequest = vi.fn().mockResolvedValue({ number: 42, state: "closed" });
+    const prClient = makeClient(prRequest);
+    const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
+    registerExecuteTool(prServer, prRegistry, prClient);
+
+    const result = await prServer.call("harness_execute", {
+      url: "https://app.harness.io/ng/account/test-account/module/code/orgs/default/projects/test-project/repos/my-repo/pull-requests/42",
+      action: "close",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(prRequest).toHaveBeenCalledOnce();
+    const call = prRequest.mock.calls[0]![0] as { method?: string; path?: string; body?: unknown };
+    expect(call.method).toBe("PATCH");
+    expect(call.path).toBe("/code/api/v1/repos/my-repo/pullreq/42");
+    expect(call.body).toEqual({ state: "closed" });
+  });
+
   it("materializes input_set_ids by GETting each input set then POSTing merged pipeline YAML", async () => {
     const inputSetYaml = `inputSet:\n  pipeline:\n    identifier: mat_pipe\n    variables:\n      - name: x\n        type: String\n        value: "1"\n`;
     mockRequest

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -791,6 +791,45 @@ describe("harness_execute", () => {
     expect(call.path).toBe("/code/api/v1/repos/my-repo/pullreq/42");
   });
 
+  it("explicit resource_id overrides URL-derived pr_number", async () => {
+    const prServer = makeMcpServer("accept");
+    const prRegistry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pull-requests" }));
+    const prRequest = vi.fn().mockResolvedValue({ number: 43, state: "closed" });
+    const prClient = makeClient(prRequest);
+    const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
+    registerExecuteTool(prServer, prRegistry, prClient);
+
+    const result = await prServer.call("harness_execute", {
+      url: "https://app.harness.io/ng/account/test-account/module/code/orgs/default/projects/test-project/repos/my-repo/pull-requests/42",
+      resource_id: "43",
+      action: "close",
+    });
+
+    expect(result.isError).toBeUndefined();
+    const call = prRequest.mock.calls[0]![0] as { path?: string };
+    expect(call.path).toBe("/code/api/v1/repos/my-repo/pullreq/43");
+  });
+
+  it("does not remap resource_id to child field when primary matches (GitOps contract)", async () => {
+    const gitopsServer = makeMcpServer("accept");
+    const gitopsRegistry = new Registry(makeConfig({ HARNESS_TOOLSETS: "gitops" }));
+    const gitopsRequest = vi.fn().mockResolvedValue({});
+    const gitopsClient = makeClient(gitopsRequest);
+    const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
+    registerExecuteTool(gitopsServer, gitopsRegistry, gitopsClient);
+
+    const result = await gitopsServer.call("harness_execute", {
+      resource_type: "gitops_application",
+      action: "cancel_operation",
+      resource_id: "account.myagent",
+      params: { agent_id: "account.myagent", app_name: "my-app" },
+    });
+
+    expect(result.isError).toBeUndefined();
+    const call = gitopsRequest.mock.calls[0]![0] as { path?: string };
+    expect(call.path).toContain("/agents/account.myagent/applications/my-app/operation");
+  });
+
   it("materializes input_set_ids by GETting each input set then POSTing merged pipeline YAML", async () => {
     const inputSetYaml = `inputSet:\n  pipeline:\n    identifier: mat_pipe\n    variables:\n      - name: x\n        type: String\n        value: "1"\n`;
     mockRequest


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Adds a first-class `close` execute action for Harness Code pull requests. The action PATCHes `/code/api/v1/repos/{repoIdentifier}/pullreq/{prNumber}` with `{ state: "closed" }`, matching the existing PR update endpoint and making close discoverable through `harness_execute`/`harness_describe`.

Also fixes `harness_execute` identifier mapping so URL-derived parent identifiers (for example `repo_id`) are not overwritten by `resource_id` when closing a PR from a Harness URL or when callers pass `resource_id` with parent identifiers in `params`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] Tests pass (`pnpm test tests/registry/registry.test.ts tests/tools/tool-handlers.test.ts`; full `pnpm test`)
- [x] Typecheck passes (`pnpm typecheck`)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://harness.slack.com/archives/C0AKBK5UF0A/p1778737833590529?thread_ts=1778737833.590529&cid=C0AKBK5UF0A)

<div><a href="https://cursor.com/agents/bc-b78637db-b0d4-5cfa-8646-e26a8b3aac78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b78637db-b0d4-5cfa-8646-e26a8b3aac78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

