### PR TITLE
feat: HTTP MCP auth hardening + single-user / multi-user deployment modes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,19 @@
-# Required
+# Deployment mode: single-user (default) or multi-user.
+# single-user — HARNESS_API_KEY required, used for all sessions.
+# multi-user  — HTTP only; sessions provide credentials via x-harness-api-key
+#               and x-harness-account-id headers. HARNESS_API_KEY must NOT be set.
+HARNESS_MCP_MODE=single-user
+
+# Required in single-user mode. Must NOT be set in multi-user mode.
 HARNESS_API_KEY=pat.xxxxx.xxxxx.xxxxx
+# Required in single-user mode (or auto-extracted from PAT). Optional in multi-user
+# mode (sessions provide their own via x-harness-account-id header).
 HARNESS_ACCOUNT_ID=your-account-id
 
 # Optional — defaults shown
 HARNESS_BASE_URL=https://app.harness.io
+# Default org/project. In multi-user mode, sessions can override via
+# x-harness-org and x-harness-project headers.
 HARNESS_ORG=
 HARNESS_PROJECT=
 HARNESS_API_TIMEOUT_MS=30000

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ LOG_LEVEL=info
 
 # HTTP transport only — ignored in stdio mode
 PORT=3000
+# Require Authorization: Bearer <token> on /mcp routes when set.
+HARNESS_MCP_AUTH_TOKEN=
+# Non-loopback HTTP binds require HARNESS_MCP_AUTH_TOKEN unless this is true.
+HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP=false
 # Comma-separated public hostnames allowed by HTTP transport Host-header validation.
 # mcp.harness.io is allowed by default for hosted MCP.
 HARNESS_MCP_ALLOWED_HOSTS=

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ The HTTP transport runs in **session-based mode**. A new MCP session is created 
 
 Operational constraints in HTTP mode:
 
+- Set `HARNESS_MCP_AUTH_TOKEN` for any shared or remotely reachable deployment. When set, every `POST`, `GET`, and `DELETE` request to `/mcp` must include `Authorization: Bearer <token>`.
+- Non-loopback binds require `HARNESS_MCP_AUTH_TOKEN` by default. To run unauthenticated on a non-loopback interface anyway, set `HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP=true` explicitly.
 - `POST /mcp` without `mcp-session-id` must be an `initialize` request.
 - `POST /mcp`, `GET /mcp`, and `DELETE /mcp` for existing sessions require the `mcp-session-id` header.
 - `GET /mcp` is used for SSE notifications (progress updates and elicitation prompts).
@@ -141,18 +143,23 @@ curl http://localhost:3000/health
 # MCP initialize request (capture mcp-session-id response header)
 curl -i -X POST http://localhost:3000/mcp \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $HARNESS_MCP_AUTH_TOKEN" \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 
 # Subsequent MCP request (use returned session ID)
 curl -X POST http://localhost:3000/mcp \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $HARNESS_MCP_AUTH_TOKEN" \
   -H "mcp-session-id: <session-id>" \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
 
 # Terminate session
 curl -X DELETE http://localhost:3000/mcp \
+  -H "Authorization: Bearer $HARNESS_MCP_AUTH_TOKEN" \
   -H "mcp-session-id: <session-id>"
 ```
+
+`HARNESS_MCP_ALLOWED_HOSTS` controls Host-header validation for DNS-rebinding protection, and CORS limits browser origins. Neither is authentication; use `HARNESS_MCP_AUTH_TOKEN` or an authenticated gateway/reverse proxy for access control.
 
 ### Client Configuration
 
@@ -512,6 +519,8 @@ The server automatically loads environment variables from a `.env` file in the p
 | `HARNESS_ALLOW_HTTP`        | No       | `false`                     | Allow non-HTTPS `HARNESS_BASE_URL`. By default, the server enforces HTTPS for security. Set to `true` only for local development against a non-TLS Harness instance                                                                                   |
 | `HARNESS_PIPELINE_VERSION`  | No       | `0`                         | **(Alpha)** Pipeline YAML version. `0` loads the `pipeline` resource type and excludes `pipeline_v1`; `1` loads `pipeline_v1` and excludes `pipeline`. HTTP sessions can override this at initialize time with `x-harness-pipeline-version: 0` or `1` |
 | `HARNESS_MCP_ALLOWED_HOSTS` | No       | --                          | Comma-separated hostnames allowed by HTTP transport Host-header validation. `mcp.harness.io` is allowed by default for localhost binds; add proxy/custom domains here                                                                                 |
+| `HARNESS_MCP_AUTH_TOKEN`    | No       | --                          | Bearer token required on `/mcp` HTTP routes when set. Required by default when HTTP transport binds to a non-loopback host                                                                                                                             |
+| `HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP` | No | `false`         | Explicitly allow unauthenticated HTTP transport on non-loopback binds. Use only behind another authenticated control                                                                                                                                    |
 | `HARNESS_MCP_LOG_FILE`      | No       | `~/.claude/harness-mcp.log` | File used for stdio disconnect/crash diagnostics when stderr may no longer be available                                                                                                                                                               |
 
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,16 @@ Operational constraints in HTTP mode:
 - Set `x-harness-pipeline-version: 0` or `1` on the `initialize` request to select V0 or V1 pipeline resources for that HTTP session.
 - Set `x-harness-auto-approve-risk: none|low_write|medium_write|high_write|all` on the `initialize` request to choose a stricter per-session auto-approval threshold. The server caps this value at the deployment-level `HARNESS_AUTO_APPROVE_RISK`, so a session can reduce but not expand the configured approval ceiling.
 
+#### Multi-User Mode
+
+Set `HARNESS_MCP_MODE=multi-user` for shared HTTP deployments where each client authenticates as a different Harness user. In this mode:
+
+- `HARNESS_API_KEY` must **not** be set in the server config — the server holds no Harness credentials.
+- Each session must provide `x-harness-api-key` and `x-harness-account-id` headers on the `initialize` request. Sessions without these headers are rejected with a 401.
+- Sessions may also provide `x-harness-org` and `x-harness-project` headers to set default scope for that session.
+- The Harness API key flows through to every Harness API call for that session, so the audit trail in Harness reflects the real user.
+- `HARNESS_MCP_AUTH_TOKEN` is independent and can still be used as an additional transport-layer gate.
+
 ```bash
 # Health check
 curl http://localhost:3000/health
@@ -502,8 +512,9 @@ The server automatically loads environment variables from a `.env` file in the p
 
 | Variable                    | Required | Default                     | Description                                                                                                                                                                                                                                           |
 | --------------------------- | -------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `HARNESS_API_KEY`           | Yes      | --                          | Harness personal access token or service account token                                                                                                                                                                                                |
