### PR TITLE
feat: support pipeline_branch param to load pipeline YAML from a specific git branch

### DIFF
--- a/src/registry/toolsets/pipelines.ts
+++ b/src/registry/toolsets/pipelines.ts
@@ -309,6 +309,7 @@ export const pipelinesToolset: ToolsetDefinition = {
             module: "module",
             input_set_ids: "inputSetIdentifiers",
             branch: "branch",
+            pipeline_branch: "pipelineBranchName",
             store_type: "storeType",
             connector_ref: "connectorRef",
             repo_name: "repoName",
@@ -348,12 +349,13 @@ export const pipelinesToolset: ToolsetDefinition = {
               skipIfPresent: "build",
             },
           ],
-          actionDescription: "Execute/run a pipeline. RECOMMENDED: first check harness_get(resource_type='runtime_input_template', resource_id='PIPELINE_ID') to see required inputs. For simple variable inputs: pass key-value pairs in inputs (e.g. {branch: 'main'}) — auto-resolved. For CI pipelines with codebase: pass {branch: 'main'}, {tag: 'v1.0'}, {pr_number: '42'}, or {commit_sha: 'abc123'} — auto-expanded to the full build structure. For complex pipelines with template inputs: use input_set_ids to reference a saved input set. List available sets with harness_list(resource_type='input_set', filters={pipeline_id: '...'}).",
+          actionDescription: "Execute/run a pipeline. RECOMMENDED: first check harness_get(resource_type='runtime_input_template', resource_id='PIPELINE_ID') to see required inputs. For simple variable inputs: pass key-value pairs in inputs (e.g. {branch: 'main'}) — auto-resolved. For CI pipelines with codebase: pass {branch: 'main'}, {tag: 'v1.0'}, {pr_number: '42'}, or {commit_sha: 'abc123'} — auto-expanded to the full build structure. For complex pipelines with template inputs: use input_set_ids to reference a saved input set. List available sets with harness_list(resource_type='input_set', filters={pipeline_id: '...'}). To load the pipeline YAML from a specific git branch (e.g. a feature branch): pass params={pipeline_branch: 'feature/my-fix'} — sent as ?pipelineBranchName= on the API call.",
           bodySchema: {
             description: "Runtime inputs for pipeline execution. For simple variables: pass key-value pairs in inputs like {branch: 'main', env: 'prod'}, auto-resolved against the pipeline's runtime input template. CI codebase shorthands (branch, tag, pr_number, commit_sha) are auto-expanded to full build structures. For complex pipelines with template inputs, use input_set_ids to reference saved input sets. You can combine both: input_set_ids for the base config + inputs for simple overrides. Check runtime_input_template first to see what the pipeline expects.",
             fields: [
               { name: "inputs", type: "yaml", required: false, description: "Key-value pairs (e.g. {branch: 'main', env: 'prod'}) — auto-resolved to full YAML. CI codebase shorthands (branch, tag, pr_number, commit_sha) are auto-expanded. For template inputs, use input_set_ids instead." },
               { name: "input_set_ids", type: "array", required: false, description: "Input set identifiers to apply. Recommended for complex pipelines with template inputs. List available: harness_list(resource_type='input_set', filters={pipeline_id: '...'})." },
+              { name: "pipeline_branch", type: "string", required: false, description: "Git branch to load the pipeline YAML from (sent as ?pipelineBranchName= on the API). Use when the pipeline definition lives on a feature branch rather than the default branch." },
             ],
           },
         },

--- a/tests/registry/registry.test.ts
+++ b/tests/registry/registry.test.ts
@@ -779,6 +779,38 @@ describe("Registry", () => {
       expect(call.params?.pipelineBranchName).toBeUndefined();
     });
 
