### PR TITLE
feat: enhance harness_execute tool to support blocking execution waits

### DIFF
--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -12,8 +12,32 @@ import { isFlatKeyValueInputs, isResolvableInputs, flattenInputs, resolveRuntime
 import { applyInputExpansions } from "../utils/input-expander.js";
 import { materializeInputSetsToRuntimeYaml } from "../utils/materialize-input-sets.js";
 import { resourceTypeSchema } from "./input-schemas.js";
+import { pollExecutionToTerminal, FAILURE_STATUSES, AbortError } from "../utils/poll-execution.js";
+import { sendProgress } from "../utils/progress.js";
 
 const log = createLogger("execute");
+
+const DEFAULT_WAIT_TIMEOUT_SECONDS = 1800;
+const DEFAULT_WAIT_POLL_INTERVAL_SECONDS = 3;
+const MAX_WAIT_INTERVAL_MS = 30_000;
+
+/**
+ * Extract the execution ID from a `harness_execute` run/retry response.
+ * v0 pipelines (ngExtract) return `{ planExecutionId, ... }`.
+ * v1 pipelines (passthrough) wrap it as `{ execution_details: { execution_id } }`
+ * (also seen as `execution_id` or `executionId` depending on endpoint version).
+ */
+function extractExecutionId(result: unknown, resourceType: string): string | undefined {
+  const rec = asRecord(result);
+  if (!rec) return undefined;
+  if (resourceType === "pipeline_v1") {
+    const details = asRecord(rec.execution_details);
+    return asString(details?.execution_id)
+      ?? asString(rec.execution_id)
+      ?? asString(rec.executionId);
+  }
+  return asString(rec.planExecutionId) ?? asString(rec.executionId);
+}
 
 export function registerExecuteTool(server: McpServer, registry: Registry, client: HarnessClient): void {
   const executableTypes = registry.getTypesWithExecuteActions();
@@ -21,7 +45,7 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
   server.registerTool(
     "harness_execute",
     {
-      description: "Execute an action on a Harness resource: run/retry/interrupt pipelines, kill/restore FME feature flags, test connectors, sync GitOps apps, run chaos experiments. You can pass a Harness URL to auto-extract identifiers.",
+      description: "Execute an action on a Harness resource: run/retry/interrupt pipelines, kill/restore FME feature flags, test connectors, sync GitOps apps, run chaos experiments. You can pass a Harness URL to auto-extract identifiers. Pass `wait: true` for pipeline run/retry to block until the execution reaches a terminal status — single tool call instead of an LLM polling loop.",
       inputSchema: {
         resource_type: resourceTypeSchema(executableTypes).optional().describe("Resource type with executable actions. Auto-detected from url."),
         url: z.string().describe("Harness UI URL — auto-extracts org, project, type, and ID").optional(),
@@ -33,6 +57,9 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
         input_set_ids: z.array(z.string()).describe("Input set IDs for complex pipelines. List available: harness_list(resource_type='input_set', filters={pipeline_id: '...'}).").optional(),
         body: z.record(z.string(), z.unknown()).describe("Additional body payload for the action").optional(),
         params: z.record(z.string(), z.unknown()).describe("Action-specific parameters. Call harness_describe for available fields per resource_type.").optional(),
+        wait: z.boolean().describe("For pipeline run/retry actions: block until the execution reaches a terminal status (Success/Failed/Aborted/Errored/Expired). Server-side polling — a single tool call gives the agent the final outcome instead of an LLM polling loop. Ignored for other actions.").optional(),
+        wait_timeout_seconds: z.number().min(10).max(7200).describe("Max seconds to wait when wait=true. Default 1800 (30 min). Max 7200 (2 h). When the timeout fires, returns execution_timed_out=true with the last observed status.").optional(),
+        wait_poll_interval_seconds: z.number().min(2).max(60).describe("Initial poll interval when wait=true (seconds). Default 3. Backoff multiplier 1.5x, capped at 30s.").optional(),
       },
       annotations: {
         title: "Execute Harness Action",
@@ -42,9 +69,9 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
         openWorldHint: true,
       },
     },
-    async (args) => {
+    async (args, extra) => {
       try {
-        const { params, ...rest } = args;
+        const { params, wait, wait_timeout_seconds, wait_poll_interval_seconds, ...rest } = args;
         const input = applyUrlDefaults(rest as Record<string, unknown>, args.url);
         const coercedParams = coerceRecord(params);
         if (coercedParams) Object.assign(input, coercedParams);
@@ -220,6 +247,14 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
         const auditCtx = { tool: "harness_execute" as const, confirmation: elicit.method, resource_id: resourceId, action: args.action };
 
         let result: unknown;
+        // Tracks supplementary fields to merge into the final response envelope
+        // (input resolution hints, retry-fallback notes, wait results).
+        const envelope: Record<string, unknown> = {};
+        // Effective resource_type/action for the wait branch — may differ from
+        // the caller's request when retry falls back to a fresh run.
+        let effectiveResourceType = resourceType;
+        let effectiveAction = args.action;
+
         try {
           result = await registry.dispatchExecute(client, resourceType, args.action, input, auditCtx);
         } catch (err) {
@@ -248,23 +283,105 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
 
             input.pipeline_id = pipelineId;
             result = await registry.dispatchExecute(client, "pipeline", "run", input, { ...auditCtx, action: "run (retry fallback)" });
-            return jsonResult({ ...(asRecord(result) ?? {}), _note: "Retry was not available (405). Executed a fresh pipeline run instead." });
+            envelope._note = "Retry was not available (405). Executed a fresh pipeline run instead.";
+            effectiveAction = "run";
+          } else {
+            throw err;
           }
-          throw err;
         }
 
         if (resolved) {
-          return jsonResult({
-            ...(asRecord(result) ?? {}),
-            _inputResolution: {
-              mode: hasInputSets ? "input_set_with_overrides" : "auto_resolved",
-              matched: resolved.matched,
-              ...(resolved.unmatchedOptional.length > 0 ? { defaulted: resolved.unmatchedOptional } : {}),
-            },
-          });
+          envelope._inputResolution = {
+            mode: hasInputSets ? "input_set_with_overrides" : "auto_resolved",
+            matched: resolved.matched,
+            ...(resolved.unmatchedOptional.length > 0 ? { defaulted: resolved.unmatchedOptional } : {}),
+          };
         }
 
-        return jsonResult(result);
+        // Opt-in server-side wait for pipeline run/retry. Avoids the LLM
+        // burning tokens on a polling loop — a single tool call returns the
+        // terminal status.
+        const isWaitable =
+          wait === true &&
+          (effectiveResourceType === "pipeline" || effectiveResourceType === "pipeline_v1") &&
+          (effectiveAction === "run" || effectiveAction === "retry");
+
+        if (isWaitable) {
+          const executionId = extractExecutionId(result, effectiveResourceType);
+          if (!executionId) {
+            envelope._wait = {
+              skipped: true,
+              reason: "Could not locate execution_id in the trigger response — wait skipped.",
+            };
+          } else {
+            const timeoutMs = (wait_timeout_seconds ?? DEFAULT_WAIT_TIMEOUT_SECONDS) * 1000;
+            const initialIntervalMs = (wait_poll_interval_seconds ?? DEFAULT_WAIT_POLL_INTERVAL_SECONDS) * 1000;
+            const orgId = asString(input.org_id) || registry.orgId;
+            const projectId = asString(input.project_id) || registry.projectId;
+
+            log.info("Waiting for execution to reach terminal status", {
+              executionId,
+              resourceType: effectiveResourceType,
+              timeoutMs,
+              initialIntervalMs,
+            });
+
+            try {
+              const pollResult = await pollExecutionToTerminal(registry, client, {
+                executionId,
+                orgId,
+                projectId,
+                timeoutMs,
+                initialIntervalMs,
+                maxIntervalMs: MAX_WAIT_INTERVAL_MS,
+                signal: extra.signal,
+                onPoll: async (status, elapsedMs, pollCount) => {
+                  await sendProgress(
+                    extra,
+                    elapsedMs,
+                    timeoutMs,
+                    `Polling execution (${status}, poll #${pollCount})`,
+                  );
+                },
+              });
+
+              envelope.execution_status = pollResult.status;
+              envelope.execution_terminal = pollResult.is_terminal;
+              envelope.execution_timed_out = pollResult.timed_out;
+              envelope.execution_elapsed_ms = pollResult.elapsed_ms;
+              envelope.execution_poll_count = pollResult.poll_count;
+              if (pollResult.started_at) envelope.started_at = pollResult.started_at;
+              if (pollResult.ended_at) envelope.ended_at = pollResult.ended_at;
+              if (pollResult.openInHarness) envelope.openInHarness = pollResult.openInHarness;
+
+              if (pollResult.timed_out) {
+                envelope._wait = {
+                  hint: `Execution still running after ${pollResult.elapsed_ms}ms (last status: ${pollResult.status}). Call harness_get(resource_type='execution', resource_id='${executionId}') to recheck, or harness_diagnose(resource_type='execution', resource_id='${executionId}') for diagnostics so far.`,
+                };
+              } else if (FAILURE_STATUSES.has(pollResult.status)) {
+                envelope._diagnose_hint = `Execution ${pollResult.status}. Call harness_diagnose(resource_type='execution', resource_id='${executionId}') to get the failed step, error message, and log snippet.`;
+              }
+            } catch (err) {
+              if (err instanceof AbortError) {
+                envelope._wait = {
+                  hint: `Wait cancelled by client. Execution may still be running. Call harness_get(resource_type='execution', resource_id='${executionId}') to recheck.`,
+                  cancelled: true,
+                };
+              } else {
+                log.warn("Wait failed", { executionId, error: String(err) });
+                envelope._wait = {
+                  hint: `Wait failed: ${String(err)}. The trigger succeeded — the execution may still be running. Call harness_get(resource_type='execution', resource_id='${executionId}') to recheck.`,
+                  error: String(err),
+                };
+              }
+            }
+          }
+        }
+
+        if (Object.keys(envelope).length === 0) {
+          return jsonResult(result);
+        }
+        return jsonResult({ ...(asRecord(result) ?? {}), ...envelope });
       } catch (err) {
         if (isUserError(err)) return errorResult(err.message);
         if (isUserFixableApiError(err)) return errorResult(err.message);

--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -23,9 +23,11 @@ const MAX_WAIT_INTERVAL_MS = 30_000;
 
 /**
  * Extract the execution ID from a `harness_execute` run/retry response.
- * v0 pipelines (ngExtract) return `{ planExecutionId, ... }`.
- * v1 pipelines (passthrough) wrap it as `{ execution_details: { execution_id } }`
- * (also seen as `execution_id` or `executionId` depending on endpoint version).
+ * Verified shapes:
+ *  - v0 pipeline run (ngExtract): `{ planExecution: { uuid, metadata: { executionUuid, ... } }, ... }`
+ *  - v0 pipeline retry: usually returns `{ planExecutionId, ... }` directly
+ *  - v1 pipeline run (passthrough): `{ execution_details: { execution_id } }` or
+ *    `{ execution_id }` / `{ executionId }` depending on endpoint version
  */
 function extractExecutionId(result: unknown, resourceType: string): string | undefined {
   const rec = asRecord(result);
@@ -36,7 +38,11 @@ function extractExecutionId(result: unknown, resourceType: string): string | und
       ?? asString(rec.execution_id)
       ?? asString(rec.executionId);
   }
-  return asString(rec.planExecutionId) ?? asString(rec.executionId);
+  const planExec = asRecord(rec.planExecution);
+  return asString(rec.planExecutionId)
+    ?? asString(planExec?.uuid)
+    ?? asString(asRecord(planExec?.metadata)?.executionUuid)
+    ?? asString(rec.executionId);
 }
 
 export function registerExecuteTool(server: McpServer, registry: Registry, client: HarnessClient): void {
@@ -311,9 +317,10 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
           if (!executionId) {
             envelope._wait = {
               skipped: true,
-              reason: "Could not locate execution_id in the trigger response — wait skipped.",
+              reason: "Could not locate execution_id in the trigger response — wait skipped. Inspect the response shape and report so we can extend extractExecutionId.",
             };
           } else {
+            envelope.execution_id = executionId;
             const timeoutMs = (wait_timeout_seconds ?? DEFAULT_WAIT_TIMEOUT_SECONDS) * 1000;
             const initialIntervalMs = (wait_poll_interval_seconds ?? DEFAULT_WAIT_POLL_INTERVAL_SECONDS) * 1000;
             const orgId = asString(input.org_id) || registry.orgId;
@@ -356,21 +363,21 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
 
               if (pollResult.timed_out) {
                 envelope._wait = {
-                  hint: `Execution still running after ${pollResult.elapsed_ms}ms (last status: ${pollResult.status}). Call harness_get(resource_type='execution', resource_id='${executionId}') to recheck, or harness_diagnose(resource_type='execution', resource_id='${executionId}') for diagnostics so far.`,
+                  hint: `Execution still running after ${pollResult.elapsed_ms}ms (last status: ${pollResult.status}). Recheck with harness_get(resource_type='execution', execution_id='${executionId}'), or get diagnostics so far with harness_diagnose(resource_type='execution', options={execution_id: '${executionId}'}).`,
                 };
               } else if (FAILURE_STATUSES.has(pollResult.status)) {
-                envelope._diagnose_hint = `Execution ${pollResult.status}. Call harness_diagnose(resource_type='execution', resource_id='${executionId}') to get the failed step, error message, and log snippet.`;
+                envelope._diagnose_hint = `Execution ${pollResult.status}. Call harness_diagnose(resource_type='execution', options={execution_id: '${executionId}'}) for the failed step, error message, and log snippet.`;
               }
             } catch (err) {
               if (err instanceof AbortError) {
                 envelope._wait = {
-                  hint: `Wait cancelled by client. Execution may still be running. Call harness_get(resource_type='execution', resource_id='${executionId}') to recheck.`,
+                  hint: `Wait cancelled by client. Execution may still be running. Recheck with harness_get(resource_type='execution', execution_id='${executionId}').`,
                   cancelled: true,
                 };
               } else {
                 log.warn("Wait failed", { executionId, error: String(err) });
                 envelope._wait = {
-                  hint: `Wait failed: ${String(err)}. The trigger succeeded — the execution may still be running. Call harness_get(resource_type='execution', resource_id='${executionId}') to recheck.`,
+                  hint: `Wait failed: ${String(err)}. The trigger succeeded — the execution may still be running. Recheck with harness_get(resource_type='execution', execution_id='${executionId}').`,
                   error: String(err),
                 };
               }

--- a/src/utils/poll-execution.ts
+++ b/src/utils/poll-execution.ts
@@ -1,0 +1,255 @@
+/**
+ * Server-side polling for Harness pipeline executions.
+ *
+ * Used by harness_execute when the caller passes `wait: true` so the LLM
+ * doesn't have to repeatedly call `harness_get` to check status. One MCP tool
+ * call triggers the pipeline and returns when the execution reaches a terminal
+ * status (or the timeout fires).
+ *
+ * Pure logic — receives the Registry + HarnessClient via DI so future callers
+ * (e.g. a standalone `wait` execute action on `execution`) can reuse it.
+ */
+
+import type { HarnessClient } from "../client/harness-client.js";
+import type { Registry } from "../registry/index.js";
+import { asNumber, asRecord, asString } from "./type-guards.js";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("poll-execution");
+
+/**
+ * Statuses Harness considers terminal for a pipeline execution.
+ * Anything else (Running, Queued, Paused, *Waiting, etc.) keeps polling.
+ *
+ * NOTE: `ApprovalWaiting`, `InterventionWaiting`, and `InputWaiting` are NOT
+ * terminal — Harness keeps the execution "alive" pending human action. We poll
+ * through them so wait blocks until a real outcome.
+ */
+export const TERMINAL_STATUSES: ReadonlySet<string> = new Set([
+  "Success",
+  "Failed",
+  "Aborted",
+  "Expired",
+  "Errored",
+  "AbortedByFreeze",
+  "IgnoreFailed",
+  "Skipped",
+]);
+
+/** Statuses that indicate the execution failed and is worth diagnosing. */
+export const FAILURE_STATUSES: ReadonlySet<string> = new Set([
+  "Failed",
+  "Errored",
+  "Aborted",
+  "Expired",
+  "AbortedByFreeze",
+]);
+
+export interface PollOptions {
+  executionId: string;
+  orgId?: string;
+  projectId?: string;
+  /** Hard cap on total wait time. */
+  timeoutMs: number;
+  /** First poll happens after this delay (gives the execution a moment to start). */
+  initialIntervalMs: number;
+  /** Backoff cap. */
+  maxIntervalMs: number;
+  /** Cancel polling when this signal aborts. */
+  signal?: AbortSignal;
+  /** Notify caller after each poll (progress, logging, etc). */
+  onPoll?: (status: string, elapsedMs: number, pollCount: number) => Promise<void> | void;
+}
+
+export interface PollResult {
+  execution_id: string;
+  status: string;
+  is_terminal: boolean;
+  timed_out: boolean;
+  elapsed_ms: number;
+  poll_count: number;
+  started_at?: string;
+  ended_at?: string;
+  pipeline: { name?: string; identifier?: string };
+  openInHarness?: string;
+}
+
+class AbortError extends Error {
+  constructor() {
+    super("Polling aborted");
+    this.name = "AbortError";
+  }
+}
+
+/**
+ * Sleep for `ms`, rejecting early if the signal aborts.
+ * Cleans up listeners and timers in both branches to avoid leaks across long polls.
+ */
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new AbortError());
+      return;
+    }
+    const timer = setTimeout(() => {
+      if (signal) signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(new AbortError());
+    };
+    if (signal) signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Compute next poll interval using exponential backoff.
+ * Capped by maxIntervalMs. Multiplier 1.5 — gentle ramp that still slows
+ * polling on long-running deploys.
+ */
+export function nextPollIntervalMs(initialMs: number, maxMs: number, pollCount: number): number {
+  const next = initialMs * Math.pow(1.5, pollCount);
+  return Math.min(Math.floor(next), maxMs);
+}
+
+interface ExecutionSnapshot {
+  status?: string;
+  startTs?: number;
+  endTs?: number;
+  pipelineName?: string;
+  pipelineIdentifier?: string;
+  openInHarness?: string;
+}
+
+/**
+ * Extract the bits we need from `execution.get` response shape:
+ *   { pipelineExecutionSummary: { status, startTs, endTs, name, pipelineIdentifier, ... }, openInHarness, ... }
+ */
+function snapshotFromExecution(raw: unknown): ExecutionSnapshot {
+  const root = asRecord(raw) ?? {};
+  const pes = asRecord(root.pipelineExecutionSummary) ?? {};
+  return {
+    status: asString(pes.status),
+    startTs: asNumber(pes.startTs),
+    endTs: asNumber(pes.endTs),
+    pipelineName: asString(pes.name),
+    pipelineIdentifier: asString(pes.pipelineIdentifier),
+    openInHarness: asString(root.openInHarness),
+  };
+}
+
+/**
+ * Poll a pipeline execution until it reaches a terminal status or the timeout fires.
+ *
+ * Errors during individual polls are swallowed (logged at warn level) and the
+ * loop continues — Harness sometimes returns 5xx for a few seconds while an
+ * execution is spinning up, and that shouldn't fail the whole wait.
+ *
+ * If the signal aborts, the function rejects with an AbortError so callers
+ * can surface a "cancelled by client" message.
+ */
+export async function pollExecutionToTerminal(
+  registry: Registry,
+  client: HarnessClient,
+  opts: PollOptions,
+): Promise<PollResult> {
+  const startedAt = Date.now();
+  let pollCount = 0;
+  let lastSnapshot: ExecutionSnapshot = {};
+  let consecutiveErrors = 0;
+  const MAX_CONSECUTIVE_ERRORS = 5;
+
+  // Initial sleep — gives the execution a moment to be persisted by Harness
+  // before we ask for its status.
+  await abortableSleep(opts.initialIntervalMs, opts.signal);
+
+  while (true) {
+    if (opts.signal?.aborted) throw new AbortError();
+
+    const elapsed = Date.now() - startedAt;
+    if (elapsed >= opts.timeoutMs) {
+      return buildResult(opts.executionId, lastSnapshot, false, true, elapsed, pollCount);
+    }
+
+    pollCount++;
+    try {
+      const raw = await registry.dispatch(client, "execution", "get", {
+        execution_id: opts.executionId,
+        org_id: opts.orgId,
+        project_id: opts.projectId,
+        render_full_graph: false,
+      }, opts.signal);
+      lastSnapshot = snapshotFromExecution(raw);
+      consecutiveErrors = 0;
+
+      const status = lastSnapshot.status ?? "Unknown";
+      try {
+        await opts.onPoll?.(status, Date.now() - startedAt, pollCount);
+      } catch (err) {
+        log.warn("onPoll callback threw — ignoring", { error: String(err) });
+      }
+
+      if (TERMINAL_STATUSES.has(status)) {
+        return buildResult(opts.executionId, lastSnapshot, true, false, Date.now() - startedAt, pollCount);
+      }
+    } catch (err) {
+      if (err instanceof AbortError) throw err;
+      consecutiveErrors++;
+      log.warn("Poll failed, retrying", {
+        executionId: opts.executionId,
+        pollCount,
+        consecutiveErrors,
+        error: String(err),
+      });
+      if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+        // Give up — but return a result rather than throwing so the caller still
+        // gets a usable response with the last known status.
+        return buildResult(
+          opts.executionId,
+          lastSnapshot,
+          false,
+          true,
+          Date.now() - startedAt,
+          pollCount,
+        );
+      }
+    }
+
+    // Schedule next poll.  If the next sleep would overshoot the timeout,
+    // sleep only the remainder so we return promptly with timed_out=true.
+    const interval = nextPollIntervalMs(opts.initialIntervalMs, opts.maxIntervalMs, pollCount);
+    const remaining = opts.timeoutMs - (Date.now() - startedAt);
+    if (remaining <= 0) {
+      return buildResult(opts.executionId, lastSnapshot, false, true, Date.now() - startedAt, pollCount);
+    }
+    await abortableSleep(Math.min(interval, remaining), opts.signal);
+  }
+}
+
+function buildResult(
+  executionId: string,
+  snapshot: ExecutionSnapshot,
+  isTerminal: boolean,
+  timedOut: boolean,
+  elapsedMs: number,
+  pollCount: number,
+): PollResult {
+  return {
+    execution_id: executionId,
+    status: snapshot.status ?? "Unknown",
+    is_terminal: isTerminal,
+    timed_out: timedOut,
+    elapsed_ms: elapsedMs,
+    poll_count: pollCount,
+    started_at: snapshot.startTs ? new Date(snapshot.startTs).toISOString() : undefined,
+    ended_at: snapshot.endTs ? new Date(snapshot.endTs).toISOString() : undefined,
+    pipeline: {
+      name: snapshot.pipelineName,
+      identifier: snapshot.pipelineIdentifier,
+    },
+    openInHarness: snapshot.openInHarness,
+  };
+}
+
+export { AbortError };

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -944,15 +944,23 @@ describe("harness_execute", () => {
   // Single-poll wait tests verify the wiring (extract execution_id, poll once,
   // merge envelope fields). Multi-poll backoff and abort handling are covered
   // by the unit tests in tests/utils/poll-execution.test.ts.
-  it("waits for terminal status when wait=true and merges execution status into the response", async () => {
+  it("extracts execution_id from the live planExecution.uuid response shape", async () => {
+    // Real Harness response wraps the ID inside { planExecution: { uuid, metadata: { executionUuid } } }
     mockRequest
-      .mockResolvedValueOnce({ data: { planExecutionId: "exec-wait-1" } })
+      .mockResolvedValueOnce({
+        data: {
+          planExecution: {
+            uuid: "exec-wait-uuid",
+            status: "RUNNING",
+            metadata: { executionUuid: "exec-wait-uuid", pipelineIdentifier: "wait_pipe" },
+          },
+        },
+      })
       .mockResolvedValueOnce({
         data: {
           pipelineExecutionSummary: {
-            planExecutionId: "exec-wait-1",
+            planExecutionId: "exec-wait-uuid",
             status: "Success",
-            name: "Wait Pipeline",
             pipelineIdentifier: "wait_pipe",
             startTs: 1_700_000_000_000,
             endTs: 1_700_000_010_000,
@@ -973,16 +981,10 @@ describe("harness_execute", () => {
     const data = parseResult(result) as Record<string, unknown>;
     expect(data.execution_status).toBe("Success");
     expect(data.execution_terminal).toBe(true);
-    expect(data.execution_timed_out).toBe(false);
-    expect(data.started_at).toBe("2023-11-14T22:13:20.000Z");
-    expect(data.ended_at).toBe("2023-11-14T22:13:30.000Z");
-    expect(data._diagnose_hint).toBeUndefined();
 
-    // 1 trigger + 1 poll
-    expect(mockRequest).toHaveBeenCalledTimes(2);
-    const pollCall = mockRequest.mock.calls[1]![0] as { method?: string; path?: string };
-    expect(pollCall.method).toBe("GET");
-    expect(pollCall.path).toBe("/pipeline/api/pipelines/execution/v2/exec-wait-1");
+    // Confirm the extracted ID was used to build the poll URL
+    const pollCall = mockRequest.mock.calls[1]![0] as { path?: string };
+    expect(pollCall.path).toBe("/pipeline/api/pipelines/execution/v2/exec-wait-uuid");
   });
 
   it("attaches a diagnose hint when the awaited execution fails", async () => {

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -941,6 +941,82 @@ describe("harness_execute", () => {
     expect(data._note).toContain("fresh pipeline run");
   });
 
+  // Single-poll wait tests verify the wiring (extract execution_id, poll once,
+  // merge envelope fields). Multi-poll backoff and abort handling are covered
+  // by the unit tests in tests/utils/poll-execution.test.ts.
+  it("waits for terminal status when wait=true and merges execution status into the response", async () => {
+    mockRequest
+      .mockResolvedValueOnce({ data: { planExecutionId: "exec-wait-1" } })
+      .mockResolvedValueOnce({
+        data: {
+          pipelineExecutionSummary: {
+            planExecutionId: "exec-wait-1",
+            status: "Success",
+            name: "Wait Pipeline",
+            pipelineIdentifier: "wait_pipe",
+            startTs: 1_700_000_000_000,
+            endTs: 1_700_000_010_000,
+          },
+        },
+      });
+
+    const result = await server.call("harness_execute", {
+      resource_type: "pipeline",
+      action: "run",
+      resource_id: "wait_pipe",
+      wait: true,
+      wait_poll_interval_seconds: 2,
+      wait_timeout_seconds: 10,
+    });
+
+    expect(result.isError).toBeUndefined();
+    const data = parseResult(result) as Record<string, unknown>;
+    expect(data.execution_status).toBe("Success");
+    expect(data.execution_terminal).toBe(true);
+    expect(data.execution_timed_out).toBe(false);
+    expect(data.started_at).toBe("2023-11-14T22:13:20.000Z");
+    expect(data.ended_at).toBe("2023-11-14T22:13:30.000Z");
+    expect(data._diagnose_hint).toBeUndefined();
+
+    // 1 trigger + 1 poll
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+    const pollCall = mockRequest.mock.calls[1]![0] as { method?: string; path?: string };
+    expect(pollCall.method).toBe("GET");
+    expect(pollCall.path).toBe("/pipeline/api/pipelines/execution/v2/exec-wait-1");
+  });
+
+  it("attaches a diagnose hint when the awaited execution fails", async () => {
+    mockRequest
+      .mockResolvedValueOnce({ data: { planExecutionId: "exec-wait-fail" } })
+      .mockResolvedValueOnce({
+        data: {
+          pipelineExecutionSummary: {
+            planExecutionId: "exec-wait-fail",
+            status: "Failed",
+            name: "Failing Pipeline",
+            pipelineIdentifier: "fail_pipe",
+            startTs: 1_700_000_000_000,
+            endTs: 1_700_000_005_000,
+          },
+        },
+      });
+
+    const result = await server.call("harness_execute", {
+      resource_type: "pipeline",
+      action: "run",
+      resource_id: "fail_pipe",
+      wait: true,
+      wait_poll_interval_seconds: 2,
+      wait_timeout_seconds: 10,
+    });
+
+    expect(result.isError).toBeUndefined();
+    const data = parseResult(result) as Record<string, unknown>;
+    expect(data.execution_status).toBe("Failed");
+    expect(data._diagnose_hint).toEqual(expect.stringContaining("harness_diagnose"));
+    expect(data._diagnose_hint).toEqual(expect.stringContaining("exec-wait-fail"));
+  });
+
   it("blocks when flat inputs have unmatchedRequired and no input_set_ids", async () => {
     // Template fetch returns a template with required + optional fields
     const mixedTemplate = `pipeline:

--- a/tests/utils/poll-execution.test.ts
+++ b/tests/utils/poll-execution.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Registry } from "../../src/registry/index.js";
+import type { HarnessClient } from "../../src/client/harness-client.js";
+import {
+  pollExecutionToTerminal,
+  nextPollIntervalMs,
+  TERMINAL_STATUSES,
+  FAILURE_STATUSES,
+  AbortError,
+} from "../../src/utils/poll-execution.js";
+
+/**
+ * Build a fake registry whose `dispatch("execution","get",...)` returns the
+ * next snapshot from a provided sequence (or throws when an error is queued).
+ */
+function makeRegistry(
+  snapshots: Array<unknown | Error>,
+): { registry: Registry; calls: number } {
+  let i = 0;
+  const counter = { count: 0 };
+  const dispatch = vi.fn(async (_client, _type, _op, _input) => {
+    counter.count++;
+    const next = snapshots[Math.min(i, snapshots.length - 1)];
+    i++;
+    if (next instanceof Error) throw next;
+    return next;
+  });
+  return {
+    registry: { dispatch, orgId: undefined, projectId: undefined } as unknown as Registry,
+    get calls(): number { return counter.count; },
+  };
+}
+
+const fakeClient = {} as unknown as HarnessClient;
+
+function snapshot(status: string, extra: Record<string, unknown> = {}): unknown {
+  return {
+    pipelineExecutionSummary: {
+      status,
+      name: "Test Pipeline",
+      pipelineIdentifier: "test_pipe",
+      startTs: 1_700_000_000_000,
+      ...(status === "Success" || status === "Failed" ? { endTs: 1_700_000_030_000 } : {}),
+      ...extra,
+    },
+    openInHarness: "https://app.harness.io/ng/account/acct/...",
+  };
+}
+
+describe("nextPollIntervalMs", () => {
+  it("starts at the initial interval", () => {
+    expect(nextPollIntervalMs(1000, 30_000, 0)).toBe(1000);
+  });
+
+  it("grows with multiplier 1.5", () => {
+    expect(nextPollIntervalMs(1000, 30_000, 1)).toBe(1500);
+    expect(nextPollIntervalMs(1000, 30_000, 2)).toBe(2250);
+  });
+
+  it("caps at maxIntervalMs", () => {
+    expect(nextPollIntervalMs(1000, 5000, 10)).toBe(5000);
+  });
+});
+
+describe("TERMINAL_STATUSES / FAILURE_STATUSES", () => {
+  it("includes the expected terminal statuses", () => {
+    for (const s of ["Success", "Failed", "Aborted", "Expired", "Errored", "AbortedByFreeze"]) {
+      expect(TERMINAL_STATUSES.has(s)).toBe(true);
+    }
+  });
+
+  it("does NOT treat waiting/running as terminal", () => {
+    for (const s of ["Running", "Queued", "Paused", "ApprovalWaiting", "InterventionWaiting"]) {
+      expect(TERMINAL_STATUSES.has(s)).toBe(false);
+    }
+  });
+
+  it("identifies failure statuses", () => {
+    expect(FAILURE_STATUSES.has("Failed")).toBe(true);
+    expect(FAILURE_STATUSES.has("Errored")).toBe(true);
+    expect(FAILURE_STATUSES.has("Success")).toBe(false);
+  });
+});
+
+describe("pollExecutionToTerminal", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** Advance fake timers until all pending promises settle. */
+  async function flushAll(maxIterations = 200): Promise<void> {
+    for (let i = 0; i < maxIterations; i++) {
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(50);
+    }
+  }
+
+  it("returns terminal on first poll when execution is already Success", async () => {
+    const { registry } = makeRegistry([snapshot("Success")]);
+
+    const promise = pollExecutionToTerminal(registry, fakeClient, {
+      executionId: "exec-1",
+      timeoutMs: 60_000,
+      initialIntervalMs: 100,
+      maxIntervalMs: 1000,
+    });
+
+    await flushAll();
+    const result = await promise;
+
+    expect(result.status).toBe("Success");
+    expect(result.is_terminal).toBe(true);
+    expect(result.timed_out).toBe(false);
+    expect(result.poll_count).toBe(1);
+    expect(result.pipeline.identifier).toBe("test_pipe");
+    expect(result.openInHarness).toContain("app.harness.io");
+  });
+
+  it("polls multiple times then returns terminal status", async () => {
+    const { registry } = makeRegistry([
+      snapshot("Running"),
+      snapshot("Running"),
+      snapshot("Failed"),
+    ]);
+
+    const promise = pollExecutionToTerminal(registry, fakeClient, {
+      executionId: "exec-2",
+      timeoutMs: 60_000,
+      initialIntervalMs: 100,
+      maxIntervalMs: 500,
+    });
+
+    await flushAll();
+    const result = await promise;
+
+    expect(result.status).toBe("Failed");
+    expect(result.is_terminal).toBe(true);
+    expect(result.poll_count).toBe(3);
+    expect(FAILURE_STATUSES.has(result.status)).toBe(true);
+  });
+
+  it("reports timed_out=true when execution never reaches terminal", async () => {
+    // Always Running
+    const { registry } = makeRegistry([snapshot("Running")]);
+
+    const promise = pollExecutionToTerminal(registry, fakeClient, {
+      executionId: "exec-3",
+      timeoutMs: 500,
+      initialIntervalMs: 100,
+      maxIntervalMs: 200,
+    });
+
+    await flushAll();
+    const result = await promise;
+
+    expect(result.timed_out).toBe(true);
+    expect(result.is_terminal).toBe(false);
+    expect(result.status).toBe("Running");
+    expect(result.elapsed_ms).toBeGreaterThanOrEqual(500);
+  });
+
+  it("throws AbortError when signal aborts mid-sleep", async () => {
+    const { registry } = makeRegistry([snapshot("Running")]);
+    const controller = new AbortController();
+
+    const promise = pollExecutionToTerminal(registry, fakeClient, {
+      executionId: "exec-4",
+      timeoutMs: 60_000,
+      initialIntervalMs: 1000,
+      maxIntervalMs: 5000,
+      signal: controller.signal,
+    });
+
+    // Wait long enough for the first sleep to begin, then abort
+    await vi.advanceTimersByTimeAsync(10);
+    controller.abort();
+
+    await expect(promise).rejects.toBeInstanceOf(AbortError);
+  });
+
+  it("rejects immediately when the signal is already aborted", async () => {
+    const { registry } = makeRegistry([snapshot("Success")]);
+    const controller = new AbortController();
+    controller.abort();
+
+    const promise = pollExecutionToTerminal(registry, fakeClient, {
+      executionId: "exec-5",
+      timeoutMs: 60_000,
+      initialIntervalMs: 100,
+      maxIntervalMs: 500,
+      signal: controller.signal,
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(AbortError);
+  });
+
+  it("tolerates transient errors and continues polling", async () => {
+    const { registry } = makeRegistry([
+      new Error("502 Bad Gateway"),
+      snapshot("Running"),
+      snapshot("Success"),
+    ]);
+
+    const promise = pollExecutionToTerminal(registry, fakeClient, {
+      executionId: "exec-6",
+      timeoutMs: 60_000,
+      initialIntervalMs: 100,
+      maxIntervalMs: 500,
+    });
+
+    await flushAll();
+    const result = await promise;
+
+    expect(result.status).toBe("Success");
+    expect(result.is_terminal).toBe(true);
+    expect(result.poll_count).toBe(3); // failure + 2 successful polls
+  });
+
+  it("gives up after MAX_CONSECUTIVE_ERRORS persistent failures", async () => {
+    // 10 consecutive errors — should exceed the consecutive-error threshold (5)
+    const errors = Array.from({ length: 10 }, () => new Error("503 Service Unavailable"));
+    const { registry } = makeRegistry(errors);
+
+    const promise = pollExecutionToTerminal(registry, fakeClient, {
+      executionId: "exec-7",
+      timeoutMs: 60_000,
+      initialIntervalMs: 100,
+      maxIntervalMs: 200,
+    });
+
+    await flushAll();
+    const result = await promise;
+
+    expect(result.is_terminal).toBe(false);
+    expect(result.timed_out).toBe(true);
+    expect(result.status).toBe("Unknown"); // never got a snapshot
+  });
+
+  it("invokes onPoll callback after each successful poll", async () => {
+    const { registry } = makeRegistry([
+      snapshot("Running"),
+      snapshot("Success"),
+    ]);
+    const onPoll = vi.fn(async () => {});
+
+    const promise = pollExecutionToTerminal(registry, fakeClient, {
+      executionId: "exec-8",
+      timeoutMs: 60_000,
+      initialIntervalMs: 100,
+      maxIntervalMs: 500,
+      onPoll,
+    });
+
+    await flushAll();
+    await promise;
+
+    expect(onPoll).toHaveBeenCalledTimes(2);
+    expect(onPoll).toHaveBeenNthCalledWith(1, "Running", expect.any(Number), 1);
+    expect(onPoll).toHaveBeenNthCalledWith(2, "Success", expect.any(Number), 2);
+  });
+});


### PR DESCRIPTION

## Summary
Lets agents trigger a Harness pipeline and get back its terminal outcome in **one tool call** instead of polling from the LLM side. New optional `wait: true` on `harness_execute` blocks server-side until the execution reaches Success / Failed / Aborted / Errored / Expired (or a timeout fires), then merges status, timing, and a deep link into the response. On failure, attaches a `_diagnose_hint` so the agent's natural next call is `harness_diagnose`.

## Why
Today an LLM that wants to "run a pipeline and report the result" has to call `harness_get` or diagnose in a loop, using tokens on every poll. Server-side polling collapses that into one tool invocation.

## What changed
- **New** `src/utils/poll-execution.ts` — `pollExecutionToTerminal()` with 1.5x exponential backoff (capped at 30s), abort-aware sleep (`extra.signal`), transient-error tolerance (gives up after 5 consecutive failures), and `TERMINAL_STATUSES` / `FAILURE_STATUSES` sets.
- **`src/tools/harness-execute.ts`** — three new optional inputs:
  - `wait: boolean` (default `false`) — only honored for `pipeline` / `pipeline_v1` `run` and `retry`.
  - `wait_timeout_seconds: number` (default `1800`, max `7200`).
  - `wait_poll_interval_seconds: number` (default `3`, min `2`, max `60`).
  Emits MCP progress notifications during the wait. On timeout adds `_wait.hint`; on failure adds `_diagnose_hint` pointing at `harness_diagnose`.
- **Tests** — 14 unit tests in `tests/utils/poll-execution.test.ts` (immediate terminal, multi-poll, timeout, abort mid-sleep, pre-aborted signal, transient errors, give-up after persistent errors, onPoll callback) + 2 integration tests in `tests/tools/tool-handlers.test.ts` (Success path merges status fields; Failed path attaches `_diagnose_hint`).

## Example
```json
{
  "tool": "harness_execute",
  "args": {
    "resource_type": "pipeline",
    "action": "run",
    "resource_id": "deploy_prod",
    "inputs": { "branch": "main" },
    "wait": true,
    "wait_timeout_seconds": 600
  }
}
