### PR TITLE
feat: add commit create operation for Harness Code repositories

### DIFF
--- a/src/registry/toolsets/repositories.ts
+++ b/src/registry/toolsets/repositories.ts
@@ -162,7 +162,7 @@ export const repositoriesToolset: ToolsetDefinition = {
       resourceType: "commit",
       displayName: "Commit",
       description:
-        "Git commit in a Harness Code repository. Supports list and get.",
+        "Git commit in a Harness Code repository. Supports list, get, and create. Use create to commit file changes (CREATE, UPDATE, DELETE, MOVE) directly via the API without cloning.",
       toolset: "repositories",
       scope: "account",
       scopeOptional: true,
@@ -203,6 +203,30 @@ export const repositoriesToolset: ToolsetDefinition = {
           },
           responseExtractor: passthrough,
           description: "Get commit details by SHA",
+        },
+        create: {
+          method: "POST",
+          path: "/code/api/v1/repos/{repoIdentifier}/commits",
+          operationPolicy: { risk: "medium_write", retryPolicy: "do_not_retry" },
+          pathParams: { repo_id: "repoIdentifier" },
+          skipScopeBodyInjection: true,
+          bodyBuilder: (input) => input.body,
+          responseExtractor: passthrough,
+          description:
+            "Commit file changes to a repository. Each action specifies a file operation (CREATE, UPDATE, DELETE, MOVE). Payload is the file content (utf8 or base64). For UPDATE, include the current blob sha. Returns the new commit_id and list of changed files.",
+          bodySchema: {
+            description:
+              "Commit with one or more file actions. branch is the target branch, message is the commit message, actions is the list of file operations.",
+            fields: [
+              { name: "title", type: "string", required: true, description: "Commit title (first line of commit message)" },
+              { name: "message", type: "string", required: false, description: "Extended commit message body" },
+              { name: "branch", type: "string", required: true, description: "Target branch to commit to (e.g. 'main')" },
+              { name: "new_branch", type: "string", required: false, description: "If set, creates a new branch from 'branch' and commits there instead" },
+              { name: "actions", type: "array", required: true, description: "File operations. Each action: {action: 'CREATE'|'UPDATE'|'DELETE'|'MOVE', path: 'file/path', payload: 'content', encoding: 'utf8'|'base64', sha: 'blob_sha (required for UPDATE)'}." },
+              { name: "bypass_rules", type: "boolean", required: false, description: "Bypass branch protection rules (requires permission)" },
+              { name: "dry_run_rules", type: "boolean", required: false, description: "Check rules without committing" },
+            ],
+          },
         },
       },
       executeActions: {


### PR DESCRIPTION
## Summary

- Adds a `create` operation to the existing `commit` resource type in the repositories toolset
- Maps to `POST /code/api/v1/repos/{repoIdentifier}/commits` (Harness Code "Commit files" API)
- Enables AI agents to commit file changes (CREATE, UPDATE, DELETE, MOVE) directly via API — no git clone required
- Includes full `bodySchema` documentation for LLM tool selection: title, message, branch, new_branch, actions array, bypass_rules, dry_run_rules

## Motivation

AI agents running inside Harness pipelines (Agent steps) cannot access the filesystem or execute shell commands. The only way they can persist state to a repository is through MCP tools. Today, `commit` only supports `list` and `get` — there's no way for an agent to **write** files to a repo.

This unblocks use cases like:
- Agent-driven state persistence (writing scan results, dashboards, remediation plans)
- Automated config/doc generation committed directly to repos
- Multi-agent feedback loops that persist artifacts between runs

## API Reference

**Endpoint**: `POST /code/api/v1/repos/{repo_identifier}/commits`  
**Docs**: https://apidocs.harness.io/repository/commitfiles

**Example usage via `harness_create`**:
```
harness_create(
  resource_type="commit",
  repo_id="my-repo",
  body={
    title: "Update scan results",
    branch: "main",
    actions: [
      { action: "CREATE", path: "results/scan.json", payload: "{...}", encoding: "utf8" },
      { action: "UPDATE", path: "state/latest.json", payload: "{...}", encoding: "utf8", sha: "abc123" }
    ]
  }
)
```

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (1352 tests, 57 files, 0 failures)
- [ ] Manual validation with MCP Inspector against a Harness Code repo


Made with [Cursor](https://cursor.com)