### PR TITLE
Add per-session auto approve risk

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,7 +63,8 @@ Tool handler validates resource_type + action
   │
   ▼
 confirmViaElicitation({
-  risk: endpoint.operationPolicy.risk   // execute: per-action; delete: destructive
+  risk: endpoint.operationPolicy.risk,  // execute: per-action; delete: destructive
+  autoApproveRisk: config.HARNESS_AUTO_APPROVE_RISK
 })
   │
   ▼
@@ -140,16 +141,16 @@ src/registry/index.ts         ← Registry class; dispatch() passes specs to
                                  elicitation (that's for tool handlers and future P5)
 
 src/tools/harness-create.ts   ┐
-src/tools/harness-update.ts   ├─ pass operationPolicy.risk to confirmViaElicitation({ risk })
-src/tools/harness-execute.ts   │
+src/tools/harness-update.ts   ├─ pass operationPolicy.risk and session config
+src/tools/harness-execute.ts   │  autoApproveRisk to confirmViaElicitation()
 src/tools/harness-delete.ts   ┘
 
-src/utils/elicitation.ts      ← confirmViaElicitation({ risk: RiskLevel })
+src/utils/elicitation.ts      ← confirmViaElicitation({ risk, autoApproveRisk })
                                  uses requiresConfirmation(), shouldAutoApprove(),
                                  clientSupportsElicitation(server)
 ```
 
-Key design choice: tool handlers thread `risk: RiskLevel` from the endpoint spec directly into `confirmViaElicitation`. The elicitation module imports confirmation helpers from `types.ts`, so failure behavior stays aligned with the registry contract (including `medium_write` blocking without elicitation). `isBlockingRisk()` remains in `types.ts` as deprecated and is not used for this gate anymore.
+Key design choice: tool handlers thread `risk: RiskLevel` from the endpoint spec and `autoApproveRisk` from the session config directly into `confirmViaElicitation`. The elicitation module imports confirmation helpers from `types.ts`, so failure behavior stays aligned with the registry contract (including `medium_write` blocking without elicitation). `isBlockingRisk()` remains in `types.ts` as deprecated and is not used for this gate anymore.
 
 ---
 
@@ -173,7 +174,7 @@ These tests run on every `pnpm test` invocation and validate all ~500+ endpoint 
 
 ### Elicitation Module (`src/utils/elicitation.ts`)
 
-Confirmation is driven by `risk: RiskLevel` plus optional auto-approve level from config (`HARNESS_AUTO_APPROVE_RISK`; deprecated `HARNESS_SKIP_ELICITATION` maps to approving all risks at startup).
+Confirmation is driven by `risk: RiskLevel` plus optional auto-approve level from the session config (`HARNESS_AUTO_APPROVE_RISK`; deprecated `HARNESS_SKIP_ELICITATION` maps to approving all risks at startup). HTTP sessions may override the deployment default during initialize with `X-Harness-Auto-Approve-Risk`; tool handlers pass the resolved session value explicitly, so different sessions do not mutate shared process state.
 
 | Risk level | Client supports elicitation | Behavior |
 |---|---|---|

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,24 +18,10 @@ import { configureElicitation } from "./utils/elicitation.js";
 import { resolveHttpHostValidationOptions } from "./utils/http-hosts.js";
 import { loadEnvFile } from "./utils/env.js";
 import { createAuditManager, type AuditManager } from "./audit/index.js";
+import { mergeConfigWithSessionHeaders } from "./utils/session-headers.js";
 
 
 const log = createLogger("main");
-
-const PIPELINE_VERSION_HEADER = "x-harness-pipeline-version";
-
-function parsePipelineVersionHeader(req: import("express").Request): "0" | "1" | undefined {
-  const raw = req.headers[PIPELINE_VERSION_HEADER];
-  const s = Array.isArray(raw) ? raw[0] : raw;
-  if (s === "0" || s === "1") return s;
-  return undefined;
-}
-
-function mergeConfigWithPipelineVersion(baseConfig: Config, req: import("express").Request): Config {
-  const pv = parsePipelineVersionHeader(req);
-  if (pv === undefined) return baseConfig;
-  return { ...baseConfig, HARNESS_PIPELINE_VERSION: pv };
-}
 
 interface HarnessServerResult {
   server: McpServer;
@@ -261,7 +247,7 @@ async function startHttp(config: Config, port: number): Promise<void> {
   app.use((_req, res, next) => {
     res.setHeader("Access-Control-Allow-Origin", `http://${host}:${port}`);
     res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
-    res.setHeader("Access-Control-Allow-Headers", "Content-Type, mcp-session-id, x-harness-pipeline-version");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type, mcp-session-id, x-harness-pipeline-version, x-harness-auto-approve-risk");
     res.setHeader("Access-Control-Expose-Headers", "mcp-session-id");
     next();
   });
