### PR TITLE
fix: warn on invalid auto-approve-risk header; make config required in write tools

### DIFF
--- a/src/tools/harness-create.ts
+++ b/src/tools/harness-create.ts
@@ -10,7 +10,7 @@ import { applyUrlDefaults } from "../utils/url-parser.js";
 import { coerceRecord } from "../utils/type-guards.js";
 import { resourceTypeSchema } from "./input-schemas.js";
 
-export function registerCreateTool(server: McpServer, registry: Registry, client: HarnessClient, config?: Config): void {
+export function registerCreateTool(server: McpServer, registry: Registry, client: HarnessClient, config: Config): void {
   const creatableTypes = registry.getTypesForOperation("create");
 
   server.registerTool(
@@ -59,7 +59,7 @@ export function registerCreateTool(server: McpServer, registry: Registry, client
           toolName: "harness_create",
           message: `Create ${args.resource_type}?\n\n${bodyPreview}`,
           risk,
-          autoApproveRisk: config?.HARNESS_AUTO_APPROVE_RISK,
+          autoApproveRisk: config.HARNESS_AUTO_APPROVE_RISK,
         });
         if (!elicit.proceed) {
           return errorResult(`Operation ${elicit.reason} by user.`);

--- a/src/tools/harness-delete.ts
+++ b/src/tools/harness-delete.ts
@@ -10,7 +10,7 @@ import { applyUrlDefaults } from "../utils/url-parser.js";
 import { coerceRecord } from "../utils/type-guards.js";
 import { resourceTypeSchema } from "./input-schemas.js";
 
-export function registerDeleteTool(server: McpServer, registry: Registry, client: HarnessClient, config?: Config): void {
+export function registerDeleteTool(server: McpServer, registry: Registry, client: HarnessClient, config: Config): void {
   const deletableTypes = registry.getTypesForOperation("delete");
 
   server.registerTool(
@@ -46,7 +46,7 @@ export function registerDeleteTool(server: McpServer, registry: Registry, client
           toolName: "harness_delete",
           message: `Delete ${args.resource_type} "${args.resource_id}"?\n\nThis is destructive and cannot be undone.`,
           risk: "destructive",
-          autoApproveRisk: config?.HARNESS_AUTO_APPROVE_RISK,
+          autoApproveRisk: config.HARNESS_AUTO_APPROVE_RISK,
         });
         if (!elicit.proceed) {
           return errorResult(`Operation ${elicit.reason} by user.`);

--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -16,7 +16,7 @@ import { resourceTypeSchema } from "./input-schemas.js";
 
 const log = createLogger("execute");
 
-export function registerExecuteTool(server: McpServer, registry: Registry, client: HarnessClient, config?: Config): void {
+export function registerExecuteTool(server: McpServer, registry: Registry, client: HarnessClient, config: Config): void {
   const executableTypes = registry.getTypesWithExecuteActions();
 
   server.registerTool(
@@ -71,7 +71,7 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
           toolName: "harness_execute",
           message: `Execute "${args.action}" on ${resourceType}${resourceId ? ` "${resourceId}"` : ""}?`,
           risk,
-          autoApproveRisk: config?.HARNESS_AUTO_APPROVE_RISK,
+          autoApproveRisk: config.HARNESS_AUTO_APPROVE_RISK,
         });
         if (!elicit.proceed) {
           return errorResult(`Operation ${elicit.reason} by user.`);

--- a/src/tools/harness-update.ts
+++ b/src/tools/harness-update.ts
@@ -10,7 +10,7 @@ import { applyUrlDefaults } from "../utils/url-parser.js";
 import { asString, isRecord, coerceRecord } from "../utils/type-guards.js";
 import { resourceTypeSchema } from "./input-schemas.js";
 
-export function registerUpdateTool(server: McpServer, registry: Registry, client: HarnessClient, config?: Config): void {
+export function registerUpdateTool(server: McpServer, registry: Registry, client: HarnessClient, config: Config): void {
   const updatableTypes = registry.getTypesForOperation("update");
 
   server.registerTool(
@@ -54,7 +54,7 @@ export function registerUpdateTool(server: McpServer, registry: Registry, client
           toolName: "harness_update",
           message: `Update ${args.resource_type} "${args.resource_id}"?\n\n${bodyPreview}`,
           risk,
-          autoApproveRisk: config?.HARNESS_AUTO_APPROVE_RISK,
+          autoApproveRisk: config.HARNESS_AUTO_APPROVE_RISK,
         });
         if (!elicit.proceed) {
           return errorResult(`Operation ${elicit.reason} by user.`);

--- a/src/utils/session-headers.ts
+++ b/src/utils/session-headers.ts
@@ -1,5 +1,8 @@
 import type { IncomingHttpHeaders } from "node:http";
 import type { Config } from "../config.js";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("session-headers");
 
 export const PIPELINE_VERSION_HEADER = "x-harness-pipeline-version";
 export const AUTO_APPROVE_RISK_HEADER = "x-harness-auto-approve-risk";
@@ -31,6 +34,7 @@ export function parseAutoApproveRiskHeader(
   ) {
     return normalized as Config["HARNESS_AUTO_APPROVE_RISK"];
   }
+  log.warn("Ignoring unrecognized X-Harness-Auto-Approve-Risk value", { value });
   return undefined;
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #204 — two review nits that were in a commit on the PR branch but didn't make it into the merge.

- **`session-headers.ts`**: log a `warn` when `X-Harness-Auto-Approve-Risk` contains an unrecognized value (e.g. `"read"`, typos) instead of silently falling back to the deployment default. Prevents confusing silent behavior where a misconfigured client gets a different security posture than intended.
- **Write tool registrars** (`harness_create`, `harness_update`, `harness_delete`, `harness_execute`): change `config?: Config` → `config: Config`. The parameter is always passed by `registerAllTools` — making it optional was a type lie that would let future callers omit it and silently use the process-global auto-approve default instead of the session value.

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes
- [ ] Sending an invalid `X-Harness-Auto-Approve-Risk: read` header in an HTTP session logs a warning and uses the deployment default

🤖 Generated with [Claude Code](https://claude.com/claude-code)