-| `HARNESS_ACCOUNT_ID`        | No       | *(from PAT)*                | Harness account identifier. Auto-extracted from PAT tokens; only needed for non-PAT API keys                                                                                                                                                          |
+| `HARNESS_MCP_MODE`          | No       | `single-user`               | Deployment mode: `single-user` (API key in config, used for all sessions) or `multi-user` (HTTP only, per-session credentials via `x-harness-api-key` and `x-harness-account-id` headers)                                                            |
+| `HARNESS_API_KEY`           | Yes*     | --                          | Harness personal access token or service account token. Required in `single-user` mode. Must NOT be set in `multi-user` mode                                                                                                                          |
+| `HARNESS_ACCOUNT_ID`        | No       | *(from PAT)*                | Harness account identifier. Auto-extracted from PAT tokens in single-user mode; sessions provide their own via `x-harness-account-id` in multi-user mode                                                                                              |
 | `HARNESS_BASE_URL`          | No       | `https://app.harness.io`    | Harness API/UI base URL for local stdio or self-hosted HTTP deployments. Set this to environments such as `https://harness0.harness.io` when running the server yourself. It does not affect the managed `https://mcp.harness.io/mcp` hosted endpoint |
 | `HARNESS_ORG`               | No       | --                          | Organization ID. Used when `org_id` is not specified per tool call. If omitted, `org_id` must be provided explicitly. Agents can also discover orgs dynamically via `harness_list(resource_type="organization")`                                      |
 | `HARNESS_PROJECT`           | No       | --                          | Project ID. Used when `project_id` is not specified per tool call. Agents can also discover projects dynamically via `harness_list(resource_type="project")`                                                                                          |

--- a/README.md
+++ b/README.md
@@ -151,9 +151,12 @@ Set `HARNESS_MCP_MODE=multi-user` for shared HTTP deployments where each client 
 curl http://localhost:3000/health
 
 # MCP initialize request (capture mcp-session-id response header)
+# In multi-user mode, x-harness-api-key and x-harness-account-id are required on initialize.
 curl -i -X POST http://localhost:3000/mcp \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $HARNESS_MCP_AUTH_TOKEN" \
+  -H "x-harness-api-key: $HARNESS_API_KEY" \
+  -H "x-harness-account-id: $HARNESS_ACCOUNT_ID" \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 
 # Subsequent MCP request (use returned session ID)

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ curl http://localhost:3000/health
 # In multi-user mode, x-harness-api-key and x-harness-account-id are required on initialize.
 curl -i -X POST http://localhost:3000/mcp \
   -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
   -H "Authorization: Bearer $HARNESS_MCP_AUTH_TOKEN" \
   -H "x-harness-api-key: $HARNESS_API_KEY" \
   -H "x-harness-account-id: $HARNESS_ACCOUNT_ID" \
@@ -162,6 +163,7 @@ curl -i -X POST http://localhost:3000/mcp \
 # Subsequent MCP request (use returned session ID)
 curl -X POST http://localhost:3000/mcp \
   -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
   -H "Authorization: Bearer $HARNESS_MCP_AUTH_TOKEN" \
   -H "mcp-session-id: <session-id>" \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'