+    it("pipeline execute omits pipelineBranchName when pipeline_branch is empty string", async () => {
+      const mockRequest = vi.fn().mockResolvedValue({ planExecution: { uuid: "exec-789" } });
+      const client = makeClient(mockRequest);
+
+      await registry.dispatchExecute(client, "pipeline", "run", {
+        pipeline_id: "my-pipeline",
+        pipeline_branch: "",
+      });
+
+      expect(mockRequest).toHaveBeenCalledOnce();
+      const call = mockRequest.mock.calls[0][0];
+      expect(call.params?.pipelineBranchName).toBeUndefined();
+    });
+
+    it("pipeline execute sends both pipeline_branch and inputs.branch independently", async () => {
+      const mockRequest = vi.fn().mockResolvedValue({ planExecution: { uuid: "exec-abc" } });
+      const client = makeClient(mockRequest);
+
+      await registry.dispatchExecute(client, "pipeline", "run", {
+        pipeline_id: "my-pipeline",
+        pipeline_branch: "feature/my-fix",
+        inputs: { branch: "feature/my-fix" },
+      });
+
+      expect(mockRequest).toHaveBeenCalledOnce();
+      const call = mockRequest.mock.calls[0][0];
+      // pipeline_branch → URL query param (which git branch loads the pipeline YAML)
+      expect(call.params).toMatchObject({ pipelineBranchName: "feature/my-fix" });
+      // inputs.branch → body build structure (which code branch the CI job checks out)
+      expect(JSON.stringify(call.body)).toContain("feature/my-fix");
+    });
+
     it("pipeline update with yamlPipeline sends raw YAML string as body with Content-Type header and returns openInHarness", async () => {
       const yaml = "pipeline:\n  name: Test\n  identifier: test_pipeline\n  stages: []";
       const mockRequest = vi.fn().mockResolvedValue({

--- a/tests/registry/registry.test.ts
+++ b/tests/registry/registry.test.ts
@@ -750,6 +750,35 @@ describe("Registry", () => {
       expect(call.body).toEqual({ state: "closed" });
     });
 
+    it("pipeline execute sends pipeline_branch as ?pipelineBranchName= query param", async () => {
+      const mockRequest = vi.fn().mockResolvedValue({ planExecution: { uuid: "exec-123" } });
+      const client = makeClient(mockRequest);
+
+      await registry.dispatchExecute(client, "pipeline", "run", {
+        pipeline_id: "my-pipeline",
+        pipeline_branch: "feature/my-fix",
+      });
+
+      expect(mockRequest).toHaveBeenCalledOnce();
+      const call = mockRequest.mock.calls[0][0];
+      expect(call.method).toBe("POST");
+      expect(call.path).toContain("/pipeline/api/pipeline/execute/my-pipeline");
+      expect(call.params).toMatchObject({ pipelineBranchName: "feature/my-fix" });
+    });
+
+    it("pipeline execute omits pipelineBranchName when pipeline_branch not provided", async () => {
+      const mockRequest = vi.fn().mockResolvedValue({ planExecution: { uuid: "exec-456" } });
+      const client = makeClient(mockRequest);
+
+      await registry.dispatchExecute(client, "pipeline", "run", {
+        pipeline_id: "my-pipeline",
+      });
+
+      expect(mockRequest).toHaveBeenCalledOnce();
+      const call = mockRequest.mock.calls[0][0];
+      expect(call.params?.pipelineBranchName).toBeUndefined();
+    });
+
     it("pipeline update with yamlPipeline sends raw YAML string as body with Content-Type header and returns openInHarness", async () => {
       const yaml = "pipeline:\n  name: Test\n  identifier: test_pipeline\n  stages: []";
       const mockRequest = vi.fn().mockResolvedValue({

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -750,6 +750,20 @@ describe("harness_execute", () => {
     expect(mockRequest).toHaveBeenCalled();
   });
 
+  it("passes pipeline_branch from params as ?pipelineBranchName= query param", async () => {
+    await server.call("harness_execute", {
+      resource_type: "pipeline",
+      action: "run",
+      resource_id: "my-pipe",
+      params: { pipeline_branch: "feature/my-fix" },
+    });
+    expect(mockRequest).toHaveBeenCalled();
+    // Find the POST execute call (pre-flight GET calls come first)
+    const postCall = mockRequest.mock.calls.find((c) => c[0].method === "POST");
+    expect(postCall).toBeDefined();
+    expect(postCall![0].params).toMatchObject({ pipelineBranchName: "feature/my-fix" });
+  });
+
   it("closes a pull request from a Harness PR URL", async () => {
     const prServer = makeMcpServer("accept");
     const prRegistry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pull-requests" }));

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -764,6 +764,18 @@ describe("harness_execute", () => {
     expect(postCall![0].params).toMatchObject({ pipelineBranchName: "feature/my-fix" });
   });
 
+  it("pipeline_branch coexists with other params without clobbering", async () => {
+    await server.call("harness_execute", {
+      resource_type: "pipeline",
+      action: "run",
+      resource_id: "my-pipe",
+      params: { pipeline_branch: "feature/my-fix", module: "ci" },
+    });
+    const postCall = mockRequest.mock.calls.find((c) => c[0].method === "POST");
+    expect(postCall).toBeDefined();
+    expect(postCall![0].params).toMatchObject({ pipelineBranchName: "feature/my-fix", module: "ci" });
+  });
+
   it("closes a pull request from a Harness PR URL", async () => {
     const prServer = makeMcpServer("accept");
     const prRegistry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pull-requests" }));


### PR DESCRIPTION
## Description

Adds support for specifying which git branch to load the pipeline YAML from when executing a pipeline via MCP.

### Problem

Passing `pipelineBranchName` to `harness_execute` was silently ignored. The `queryParams` map for the pipeline `run` action had no entry for it, so the value was placed in the YAML request body where Harness ignores it. Harness only reads `pipelineBranchName` as a URL query parameter.

### Fix

Added `pipeline_branch: "pipelineBranchName"` to the `queryParams` mapping in `src/registry/toolsets/pipelines.ts`. Updated `actionDescription` and `bodySchema.fields` so the param is discoverable via `harness_describe`.

### Usage

```
harness_execute(
  url="<pipeline URL>",
  action="run",
  params={"pipeline_branch": "feature/my-fix"}
)
```

When `pipeline_branch` is omitted, `?pipelineBranchName=` is not sent and Harness falls back to the pipeline's configured default branch.

### Tests

6 new tests covering the fix:

| Test | Location | What it verifies |
|---|---|---|
| `pipeline execute sends pipeline_branch as ?pipelineBranchName= query param` | `tests/registry/registry.test.ts` | Registry queryParams mapping |
| `pipeline execute omits pipelineBranchName when pipeline_branch not provided` | `tests/registry/registry.test.ts` | Param absent when not passed |
| `pipeline execute omits pipelineBranchName when pipeline_branch is empty string` | `tests/registry/registry.test.ts` | Empty string treated as absent (guards `value !== ""` filter) |
| `pipeline execute sends both pipeline_branch and inputs.branch independently` | `tests/registry/registry.test.ts` | `pipelineBranchName` goes to URL query string; `inputs.branch` expands into body build structure — no interference |
| `passes pipeline_branch from params as ?pipelineBranchName= query param` | `tests/tools/tool-handlers.test.ts` | Full tool handler path |
| `pipeline_branch coexists with other params without clobbering` | `tests/tools/tool-handlers.test.ts` | Multi-key params Object.assign path; `pipeline_branch` + `module` both arrive on the POST |

## Type of Change
- [x] Bug fix
- [x] New feature

## Checklist
- [x] Tests pass
- [x] Typecheck passes