@@ -364,7 +350,7 @@ async function startHttp(config: Config, port: number): Promise<void> {
     let server: McpServer | undefined;
     let transport: StreamableHTTPServerTransport | undefined;
     try {
-      const sessionConfig = mergeConfigWithPipelineVersion(config, req);
+      const sessionConfig = mergeConfigWithSessionHeaders(config, req.headers);
       const result = createHarnessServer(sessionConfig, sharedAuditManager);
       server = result.server;
       transport = new StreamableHTTPServerTransport({

--- a/src/tools/harness-create.ts
+++ b/src/tools/harness-create.ts
@@ -2,6 +2,7 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
+import type { Config } from "../config.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { isUserError, isUserFixableApiError, toMcpError } from "../utils/errors.js";
 import { confirmViaElicitation } from "../utils/elicitation.js";
@@ -9,7 +10,7 @@ import { applyUrlDefaults } from "../utils/url-parser.js";
 import { coerceRecord } from "../utils/type-guards.js";
 import { resourceTypeSchema } from "./input-schemas.js";
 
-export function registerCreateTool(server: McpServer, registry: Registry, client: HarnessClient): void {
+export function registerCreateTool(server: McpServer, registry: Registry, client: HarnessClient, config?: Config): void {
   const creatableTypes = registry.getTypesForOperation("create");
 
   server.registerTool(
@@ -58,6 +59,7 @@ export function registerCreateTool(server: McpServer, registry: Registry, client
           toolName: "harness_create",
           message: `Create ${args.resource_type}?\n\n${bodyPreview}`,
           risk,
+          autoApproveRisk: config?.HARNESS_AUTO_APPROVE_RISK,
         });
         if (!elicit.proceed) {
           return errorResult(`Operation ${elicit.reason} by user.`);

--- a/src/tools/harness-delete.ts
+++ b/src/tools/harness-delete.ts
@@ -2,6 +2,7 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
+import type { Config } from "../config.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { isUserError, isUserFixableApiError, toMcpError } from "../utils/errors.js";
 import { confirmViaElicitation } from "../utils/elicitation.js";
@@ -9,7 +10,7 @@ import { applyUrlDefaults } from "../utils/url-parser.js";
 import { coerceRecord } from "../utils/type-guards.js";
 import { resourceTypeSchema } from "./input-schemas.js";
 
-export function registerDeleteTool(server: McpServer, registry: Registry, client: HarnessClient): void {
+export function registerDeleteTool(server: McpServer, registry: Registry, client: HarnessClient, config?: Config): void {
   const deletableTypes = registry.getTypesForOperation("delete");
 
   server.registerTool(
@@ -45,6 +46,7 @@ export function registerDeleteTool(server: McpServer, registry: Registry, client
           toolName: "harness_delete",
           message: `Delete ${args.resource_type} "${args.resource_id}"?\n\nThis is destructive and cannot be undone.`,
           risk: "destructive",
+          autoApproveRisk: config?.HARNESS_AUTO_APPROVE_RISK,
         });
         if (!elicit.proceed) {
           return errorResult(`Operation ${elicit.reason} by user.`);

--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -2,6 +2,7 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
+import type { Config } from "../config.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { isUserError, isUserFixableApiError, toMcpError, HarnessApiError } from "../utils/errors.js";
 import { confirmViaElicitation } from "../utils/elicitation.js";
@@ -15,7 +16,7 @@ import { resourceTypeSchema } from "./input-schemas.js";
 
 const log = createLogger("execute");
 
-export function registerExecuteTool(server: McpServer, registry: Registry, client: HarnessClient): void {
+export function registerExecuteTool(server: McpServer, registry: Registry, client: HarnessClient, config?: Config): void {
   const executableTypes = registry.getTypesWithExecuteActions();
 
   server.registerTool(
@@ -70,6 +71,7 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
           toolName: "harness_execute",
           message: `Execute "${args.action}" on ${resourceType}${resourceId ? ` "${resourceId}"` : ""}?`,
           risk,
+          autoApproveRisk: config?.HARNESS_AUTO_APPROVE_RISK,
         });
         if (!elicit.proceed) {
           return errorResult(`Operation ${elicit.reason} by user.`);

--- a/src/tools/harness-update.ts
+++ b/src/tools/harness-update.ts
@@ -2,6 +2,7 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
+import type { Config } from "../config.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { isUserError, isUserFixableApiError, toMcpError } from "../utils/errors.js";
 import { confirmViaElicitation } from "../utils/elicitation.js";
@@ -9,7 +10,7 @@ import { applyUrlDefaults } from "../utils/url-parser.js";
 import { asString, isRecord, coerceRecord } from "../utils/type-guards.js";
 import { resourceTypeSchema } from "./input-schemas.js";
 
-export function registerUpdateTool(server: McpServer, registry: Registry, client: HarnessClient): void {
+export function registerUpdateTool(server: McpServer, registry: Registry, client: HarnessClient, config?: Config): void {
   const updatableTypes = registry.getTypesForOperation("update");
 
   server.registerTool(
@@ -53,6 +54,7 @@ export function registerUpdateTool(server: McpServer, registry: Registry, client
           toolName: "harness_update",
           message: `Update ${args.resource_type} "${args.resource_id}"?\n\n${bodyPreview}`,
           risk,
+          autoApproveRisk: config?.HARNESS_AUTO_APPROVE_RISK,
         });
         if (!elicit.proceed) {
           return errorResult(`Operation ${elicit.reason} by user.`);

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -20,10 +20,10 @@ import "../data/examples/load-all.js";
 export function registerAllTools(server: McpServer, registry: Registry, client: HarnessClient, config: Config): void {
   registerListTool(server, registry, client);
   registerGetTool(server, registry, client);
-  registerCreateTool(server, registry, client);
-  registerUpdateTool(server, registry, client);
-  registerDeleteTool(server, registry, client);
-  registerExecuteTool(server, registry, client);
+  registerCreateTool(server, registry, client, config);
+  registerUpdateTool(server, registry, client, config);
+  registerDeleteTool(server, registry, client, config);
+  registerExecuteTool(server, registry, client, config);
   registerDiagnoseTool(server, registry, client, config);
   registerSearchTool(server, registry, client);
   registerDescribeTool(server, registry);

--- a/src/utils/elicitation.ts
+++ b/src/utils/elicitation.ts
@@ -48,15 +48,19 @@ export async function confirmViaElicitation({
   toolName,
   message,
   risk,
+  autoApproveRisk,
 }: {
   server: McpServer;
   toolName: string;
   message: string;
   /** The risk level of the operation (from operationPolicy). */
   risk: RiskLevel;
+  /** Optional per-session threshold. Falls back to the process default. */
+  autoApproveRisk?: AutoApproveRisk;
 }): Promise<ElicitationResult> {
-  if (shouldAutoApprove(risk, _autoApproveRisk)) {
-    log.debug("Auto-approved (risk within autonomous threshold)", { toolName, risk, threshold: _autoApproveRisk });
+  const threshold = autoApproveRisk ?? _autoApproveRisk;
+  if (shouldAutoApprove(risk, threshold)) {
+    log.debug("Auto-approved (risk within autonomous threshold)", { toolName, risk, threshold });
     return { proceed: true, method: "auto_approved" };
   }
 

--- a/src/utils/session-headers.ts
+++ b/src/utils/session-headers.ts
@@ -1,0 +1,49 @@
+import type { IncomingHttpHeaders } from "node:http";
+import type { Config } from "../config.js";
+
+export const PIPELINE_VERSION_HEADER = "x-harness-pipeline-version";
+export const AUTO_APPROVE_RISK_HEADER = "x-harness-auto-approve-risk";
+
+function getHeader(headers: IncomingHttpHeaders, name: string): string | undefined {
+  const raw = headers[name];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return typeof value === "string" ? value : undefined;
+}
+
+export function parsePipelineVersionHeader(headers: IncomingHttpHeaders): "0" | "1" | undefined {
+  const value = getHeader(headers, PIPELINE_VERSION_HEADER);
+  if (value === "0" || value === "1") return value;
+  return undefined;
+}
+
+export function parseAutoApproveRiskHeader(
+  headers: IncomingHttpHeaders,
+): Config["HARNESS_AUTO_APPROVE_RISK"] | undefined {
+  const value = getHeader(headers, AUTO_APPROVE_RISK_HEADER);
+  if (value === undefined) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (
+    normalized === "none" ||
+    normalized === "low_write" ||
+    normalized === "medium_write" ||
+    normalized === "high_write" ||
+    normalized === "all"
+  ) {
+    return normalized as Config["HARNESS_AUTO_APPROVE_RISK"];
+  }
+  return undefined;
+}
+
+export function mergeConfigWithSessionHeaders(
+  baseConfig: Config,
+  headers: IncomingHttpHeaders,
+): Config {
+  const pipelineVersion = parsePipelineVersionHeader(headers);
+  const autoApproveRisk = parseAutoApproveRiskHeader(headers);
+  if (pipelineVersion === undefined && autoApproveRisk === undefined) return baseConfig;
+  return {
+    ...baseConfig,
+    ...(pipelineVersion !== undefined ? { HARNESS_PIPELINE_VERSION: pipelineVersion } : {}),
+    ...(autoApproveRisk !== undefined ? { HARNESS_AUTO_APPROVE_RISK: autoApproveRisk } : {}),
+  };
+}

--- a/tests/utils/elicitation.test.ts
+++ b/tests/utils/elicitation.test.ts
@@ -233,6 +233,20 @@ describe("confirmViaElicitation", () => {
     expect(mcpServer.server.elicitInput).not.toHaveBeenCalled();
   });
 
+  it("uses explicit autoApproveRisk before the module default", async () => {
+    configureElicitation({ autoApproveRisk: "none" });
+    const mcpServer = makeServerStub(undefined);
+    const result = await confirmViaElicitation({
+      server: mcpServer,
+      toolName: "harness_delete",
+      message: "Delete pipeline?",
+      risk: "destructive",
+      autoApproveRisk: "all",
+    });
+    expect(result).toEqual({ proceed: true, method: "auto_approved" });
+    expect(mcpServer.server.elicitInput).not.toHaveBeenCalled();
+  });
+
   it("auto-approves low_write when threshold is low_write", async () => {
     configureElicitation({ autoApproveRisk: "low_write" });
     const mcpServer = makeServerStub(undefined);

--- a/tests/utils/session-headers.test.ts
+++ b/tests/utils/session-headers.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import type { Config } from "../../src/config.js";
+import {
+  mergeConfigWithSessionHeaders,
+  parseAutoApproveRiskHeader,
+  parsePipelineVersionHeader,
+} from "../../src/utils/session-headers.js";
+
+function makeConfig(): Config {
+  return {
+    HARNESS_API_KEY: "pat.test.abc.xyz",
+    HARNESS_ACCOUNT_ID: "test-account",
+    HARNESS_BASE_URL: "https://app.harness.io",
+    HARNESS_ORG: "default",
+    HARNESS_PROJECT: "test-project",
+    HARNESS_API_TIMEOUT_MS: 30000,
+    HARNESS_MAX_RETRIES: 3,
+    LOG_LEVEL: "info",
+    HARNESS_TOOLSETS: undefined,
+    HARNESS_MAX_BODY_SIZE_MB: 10,
+    HARNESS_RATE_LIMIT_RPS: 10,
+    HARNESS_READ_ONLY: false,
+    HARNESS_SKIP_ELICITATION: false,
+    HARNESS_AUTO_APPROVE_RISK: "none",
+    HARNESS_ALLOW_HTTP: false,
+    HARNESS_MCP_ALLOWED_HOSTS: undefined,
+    HARNESS_FME_BASE_URL: "https://api.split.io",
+    HARNESS_LOG_UNSAFE_BODIES: false,
+    HARNESS_PIPELINE_VERSION: undefined,
+    HARNESS_AUDIT_FILE: undefined,
+    HARNESS_AUDIT_WEBHOOK_URL: undefined,
+    HARNESS_AUDIT_WEBHOOK_TOKEN: undefined,
+    HARNESS_AUDIT_WEBHOOK_BATCH_SIZE: 10,
+    HARNESS_AUDIT_WEBHOOK_FLUSH_MS: 5000,
+  };
+}
+
+describe("session header parsing", () => {
+  it("parses pipeline version headers", () => {
+    expect(parsePipelineVersionHeader({ "x-harness-pipeline-version": "1" })).toBe("1");
+    expect(parsePipelineVersionHeader({ "x-harness-pipeline-version": "0" })).toBe("0");
+    expect(parsePipelineVersionHeader({ "x-harness-pipeline-version": "2" })).toBeUndefined();
+  });
+
+  it("parses auto-approve risk headers case-insensitively", () => {
+    expect(parseAutoApproveRiskHeader({ "x-harness-auto-approve-risk": "ALL" })).toBe("all");
+    expect(parseAutoApproveRiskHeader({ "x-harness-auto-approve-risk": " medium_write " })).toBe("medium_write");
+    expect(parseAutoApproveRiskHeader({ "x-harness-auto-approve-risk": "read" })).toBeUndefined();
+  });
+
+  it("merges valid session headers without mutating the base config", () => {
+    const base = makeConfig();
+    const merged = mergeConfigWithSessionHeaders(base, {
+      "x-harness-pipeline-version": "1",
+      "x-harness-auto-approve-risk": "high_write",
+    });
+    expect(merged).not.toBe(base);
+    expect(merged.HARNESS_PIPELINE_VERSION).toBe("1");
+    expect(merged.HARNESS_AUTO_APPROVE_RISK).toBe("high_write");
+    expect(base.HARNESS_PIPELINE_VERSION).toBeUndefined();
+    expect(base.HARNESS_AUTO_APPROVE_RISK).toBe("none");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds per-session `X-Harness-Auto-Approve-Risk` support for HTTP MCP sessions.
- Threads `HARNESS_AUTO_APPROVE_RISK` explicitly into write-tool elicitation checks instead of relying only on process-global state.
- Keeps env config as the default while allowing HTTP initialize requests to override the auto-approve threshold for that session.