--- a/src/config.ts
+++ b/src/config.ts
@@ -78,6 +78,8 @@ const RawConfigSchema = z.object({
   ),
   HARNESS_ALLOW_HTTP: booleanFromEnv.default(false),
   HARNESS_MCP_ALLOWED_HOSTS: optionalStringFromEnv.transform(validateAllowedHosts),
+  HARNESS_MCP_AUTH_TOKEN: optionalStringFromEnv,
+  HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP: booleanFromEnv.default(false),
   HARNESS_FME_BASE_URL: urlFromEnv("https://api.split.io"),
   HARNESS_LOG_UNSAFE_BODIES: booleanFromEnv.default(false),
   HARNESS_PIPELINE_VERSION: z.enum(["0", "1"]).optional(),

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,7 +52,11 @@ export function extractAccountIdFromToken(apiKey: string): string | undefined {
 }
 
 const RawConfigSchema = z.object({
-  HARNESS_API_KEY: z.string().min(1, "HARNESS_API_KEY is required"),
+  HARNESS_MCP_MODE: z.preprocess(
+    emptyStringAsUndefined,
+    z.enum(["single-user", "multi-user"]).default("single-user"),
+  ),
+  HARNESS_API_KEY: optionalStringFromEnv,
   HARNESS_ACCOUNT_ID: optionalStringFromEnv,
   HARNESS_BASE_URL: urlFromEnv("https://app.harness.io"),
   // New names (preferred)
@@ -91,11 +95,31 @@ const RawConfigSchema = z.object({
 });
 
 export const ConfigSchema = RawConfigSchema.transform((data) => {
-  const accountId = data.HARNESS_ACCOUNT_ID ?? extractAccountIdFromToken(data.HARNESS_API_KEY);
-  if (!accountId) {
+  const isMultiUser = data.HARNESS_MCP_MODE === "multi-user";
+
+  if (isMultiUser && data.HARNESS_API_KEY) {
     throw new Error(
-      "HARNESS_ACCOUNT_ID is required when the API key is not a PAT (pat.<accountId>.<tokenId>.<secret>)",
+      "HARNESS_API_KEY must not be set in multi-user mode. " +
+      "Each session must provide its own API key via the x-harness-api-key header.",
     );
+  }
+
+  if (!isMultiUser && !data.HARNESS_API_KEY) {
+    throw new Error(
+      "HARNESS_API_KEY is required in single-user mode.",
+    );
+  }
+
+  let accountId: string | undefined;
+  if (isMultiUser) {
+    accountId = data.HARNESS_ACCOUNT_ID ?? "";
+  } else {
+    accountId = data.HARNESS_ACCOUNT_ID ?? extractAccountIdFromToken(data.HARNESS_API_KEY!);
+    if (!accountId) {
+      throw new Error(
+        "HARNESS_ACCOUNT_ID is required when the API key is not a PAT (pat.<accountId>.<tokenId>.<secret>)",
+      );
+    }
   }
 
   if (!data.HARNESS_BASE_URL.startsWith("https://") && !data.HARNESS_ALLOW_HTTP) {
@@ -142,7 +166,7 @@ export const ConfigSchema = RawConfigSchema.transform((data) => {
   // Remove deprecated keys from output, expose only the canonical names
   const { HARNESS_DEFAULT_ORG_ID: _oldOrg, HARNESS_DEFAULT_PROJECT_ID: _oldProject, ...rest } = data;
 
-  return { ...rest, HARNESS_ACCOUNT_ID: accountId, HARNESS_ORG, HARNESS_PROJECT, HARNESS_AUTO_APPROVE_RISK };
+  return { ...rest, HARNESS_API_KEY: data.HARNESS_API_KEY ?? "", HARNESS_ACCOUNT_ID: accountId, HARNESS_ORG, HARNESS_PROJECT, HARNESS_AUTO_APPROVE_RISK };
 });
 
 export type Config = z.infer<typeof ConfigSchema>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { registerAllPrompts } from "./prompts/index.js";
 import { parseArgs, resolvePort, getVersion } from "./utils/cli.js";
 import { configureElicitation } from "./utils/elicitation.js";
 import { resolveHttpHostValidationOptions } from "./utils/http-hosts.js";
+import { createHttpAuthMiddleware, validateHttpAuthForBindHost, isLoopbackBindHost } from "./utils/http-auth.js";
 import { loadEnvFile } from "./utils/env.js";
 import { createAuditManager, type AuditManager } from "./audit/index.js";
 import { mergeConfigWithSessionHeaders } from "./utils/session-headers.js";
@@ -227,12 +228,12 @@ const REAP_INTERVAL_MS = 60_000;    // check every minute
 async function startHttp(config: Config, port: number): Promise<void> {
   const host = process.env.HOST || "127.0.0.1";
 
-  const isLoopback = host === "127.0.0.1" || host === "::1" || host === "localhost";
-  if (!isLoopback) {
+  validateHttpAuthForBindHost(host, config);
+  if (!isLoopbackBindHost(host) && config.HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP) {
     log.warn(
       "HTTP server binding to non-loopback address without authentication. " +
       "Any client that can reach this address will have full access to Harness resources via the configured API key. " +
-      "Deploy behind an authenticated reverse proxy or use HARNESS_ALLOWED_ORIGINS to restrict access.",
+      "Set HARNESS_MCP_AUTH_TOKEN or deploy behind an authenticated reverse proxy.",
       { host, port },
     );
   }
@@ -247,7 +248,7 @@ async function startHttp(config: Config, port: number): Promise<void> {
   app.use((_req, res, next) => {
     res.setHeader("Access-Control-Allow-Origin", `http://${host}:${port}`);
     res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
-    res.setHeader("Access-Control-Allow-Headers", "Content-Type, mcp-session-id, x-harness-pipeline-version, x-harness-auto-approve-risk");
+    res.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type, mcp-session-id, x-harness-pipeline-version, x-harness-auto-approve-risk");
     res.setHeader("Access-Control-Expose-Headers", "mcp-session-id");
     next();
   });
@@ -276,6 +277,7 @@ async function startHttp(config: Config, port: number): Promise<void> {
     }
     next();
   });
+  app.use(createHttpAuthMiddleware(config.HARNESS_MCP_AUTH_TOKEN));
 
   // ---- Session store ----
   const sessions = new Map<string, Session>();

--- a/src/index.ts
+++ b/src/index.ts
@@ -240,10 +240,6 @@ async function startHttp(config: Config, port: number): Promise<void> {
 
   const app = createMcpExpressApp(resolveHttpHostValidationOptions(host, config));
 
-  const maxBodySize = config.HARNESS_MAX_BODY_SIZE_MB * 1024 * 1024;
-  const { json } = await import("express");
-  app.use(json({ limit: maxBodySize }));
-
   // CORS — allow GET, POST, DELETE for session-based MCP
   app.use((_req, res, next) => {
     res.setHeader("Access-Control-Allow-Origin", `http://${host}:${port}`);
@@ -252,6 +248,9 @@ async function startHttp(config: Config, port: number): Promise<void> {
     res.setHeader("Access-Control-Expose-Headers", "mcp-session-id");
     next();
   });
+
+  // Auth gate before body parsing — reject unauthenticated requests without allocating body memory
+  app.use(createHttpAuthMiddleware(config.HARNESS_MCP_AUTH_TOKEN));
 
   // Simple per-IP rate limiting: 60 requests per minute
   const ipHits = new Map<string, { count: number; resetAt: number }>();
@@ -277,7 +276,10 @@ async function startHttp(config: Config, port: number): Promise<void> {
     }
     next();
   });
-  app.use(createHttpAuthMiddleware(config.HARNESS_MCP_AUTH_TOKEN));
+
+  const maxBodySize = config.HARNESS_MAX_BODY_SIZE_MB * 1024 * 1024;
+  const { json } = await import("express");
+  app.use(json({ limit: maxBodySize }));
 
   // ---- Session store ----
   const sessions = new Map<string, Session>();

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import { resolveHttpHostValidationOptions } from "./utils/http-hosts.js";
 import { createHttpAuthMiddleware, validateHttpAuthForBindHost, isLoopbackBindHost } from "./utils/http-auth.js";
 import { loadEnvFile } from "./utils/env.js";
 import { createAuditManager, type AuditManager } from "./audit/index.js";
-import { mergeConfigWithSessionHeaders } from "./utils/session-headers.js";
+import { mergeConfigWithSessionHeaders, MissingSessionCredentialsError } from "./utils/session-headers.js";
 
 
 const log = createLogger("main");
@@ -229,10 +229,10 @@ async function startHttp(config: Config, port: number): Promise<void> {
   const host = process.env.HOST || "127.0.0.1";
 
   validateHttpAuthForBindHost(host, config);
-  if (!isLoopbackBindHost(host) && config.HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP) {
+  if (!isLoopbackBindHost(host) && !config.HARNESS_MCP_AUTH_TOKEN && config.HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP) {
     log.warn(
       "HTTP server binding to non-loopback address without authentication. " +
-      "Any client that can reach this address will have full access to Harness resources via the configured API key. " +
+      "Any client that can reach this address will have access to Harness resources. " +
       "Set HARNESS_MCP_AUTH_TOKEN or deploy behind an authenticated reverse proxy.",
       { host, port },
     );
@@ -248,7 +248,7 @@ async function startHttp(config: Config, port: number): Promise<void> {
   app.use((_req, res, next) => {
     res.setHeader("Access-Control-Allow-Origin", `http://${host}:${port}`);
     res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
-    res.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type, mcp-session-id, x-harness-pipeline-version, x-harness-auto-approve-risk");
+    res.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type, mcp-session-id, x-harness-api-key, x-harness-account-id, x-harness-org, x-harness-project, x-harness-pipeline-version, x-harness-auto-approve-risk");
     res.setHeader("Access-Control-Expose-Headers", "mcp-session-id");
     next();
   });
@@ -372,6 +372,17 @@ async function startHttp(config: Config, port: number): Promise<void> {
       await server.connect(transport);
       await transport.handleRequest(req, res, req.body);
     } catch (err) {
+      if (err instanceof MissingSessionCredentialsError) {
+        log.warn("Session rejected — missing credentials", { error: err.message });
+        if (!res.headersSent) {
+          res.status(401).json({
+            jsonrpc: "2.0",
+            error: { code: -32001, message: err.message },
+            id: null,
+          });
+        }
+        return;
+      }
       log.error("Error initializing session", { error: String(err) });
       if (!res.headersSent) {
         res.status(400).json({
@@ -545,11 +556,19 @@ async function main(): Promise<void> {
   const config = loadConfig();
   setLogLevel(config.LOG_LEVEL);
 
+  if (config.HARNESS_MCP_MODE === "multi-user" && transport === "stdio") {
+    throw new Error(
+      "Multi-user mode is only supported with HTTP transport. " +
+      "Use --transport http or set HARNESS_MCP_MODE=single-user for stdio.",
+    );
+  }
+
   log.info("Starting harness-mcp-server", {
     transport,
+    mode: config.HARNESS_MCP_MODE,
     baseUrl: config.HARNESS_BASE_URL,
-    accountId: config.HARNESS_ACCOUNT_ID,
-    defaultOrg: config.HARNESS_ORG,
+    accountId: config.HARNESS_ACCOUNT_ID || "(per-session)",
+    defaultOrg: config.HARNESS_ORG ?? "(none)",
     defaultProject: config.HARNESS_PROJECT ?? "(none)",
     toolsets: config.HARNESS_TOOLSETS ?? "(all)",
   });

--- a/src/utils/http-auth.ts
+++ b/src/utils/http-auth.ts
@@ -1,0 +1,66 @@
+import { timingSafeEqual } from "node:crypto";
+import type { IncomingHttpHeaders } from "node:http";
+import type { RequestHandler } from "express";
+import type { Config } from "../config.js";
+
+type HttpAuthConfig = Pick<Config, "HARNESS_MCP_AUTH_TOKEN" | "HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP">;
+
+export function isLoopbackBindHost(host: string): boolean {
+  return host === "127.0.0.1" || host === "::1" || host === "localhost";
+}
+
+function getHeader(headers: IncomingHttpHeaders, name: string): string | undefined {
+  const raw = headers[name.toLowerCase()];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return typeof value === "string" ? value : undefined;
+}
+
+function timingSafeStringEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  if (leftBuffer.length !== rightBuffer.length) {
+    const maxLength = Math.max(leftBuffer.length, rightBuffer.length);
+    timingSafeEqual(
+      Buffer.from(left.padEnd(maxLength, "\0")),
+      Buffer.from(right.padEnd(maxLength, "\0")),
+    );
+    return false;
+  }
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+export function isAuthorizedHttpRequest(
+  headers: IncomingHttpHeaders,
+  token: string | undefined,
+): boolean {
+  if (!token) return true;
+  const authorization = getHeader(headers, "authorization");
+  if (!authorization) return false;
+  return timingSafeStringEqual(authorization, `Bearer ${token}`);
+}
+
+export function createHttpAuthMiddleware(token: string | undefined): RequestHandler {
+  return (req, res, next) => {
+    if (req.path === "/health" || req.method === "OPTIONS" || isAuthorizedHttpRequest(req.headers, token)) {
+      next();
+      return;
+    }
+
+    res.status(401).json({
+      jsonrpc: "2.0",
+      error: { code: -32001, message: "Unauthorized" },
+      id: null,
+    });
+  };
+}
+
+export function validateHttpAuthForBindHost(host: string, config: HttpAuthConfig): void {
+  if (isLoopbackBindHost(host)) return;
+  if (config.HARNESS_MCP_AUTH_TOKEN) return;
+  if (config.HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP) return;
+
+  throw new Error(
+    "HARNESS_MCP_AUTH_TOKEN is required when HTTP transport binds to a non-loopback host. " +
+    "Set HARNESS_MCP_AUTH_TOKEN or explicitly set HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP=true.",
+  );
+}

--- a/src/utils/session-headers.ts
+++ b/src/utils/session-headers.ts
@@ -1,5 +1,6 @@
 import type { IncomingHttpHeaders } from "node:http";
 import type { Config } from "../config.js";
+import { extractAccountIdFromToken } from "../config.js";
 import { RISK_SEVERITY, type RiskLevel } from "../registry/types.js";
 
 export const PIPELINE_VERSION_HEADER = "x-harness-pipeline-version";
@@ -90,6 +91,13 @@ export function mergeConfigWithSessionHeaders(
     if (!sessionAccountId) missing.push(ACCOUNT_ID_HEADER);
     if (missing.length > 0) {
       throw new MissingSessionCredentialsError(missing);
+    }
+
+    const patAccountId = extractAccountIdFromToken(sessionApiKey!);
+    if (patAccountId && patAccountId !== sessionAccountId) {
+      throw new MissingSessionCredentialsError([
+        `${ACCOUNT_ID_HEADER} (value "${sessionAccountId}" does not match PAT account "${patAccountId}")`,
+      ]);
     }
   }
 

--- a/src/utils/session-headers.ts
+++ b/src/utils/session-headers.ts
@@ -4,6 +4,10 @@ import { RISK_SEVERITY, type RiskLevel } from "../registry/types.js";
 
 export const PIPELINE_VERSION_HEADER = "x-harness-pipeline-version";
 export const AUTO_APPROVE_RISK_HEADER = "x-harness-auto-approve-risk";
+export const API_KEY_HEADER = "x-harness-api-key";
+export const ACCOUNT_ID_HEADER = "x-harness-account-id";
+export const ORG_HEADER = "x-harness-org";
+export const PROJECT_HEADER = "x-harness-project";
 
 type ConfigAutoApproveRisk = Config["HARNESS_AUTO_APPROVE_RISK"];
 
@@ -50,13 +54,54 @@ function capAutoApproveRisk(
   return autoApproveSeverity(requested) <= autoApproveSeverity(maximum) ? requested : maximum;
 }
 
+/**
+ * Error thrown when a multi-user session is missing required credentials.
+ * Handled in the HTTP session creation path to return a JSON-RPC error.
+ */
+export class MissingSessionCredentialsError extends Error {
+  constructor(missing: string[]) {
+    super(
+      `Multi-user mode requires ${missing.join(" and ")} headers on the initialize request. ` +
+      `Missing: ${missing.join(", ")}`,
+    );
+    this.name = "MissingSessionCredentialsError";
+  }
+}
+
 export function mergeConfigWithSessionHeaders(
   baseConfig: Config,
   headers: IncomingHttpHeaders,
 ): Config {
   const pipelineVersion = parsePipelineVersionHeader(headers);
   const autoApproveRisk = parseAutoApproveRiskHeader(headers);
-  if (pipelineVersion === undefined && autoApproveRisk === undefined) return baseConfig;
+
+  const isMultiUser = baseConfig.HARNESS_MCP_MODE === "multi-user";
+
+  // Identity headers are only accepted in multi-user mode.
+  // In single-user mode, the operator's config is authoritative.
+  const sessionApiKey = isMultiUser ? getHeader(headers, API_KEY_HEADER) : undefined;
+  const sessionAccountId = isMultiUser ? getHeader(headers, ACCOUNT_ID_HEADER) : undefined;
+  const sessionOrg = getHeader(headers, ORG_HEADER);
+  const sessionProject = getHeader(headers, PROJECT_HEADER);
+
+  if (isMultiUser) {
+    const missing: string[] = [];
+    if (!sessionApiKey) missing.push(API_KEY_HEADER);
+    if (!sessionAccountId) missing.push(ACCOUNT_ID_HEADER);
+    if (missing.length > 0) {
+      throw new MissingSessionCredentialsError(missing);
+    }
+  }
+
+  const hasOverrides = pipelineVersion !== undefined
+    || autoApproveRisk !== undefined
+    || sessionApiKey !== undefined
+    || sessionAccountId !== undefined
+    || sessionOrg !== undefined
+    || sessionProject !== undefined;
+
+  if (!hasOverrides) return baseConfig;
+
   const cappedAutoApproveRisk = autoApproveRisk === undefined
     ? undefined
     : capAutoApproveRisk(autoApproveRisk, baseConfig.HARNESS_AUTO_APPROVE_RISK ?? "none");
@@ -64,5 +109,9 @@ export function mergeConfigWithSessionHeaders(
     ...baseConfig,
     ...(pipelineVersion !== undefined ? { HARNESS_PIPELINE_VERSION: pipelineVersion } : {}),
     ...(cappedAutoApproveRisk !== undefined ? { HARNESS_AUTO_APPROVE_RISK: cappedAutoApproveRisk } : {}),
+    ...(sessionApiKey !== undefined ? { HARNESS_API_KEY: sessionApiKey } : {}),
+    ...(sessionAccountId !== undefined ? { HARNESS_ACCOUNT_ID: sessionAccountId } : {}),
+    ...(sessionOrg !== undefined ? { HARNESS_ORG: sessionOrg } : {}),
+    ...(sessionProject !== undefined ? { HARNESS_PROJECT: sessionProject } : {}),
   };
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -433,3 +433,17 @@
 - Supporting docs now align risk classification/testing expectations for STO exemption creation and derived approver IDs, PR state endpoint behavior, and template list/get/create/update paths.
 - Addressed review feedback by adding required STO promote `scope` examples and correcting refreshed testing examples to use current `filters`, `params`, and `resource_id` tool input shapes.
 - Verified with `pnpm install --frozen-lockfile`, `pnpm build`, `pnpm docs:check`, and `git diff --check`.
+
+## HTTP MCP Auth Hardening (2026-05-17)
+- [x] Add config for optional HTTP bearer auth and explicit unauthenticated opt-out
+- [x] Add focused regression tests for auth parsing, route authentication, and non-loopback fail-closed behavior
+- [x] Gate all `/mcp` HTTP routes before session creation or session reuse
+- [x] Update README and env documentation so CORS/Host validation are not presented as authentication
+- [x] Run focused tests, typecheck, build, commit, and push
+
+### Plan
+- Keep stdio behavior unchanged.
+- Add `HARNESS_MCP_AUTH_TOKEN` as the HTTP transport bearer token. When set, `/mcp` requires `Authorization: Bearer <token>` for `POST`, `GET`, and `DELETE`.
+- Add `HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP` as an explicit escape hatch. If HTTP binds to a non-loopback host without `HARNESS_MCP_AUTH_TOKEN`, startup fails unless this escape hatch is true.
+- Preserve `/health` as unauthenticated for probes, because it returns only status and session count.
+- Keep Host-header validation and CORS as defense-in-depth controls, not auth controls.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -447,3 +447,10 @@
 - Add `HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP` as an explicit escape hatch. If HTTP binds to a non-loopback host without `HARNESS_MCP_AUTH_TOKEN`, startup fails unless this escape hatch is true.
 - Preserve `/health` as unauthenticated for probes, because it returns only status and session count.
 - Keep Host-header validation and CORS as defense-in-depth controls, not auth controls.
+
+### Review
+- Added `HARNESS_MCP_AUTH_TOKEN` and `HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP` config fields.
+- Added `src/utils/http-auth.ts` to validate non-loopback binds, check exact Bearer tokens with timing-safe comparison, and reject unauthenticated `/mcp` requests before handlers run.
+- Wired the auth middleware after CORS/rate-limit middleware and before MCP session creation/reuse in `src/index.ts`; `/health` and CORS preflight remain unauthenticated.
+- Updated README and `.env.example` to document HTTP auth and clarify that CORS/Host validation are not authentication.
+- Verified with `pnpm test tests/utils/http-auth.test.ts tests/config.test.ts tests/integration/http-transport.test.ts`, `pnpm typecheck`, `pnpm build`, and full `pnpm test` (58 files / 1360 tests).

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -55,8 +55,9 @@ describe("ConfigSchema", () => {
   });
 
   it("fails when HARNESS_API_KEY is missing", () => {
-    const result = ConfigSchema.safeParse({ HARNESS_ACCOUNT_ID: "acct123" });
-    expect(result.success).toBe(false);
+    expect(() =>
+      ConfigSchema.parse({ HARNESS_ACCOUNT_ID: "acct123" }),
+    ).toThrow("HARNESS_API_KEY is required in single-user mode");
   });
 
   it("HARNESS_ACCOUNT_ID is optional in schema", () => {
@@ -65,8 +66,9 @@ describe("ConfigSchema", () => {
   });
 
   it("fails when HARNESS_API_KEY is empty", () => {
-    const result = ConfigSchema.safeParse({ HARNESS_API_KEY: "", HARNESS_ACCOUNT_ID: "acct" });
-    expect(result.success).toBe(false);
+    expect(() =>
+      ConfigSchema.parse({ HARNESS_API_KEY: "", HARNESS_ACCOUNT_ID: "acct" }),
+    ).toThrow("HARNESS_API_KEY is required in single-user mode");
   });
 
   it("applies default HARNESS_BASE_URL", () => {
@@ -166,6 +168,44 @@ describe("ConfigSchema", () => {
     if (result.success) {
       expect(result.data.HARNESS_MCP_ALLOWED_HOSTS).toBe("mcp.example.com,localhost");
     }
+  });
+
+  it("defaults HARNESS_MCP_MODE to single-user", () => {
+    const result = ConfigSchema.safeParse(validConfig);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.HARNESS_MCP_MODE).toBe("single-user");
+    }
+  });
+
+  it("accepts multi-user mode without HARNESS_API_KEY", () => {
+    const result = ConfigSchema.safeParse({
+      HARNESS_MCP_MODE: "multi-user",
+      HARNESS_ACCOUNT_ID: "acct123",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.HARNESS_MCP_MODE).toBe("multi-user");
+      expect(result.data.HARNESS_API_KEY).toBe("");
+    }
+  });
+
+  it("rejects multi-user mode when HARNESS_API_KEY is set", () => {
+    expect(() =>
+      ConfigSchema.parse({
+        ...validConfig,
+        HARNESS_MCP_MODE: "multi-user",
+      }),
+    ).toThrow("HARNESS_API_KEY must not be set in multi-user mode");
+  });
+
+  it("requires HARNESS_API_KEY in single-user mode", () => {
+    expect(() =>
+      ConfigSchema.parse({
+        HARNESS_MCP_MODE: "single-user",
+        HARNESS_ACCOUNT_ID: "acct123",
+      }),
+    ).toThrow("HARNESS_API_KEY is required in single-user mode");
   });
 
   it("parses HTTP MCP auth token and unauthenticated opt-out config", () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -168,6 +168,33 @@ describe("ConfigSchema", () => {
     }
   });
 
+  it("parses HTTP MCP auth token and unauthenticated opt-out config", () => {
+    const result = ConfigSchema.safeParse({
+      ...validConfig,
+      HARNESS_MCP_AUTH_TOKEN: "shared-secret",
+      HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP: "true",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.HARNESS_MCP_AUTH_TOKEN).toBe("shared-secret");
+      expect(result.data.HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP).toBe(true);
+    }
+  });
+
+  it("treats an empty HTTP MCP auth token as unset", () => {
+    const result = ConfigSchema.safeParse({
+      ...validConfig,
+      HARNESS_MCP_AUTH_TOKEN: "",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.HARNESS_MCP_AUTH_TOKEN).toBeUndefined();
+      expect(result.data.HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP).toBe(false);
+    }
+  });
+
   it("rejects malformed MCP allowed host entries during config validation", () => {
     expect(() =>
       ConfigSchema.parse({

--- a/tests/integration/http-transport.test.ts
+++ b/tests/integration/http-transport.test.ts
@@ -176,12 +176,13 @@ describe("HTTP transport session management", () => {
       // Simulate CORS middleware
       headers["Access-Control-Allow-Origin"] = `http://${host}:${port}`;
       headers["Access-Control-Allow-Methods"] = "GET, POST, DELETE, OPTIONS";
-      headers["Access-Control-Allow-Headers"] = "Content-Type, mcp-session-id, x-harness-pipeline-version";
+      headers["Access-Control-Allow-Headers"] = "Authorization, Content-Type, mcp-session-id, x-harness-pipeline-version, x-harness-auto-approve-risk";
       headers["Access-Control-Expose-Headers"] = "mcp-session-id";
 
       expect(headers["Access-Control-Allow-Origin"]).toBe("http://127.0.0.1:3000");
       expect(headers["Access-Control-Allow-Methods"]).toContain("POST");
       expect(headers["Access-Control-Allow-Methods"]).toContain("DELETE");
+      expect(headers["Access-Control-Allow-Headers"]).toContain("Authorization");
       expect(headers["Access-Control-Allow-Headers"]).toContain("mcp-session-id");
       expect(headers["Access-Control-Expose-Headers"]).toContain("mcp-session-id");
     });

--- a/tests/integration/http-transport.test.ts
+++ b/tests/integration/http-transport.test.ts
@@ -176,7 +176,7 @@ describe("HTTP transport session management", () => {
       // Simulate CORS middleware
       headers["Access-Control-Allow-Origin"] = `http://${host}:${port}`;
       headers["Access-Control-Allow-Methods"] = "GET, POST, DELETE, OPTIONS";
-      headers["Access-Control-Allow-Headers"] = "Authorization, Content-Type, mcp-session-id, x-harness-pipeline-version, x-harness-auto-approve-risk";
+      headers["Access-Control-Allow-Headers"] = "Authorization, Content-Type, mcp-session-id, x-harness-api-key, x-harness-account-id, x-harness-org, x-harness-project, x-harness-pipeline-version, x-harness-auto-approve-risk";
       headers["Access-Control-Expose-Headers"] = "mcp-session-id";
 
       expect(headers["Access-Control-Allow-Origin"]).toBe("http://127.0.0.1:3000");

--- a/tests/integration/http-transport.test.ts
+++ b/tests/integration/http-transport.test.ts
@@ -13,6 +13,8 @@ import { request as httpRequest } from "node:http";
 import type { AddressInfo } from "node:net";
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import { resolveHttpHostValidationOptions } from "../../src/utils/http-hosts.js";
+import { createHttpAuthMiddleware } from "../../src/utils/http-auth.js";
+import { mergeConfigWithSessionHeaders, MissingSessionCredentialsError } from "../../src/utils/session-headers.js";
 
 // We can't easily test the full HTTP server without starting it,
 // so we test the session management patterns and transport lifecycle
@@ -270,6 +272,174 @@ describe("HTTP transport session management", () => {
 
       expect(sessionId).toBeUndefined();
       expect(errorResponse.error.message).toContain("mcp-session-id");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Route-level tests — exercises the real middleware stack (auth → body parse → route)
+// ---------------------------------------------------------------------------
+
+async function postMcp(
+  baseUrl: string,
+  opts: { headers?: Record<string, string>; body?: unknown },
+): Promise<{ status: number; body: unknown; headers: Record<string, string> }> {
+  const url = new URL("/mcp", baseUrl);
+  const payload = opts.body !== undefined ? JSON.stringify(opts.body) : undefined;
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept": "application/json, text/event-stream",
+          ...(payload ? { "Content-Length": Buffer.byteLength(payload).toString() } : {}),
+          ...opts.headers,
+        },
+      },
+      (res) => {
+        let rawBody = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => { rawBody += chunk; });
+        res.on("end", () => {
+          let parsed: unknown;
+          try { parsed = JSON.parse(rawBody); } catch { parsed = rawBody; }
+          const responseHeaders: Record<string, string> = {};
+          for (const [k, v] of Object.entries(res.headers)) {
+            if (typeof v === "string") responseHeaders[k] = v;
+          }
+          resolve({ status: res.statusCode ?? 0, body: parsed, headers: responseHeaders });
+        });
+      },
+    );
+    req.on("error", reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+function buildInitializeBody(): unknown {
+  return {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+      clientInfo: { name: "test", version: "1.0" },
+    },
+  };
+}
+
+/**
+ * Build a minimal Express app that mirrors the real src/index.ts middleware
+ * stack for the auth + multi-user credential path, but without starting the
+ * full Harness MCP server (which requires a real API key).
+ */
+function buildAuthTestApp(opts: {
+  authToken?: string;
+  multiUser?: boolean;
+}): Express {
+  const { json } = require("express");
+  const app = createMcpExpressApp(resolveHttpHostValidationOptions("127.0.0.1", {}));
+
+  // Mirror src/index.ts ordering: CORS → auth → rate limit → body parse → route
+  app.use((_req: any, res: any, next: any) => {
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    next();
+  });
+  app.use(createHttpAuthMiddleware(opts.authToken));
+  app.use(json({ limit: "1mb" }));
+
+  app.post("/mcp", (req: any, res: any) => {
+    // Simulate multi-user credential check from src/index.ts POST /mcp handler
+    if (opts.multiUser) {
+      const baseConfig = {
+        HARNESS_MCP_MODE: "multi-user" as const,
+        HARNESS_API_KEY: "",
+        HARNESS_ACCOUNT_ID: "",
+        HARNESS_AUTO_APPROVE_RISK: "none" as const,
+      };
+      try {
+        mergeConfigWithSessionHeaders(baseConfig as any, req.headers);
+      } catch (err) {
+        if (err instanceof MissingSessionCredentialsError) {
+          res.status(401).json({
+            jsonrpc: "2.0",
+            error: { code: -32001, message: err.message },
+            id: null,
+          });
+          return;
+        }
+        throw err;
+      }
+    }
+    // If we get here, auth + credentials passed
+    res.json({ jsonrpc: "2.0", id: 1, result: { ok: true } });
+  });
+
+  return app;
+}
+
+describe("HTTP /mcp route-level auth", () => {
+  it("returns 401 when bearer token is required but missing", async () => {
+    const app = buildAuthTestApp({ authToken: "secret-token" });
+    await withListeningApp(app, async (baseUrl) => {
+      const res = await postMcp(baseUrl, { body: buildInitializeBody() });
+      expect(res.status).toBe(401);
+      expect(res.body).toMatchObject({
+        jsonrpc: "2.0",
+        error: { code: -32001, message: "Unauthorized" },
+      });
+    });
+  });
+
+  it("returns 401 when multi-user headers are missing on initialize", async () => {
+    const app = buildAuthTestApp({ multiUser: true });
+    await withListeningApp(app, async (baseUrl) => {
+      const res = await postMcp(baseUrl, { body: buildInitializeBody() });
+      expect(res.status).toBe(401);
+      expect(res.body).toMatchObject({
+        jsonrpc: "2.0",
+        error: { code: -32001 },
+      });
+    });
+  });
+
+  it("returns 401 when PAT account ID mismatches x-harness-account-id", async () => {
+    const app = buildAuthTestApp({ multiUser: true });
+    await withListeningApp(app, async (baseUrl) => {
+      const res = await postMcp(baseUrl, {
+        body: buildInitializeBody(),
+        headers: {
+          "x-harness-api-key": "pat.accountA.token.secret",
+          "x-harness-account-id": "accountB",
+        },
+      });
+      expect(res.status).toBe(401);
+      expect(res.body).toMatchObject({
+        jsonrpc: "2.0",
+        error: { code: -32001 },
+      });
+    });
+  });
+
+  it("succeeds with correct bearer token and multi-user credentials", async () => {
+    const app = buildAuthTestApp({ authToken: "my-token", multiUser: true });
+    await withListeningApp(app, async (baseUrl) => {
+      const res = await postMcp(baseUrl, {
+        body: buildInitializeBody(),
+        headers: {
+          "Authorization": "Bearer my-token",
+          "x-harness-api-key": "pat.myaccount.token.secret",
+          "x-harness-account-id": "myaccount",
+        },
+      });
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ jsonrpc: "2.0", id: 1, result: { ok: true } });
     });
   });
 });

--- a/tests/utils/http-auth.test.ts
+++ b/tests/utils/http-auth.test.ts
@@ -1,0 +1,132 @@
+import express from "express";
+import { describe, expect, it } from "vitest";
+import { request as httpRequest } from "node:http";
+import type { AddressInfo } from "node:net";
+import {
+  createHttpAuthMiddleware,
+  isAuthorizedHttpRequest,
+  validateHttpAuthForBindHost,
+} from "../../src/utils/http-auth.js";
+
+async function withListeningApp(app: express.Express, fn: (baseUrl: string) => Promise<void>): Promise<void> {
+  const server = app.listen(0, "127.0.0.1");
+  await new Promise<void>((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const address = server.address() as AddressInfo;
+    await fn(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => err ? reject(err) : resolve());
+    });
+  }
+}
+
+async function getWithAuth(
+  baseUrl: string,
+  path: string,
+  authorization?: string,
+): Promise<{ status: number; body: unknown }> {
+  return requestWithAuth(baseUrl, "GET", path, authorization);
+}
+
+async function requestWithAuth(
+  baseUrl: string,
+  method: string,
+  path: string,
+  authorization?: string,
+): Promise<{ status: number; body: unknown }> {
+  const url = new URL(path, baseUrl);
+  return new Promise((resolve, reject) => {
+    const headers = authorization ? { Authorization: authorization } : undefined;
+    const req = httpRequest(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname,
+        method,
+        headers,
+      },
+      (res) => {
+        let rawBody = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => { rawBody += chunk; });
+        res.on("end", () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            body: rawBody ? JSON.parse(rawBody) : undefined,
+          });
+        });
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("HTTP MCP auth", () => {
+  it("allows requests when no HTTP auth token is configured", () => {
+    expect(isAuthorizedHttpRequest({}, undefined)).toBe(true);
+  });
+
+  it("requires an exact Bearer token when HTTP auth is configured", () => {
+    expect(isAuthorizedHttpRequest({}, "secret-token")).toBe(false);
+    expect(isAuthorizedHttpRequest({ authorization: "Bearer wrong" }, "secret-token")).toBe(false);
+    expect(isAuthorizedHttpRequest({ authorization: "Basic secret-token" }, "secret-token")).toBe(false);
+    expect(isAuthorizedHttpRequest({ authorization: "Bearer secret-token" }, "secret-token")).toBe(true);
+  });
+
+  it("rejects unauthenticated MCP routes before handlers run", async () => {
+    const app = express();
+    app.use(createHttpAuthMiddleware("secret-token"));
+    app.get("/health", (_req, res) => res.json({ status: "ok" }));
+    app.options("/mcp", (_req, res) => res.status(204).end());
+    app.get("/mcp", (_req, res) => res.json({ ok: true }));
+
+    await withListeningApp(app, async (baseUrl) => {
+      const health = await getWithAuth(baseUrl, "/health");
+      expect(health.status).toBe(200);
+      expect(health.body).toEqual({ status: "ok" });
+
+      const preflight = await requestWithAuth(baseUrl, "OPTIONS", "/mcp");
+      expect(preflight.status).toBe(204);
+
+      const rejected = await getWithAuth(baseUrl, "/mcp");
+      expect(rejected.status).toBe(401);
+      expect(rejected.body).toMatchObject({
+        jsonrpc: "2.0",
+        error: { code: -32001, message: "Unauthorized" },
+      });
+
+      const accepted = await getWithAuth(baseUrl, "/mcp", "Bearer secret-token");
+      expect(accepted.status).toBe(200);
+      expect(accepted.body).toEqual({ ok: true });
+    });
+  });
+
+  it("fails closed for non-loopback binds without auth unless explicitly allowed", () => {
+    expect(() =>
+      validateHttpAuthForBindHost("0.0.0.0", {
+        HARNESS_MCP_AUTH_TOKEN: undefined,
+        HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP: false,
+      }),
+    ).toThrow("HARNESS_MCP_AUTH_TOKEN is required");
+
+    expect(() =>
+      validateHttpAuthForBindHost("0.0.0.0", {
+        HARNESS_MCP_AUTH_TOKEN: undefined,
+        HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP: true,
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      validateHttpAuthForBindHost("0.0.0.0", {
+        HARNESS_MCP_AUTH_TOKEN: "secret-token",
+        HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP: false,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/tests/utils/session-headers.test.ts
+++ b/tests/utils/session-headers.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from "vitest";
 import type { Config } from "../../src/config.js";
 import {
   mergeConfigWithSessionHeaders,
+  MissingSessionCredentialsError,
   parseAutoApproveRiskHeader,
   parsePipelineVersionHeader,
 } from "../../src/utils/session-headers.js";
 
-function makeConfig(): Config {
+function makeConfig(overrides?: Partial<Config>): Config {
   return {
+    HARNESS_MCP_MODE: "single-user",
     HARNESS_API_KEY: "pat.test.abc.xyz",
     HARNESS_ACCOUNT_ID: "test-account",
     HARNESS_BASE_URL: "https://app.harness.io",
@@ -24,6 +26,8 @@ function makeConfig(): Config {
     HARNESS_AUTO_APPROVE_RISK: "none",
     HARNESS_ALLOW_HTTP: false,
     HARNESS_MCP_ALLOWED_HOSTS: undefined,
+    HARNESS_MCP_AUTH_TOKEN: undefined,
+    HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP: false,
     HARNESS_FME_BASE_URL: "https://api.split.io",
     HARNESS_LOG_UNSAFE_BODIES: false,
     HARNESS_PIPELINE_VERSION: undefined,
@@ -32,6 +36,7 @@ function makeConfig(): Config {
     HARNESS_AUDIT_WEBHOOK_TOKEN: undefined,
     HARNESS_AUDIT_WEBHOOK_BATCH_SIZE: 10,
     HARNESS_AUDIT_WEBHOOK_FLUSH_MS: 5000,
+    ...overrides,
   };
 }
 
@@ -83,5 +88,74 @@ describe("session header parsing", () => {
     });
 
     expect(merged.HARNESS_AUTO_APPROVE_RISK).toBe("none");
+  });
+});
+
+describe("multi-user session credentials", () => {
+  it("merges x-harness-api-key and x-harness-account-id into session config", () => {
+    const base = makeConfig({ HARNESS_MCP_MODE: "multi-user", HARNESS_API_KEY: "", HARNESS_ACCOUNT_ID: "" });
+    const merged = mergeConfigWithSessionHeaders(base, {
+      "x-harness-api-key": "pat.user1.tok.sec",
+      "x-harness-account-id": "user1-account",
+    });
+    expect(merged.HARNESS_API_KEY).toBe("pat.user1.tok.sec");
+    expect(merged.HARNESS_ACCOUNT_ID).toBe("user1-account");
+  });
+
+  it("merges x-harness-org and x-harness-project as session defaults", () => {
+    const base = makeConfig({ HARNESS_MCP_MODE: "multi-user", HARNESS_API_KEY: "", HARNESS_ACCOUNT_ID: "" });
+    const merged = mergeConfigWithSessionHeaders(base, {
+      "x-harness-api-key": "pat.user1.tok.sec",
+      "x-harness-account-id": "user1-account",
+      "x-harness-org": "user-org",
+      "x-harness-project": "user-project",
+    });
+    expect(merged.HARNESS_ORG).toBe("user-org");
+    expect(merged.HARNESS_PROJECT).toBe("user-project");
+  });
+
+  it("throws MissingSessionCredentialsError when api key is missing in multi-user mode", () => {
+    const base = makeConfig({ HARNESS_MCP_MODE: "multi-user", HARNESS_API_KEY: "", HARNESS_ACCOUNT_ID: "" });
+    expect(() =>
+      mergeConfigWithSessionHeaders(base, {
+        "x-harness-account-id": "user1-account",
+      }),
+    ).toThrow(MissingSessionCredentialsError);
+  });
+
+  it("throws MissingSessionCredentialsError when account id is missing in multi-user mode", () => {
+    const base = makeConfig({ HARNESS_MCP_MODE: "multi-user", HARNESS_API_KEY: "", HARNESS_ACCOUNT_ID: "" });
+    expect(() =>
+      mergeConfigWithSessionHeaders(base, {
+        "x-harness-api-key": "pat.user1.tok.sec",
+      }),
+    ).toThrow(MissingSessionCredentialsError);
+  });
+
+  it("does not require session credential headers in personal mode", () => {
+    const base = makeConfig();
+    const merged = mergeConfigWithSessionHeaders(base, {});
+    expect(merged).toBe(base);
+  });
+
+  it("allows personal mode sessions to override org and project via headers", () => {
+    const base = makeConfig();
+    const merged = mergeConfigWithSessionHeaders(base, {
+      "x-harness-org": "override-org",
+      "x-harness-project": "override-project",
+    });
+    expect(merged.HARNESS_ORG).toBe("override-org");
+    expect(merged.HARNESS_PROJECT).toBe("override-project");
+    expect(merged.HARNESS_API_KEY).toBe(base.HARNESS_API_KEY);
+  });
+
+  it("ignores x-harness-api-key and x-harness-account-id in personal mode", () => {
+    const base = makeConfig();
+    const merged = mergeConfigWithSessionHeaders(base, {
+      "x-harness-api-key": "pat.attacker.tok.sec",
+      "x-harness-account-id": "attacker-account",
+    });
+    expect(merged.HARNESS_API_KEY).toBe(base.HARNESS_API_KEY);
+    expect(merged.HARNESS_ACCOUNT_ID).toBe(base.HARNESS_ACCOUNT_ID);
   });
 });

--- a/tests/utils/session-headers.test.ts
+++ b/tests/utils/session-headers.test.ts
@@ -96,17 +96,17 @@ describe("multi-user session credentials", () => {
     const base = makeConfig({ HARNESS_MCP_MODE: "multi-user", HARNESS_API_KEY: "", HARNESS_ACCOUNT_ID: "" });
     const merged = mergeConfigWithSessionHeaders(base, {
       "x-harness-api-key": "pat.user1.tok.sec",
-      "x-harness-account-id": "user1-account",
+      "x-harness-account-id": "user1",
     });
     expect(merged.HARNESS_API_KEY).toBe("pat.user1.tok.sec");
-    expect(merged.HARNESS_ACCOUNT_ID).toBe("user1-account");
+    expect(merged.HARNESS_ACCOUNT_ID).toBe("user1");
   });
 
   it("merges x-harness-org and x-harness-project as session defaults", () => {
     const base = makeConfig({ HARNESS_MCP_MODE: "multi-user", HARNESS_API_KEY: "", HARNESS_ACCOUNT_ID: "" });
     const merged = mergeConfigWithSessionHeaders(base, {
       "x-harness-api-key": "pat.user1.tok.sec",
-      "x-harness-account-id": "user1-account",
+      "x-harness-account-id": "user1",
       "x-harness-org": "user-org",
       "x-harness-project": "user-project",
     });
@@ -118,7 +118,7 @@ describe("multi-user session credentials", () => {
     const base = makeConfig({ HARNESS_MCP_MODE: "multi-user", HARNESS_API_KEY: "", HARNESS_ACCOUNT_ID: "" });
     expect(() =>
       mergeConfigWithSessionHeaders(base, {
-        "x-harness-account-id": "user1-account",
+        "x-harness-account-id": "user1",
       }),
     ).toThrow(MissingSessionCredentialsError);
   });
@@ -130,6 +130,25 @@ describe("multi-user session credentials", () => {
         "x-harness-api-key": "pat.user1.tok.sec",
       }),
     ).toThrow(MissingSessionCredentialsError);
+  });
+
+  it("throws when PAT account ID does not match x-harness-account-id", () => {
+    const base = makeConfig({ HARNESS_MCP_MODE: "multi-user", HARNESS_API_KEY: "", HARNESS_ACCOUNT_ID: "" });
+    expect(() =>
+      mergeConfigWithSessionHeaders(base, {
+        "x-harness-api-key": "pat.accountA.tok.sec",
+        "x-harness-account-id": "accountB",
+      }),
+    ).toThrow(MissingSessionCredentialsError);
+  });
+
+  it("allows non-PAT tokens without account ID validation", () => {
+    const base = makeConfig({ HARNESS_MCP_MODE: "multi-user", HARNESS_API_KEY: "", HARNESS_ACCOUNT_ID: "" });
+    const merged = mergeConfigWithSessionHeaders(base, {
+      "x-harness-api-key": "sat.sometoken.secret",
+      "x-harness-account-id": "any-account",
+    });
+    expect(merged.HARNESS_ACCOUNT_ID).toBe("any-account");
   });
 
   it("does not require session credential headers in personal mode", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds two capabilities to the HTTP MCP transport:

**1. Bearer token auth for HTTP `/mcp` routes** (commits beebff6f, e34f1b38)
- `HARNESS_MCP_AUTH_TOKEN` — when set, every POST/GET/DELETE to `/mcp` requires `Authorization: Bearer <token>`.
- `HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP` — escape hatch for non-loopback binds without a token.
- Timing-safe token comparison. `/health` and CORS preflight remain unauthenticated.
- Startup fails for non-loopback HTTP binds unless auth token is set or unauthenticated mode is explicitly allowed.

**2. Single-user and multi-user deployment modes** (commit 798e351e)

`HARNESS_MCP_MODE` controls how the server handles Harness credentials:

| Mode | `HARNESS_API_KEY` | Session credentials | Transport |
|------|-------------------|---------------------|-----------|
| `single-user` (default) | Required in config | All sessions share it | stdio or HTTP |
| `multi-user` | Must NOT be set | Each session provides `x-harness-api-key` + `x-harness-account-id` headers on initialize | HTTP only |

In multi-user mode:
- The server holds no Harness credentials — it's a stateless proxy.
- Missing credentials on initialize → 401 before any session is created.
- Sessions can also provide `x-harness-org` and `x-harness-project` for default scope.
- The Harness API key flows through to every API call, so the audit trail reflects the real user.
- Identity headers are ignored in single-user mode to prevent clients from overriding the operator's config.

The bearer token (`HARNESS_MCP_AUTH_TOKEN`) is independent and works in both modes as an optional transport-layer gate.

## Type of Change
- [x] New feature
- [x] Bug fix

## Checklist
- [x] Tests pass (58 files / 1371 tests — 11 new tests for mode validation, session credential merging, and auth middleware)
- [x] Typecheck passes
- [x] Build passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d13175bd-14fa-412e-81b3-d0a6bb8580d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d13175bd-14fa-412e-81b3-d0a6bb8580d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

