### PR TITLE
fix: route Harness-internal pre-signed URLs through client, not direct fetch

### DIFF
--- a/src/utils/log-resolver.ts
+++ b/src/utils/log-resolver.ts
@@ -1,5 +1,6 @@
 import { gunzipSync, inflateRawSync } from "node:zlib";
 import type { HarnessClient } from "../client/harness-client.js";
+import { HarnessApiError } from "./errors.js";
 import { createLogger } from "./logger.js";
 
 const log = createLogger("log-resolver");
@@ -53,6 +54,16 @@ function isExternalStorageHost(host: string): boolean {
   if (S3_BUCKET_HOST_RE.test(h)) return true;
   if (h.endsWith(".storage.googleapis.com")) return true;
   return false;
+}
+
+/**
+ * Detect Harness-internal hosts that are never publicly routable.
+ * Even when these URLs carry pre-signed query params, they must route
+ * through the client so internal deployments can rewrite the host.
+ */
+function isHarnessHost(host: string): boolean {
+  const h = host.toLowerCase();
+  return h === "harness.io" || h.endsWith(".harness.io");
 }
 
 /**
@@ -328,20 +339,39 @@ async function downloadBlobContent(
 ): Promise<Response> {
   const blobUrl = safeParseUrl(blobLink);
 
-  if (blobUrl && (isExternalStorageHost(blobUrl.host) || isPresignedUrl(blobUrl))) {
-    log.debug("Downloading log blob (direct)", { prefix, url: blobLink.slice(0, 80) });
+  // Two routing strategies based on the blob URL:
+  //
+  // 1. True external storage (S3, GCS domains) → direct fetch, no auth headers.
+  //    The URL is publicly routable with embedded signature params; routing through
+  //    the client or adding extra headers would invalidate the AWS/GCS signature.
+  //
+  // 2. All other URLs (including *.harness.io pre-signed) → client.requestStream()
+  //    so PAT/JWT auth and proxy are applied. Harness pre-signed params are internal
+  //    tokens that are not AWS host-bound, so they survive client proxying.
+  //    For Harness pre-signed paths, use rawPath directly (already absolute on host);
+  //    for standard log-service paths, prepend the gateway prefix if absent.
+
+  if (blobUrl && isExternalStorageHost(blobUrl.hostname)) {
+    // Strategy 1: true external storage — always direct fetch
+    log.debug("Downloading log blob (direct, external storage)", { prefix, url: blobLink.slice(0, 80) });
     try {
       return await fetch(blobLink, { signal });
     } catch (err) {
       const cause = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
-      throw new Error(`Log download fetch failed for ${blobUrl.host}: ${cause}`);
+      throw new Error(`Log download fetch failed for ${blobUrl.hostname}: ${cause}`);
     }
   }
 
-  const rawPath = blobUrl ? blobUrl.pathname + blobUrl.search : blobLink;
-  const downloadPath = rawPath.startsWith(LOG_SERVICE_GATEWAY_PREFIX)
-    ? rawPath
-    : `${LOG_SERVICE_GATEWAY_PREFIX}${rawPath}`;
+  // Strategy 2: route through client for auth injection and proxy support.
+  const rawPath = blobUrl
+    ? blobUrl.pathname + blobUrl.search
+    : blobLink.startsWith("/") ? blobLink : `/${blobLink}`;
+  const downloadPath =
+    blobUrl && isPresignedUrl(blobUrl) && isHarnessHost(blobUrl.hostname)
+      ? rawPath
+      : rawPath.startsWith(LOG_SERVICE_GATEWAY_PREFIX)
+      ? rawPath
+      : `${LOG_SERVICE_GATEWAY_PREFIX}${rawPath}`;
   log.debug("Downloading log blob (client)", { prefix, path: downloadPath.slice(0, 80) });
   try {
     return await client.requestStream({
@@ -350,8 +380,9 @@ async function downloadBlobContent(
       signal,
     });
   } catch (err) {
+    if (err instanceof HarnessApiError) throw err;
     const cause = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
-    throw new Error(`Log download fetch failed for ${blobUrl?.host ?? "harness"}: ${cause}`);
+    throw new Error(`Log download fetch failed for ${blobUrl?.hostname ?? "harness"}: ${cause}`);
   }
 }
 

--- a/tests/utils/log-resolver.test.ts
+++ b/tests/utils/log-resolver.test.ts
@@ -179,6 +179,127 @@ describe("resolveLogContent", () => {
     );
   });
 
+  // ── Regression tests: Harness-internal hosts with pre-signed params ──────────
+  // Pre-signed params on app.harness.io or any *.harness.io host do NOT mean
+  // the URL is publicly routable. Internal/on-prem deployments proxy these through
+  // their own host. The fix: only bypass client routing for TRUE external storage.
+
+  it("REGRESSION: app.harness.io pre-signed URL routes through client.requestStream, not direct fetch", async () => {
+    const blobLink =
+      "https://app.harness.io/storage/logs/blob.zip?X-Amz-Signature=abc123&X-Amz-Expires=900";
+    const streamFn = vi.fn().mockResolvedValue(new Response('{"out":"log from internal harness"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { requestStream: streamFn },
+    );
+
+    const result = await resolveLogContent(client, "prefix");
+
+    expect(result).toContain("log from internal harness");
+    // Must route through client — NOT bypass via direct fetch
+    expect(streamFn).toHaveBeenCalledWith(
+      expect.objectContaining({ path: expect.stringContaining("/storage/logs/blob.zip") }),
+    );
+    expect(fetchSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("harness.io"),
+      expect.any(Object),
+    );
+  });
+
+  it("REGRESSION: custom.harness.io pre-signed URL routes through client.requestStream, not direct fetch", async () => {
+    const blobLink =
+      "https://custom.harness.io/storage/blob?X-Goog-Signature=sig&X-Goog-Expires=3600";
+    const streamFn = vi.fn().mockResolvedValue(new Response('{"out":"internal gcs proxy log"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { requestStream: streamFn },
+    );
+
+    const result = await resolveLogContent(client, "prefix");
+
+    expect(result).toContain("internal gcs proxy log");
+    expect(streamFn).toHaveBeenCalledWith(
+      expect.objectContaining({ path: expect.stringContaining("/storage/blob") }),
+    );
+    expect(fetchSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("harness.io"),
+      expect.any(Object),
+    );
+  });
+
+  // ── On-prem / custom-gateway invariant ───────────────────────────────────────
+  // INVARIANT: any *.harness.io blob URL — with or without pre-signed params —
+  // MUST route through client.requestStream(), never global fetch().
+  // This has broken TWICE (PR #189, fixed in PR #195). If you change routing
+  // logic and this test fails, you are re-introducing the same bug.
+
+  it("REGRESSION: app.harness.io blob with custom gateway baseURL routes through client", async () => {
+    // On-prem/self-managed scenario: HARNESS_BASE_URL points to a custom gateway host,
+    // but the blob link returned by log-service still points to app.harness.io.
+    // app.harness.io is not directly reachable — must go through client.requestStream().
+    const blobLink =
+      "https://app.harness.io/gateway/log-service/blob/download?accountId=jLO&X-Amz-Signature=tok";
+    const streamFn = vi.fn().mockResolvedValue(new Response('{"out":"on-prem log line"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://custom-gateway.example.com/gateway", requestStream: streamFn },
+    );
+
+    const result = await resolveLogContent(client, "prefix");
+
+    expect(result).toContain("on-prem log line");
+    expect(streamFn).toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("app.harness.io"),
+      expect.any(Object),
+    );
+  });
+
+  it("REGRESSION: app.harness.io URL with explicit port still classified as Harness host", async () => {
+    // URL.host includes port (app.harness.io:443) — isHarnessHost must use .hostname not .host
+    const blobLink =
+      "https://app.harness.io:443/gateway/log-service/blob/download?X-Amz-Signature=tok";
+    const streamFn = vi.fn().mockResolvedValue(new Response('{"out":"port log"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://custom-gateway.example.com/gateway", requestStream: streamFn },
+    );
+
+    const result = await resolveLogContent(client, "prefix");
+
+    expect(result).toContain("port log");
+    expect(streamFn).toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("harness.io"),
+      expect.any(Object),
+    );
+  });
+
+  it("true S3 pre-signed URL still uses direct fetch (external storage host)", async () => {
+    const blobLink =
+      "https://harness-prod-logs.s3.us-east-1.amazonaws.com/logs.zip?X-Amz-Signature=abc&X-Amz-Expires=900";
+    const client = makeClient(vi.fn().mockResolvedValue({ status: "success", link: blobLink }));
+    fetchSpy.mockResolvedValue(new Response('{"out":"s3 log line"}', { status: 200 }));
+
+    const result = await resolveLogContent(client, "prefix");
+
+    expect(result).toContain("s3 log line");
+    // True external S3 → direct fetch is correct
+    expect(fetchSpy).toHaveBeenCalledWith(blobLink, expect.any(Object));
+  });
+
+  it("true GCS pre-signed URL still uses direct fetch (external storage host)", async () => {
+    const blobLink =
+      "https://storage.googleapis.com/harness-logs/run.zip?X-Goog-Signature=sig&X-Goog-Expires=3600";
+    const client = makeClient(vi.fn().mockResolvedValue({ status: "success", link: blobLink }));
+    fetchSpy.mockResolvedValue(new Response('{"out":"gcs log line"}', { status: 200 }));
+
+    const result = await resolveLogContent(client, "prefix");
+
+    expect(result).toContain("gcs log line");
+    expect(fetchSpy).toHaveBeenCalledWith(blobLink, expect.any(Object));
+  });
+
   it("throws when log file exceeds max size", async () => {
     const bigContent = "x".repeat(1024);
     const streamFn = vi.fn().mockResolvedValue(new Response(bigContent, {


### PR DESCRIPTION
## Description

Routes Harness-internal pre-signed URLs through the configured client, fixing log download failures on on-prem and self-managed deployments.

PR #189 introduced `isPresignedUrl()` to bypass client routing for S3/GCS pre-signed URLs (correct — those carry credentials in query params that break if headers are added). However, the check also matched Harness-hosted log blob URLs like `app.harness.io` that carry `X-Amz-Signature`/`X-Goog-Signature` as params. These hosts **must** route through the client proxy — they're not publicly routable in all deployments.

**Symptom:** `Error: Log download fetch failed for app.harness.io: TypeError: fetch failed`

### Root Cause

```typescript
// Before (broken for on-prem/self-managed):
if (blobUrl && (isExternalStorageHost(blobUrl.host) || isPresignedUrl(blobUrl))) {
    return await fetch(blobLink, { signal });  // app.harness.io unreachable
}
```

### Fix

Changes in `src/utils/log-resolver.ts`:

1. **Correct routing**: Harness pre-signed URLs now route through `client.requestStream()` instead of being direct-fetched. Only true external storage hosts (S3, GCS) bypass the client.

   ```typescript
   // After — two strategies:
   if (blobUrl && isExternalStorageHost(blobUrl.hostname)) {
       return await fetch(blobLink, { signal });  // S3/GCS only
   }
   // Everything else (including *.harness.io pre-signed) → client.requestStream()
   const downloadPath =
       blobUrl && isPresignedUrl(blobUrl) && isHarnessHost(blobUrl.hostname)
           ? rawPath                              // Harness pre-signed: raw path, no gateway prefix
           : rawPath.startsWith(LOG_SERVICE_GATEWAY_PREFIX)
           ? rawPath
           : `${LOG_SERVICE_GATEWAY_PREFIX}${rawPath}`;
   return await client.requestStream({ method: 'GET', path: downloadPath, signal });
   ```

2. **Port-safe host matching**: Switched `blobUrl.host` → `blobUrl.hostname` throughout. `URL.host` includes the port (e.g. `app.harness.io:443`), silently misclassifying URLs with explicit ports.

3. **Preserve `HarnessApiError` on client failure**: The `requestStream` catch block was wrapping all errors as plain `Error`, dropping `statusCode`/`correlationId` fields that callers use for auth failure detection. `HarnessApiError` is now re-thrown directly.

4. **Guard relative blob paths**: Relative `blobLink` values without a leading `/` produced a malformed path (`/gateway/log-service<rawPath>` with no separator). The fallback `rawPath` is now normalized to always start with `/`.

### Regression Tests

6 tests in `tests/utils/log-resolver.test.ts` — the last two are named `REGRESSION` and will catch any future attempt to re-introduce direct fetch for `*.harness.io` URLs:

| Scenario | Expected | Result |
|---|---|---|
| `app.harness.io` + `X-Amz-Signature` | routes through `client.requestStream()` | ✅ fixed |
| `custom.harness.io` + `X-Goog-Signature` | routes through `client.requestStream()` | ✅ fixed |
| True S3 pre-signed URL (`*.amazonaws.com`) | direct fetch | ✅ still works |
| True GCS pre-signed URL (`storage.googleapis.com`) | direct fetch | ✅ still works |
| `app.harness.io` blob with custom gateway `baseURL` | routes through `client.requestStream()` | ✅ on-prem guard |
| `app.harness.io:443` (explicit port) | routes through `client.requestStream()` | ✅ port-safety guard |

## Type of Change
- [x] Bug fix

## Checklist
- [x] Tests pass
- [x] Typecheck passes