### PR TITLE
chore: bump version to 3.0.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "harness-mcp-server",
   "display_name": "Harness MCP Server",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Connect AI agents to Harness for CI/CD, code repositories, pull requests, services, environments, and feature flags.",
   "long_description": "The Harness MCP Server gives MCP-compatible clients access to Harness platform workflows through consolidated tools, resources, and prompts. It supports local stdio usage and can be bundled as a Node-based MCPB extension.",
   "author": {

--- a/mcp-directory/manifest.json
+++ b/mcp-directory/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "harness-mcp-server",
   "display_name": "Harness MCP Server",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Connect AI agents to Harness for CI/CD, code repositories, pull requests, services, environments, and feature flags.",
   "long_description": "The Harness MCP Server gives MCP-compatible clients access to Harness platform workflows through consolidated tools, resources, and prompts. It supports local stdio usage and can be bundled as a Node-based MCPB extension.",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-mcp-v2",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Give AI agents full access to the Harness.io platform — manage pipelines, deployments, cloud costs, chaos engineering, feature flags, SEI, and 125+ resource types through 11 MCP tools",
   "type": "module",
   "main": "build/index.js",

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -14,7 +14,7 @@ describe("release metadata", () => {
     const rootManifest = readJson("manifest.json");
     const directoryManifest = readJson("mcp-directory/manifest.json");
 
-    expect(packageJson.version).toBe("3.0.1");
+    expect(packageJson.version).toBe("3.0.2");
     expect(rootManifest.version).toBe(packageJson.version);
     expect(directoryManifest.version).toBe(packageJson.version);
   });


### PR DESCRIPTION
## Summary
- Bump version from 3.0.1 → 3.0.2 across package.json, manifest.json, mcp-directory/manifest.json, and release metadata test

## Test plan
- [x] CI passes
- [x] `release-metadata` test validates version sync across all files

🤖 Generated with [Claude Code](https://claude.com/claude-code)