### PR TITLE
Onboard STO vuln tab to mcp and skill to exempt failed policy issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Harness MCP Server 2.0
 
-An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 188 resource types.
+An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 190 resource types.
 
 ## Why Use This MCP Server
 
@@ -8,10 +8,10 @@ Most MCP servers map one tool per API endpoint. For a platform as broad as Harne
 
 This server is built differently:
 
-- **11 tools, 188 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
+- **11 tools, 190 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
 - **Full platform coverage.** 32 toolsets spanning CI/CD, GitOps, Feature Flags, Cloud Cost Management, Security Testing, Chaos Engineering, Database DevOps, Internal Developer Portal, Software Supply Chain, Governance, Service Overrides, Visualizations, and more. Not just pipelines — the entire Harness platform.
 - **Multi-project workflows out of the box.** Agents discover organizations and projects dynamically — no hardcoded env vars needed. Ask "show failed executions across all projects" and the agent can navigate the full account hierarchy.
-- **31 prompt templates.** Pre-built prompts for common workflows: build & deploy apps end-to-end, debug failed pipelines, review DORA metrics, triage vulnerabilities, optimize cloud costs, audit access control, plan feature flag rollouts, review pull requests, approve pending pipelines, and more.
+- **32 prompt templates.** Pre-built prompts for common workflows: build & deploy apps end-to-end, debug failed pipelines, review DORA metrics, triage vulnerabilities, optimize cloud costs, audit access control, plan feature flag rollouts, review pull requests, approve pending pipelines, and more.
 - **Works everywhere.** Stdio transport for local clients (Claude Desktop, Cursor, Windsurf), HTTP transport for remote/shared deployments, Docker and Kubernetes ready.
 - **Zero-config start.** Just provide a Harness API key. Account ID is auto-extracted from PAT tokens, org/project defaults are optional, and toolset filtering lets you expose only what you need.
 - **Extensible by design.** Adding a new Harness resource means adding a declarative data file — no new tool registration, no schema changes, no prompt updates.
@@ -991,7 +991,7 @@ Harness pipelines can be stored in three ways:
 
 ## Resource Types
 
-188 resource types organized across 32 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
+190 resource types organized across 32 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
 
 ### Platform
 
@@ -1537,7 +1537,7 @@ Available toolset names:
                  +--------v---------+
                 |    Registry       |  <-- Declarative resource definitions
                 |  32 Toolsets      |      (data files, not code)
-                |  188 Resource Types|
+                |  190 Resource Types|
                  +--------+---------+
                           |
                  +--------v---------+

--- a/src/prompts/exempt-opa-failed-issues.ts
+++ b/src/prompts/exempt-opa-failed-issues.ts
@@ -1,5 +1,6 @@
 import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { parseHarnessUrl } from "../utils/url-parser.js";
 
 /**
  * Skill: exempt-opa-failed-issues
@@ -28,9 +29,10 @@ export function registerExemptOpaFailedIssuesPrompt(server: McpServer): void {
         + "execution's Pipeline Security issues + scan steps, correlates the deny signals to "
         + "specific issue_ids, asks for confirmation, then bulk-creates exemptions.",
       argsSchema: {
-        executionId: z.string().describe("Pipeline plan execution ID (e.g. 'ehsPKtczTRO5CUDAt-NR'), OR any Harness UI URL that contains '/executions/<executionId>/' in its path. Examples: the pipeline execution page, the Security Tests / vulnerabilities tab, the Policy Evaluations tab. If a URL is pasted, the prompt extracts the executionId segment automatically. orgId and projectId are also extracted from the URL if present."),
-        projectId: z.string().describe("Project identifier (optional; defaults to configured project)").optional(),
-        orgId: z.string().describe("Organization identifier (optional; defaults to configured org)").optional(),
+        executionId: z.string().describe("Pipeline plan execution ID (e.g. 'ehsPKtczTRO5CUDAt-NR'). Either this OR `url` is required. If both are supplied, `executionId` wins.").optional(),
+        url: z.string().describe("Any Harness UI URL referencing the failed execution — pipeline run page, Security Tests tab, Policy Evaluations tab, etc. Auto-extracts executionId, pipelineId, orgId, projectId. Works for both '/executions/<id>/' and '/deployments/<id>/' URL shapes.").optional(),
+        projectId: z.string().describe("Project identifier (optional; defaults to configured project or URL-extracted value)").optional(),
+        orgId: z.string().describe("Organization identifier (optional; defaults to configured org or URL-extracted value)").optional(),
         exemption_type: z.string().describe("Exemption type to apply: 'Compensating Controls' | 'Acceptable Use' | 'Acceptable Risk' | 'False Positive' | 'Fix Unavailable' | 'Other'. Optional — if omitted, the prompt will ask after showing the candidate table.").optional(),
         reason: z.string().describe("Business/security justification for the exemption. Optional — if omitted, the prompt will ask after showing the candidate table.").optional(),
         duration_days: z.number().describe("Exemption duration in days (defaults to 30 when omitted)").optional(),
@@ -49,6 +51,7 @@ export function registerExemptOpaFailedIssuesPrompt(server: McpServer): void {
     },
     async ({
       executionId,
+      url,
       projectId,
       orgId,
       exemption_type,
@@ -59,8 +62,27 @@ export function registerExemptOpaFailedIssuesPrompt(server: McpServer): void {
       extra_filters,
       dry_run,
     }) => {
-      const orgScope = orgId ? `, org_id="${orgId}"` : "";
-      const projectScope = projectId ? `, project_id="${projectId}"` : "";
+      // Pre-resolve identifiers from a pasted Harness URL (handles both
+      // /executions/<id>/ and /deployments/<id>/ shapes via the shared parser).
+      // Explicit args take precedence over URL-extracted values.
+      let resolvedExecutionId = executionId;
+      let resolvedOrgId = orgId;
+      let resolvedProjectId = projectId;
+      let resolvedPipelineId: string | undefined;
+      let urlParseError: string | undefined;
+      if (url) {
+        try {
+          const parsed = parseHarnessUrl(url);
+          resolvedExecutionId = resolvedExecutionId || parsed.execution_id;
+          resolvedOrgId = resolvedOrgId || parsed.org_id;
+          resolvedProjectId = resolvedProjectId || parsed.project_id;
+          resolvedPipelineId = parsed.pipeline_id;
+        } catch (e) {
+          urlParseError = e instanceof Error ? e.message : String(e);
+        }
+      }
+      const orgScope = resolvedOrgId ? `, org_id="${resolvedOrgId}"` : "";
+      const projectScope = resolvedProjectId ? `, project_id="${resolvedProjectId}"` : "";
       const scope = `${orgScope}${projectScope}`;
       const extraFiltersHint = extra_filters
         ? `\n- extra_filters: ${JSON.stringify(extra_filters)}`
@@ -75,7 +97,7 @@ export function registerExemptOpaFailedIssuesPrompt(server: McpServer): void {
             text: `Create STO exemptions for the issues that an OPA Policy step denied during a pipeline execution, using a PURE DETERMINISTIC join — no fuzzy correlation, no severity guessing.
 
 Inputs for this run:
-- executionId: "${executionId}"${orgId ? `\n- orgId: "${orgId}"` : ""}${projectId ? `\n- projectId: "${projectId}"` : ""}
+${resolvedExecutionId ? `- executionId: "${resolvedExecutionId}"` : "- executionId: (NOT RESOLVED — see Step 0)"}${resolvedOrgId ? `\n- orgId: "${resolvedOrgId}"` : ""}${resolvedProjectId ? `\n- projectId: "${resolvedProjectId}"` : ""}${resolvedPipelineId ? `\n- pipelineId: "${resolvedPipelineId}" (from URL — informational only)` : ""}${url ? `\n- url (raw input): "${url}"` : ""}${urlParseError ? `\n- urlParseError: "${urlParseError}"` : ""}
 ${exemption_type ? `- exemption_type: "${exemption_type}"` : "- exemption_type: (NOT PROVIDED — ask at the confirmation gate)"}
 ${reason ? `- reason: "${reason}"` : "- reason: (NOT PROVIDED — ask at the confirmation gate)"}${duration_days ? `\n- duration_days: ${duration_days}` : "\n- duration_days: 30 (default — confirm with user)"}${link ? `\n- link: ${link}` : ""}${expiration ? `\n- expiration: ${expiration}` : ""}${extraFiltersHint}${dryRunHint}
 
@@ -99,11 +121,17 @@ ${reason ? `- reason: "${reason}"` : "- reason: (NOT PROVIDED — ask at the con
 
 ## 0. Normalize the input
 
-If \`executionId\` contains \`/executions/\`, extract the segment immediately after it. Also extract \`orgId\` / \`projectId\` from \`/orgs/<id>/\` and \`/projects/<id>/\` when not provided as arguments. If the value is a bare ID, use it as-is. Print one line: \`Resolved: executionId=<id>, orgId=<...>, projectId=<...>\`. If executionId is empty after extraction, ask the user to repaste.
+The prompt handler has already parsed any pasted URL via the shared \`url-parser\` utility (which understands both \`/executions/<id>/\` and \`/deployments/<id>/\` shapes). Use the resolved values above. Print one line: \`Resolved: executionId=<id>, orgId=<...>, projectId=<...>\`.
+
+If \`executionId\` is still empty (no \`url\` supplied, no \`executionId\` arg, or URL parse error reported above), STOP and ask the user to either:
+- Paste a Harness URL of the failed execution (the pipeline run page works), OR
+- Provide the bare \`executionId\` (e.g. \`ehsPKtczTRO5CUDAt-NR\`).
+
+For every \`harness_*\` call in subsequent steps, you may also pass the raw \`url\` as the \`url\` parameter — the MCP tools auto-extract identifiers from it. This is a fallback in case the handler-side parse missed anything.
 
 ## 1. Resolve the execution
 
-  harness_get(resource_type="execution", execution_id="${executionId}"${scope})
+  harness_get(resource_type="execution", execution_id="${resolvedExecutionId ?? "<resolved above>"}"${scope})
 
 - Capture \`pipelineId\` and \`status\`. If status is "Success" (or any non-failure), stop — exemptions are unnecessary.
 - If the execution does not exist, surface the error verbatim and stop.
@@ -111,11 +139,11 @@ If \`executionId\` contains \`/executions/\`, extract the segment immediately af
 ## 2. Fetch the failing policy evaluation(s)
 
   harness_list(resource_type="policy_evaluation",
-               filters={ execution_id: "${executionId}", status: "error" }${scope})
+               filters={ execution_id: "${resolvedExecutionId ?? "<executionId>"}", status: "error" }${scope})
 
 The resource definition sets \`created_date_from=0\` so older executions are not filtered by policy-mgmt's silent 7-day default. Paginate until exhausted.
 
-If the result is empty, stop and report verbatim: "No failing OPA evaluation was recorded for execution ${executionId}. This is likely not an OPA failure — try \`harness_diagnose(resource_type='execution', execution_id='${executionId}')\` to find the real cause."
+If the result is empty, stop and report verbatim: "No failing OPA evaluation was recorded for execution ${resolvedExecutionId ?? "<executionId>"}. This is likely not an OPA failure — try \`harness_diagnose(resource_type='execution', execution_id='${resolvedExecutionId ?? "<executionId>"}')\` to find the real cause."
 
 For every returned item, call:
 
@@ -207,7 +235,7 @@ Where \`source\` ∈ { \`output.deny_list_violations\`, \`deny_messages_regex\` 
 
   harness_list(resource_type="pipeline_security_issue",
                filters={
-                 execution_id: "${executionId}",
+                 execution_id: "${resolvedExecutionId ?? "<executionId>"}",
                  include_exempted: false,
                  status: "ACTIVE,PENDING_EXEMPTION",
                  page_size_existing: 100,

--- a/src/prompts/exempt-opa-failed-issues.ts
+++ b/src/prompts/exempt-opa-failed-issues.ts
@@ -72,213 +72,139 @@ export function registerExemptOpaFailedIssuesPrompt(server: McpServer): void {
           role: "user" as const,
           content: {
             type: "text" as const,
-            text: `Create STO exemptions for the issues that caused an OPA Policy step to fail a pipeline execution.
+            text: `Create STO exemptions for the issues that an OPA Policy step denied during a pipeline execution, using a PURE DETERMINISTIC join — no fuzzy correlation, no severity guessing.
 
 Inputs for this run:
 - executionId: "${executionId}"${orgId ? `\n- orgId: "${orgId}"` : ""}${projectId ? `\n- projectId: "${projectId}"` : ""}
-${exemption_type ? `- exemption_type: "${exemption_type}"` : "- exemption_type: (NOT PROVIDED — ask the user at the confirmation gate)"}
-${reason ? `- reason: "${reason}"` : "- reason: (NOT PROVIDED — ask the user at the confirmation gate)"}${duration_days ? `\n- duration_days: ${duration_days}` : "\n- duration_days: 30 (default — confirm with user)"}${link ? `\n- link: ${link}` : ""}${expiration ? `\n- expiration: ${expiration}` : ""}${extraFiltersHint}${dryRunHint}
+${exemption_type ? `- exemption_type: "${exemption_type}"` : "- exemption_type: (NOT PROVIDED — ask at the confirmation gate)"}
+${reason ? `- reason: "${reason}"` : "- reason: (NOT PROVIDED — ask at the confirmation gate)"}${duration_days ? `\n- duration_days: ${duration_days}` : "\n- duration_days: 30 (default — confirm with user)"}${link ? `\n- link: ${link}` : ""}${expiration ? `\n- expiration: ${expiration}` : ""}${extraFiltersHint}${dryRunHint}
+
+═══════════════════════════════════════════════════════════════════
+🛑 CRITICAL RULES — OBEY ABSOLUTELY 🛑
+═══════════════════════════════════════════════════════════════════
+
+1. The candidate set is produced ONLY by the deterministic title-join in Step 3.
+   - Inputs to the join: \`evaluation.input\` (per-issue records with \`id\` + \`title\`) and \`evaluation.details[].details[].output.<package>.deny_list_violations[].issue.title\` (or, as fallback, bracketed-title regex on \`deny_messages\`).
+   - There is no fuzzy matching, no severity inference, no CVE/component string-fuzz, no scanner narrowing. If the join cannot be performed, you STOP — you do NOT guess.
+
+2. If \`evaluation.input\` has no \`{ name: "securityTestData", outcome: { issues: [...] } }\` segment OR \`output\` exposes no canonical \`deny_list_violations\` AND \`deny_messages\` do not match the canonical \`Vulnerability ['<title>'] …\` shape, REFUSE to produce candidates. Tell the user the rego is non-canonical and ask for explicit \`issue_ids\`. Never substitute severity / CVE / component heuristics.
+
+3. Never use \`harness_list(resource_type="security_issue")\` (that's the cross-execution Issues page). Always use \`pipeline_security_issue\` (execution-scoped).
+
+4. Never send \`requester_id\` or \`exempt_future_occurrences\` in the exemption body — server enforces both.
+
+5. No exemption is created without explicit user confirmation at the gate in Step 5. If \`dry_run=true\`, Step 6 is skipped entirely.
+
+═══════════════════════════════════════════════════════════════════
 
 ## 0. Normalize the input
 
-The \`executionId\` argument may be either a raw ID or a full Harness UI URL. Before any other step:
-
-- If the value contains \`/executions/\`, extract the segment immediately after it as the executionId. Example: \`https://app.harness.io/ng/account/<acct>/all/orgs/<org>/projects/<proj>/pipelines/<pid>/executions/drWLj24BRQCHZYeIuaquEQ/pipeline?stage=...\` → executionId = \`drWLj24BRQCHZYeIuaquEQ\`. The same shape covers the Security Tests / vulnerabilities tab, the Policy Evaluations tab, and the default pipeline view — they all have \`/executions/<id>/\` in the path.
-- If the URL also contains \`/orgs/<orgId>/\` and/or \`/projects/<projectId>/\` and the corresponding argument was NOT provided, use the URL values for scope.
-- If the value is already a bare ID (no \`/\` in it), use it as-is.
-- Print the normalized values back to the user in one line before continuing: \`Resolved: executionId=<id>, orgId=<...>, projectId=<...>\`. Do not proceed if executionId is empty after extraction — ask the user to paste a valid ID or URL.
-
-═══════════════════════════════════════════════════════════════════
-🛑 CRITICAL RULES — READ FIRST, OBEY ABSOLUTELY 🛑
-═══════════════════════════════════════════════════════════════════
-
-These rules override anything else in this prompt and the user's phrasing:
-
-A. **"Active issues in the execution" ≠ "Issues OPA denied on".**
-   The Pipeline Security tab lists every issue the scan found. OPA only failed the pipeline because of a SUBSET of those — the ones its rego matched. Your job is to find that subset. NEVER treat the full active-issue list as the candidate set.
-
-B. **No questions, no parameter prompts, no scope confirmations until Step 3a is printed.**
-   You may NOT ask the user "what exemption type / reason / duration / scope?" or "which issues should I exempt?" before printing the "Extracted OPA deny signals" table from Step 3a. Asking for exemption parameters before showing evidence is a banned shortcut.
-
-C. **You MUST fetch policy_evaluation or policy_set data — never guess from the policy name.**
-   - Pathway B (primary): harness_list(policy_evaluation, {execution_id, status: "error"}) → harness_get(policy_evaluation, <id>) for each. This is deterministic and works for both STO scan-step enforcement and explicit OPA Evaluation steps.
-   - Pathway A (fallback, only when Pathway B returns 0): harness_get(policy_set, <identifier>) and parse the rego's deny_list. Use this when the evaluation record isn't available.
-   If both paths fail, your only legal output is to stop and report what you got.
-
-D. **Banned phrases in your output (these signal guessing, not correlation):**
-   - "typical pattern is denial on High/Critical"
-   - "OPA likely denies on High+"
-   - "Exemption parameters for all N active issues"
-   - "Found N active issues blocking the policy" (without per-issue deny-signal evidence)
-   - Any menu option of the form "All active <severity bucket> (N issues)"
-
-E. **The candidate set comes from Step 5 correlation only.** Not from Step 4's active-issue list. If correlation yields fewer issues than the active list, that is CORRECT and EXPECTED — most active issues are not what OPA denied on.
-
-F. **If you cannot extract any deny signal**, ask the user for explicit issue_ids. Do NOT offer to exempt all-by-severity as a fallback.
-
-═══════════════════════════════════════════════════════════════════
-
-Follow this workflow EXACTLY. Do not skip steps. Do not create any exemption before the explicit confirmation gate.
-
----
+If \`executionId\` contains \`/executions/\`, extract the segment immediately after it. Also extract \`orgId\` / \`projectId\` from \`/orgs/<id>/\` and \`/projects/<id>/\` when not provided as arguments. If the value is a bare ID, use it as-is. Print one line: \`Resolved: executionId=<id>, orgId=<...>, projectId=<...>\`. If executionId is empty after extraction, ask the user to repaste.
 
 ## 1. Resolve the execution
 
-Call:
   harness_get(resource_type="execution", execution_id="${executionId}"${scope})
 
-- Capture: pipelineId, status.
-- If status indicates the run succeeded (e.g. "Success"), stop and tell the user the execution did NOT fail — exemptions are unnecessary. Suggest they re-check the executionId.
+- Capture \`pipelineId\` and \`status\`. If status is "Success" (or any non-failure), stop — exemptions are unnecessary.
 - If the execution does not exist, surface the error verbatim and stop.
 
-## 2. Find the failing OPA evaluation(s) for this execution
+## 2. Fetch the failing policy evaluation(s)
 
-The policy_evaluation resource indexes BOTH enforcement pathways:
-  - Pipeline governance (action=onrun, type=pipeline) — pre-run policies.
-  - STO scan-step enforcement (action=onstep, type=securityTests) — the \`enforce.policySets\` field on a Semgrep/Trivy/etc. step.
-  - Explicit OPA Evaluation step (action=onstep, type=custom or type=securityTests).
-
-The resource definition automatically sets \`created_date_from=0\` so older executions are not silently filtered out by policy-mgmt's default 7-day window.
-
-### Pathway B (PRIMARY) — direct lookup by execution_id
-
-Call:
   harness_list(resource_type="policy_evaluation",
                filters={ execution_id: "${executionId}", status: "error" }${scope})
 
-- Paginate until exhausted.
-- If the result is non-empty, proceed to Step 3 (read each evaluation's deny_messages — deterministic).
-- If the result is empty, proceed to Pathway A below.
+The resource definition sets \`created_date_from=0\` so older executions are not filtered by policy-mgmt's silent 7-day default. Paginate until exhausted.
 
-### Pathway A (FALLBACK) — derive from policy_set rego
+If the result is empty, stop and report verbatim: "No failing OPA evaluation was recorded for execution ${executionId}. This is likely not an OPA failure — try \`harness_diagnose(resource_type='execution', execution_id='${executionId}')\` to find the real cause."
 
-Use this ONLY when Pathway B genuinely returned 0 items (e.g. policy-mgmt is degraded, the evaluation hasn't been persisted yet, or the upstream date-window override was bypassed). It produces a candidate set without any evaluation record, by reading the policy set definition directly:
+For every returned item, call:
 
-1. Read the execution's failure message from Step 1. It is typically: \`"The following Policy Set was not adhered to: <display_name>"\`.
-2. Extract the display name(s). Note: the *display* name (e.g. "anurag-set") may differ from the *identifier* (e.g. "anuragset").
-3. Resolve display name → identifier: inspect the execution's pipeline YAML for \`enforce.policySets: ["<identifier>"]\`, OR call \`harness_list(resource_type="policy_set", filters={ search_term: "<display name>" }${scope})\` and match by name.
-4. For each resolved identifier, call \`harness_get(resource_type="policy_set", resource_id="<identifier>"${scope})\`. The response includes each policy's \`rego\` source and per-policy \`severity\` ("error" = Error & Exit, "warning" = Warn & Continue — only the "error" policies can fail the pipeline).
-5. Skip Step 3 entirely and jump to Step 3b (rego-based filter extraction).
-
-If BOTH pathways fail to produce a candidate signal → stop and tell the user verbatim:
-    "No failing OPA artifact found for execution ${executionId}. Pathway B (policy_evaluation list) returned 0 items and Pathway A (policy_set lookup from failure message) also produced no usable signal. This may be a non-OPA failure (e.g. an STO step 'Fail On' severity threshold). Try harness_diagnose(resource_type='execution', execution_id='${executionId}') to find the real cause."
-
-## 3. Read each failing evaluation and classify
-
-For each evaluation in the list, call:
   harness_get(resource_type="policy_evaluation", evaluation_id=<id>${scope})
 
-This call is MANDATORY — you cannot proceed using only the list response. The list returns summary metadata; only the get response contains evaluation.details[].details[] with deny_messages, output, and policy_severity. If you skip this call you have no evidence and you must stop, not guess.
+The list response is summary metadata only; \`details[].details[]\` with \`deny_messages\`, \`output\`, \`policy_severity\`, and the top-level \`input\` come only from the get response. This call is MANDATORY.
 
-If harness_get returns an error or empty details for every evaluation_id, stop and tell the user verbatim: "Called harness_get(policy_evaluation, <id>) and received <actual response summary>. Cannot extract deny signals without evaluation details — please verify the evaluation exists or check permissions." Do NOT proceed to ask the user which severity to exempt — that is guessing.
-
-The returned Evaluation has a TWO-LEVEL details structure (per policy-mgmt's schema):
+The fetched Evaluation has this shape:
 
   Evaluation
-    .input                                   ← raw policy input (used in Shortcut 2 below)
-    .details[]                               ← one entry per POLICY_SET (EvaluationDetail)
-        .identifier                          ← the policy_set identifier (already embedded — no separate fetch needed)
-        .name, .type, .action, .enabled
-        .status: "error"|"warning"|"pass"|"pending"
-        .details[]                           ← one entry per POLICY inside the set (EvaluatedPolicy)
-            .status: "error"|"warning"|"pass"|"pending"
-            .policy_severity: "Warn & Continue" | "Error & Exit"
+    .input                                  ← entity input fed to OPA (the deterministic-join SOURCE)
+    .details[]                              ← one per POLICY_SET (EvaluationDetail)
+        .identifier, .name, .type, .action
+        .status
+        .details[]                          ← one per POLICY (EvaluatedPolicy)
+            .status
+            .policy_severity                ← "Error & Exit" | "Warn & Continue"
             .policy: { identifier, name, rego, ... }
-            .output: Any                     ← typically { "deny": [...] } (used in Shortcut 1 below)
+            .output                         ← full structured rego result (NOT just the deny-strings list)
             .deny_messages: string[]
-            .error: string                   ← rego parse error, if any
 
-For each evaluation, walk evaluation.details[] (the per-policy-set level) and classify by the embedded type/action (do NOT fetch the policy_set separately — its identifier, name, type, action are already on EvaluationDetail). Valid (type, action) combinations are fixed by policy-mgmt's ValidPolicySetTypeActions map:
+## 3. Classify each policy_set and perform the deterministic title-join
 
-- CASE A (REFUSE — pipeline governance) — set.type == "pipeline" AND set.action in ("onrun", "onsave", "onstepstart"):
-    The OPA blocked the pipeline at run/save time, before any scan executed. There are no scan-issue findings to exempt. REFUSE this set: tell the user the failure is pipeline governance, not scan results — they need to amend the pipeline YAML or the governance policy itself. (Note: type=pipeline CANNOT have action=onstep — that combination is not valid in policy-mgmt.)
+For each \`evaluation.details[]\` (per policy_set), classify by \`(type, action)\`:
 
-- CASE B (REFUSE — SBOM enforcement) — set.type == "sbom" AND set.action == "onstep":
-    SBOM / SCS BOM enforcement — different domain (artifact components, not STO issues). REFUSE this set and route the user to:
-      harness_list(resource_type="scs_bom_violation", filters={ enforcement_id: ... })
+- **REFUSE — pipeline governance**: \`type=="pipeline"\` AND \`action in ("onrun","onsave","onstepstart")\`. Pre-run block; nothing to exempt. Report verbatim and skip this set.
+- **REFUSE — SBOM enforcement**: \`type=="sbom"\` AND \`action=="onstep"\`. Different domain. Route the user to \`harness_list(resource_type="scs_bom_violation", …)\` and skip this set.
+- **PROCEED**: \`type=="securityTests"\` AND \`action=="onstep"\` (canonical STO step), OR \`type=="custom"\` AND \`action=="onstep"\` (Custom Stage OPA Evaluation step). For \`custom\`, the input shape is customer-defined — proceed only if the rules below detect the canonical \`securityTestData\` shape.
+- **ANYTHING ELSE**: treat as REFUSE; surface the unfamiliar \`(type, action)\` to the user.
 
-- CASE C (PROCEED — STO-driven OPA step) — EITHER:
-    (i)  set.type == "securityTests" AND set.action == "onstep"   ← canonical STO policy step in a SecurityTests stage
-    (ii) set.type == "custom"        AND set.action == "onstep"   ← Custom Stage OPA Evaluation step (may or may not be evaluating STO output)
-    For (ii) the input shape is fully customer-defined; the skill still proceeds but should warn that correlation accuracy depends on what the customer's Rego consumes.
+If zero policy_sets PROCEED, stop and explain why.
 
-If a policy_set's (type, action) combination falls outside the cases above, treat it as CASE A by default (refuse, surface the unfamiliar type/action to the user).
+For each PROCEEDing policy_set, walk its inner \`details[]\` (per policy) and KEEP only entries where BOTH:
 
-If after classification ZERO policy_sets are in CASE C across all evaluations, stop and explain why — typically this means the failure is pipeline governance or SBOM enforcement, not STO scan denial.
+  policy.status == "error"            — the policy actually denied this run
+  policy.policy_severity == "Error & Exit"   — this policy is configured to fail the pipeline (not just warn)
 
-For each remaining CASE C policy_set, walk its inner details[] (EvaluatedPolicy level) and KEEP ONLY entries where BOTH conditions hold:
+Both checks are required: a Warn & Continue policy with status=error emits a message but does NOT block the run, and exempting its issues would be over-exemption.
 
-    (1) policy.status == "error"                   — the policy actually denied this run
-    (2) policy.policy_severity == "Error & Exit"   — this policy is configured to FAIL the pipeline on deny
+For each kept \`EvaluatedPolicy\`, perform this deterministic title-join — do not perform any other matching:
 
-Both checks are required. A policy with policy_severity = "Warn & Continue" that has status = "error" emits a warning but does NOT fail the pipeline — its deny messages must NOT be collected (otherwise we would over-exempt).
+### 3.1. Locate the issue-source segment in \`evaluation.input\`
 
-Collect from each kept EvaluatedPolicy:
-- policy.identifier, policy.name (for display + Rego fallback)
-- policy.rego (only if needed in correlation fallback when deny_messages are opaque)
-- deny_messages (string[])
-- output (typically { "deny": [...] } — used in Shortcut 1 below)
-- parent policy_set identifier + name (for "Denied by policy set …" attribution in the candidate table)
+Walk \`evaluation.input\` (it is typically a top-level array) and find the first element matching:
 
-Build a deduplicated set of deny_signals across all kept policies.
+  { "name": "securityTestData",
+    "outcome": { "issues": [ { "id": "<22-char>", "title": "<...>", "severityCode": "...", ... }, ... ] } }
 
-### 3b. Pathway A — extract filters directly from the policy_set rego
+This is the canonical pipeline-service "aggregator" shape emitted when STO scan outputs are referenced via \`<+steps.scan_x.output.outputVariables.Issues>\`. Build a map:
 
-(Use this ONLY when you arrived from Pathway A in Step 2 — i.e. you have a policy_set object from harness_get(policy_set, …) but NO policy_evaluation record.)
+  titleToIds: Map<string, string[]>   // title → list of issue IDs (1:N safe; same title can appear on multiple targets)
 
-The canonical Harness STO deny-list / allow-list rego template (used by 95%+ of customers) parses a structured \`deny_list\` block at the top of the rego. Extract it:
+iterating \`outcome.issues[]\` and pushing each \`{title -> id}\`.
 
-1. For each policy in \`policy_set.policies[]\` where \`policy.severity == "error"\` (= "Error & Exit"; "warning" policies don't fail the pipeline):
-2. Parse the rego source. Locate the assignment of the form:
-     deny_list := fill_defaults([
-       { "severity": {"value": "High", "operator": "=="}, ... },
-       { "title":    {"value": "log4j", "operator": "~"},  ... },
-       ...
-     ])
-   Each entry is an object with keys: \`severity\`, \`title\`, \`refId\`, \`refType\`, \`year\`, \`maxOccurrences\`, \`epssScore\` (each with \`{value, operator}\`).
-3. Translate each rule entry into a pipeline_security_issue filter:
-     - \`severity == X\`            → severity_codes filter contains X
-     - \`severity (>=|>) X\`        → severity_codes includes X and everything above (Critical > High > Medium > Low > Info)
-     - \`title == X\` or \`~ X\`     → search="X" (or post-filter on title)
-     - \`refId == CVE-…\`           → match against issue.key (post-filter)
-     - \`refType == cve\`           → matches all CVE entries (use issue.key prefix "CVE-")
-     - \`maxOccurrences >= N\`      → post-filter on issue.numOccurrences >= N
-4. Print the **"Extracted OPA deny signals"** table from Step 3a, but with these rows:
+If NO such segment exists in \`evaluation.input\`:
 
-| policy_set | policy | source | extracted_signal_type | extracted_signal_value |
-|---|---|---|---|---|
-| anurag-set | anuraghigh | rego deny_list | severity_eq | High |
+  → STOP for this policy. Report verbatim: "Policy '<policy.identifier>' under set '<set.identifier>' fed OPA a non-canonical input (no \`securityTestData\` segment). Cannot deterministically resolve deny messages to issue IDs. Please supply the \`issue_ids\` you want exempted explicitly." Do NOT fall back to fuzzy correlation. Do NOT severity-guess.
 
-The signal_type vocabulary is the same as Step 3a (\`bracketed_title\`, \`cve\`, \`component\`, \`severity_only\`, \`criteria_json\`, \`opaque\`) plus the new types from rego parsing: \`severity_eq\`, \`severity_gte\`, \`title_regex\`, \`refid_eq\`, \`reftype_cve\`, \`occurrence_gte\`.
+### 3.2. Extract the matched titles from the policy's output
 
-5. CRITICAL: if you can extract structured filters from the rego, the candidate set IS the result of applying those filters to pipeline_security_issue. **Do not include any issue that doesn't match the extracted filters.** Severity-only is acceptable here BECAUSE we read it from the rego, not from a deny message.
+Try, in order:
 
-6. If the rego does not match the canonical template (e.g. customer-authored rego with custom logic), fall back to the no-correlation flow: print the rego source for the user to read, ask them which issues to exempt, do not guess.
+a) **Canonical**: read \`policy.output\`. It is the full rego result data. Look for \`deny_list_violations\` anywhere in the tree (top level or nested under a package name). Each entry is shaped \`{ "issue": {"title": "<...>"}, "violation": {...} }\`. Collect every \`issue.title\`.
 
-### 3a. MANDATORY: print the extracted deny signals before correlating
+b) **Fallback**: regex over each entry in \`policy.deny_messages\`:
 
-Before doing any matching, print a markdown table titled **"Extracted OPA deny signals"** with one row per kept EvaluatedPolicy:
+  /Vulnerability \\['([^']+)'\\] matches the following item found on the deny list/
 
-| policy_set | policy | deny_message (raw) | extracted_signal_type | extracted_signal_value |
+  Capture group 1 is the title. If at least one deny_message matches this regex, use those titles.
+
+If neither (a) nor (b) yields any titles:
+
+  → STOP for this policy. Report verbatim: "Policy '<policy.identifier>' produced \`deny_messages\` whose format is non-canonical (no \`deny_list_violations\` block in \`output\` and no \`Vulnerability ['<title>']\` pattern in \`deny_messages\`). Cannot deterministically resolve them to issue IDs. Please supply \`issue_ids\` explicitly." Do NOT fall back to fuzzy correlation.
+
+### 3.3. Join titles → issue IDs
+
+For each extracted title, look up \`titleToIds[title]\`. If the title is not in the map, record it as an "unjoined deny" — surface this to the user in the table below but do NOT include any candidate for it. (This is rare; it means the rego matched something that wasn't in its own input segment, which indicates a customer-specific transformation.)
+
+Accumulate the resulting \`issue_id\` set across all kept policies. De-duplicate.
+
+Print this table BEFORE moving to the next step:
+
+| policy_set | policy | deny_title | source | matched_issue_ids |
 |---|---|---|---|---|
 
-Where extracted_signal_type ∈ { bracketed_title, cve, component, severity_only, criteria_json, opaque }.
+Where \`source\` ∈ { \`output.deny_list_violations\`, \`deny_messages_regex\` }, and \`matched_issue_ids\` is the comma-separated list from \`titleToIds\` (or \`(unjoined)\` if the title wasn't in the input map).
 
-This table is NON-OPTIONAL. It is the audit trail for the user. If you cannot show this table you must not proceed — instead stop and tell the user exactly what you found in evaluation.details.
+## 4. Verify candidates against Pipeline Security and present the table
 
-If the ONLY signal_type you can extract across every row is "severity_only" or "opaque", treat the run as low-confidence and go to the no-correlation fallback in step 5 — do NOT silently bulk-exempt by severity.
-
-HARD GATE: you are forbidden from asking the user ANY question (including "which issues should I exempt?", scope-confirmation questions, or severity-pick menus) until this Step 3a table has been printed. If you have not extracted deny signals, you have no basis to offer choices — the only legal output is the error message from Step 3 above. NEVER present menu options of the form "exempt all High" / "exempt all High + Medium + Low" / "exempt every active issue" — those options are categorically banned, regardless of how the user phrases their request, because they bypass correlation entirely.
-
-## 4. Pull execution context (scan steps + Pipeline Security issues)
-
-Call:
-  harness_list(resource_type="pipeline_security_step",
-               filters={ execution_id: "${executionId}" }${scope})
-
-- Capture the list of scan steps (Trivy, Semgrep, Snyk, …) for diagnostic attribution and possible scanner-based narrowing.
-
-Then call:
   harness_list(resource_type="pipeline_security_issue",
                filters={
                  execution_id: "${executionId}",
@@ -289,124 +215,44 @@ Then call:
                  ...${JSON.stringify(extra_filters).replace(/[{}]/g, "").trim()}` : ""}
                }${scope})
 
-Pagination note: this endpoint uses DIFF pagination — \`page_existing\`/\`page_size_existing\` and \`page_new\`/\`page_size_new\` are independent counters for the two partitions, NOT a single \`page\`/\`size\`. If \`existing_total > 100\` or \`new_total > 100\` after the first call, paginate each partition independently by incrementing its respective \`page_*\` while keeping its \`page_size_*\` constant. For most chat-driven cases the first call with size 100 is sufficient.
+Pagination note: this endpoint uses DIFF pagination — \`page_existing\`/\`page_size_existing\` and \`page_new\`/\`page_size_new\` are independent counters; if either total exceeds 100, paginate that partition independently.
 
-- If the list is empty, stop and tell the user "no active, unexempted issues remain for this execution — nothing to exempt."
+Filter the deterministic candidate ID set from Step 3 to those present in this list. An ID that doesn't appear here is already exempted or remediated — keep its row in the table but mark it skipped.
 
-## 5. Correlate deny signals → candidate issue_ids
+Render:
 
-This is the LLM-mediated step. For every deny_signal collected in step 3, try these shortcuts FIRST (deterministic where possible):
-
-  Shortcut 1 — Issue ID in EvaluatedPolicy.output.deny:
-    For each kept policy, inspect output.deny[]. Issue IDs are typically 22-char URL-safe base64 strings (regex: /^[A-Za-z0-9_-]{22}$/). If any entry matches and that ID is present in the pipeline_security_issue list, use it directly (zero-correlation path).
-
-  Shortcut 2 — Issue ID in Evaluation.input (USUALLY WORKS for the Harness STO+OPA pattern):
-    The Evaluation.input is whatever the customer's pipeline YAML fed into the OPA step. For the CANONICAL Harness pattern (STO scan step → OPA Evaluation step referencing <+steps.scan_x.output.outputVariables.Issues>), the input contains the response of sto-core's GET /api/v2/scans/{scanId}/issues. Crucially, IDs in that response come from the SAME IssueID type as pipeline_security_issue.id, so a deterministic join is possible.
-
-    KNOWN INPUT SHAPES (do NOT give up after checking only one):
-      Shape A — pipeline-service "aggregator" wrapping (very common for SecurityTests stage Policy steps):
-          [
-            { "name": "securityTestData",
-              "outcome": { "issues": [ { "id": "abc...22", "title": "...", "severityCode": "High", ... }, ... ] } },
-            ...
-          ]
-          The Rego identifies its own step block via input[i].name == "securityTestData", then reads input[i].outcome.issues[j].
-      Shape B — direct passthrough (less common):
-          { "issues": [ { "id": "abc...22", ... }, ... ]  }
-      Shape C — Custom Stage policy where the customer wired the payload by hand:
-          fully custom; could be anything.
-
-    Strategy:
-      1. Walk Evaluation.input RECURSIVELY (objects + arrays at any depth).
-      2. Collect every object that has an "id" field matching /^[A-Za-z0-9_-]{22}$/ AND at least one other STO-like field (title, severityCode, scanId, key) — this filters out unrelated 22-char IDs.
-      3. Intersect those .id values with the pipeline_security_issue list (match on .id).
-      4. Any matches are deterministic candidates — use them directly.
-
-    This works out of the box for customers who wire STO output variables into the Policy step the standard way. It does NOT work when:
-      - The customer transforms the payload (e.g. extracts only counts / CVE strings before passing to OPA).
-      - The customer feeds raw scanner JSON instead of going through STO output variables.
-      - The OPA step is a Custom Stage policy step evaluating unrelated data.
-
-    On no match, fall through silently to the fuzzy path below — do NOT raise an error.
-
-If neither shortcut yields matches, fall back to fuzzy extraction from deny_messages and (when present) policy.rego. Extract signals in this priority order:
-
-  (a) Bracketed/quoted substrings inside the deny message — these are usually the issue title.
-      Common Harness deny-list template format:
-        "Vulnerability ['<issue.title>'] matches the following item found on the deny list '<criteria>'"
-      Regex: /\\['([^']+)'\\]|"([^"]+)"/g  — collect every captured substring.
-      Match each captured substring against pipeline_security_issue.title (case-insensitive substring match).
-      This is the SINGLE BIGGEST signal for the deny-list policy template; do NOT skip this step.
-  (b) CVE pattern: /CVE-\\d{4}-\\d{4,}/   — match against pipeline_security_issue.key (IssueSummary has .key, NOT .cve).
-  (c) Severity keyword: Critical / High / Medium / Low / Info   — match against pipeline_security_issue.severityCode.
-      ⚠️ Severity-only is the WEAKEST signal and is the #1 source of over-exemption. Apply it ONLY when ALL of the following hold:
-        - the deny message contains NO bracketed title, NO CVE, NO component name, and no parseable criteria JSON, AND
-        - the deny message explicitly names a severity (e.g. "High severity vulnerabilities are not allowed"), AND
-        - the severity-filtered candidate count is reasonable relative to the number of failing policies (a single deny message should not justify exempting dozens of unrelated issues).
-      Do NOT infer "OPA probably denies on High+" from the policy name or rego — that is a guess, not a signal. If the deny message itself does not name a severity, this rule does not apply.
-  (d) Issue type keyword: SAST / DAST / SCA / IAC / SECRET / MISCONFIG / EXTERNAL_POLICY   — match against pipeline_security_issue.type.
-  (e) Target / variant identifier (e.g. image tag, repo name)   — match against pipeline_security_issue.targetVariantName.
-  (f) Component / library name (e.g. "log4j", "openssl") not already captured by (a)   — fuzzy substring match against pipeline_security_issue.title.
-
-  Note on the deny-list rule criteria (the second '%s' in the message — Harness deny-list template): the criteria string contains structured key-value pairs like:
-    - {"severity": {"value": "High", "operator": "=="}}         → severity filter (exact / range)
-    - {"title":    {"value": "log4j", "operator": "~"}}         → title is a REGEX (operator "~"); use as a case-insensitive title regex filter
-    - {"refId":    {"value": "CVE-2021-44228", "operator": "=="}} → match against pipeline_security_issue.key
-    - {"refType":  {"value": "cve", "operator": "=="}}          → narrows the kind of identifier
-    - {"year":     {"value": 2021, "operator": ">="}}            → CVE year range (applies to refType="cve")
-    - {"maxOccurrences": {"value": 5, "operator": ">="}}        → match against pipeline_security_issue.numOccurrences
-
-  Operators: "==" exact, "!" not, "~" regex, "<=" "<" ">=" ">" numeric/semver ranges. Parse what you can and translate to pipeline_security_issue filters. For policies that emit ONE deny per matching issue, the bracketed title from signal (a) is usually enough on its own; the criteria parse is a useful cross-check.
-
-For SCANNER-based narrowing, IssueSummary itself does NOT carry a scanner name. Use the matching_steps array returned alongside the issue list (each entry is { stageId, stepId }), or cross-reference the pipeline_security_step list from step 4 (each step has a productName / scanner identifier). If the deny message clearly implicates one scanner, re-list with steps="stageId.stepId" to tighten:
-  harness_list(resource_type="pipeline_security_issue",
-               filters={ execution_id, include_exempted=false, status="ACTIVE,PENDING_EXEMPTION", steps: "<stageId>.<stepId>" }${scope})
-
-If after all of the above NO candidates are found, do NOT silently assume "exempt everything" and do NOT propose "exempt all N" as a default. Instead:
-  1. Print the deny_signals table (from step 3a) AND the full pipeline_security_issue list as two separate tables.
-  2. Ask the user verbatim: "I could not deterministically correlate the OPA deny signals above to specific issues in this execution. Please reply with the issue_ids (or a filter like severity=High) you want exempted. I will NOT default to exempting all issues."
-  3. Wait for an explicit issue list or filter. Do not proceed otherwise.
-
-### 5a. Sanity check the candidate set BEFORE step 6
-
-Before rendering the candidate table, verify ALL of the following. If ANY check fails, stop and surface the discrepancy to the user instead of proceeding:
-
-  - Every candidate issue_id was produced by AT LEAST ONE deny_signal from step 3a — record which signal in a \`matched_deny\` field. Issues with no matched signal MUST NOT be candidates.
-  - The candidate count is plausible given the deny messages. Rough heuristic: for deny-list-template policies (one deny per matching issue), expect \`candidates ≈ deny_messages.length\`. If candidates exceeds deny_messages.length by more than 2× AND the extra issues were added by severity-only matching, drop the severity-only-only candidates and re-check.
-  - You did NOT pull in issues whose only relationship to the deny signal is sharing a severity with the failing policies' rego — that is a guess.
-
-If the candidate count differs substantially from the number of deny messages, state this explicitly in your reply (e.g. "3 deny messages → 3 candidates" or "3 deny messages but 17 candidates — flagging mismatch").
-
-## 6. Present the candidate table
-
-Render a markdown table with one row per candidate issue:
-
-| issue_id | severity | cve / key | component / title | scanStep | partition | matched_deny |
+| issue_id | severity | key | title | partition | status | matched_deny_title |
 |---|---|---|---|---|---|---|
 
-Also print summary lines:
-- "Denied by policy_set(s): <names from step 3>"
-- "Total candidates: N"
-- "Already exempted (will skip): M"
-- "Created on this run: 0 (pending confirmation)"
+Then:
+- "Denied by policy_set(s): <set.name list>"
+- "Total candidates (deterministic join): N"
+- "Already exempted / not active (will skip): M"
+- "Ready to create: N - M"
+- If any deny title is \`(unjoined)\`, append: "Unjoined deny titles: K — these were in deny_messages but not in \`evaluation.input.securityTestData.outcome.issues\`."
 
-## 7. Confirmation gate
+If \`N - M == 0\`, stop and tell the user nothing remains to be exempted.
 
-If \`exemption_type\` or \`reason\` was NOT provided at invocation time, ask for them HERE (after the candidate table has been shown) with a single combined question:
-  "Found <N> candidate exemption(s). To create them I need:
-   - exemption_type: one of 'Compensating Controls' | 'Acceptable Use' | 'Acceptable Risk' | 'False Positive' | 'Fix Unavailable' | 'Other'
-   - reason: a one-line justification
+## 5. Confirmation gate
+
+If \`exemption_type\` or \`reason\` is missing, ask now in ONE combined message:
+
+  "Found <N - M> candidate exemption(s). To create them I need:
+   - exemption_type: 'Compensating Controls' | 'Acceptable Use' | 'Acceptable Risk' | 'False Positive' | 'Fix Unavailable' | 'Other'
+   - reason: one-line justification
    - duration_days: number (default 30)
    Reply with these, or 'cancel' to abort."
 
-Otherwise (both were provided), ask EXACTLY once:
-  "Confirm creating <N> exemption(s) with type='${exemption_type ?? "<to be supplied>"}', reason='${reason ?? "<to be supplied>"}'${duration_days ? `, duration_days=${duration_days}` : ", duration_days=30 (default)"}? Reply 'yes' to proceed or list the issue_ids to keep."
+If both were already provided, ask exactly once:
 
-DO NOT proceed without an affirmative reply AND a populated exemption_type + reason. If dry_run was true at the top of this run, STOP HERE and do not create anything regardless of the reply.
+  "Confirm creating <N - M> exemption(s) with type='${exemption_type ?? "<…>"}', reason='${reason ?? "<…>"}'${duration_days ? `, duration_days=${duration_days}` : ", duration_days=30 (default)"}? Reply 'yes' to proceed or list \`issue_ids\` to drop."
 
-## 8. Bulk create exemptions
+If \`dry_run=true\`, STOP HERE regardless of reply. Do not create.
 
-For every confirmed issue_id call:
+## 6. Bulk create
+
+For every confirmed \`issue_id\`:
+
   harness_create(
     resource_type="security_exemption"${scope},
     body={
@@ -419,50 +265,21 @@ For every confirmed issue_id call:
     }
   )
 
-DO NOT send requester_id. DO NOT send exempt_future_occurrences. The server enforces both.
-
-## 9. Final summary
-
-Render a results table:
+## 7. Final summary
 
 | issue_id | status | exemption_id | failure_reason |
 |---|---|---|---|
 
-Where status is "created" | "skipped (already exempt)" | "failed".
+Status ∈ { \`created\`, \`skipped (already exempt)\`, \`failed\` }. Then totals (Total / Created / Skipped / Failed).
 
-Then totals:
-- Total candidates: <N>
-- Created: <created>
-- Skipped: <skipped>
-- Failed: <failed>
+## 8. Suggested next steps
 
-## 10. Suggested next steps
+Append "## Suggested next steps" with 3–5 bold imperative sentences using real values (policy_set name, execution ID, etc.). Omit the section if nothing was created and nothing is actionable. Examples:
 
-Append a section titled "## Suggested next steps" with 3–5 personalized, send-as-is sentences. Use real human-readable values (CVE / component / policy_set name); NEVER raw UUIDs in the visible text. Examples (shape only — use real values):
-
-- Retry pipeline execution <execId> now that the blocking issues are exempted.
-- Promote these exemptions to ORG scope so other projects benefit from the same waiver.
-- Review the newly created Pending exemptions with the security-exemption-review prompt.
-- Inspect the OPA policy_set <name> to consider tightening or relaxing its rules.
-
-Rules:
-- Bold imperative sentences only, one per bullet.
-- Maximum 5 suggestions.
-- Omit the section entirely if NOTHING was created and NOTHING is actionable.
-
----
-
-Guardrails (must hold throughout):
-
-1. NEVER create an exemption without an explicit affirmative reply from the user (or dry_run=true bypass — and dry_run=true means: stop, do not create).
-2. NEVER collect deny signals from EvaluatedPolicy entries unless BOTH status == "error" AND policy_severity == "Error & Exit". A policy configured as "Warn & Continue" does not fail the pipeline even when its rego returns error — collecting from such policies over-exempts.
-3. NEVER use harness_list(resource_type="security_issue") for this skill — that is the cross-execution Issues page. Use pipeline_security_issue (execution-scoped) only.
-4. NEVER send requester_id or exempt_future_occurrences in the exemption body.
-5. If correlation yields 0 candidates, ASK with an explicit issue-id / filter request — NEVER propose "exempt all N", "exempt all High", or any severity-bucket option as a menu choice. The user must supply the IDs.
-6. Every candidate row in step 6 MUST cite at least one specific deny_signal from the step 3a table. "OPA likely denies on High+", "typical pattern is denial on High/Critical", or similar inferences from the policy name/rego are NOT valid signals and must not appear as \`matched_deny\` — nor may they appear anywhere in your reasoning shown to the user.
-7. If the only signal type extracted is severity_only or opaque, you MUST go to the no-correlation fallback (step 5) and ask the user for explicit IDs — do not silently severity-filter and do not offer severity-based menu options.
-8. You are FORBIDDEN from asking the user any question before printing the Step 3a deny-signals table. If you reach a state where you want to ask "which issues should I exempt?" or similar, that is a signal you skipped Step 3 — go back and call harness_get on each evaluation_id first.
-9. Menu options of the form "All active High + Medium + Low (N issues)" or "High severity only (N issues)" are categorically banned. You may present a candidate table derived from extracted deny signals, or you may ask for explicit issue_ids — nothing else.`,
+- **Retry pipeline execution <execId>** now that the blocking issues are exempted.
+- **Promote these exemptions to ORG scope** so other projects benefit from the same waiver.
+- **Review the newly created Pending exemptions** with the \`exemption-review\` prompt.
+- **Inspect OPA policy_set <name>** to consider tightening or relaxing its rules.`,
           },
         }],
       };

--- a/src/prompts/exempt-opa-failed-issues.ts
+++ b/src/prompts/exempt-opa-failed-issues.ts
@@ -129,12 +129,12 @@ The fetched Evaluation has this shape:
     .input                                  ← entity input fed to OPA (the deterministic-join SOURCE)
     .details[]                              ← one per POLICY_SET (EvaluationDetail)
         .identifier, .name, .type, .action
-        .status
+        .status: "error" | "warning" | "pass" | "pending"
         .details[]                          ← one per POLICY (EvaluatedPolicy)
-            .status
-            .policy_severity                ← "Error & Exit" | "Warn & Continue"
+            .status: "error" | "warning" | "pass" | "pending"
+            .policy_severity: "error" | "warning"     ← API value (NOT UI labels "Error & Exit"/"Warn & Continue")
             .policy: { identifier, name, rego, ... }
-            .output                         ← full structured rego result (NOT just the deny-strings list)
+            .output                         ← OPA ResultSet: [{ expressions: [{ value: { <pkg>: { deny: [...], deny_list_violations: [[...]] } } }] }]
             .deny_messages: string[]
 
 ## 3. Classify each policy_set and perform the deterministic title-join
@@ -150,10 +150,10 @@ If zero policy_sets PROCEED, stop and explain why.
 
 For each PROCEEDing policy_set, walk its inner \`details[]\` (per policy) and KEEP only entries where BOTH:
 
-  policy.status == "error"            — the policy actually denied this run
-  policy.policy_severity == "Error & Exit"   — this policy is configured to fail the pipeline (not just warn)
+  policy.status == "error"             — the policy actually denied this run
+  policy.policy_severity == "error"    — this policy is configured to fail the pipeline (Error & Exit), not just warn
 
-Both checks are required: a Warn & Continue policy with status=error emits a message but does NOT block the run, and exempting its issues would be over-exemption.
+Both checks are required. \`policy_severity == "warning"\` corresponds to the UI's "Warn & Continue" setting — such a policy emits messages but does NOT block the pipeline; collecting its deny strings would over-exempt.
 
 For each kept \`EvaluatedPolicy\`, perform this deterministic title-join — do not perform any other matching:
 
@@ -178,7 +178,7 @@ If NO such segment exists in \`evaluation.input\`:
 
 Try, in order:
 
-a) **Canonical**: read \`policy.output\`. It is the full rego result data. Look for \`deny_list_violations\` anywhere in the tree (top level or nested under a package name). Each entry is shaped \`{ "issue": {"title": "<...>"}, "violation": {...} }\`. Collect every \`issue.title\`.
+a) **Canonical**: read \`policy.output\`. It is an OPA ResultSet wrapped as \`output[].expressions[].value.<package>\` (e.g. \`output[0].expressions[0].value.securityTests\`). Inside that package object, find \`deny_list_violations\`. NOTE: it is a 2D array — \`[[{issue, violation}], [{issue, violation}], ...]\` — because the rego defines it via set comprehension that yields per-issue arrays. Flatten one level, then collect every \`issue.title\`. If you can't predict the package name, recurse the whole \`output\` tree looking for any \`deny_list_violations\` key — both work.
 
 b) **Fallback**: regex over each entry in \`policy.deny_messages\`:
 

--- a/src/prompts/exempt-opa-failed-issues.ts
+++ b/src/prompts/exempt-opa-failed-issues.ts
@@ -1,0 +1,464 @@
+import * as z from "zod/v4";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+/**
+ * Skill: exempt-opa-failed-issues
+ *
+ * Customer types into chat after observing an STO pipeline execution that was
+ * denied by an OPA Policy step ("exempt the issues that failed OPA for
+ * execution <id>"). This prompt orchestrates:
+ *
+ *   1. Resolve the execution and its OPA policy_evaluation(s).
+ *   2. Read per-policy deny details (status='error' only; warnings don't fail).
+ *   3. Read scan-step metadata + Pipeline Security issues for that execution.
+ *   4. Correlate deny signals → candidate STO issue_ids (LLM-mediated).
+ *   5. Show a candidate table; require explicit user confirmation.
+ *   6. Loop create security_exemption per issue.
+ *   7. Summary + suggested next steps.
+ *
+ * See docs/exempt-opa-failed-issues-design.md for the full design.
+ */
+export function registerExemptOpaFailedIssuesPrompt(server: McpServer): void {
+  server.registerPrompt(
+    "exempt-opa-failed-issues",
+    {
+      description:
+        "Create STO security exemptions for the issues that caused an OPA Policy step to fail a "
+        + "pipeline execution. Reads policy_evaluation results for the execution, pulls the "
+        + "execution's Pipeline Security issues + scan steps, correlates the deny signals to "
+        + "specific issue_ids, asks for confirmation, then bulk-creates exemptions.",
+      argsSchema: {
+        executionId: z.string().describe("Pipeline plan execution ID (e.g. 'ehsPKtczTRO5CUDAt-NR'). Accepts a Harness UI execution URL too — extract the executionId segment."),
+        projectId: z.string().describe("Project identifier (optional; defaults to configured project)").optional(),
+        orgId: z.string().describe("Organization identifier (optional; defaults to configured org)").optional(),
+        exemption_type: z.string().describe("Exemption type to apply: 'Compensating Controls' | 'Acceptable Use' | 'Acceptable Risk' | 'False Positive' | 'Fix Unavailable' | 'Other'. Optional — if omitted, the prompt will ask after showing the candidate table.").optional(),
+        reason: z.string().describe("Business/security justification for the exemption. Optional — if omitted, the prompt will ask after showing the candidate table.").optional(),
+        duration_days: z.number().describe("Exemption duration in days (defaults to 30 when omitted)").optional(),
+        link: z.string().describe("Optional URL for Jira / ticket / reference").optional(),
+        expiration: z.number().describe("Optional Unix timestamp at which exemptions expire").optional(),
+        extra_filters: z.object({
+          severity_codes: z.string().optional(),
+          issue_types: z.string().optional(),
+          target_ids: z.string().optional(),
+          target_types: z.string().optional(),
+          search: z.string().optional(),
+          steps: z.string().optional(),
+        }).describe("Optional additional pipeline_security_issue filters to narrow further (e.g. severity_codes='Critical').").optional(),
+        dry_run: z.boolean().describe("When true, stop after the candidate table — do not create exemptions even on user confirmation. Useful for previewing.").optional(),
+      },
+    },
+    async ({
+      executionId,
+      projectId,
+      orgId,
+      exemption_type,
+      reason,
+      duration_days,
+      link,
+      expiration,
+      extra_filters,
+      dry_run,
+    }) => {
+      const orgScope = orgId ? `, org_id="${orgId}"` : "";
+      const projectScope = projectId ? `, project_id="${projectId}"` : "";
+      const scope = `${orgScope}${projectScope}`;
+      const extraFiltersHint = extra_filters
+        ? `\n- extra_filters: ${JSON.stringify(extra_filters)}`
+        : "";
+      const dryRunHint = dry_run ? "\n- dry_run: true (STOP after the candidate table — do NOT create exemptions, even if user confirms)" : "";
+
+      return {
+        messages: [{
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text: `Create STO exemptions for the issues that caused an OPA Policy step to fail a pipeline execution.
+
+Inputs for this run:
+- executionId: "${executionId}"${orgId ? `\n- orgId: "${orgId}"` : ""}${projectId ? `\n- projectId: "${projectId}"` : ""}
+${exemption_type ? `- exemption_type: "${exemption_type}"` : "- exemption_type: (NOT PROVIDED — ask the user at the confirmation gate)"}
+${reason ? `- reason: "${reason}"` : "- reason: (NOT PROVIDED — ask the user at the confirmation gate)"}${duration_days ? `\n- duration_days: ${duration_days}` : "\n- duration_days: 30 (default — confirm with user)"}${link ? `\n- link: ${link}` : ""}${expiration ? `\n- expiration: ${expiration}` : ""}${extraFiltersHint}${dryRunHint}
+
+If executionId looks like a URL, extract the plan-execution ID segment (typically a 20+ character base64-ish token) before any further calls.
+
+═══════════════════════════════════════════════════════════════════
+🛑 CRITICAL RULES — READ FIRST, OBEY ABSOLUTELY 🛑
+═══════════════════════════════════════════════════════════════════
+
+These rules override anything else in this prompt and the user's phrasing:
+
+A. **"Active issues in the execution" ≠ "Issues OPA denied on".**
+   The Pipeline Security tab lists every issue the scan found. OPA only failed the pipeline because of a SUBSET of those — the ones its rego matched. Your job is to find that subset. NEVER treat the full active-issue list as the candidate set.
+
+B. **No questions, no parameter prompts, no scope confirmations until Step 3a is printed.**
+   You may NOT ask the user "what exemption type / reason / duration / scope?" or "which issues should I exempt?" before printing the "Extracted OPA deny signals" table from Step 3a. Asking for exemption parameters before showing evidence is a banned shortcut.
+
+C. **You MUST fetch policy_evaluation or policy_set data — never guess from the policy name.**
+   - Pathway B (primary): harness_list(policy_evaluation, {execution_id, status: "error"}) → harness_get(policy_evaluation, <id>) for each. This is deterministic and works for both STO scan-step enforcement and explicit OPA Evaluation steps.
+   - Pathway A (fallback, only when Pathway B returns 0): harness_get(policy_set, <identifier>) and parse the rego's deny_list. Use this when the evaluation record isn't available.
+   If both paths fail, your only legal output is to stop and report what you got.
+
+D. **Banned phrases in your output (these signal guessing, not correlation):**
+   - "typical pattern is denial on High/Critical"
+   - "OPA likely denies on High+"
+   - "Exemption parameters for all N active issues"
+   - "Found N active issues blocking the policy" (without per-issue deny-signal evidence)
+   - Any menu option of the form "All active <severity bucket> (N issues)"
+
+E. **The candidate set comes from Step 5 correlation only.** Not from Step 4's active-issue list. If correlation yields fewer issues than the active list, that is CORRECT and EXPECTED — most active issues are not what OPA denied on.
+
+F. **If you cannot extract any deny signal**, ask the user for explicit issue_ids. Do NOT offer to exempt all-by-severity as a fallback.
+
+═══════════════════════════════════════════════════════════════════
+
+Follow this workflow EXACTLY. Do not skip steps. Do not create any exemption before the explicit confirmation gate.
+
+---
+
+## 1. Resolve the execution
+
+Call:
+  harness_get(resource_type="execution", execution_id="${executionId}"${scope})
+
+- Capture: pipelineId, status.
+- If status indicates the run succeeded (e.g. "Success"), stop and tell the user the execution did NOT fail — exemptions are unnecessary. Suggest they re-check the executionId.
+- If the execution does not exist, surface the error verbatim and stop.
+
+## 2. Find the failing OPA evaluation(s) for this execution
+
+The policy_evaluation resource indexes BOTH enforcement pathways:
+  - Pipeline governance (action=onrun, type=pipeline) — pre-run policies.
+  - STO scan-step enforcement (action=onstep, type=securityTests) — the \`enforce.policySets\` field on a Semgrep/Trivy/etc. step.
+  - Explicit OPA Evaluation step (action=onstep, type=custom or type=securityTests).
+
+The resource definition automatically sets \`created_date_from=0\` so older executions are not silently filtered out by policy-mgmt's default 7-day window.
+
+### Pathway B (PRIMARY) — direct lookup by execution_id
+
+Call:
+  harness_list(resource_type="policy_evaluation",
+               filters={ execution_id: "${executionId}", status: "error" }${scope})
+
+- Paginate until exhausted.
+- If the result is non-empty, proceed to Step 3 (read each evaluation's deny_messages — deterministic).
+- If the result is empty, proceed to Pathway A below.
+
+### Pathway A (FALLBACK) — derive from policy_set rego
+
+Use this ONLY when Pathway B genuinely returned 0 items (e.g. policy-mgmt is degraded, the evaluation hasn't been persisted yet, or the upstream date-window override was bypassed). It produces a candidate set without any evaluation record, by reading the policy set definition directly:
+
+1. Read the execution's failure message from Step 1. It is typically: \`"The following Policy Set was not adhered to: <display_name>"\`.
+2. Extract the display name(s). Note: the *display* name (e.g. "anurag-set") may differ from the *identifier* (e.g. "anuragset").
+3. Resolve display name → identifier: inspect the execution's pipeline YAML for \`enforce.policySets: ["<identifier>"]\`, OR call \`harness_list(resource_type="policy_set", filters={ search_term: "<display name>" }${scope})\` and match by name.
+4. For each resolved identifier, call \`harness_get(resource_type="policy_set", resource_id="<identifier>"${scope})\`. The response includes each policy's \`rego\` source and per-policy \`severity\` ("error" = Error & Exit, "warning" = Warn & Continue — only the "error" policies can fail the pipeline).
+5. Skip Step 3 entirely and jump to Step 3b (rego-based filter extraction).
+
+If BOTH pathways fail to produce a candidate signal → stop and tell the user verbatim:
+    "No failing OPA artifact found for execution ${executionId}. Pathway B (policy_evaluation list) returned 0 items and Pathway A (policy_set lookup from failure message) also produced no usable signal. This may be a non-OPA failure (e.g. an STO step 'Fail On' severity threshold). Try harness_diagnose(resource_type='execution', execution_id='${executionId}') to find the real cause."
+
+## 3. Read each failing evaluation and classify
+
+For each evaluation in the list, call:
+  harness_get(resource_type="policy_evaluation", evaluation_id=<id>${scope})
+
+This call is MANDATORY — you cannot proceed using only the list response. The list returns summary metadata; only the get response contains evaluation.details[].details[] with deny_messages, output, and policy_severity. If you skip this call you have no evidence and you must stop, not guess.
+
+If harness_get returns an error or empty details for every evaluation_id, stop and tell the user verbatim: "Called harness_get(policy_evaluation, <id>) and received <actual response summary>. Cannot extract deny signals without evaluation details — please verify the evaluation exists or check permissions." Do NOT proceed to ask the user which severity to exempt — that is guessing.
+
+The returned Evaluation has a TWO-LEVEL details structure (per policy-mgmt's schema):
+
+  Evaluation
+    .input                                   ← raw policy input (used in Shortcut 2 below)
+    .details[]                               ← one entry per POLICY_SET (EvaluationDetail)
+        .identifier                          ← the policy_set identifier (already embedded — no separate fetch needed)
+        .name, .type, .action, .enabled
+        .status: "error"|"warning"|"pass"|"pending"
+        .details[]                           ← one entry per POLICY inside the set (EvaluatedPolicy)
+            .status: "error"|"warning"|"pass"|"pending"
+            .policy_severity: "Warn & Continue" | "Error & Exit"
+            .policy: { identifier, name, rego, ... }
+            .output: Any                     ← typically { "deny": [...] } (used in Shortcut 1 below)
+            .deny_messages: string[]
+            .error: string                   ← rego parse error, if any
+
+For each evaluation, walk evaluation.details[] (the per-policy-set level) and classify by the embedded type/action (do NOT fetch the policy_set separately — its identifier, name, type, action are already on EvaluationDetail). Valid (type, action) combinations are fixed by policy-mgmt's ValidPolicySetTypeActions map:
+
+- CASE A (REFUSE — pipeline governance) — set.type == "pipeline" AND set.action in ("onrun", "onsave", "onstepstart"):
+    The OPA blocked the pipeline at run/save time, before any scan executed. There are no scan-issue findings to exempt. REFUSE this set: tell the user the failure is pipeline governance, not scan results — they need to amend the pipeline YAML or the governance policy itself. (Note: type=pipeline CANNOT have action=onstep — that combination is not valid in policy-mgmt.)
+
+- CASE B (REFUSE — SBOM enforcement) — set.type == "sbom" AND set.action == "onstep":
+    SBOM / SCS BOM enforcement — different domain (artifact components, not STO issues). REFUSE this set and route the user to:
+      harness_list(resource_type="scs_bom_violation", filters={ enforcement_id: ... })
+
+- CASE C (PROCEED — STO-driven OPA step) — EITHER:
+    (i)  set.type == "securityTests" AND set.action == "onstep"   ← canonical STO policy step in a SecurityTests stage
+    (ii) set.type == "custom"        AND set.action == "onstep"   ← Custom Stage OPA Evaluation step (may or may not be evaluating STO output)
+    For (ii) the input shape is fully customer-defined; the skill still proceeds but should warn that correlation accuracy depends on what the customer's Rego consumes.
+
+If a policy_set's (type, action) combination falls outside the cases above, treat it as CASE A by default (refuse, surface the unfamiliar type/action to the user).
+
+If after classification ZERO policy_sets are in CASE C across all evaluations, stop and explain why — typically this means the failure is pipeline governance or SBOM enforcement, not STO scan denial.
+
+For each remaining CASE C policy_set, walk its inner details[] (EvaluatedPolicy level) and KEEP ONLY entries where BOTH conditions hold:
+
+    (1) policy.status == "error"                   — the policy actually denied this run
+    (2) policy.policy_severity == "Error & Exit"   — this policy is configured to FAIL the pipeline on deny
+
+Both checks are required. A policy with policy_severity = "Warn & Continue" that has status = "error" emits a warning but does NOT fail the pipeline — its deny messages must NOT be collected (otherwise we would over-exempt).
+
+Collect from each kept EvaluatedPolicy:
+- policy.identifier, policy.name (for display + Rego fallback)
+- policy.rego (only if needed in correlation fallback when deny_messages are opaque)
+- deny_messages (string[])
+- output (typically { "deny": [...] } — used in Shortcut 1 below)
+- parent policy_set identifier + name (for "Denied by policy set …" attribution in the candidate table)
+
+Build a deduplicated set of deny_signals across all kept policies.
+
+### 3b. Pathway A — extract filters directly from the policy_set rego
+
+(Use this ONLY when you arrived from Pathway A in Step 2 — i.e. you have a policy_set object from harness_get(policy_set, …) but NO policy_evaluation record.)
+
+The canonical Harness STO deny-list / allow-list rego template (used by 95%+ of customers) parses a structured \`deny_list\` block at the top of the rego. Extract it:
+
+1. For each policy in \`policy_set.policies[]\` where \`policy.severity == "error"\` (= "Error & Exit"; "warning" policies don't fail the pipeline):
+2. Parse the rego source. Locate the assignment of the form:
+     deny_list := fill_defaults([
+       { "severity": {"value": "High", "operator": "=="}, ... },
+       { "title":    {"value": "log4j", "operator": "~"},  ... },
+       ...
+     ])
+   Each entry is an object with keys: \`severity\`, \`title\`, \`refId\`, \`refType\`, \`year\`, \`maxOccurrences\`, \`epssScore\` (each with \`{value, operator}\`).
+3. Translate each rule entry into a pipeline_security_issue filter:
+     - \`severity == X\`            → severity_codes filter contains X
+     - \`severity (>=|>) X\`        → severity_codes includes X and everything above (Critical > High > Medium > Low > Info)
+     - \`title == X\` or \`~ X\`     → search="X" (or post-filter on title)
+     - \`refId == CVE-…\`           → match against issue.key (post-filter)
+     - \`refType == cve\`           → matches all CVE entries (use issue.key prefix "CVE-")
+     - \`maxOccurrences >= N\`      → post-filter on issue.numOccurrences >= N
+4. Print the **"Extracted OPA deny signals"** table from Step 3a, but with these rows:
+
+| policy_set | policy | source | extracted_signal_type | extracted_signal_value |
+|---|---|---|---|---|
+| anurag-set | anuraghigh | rego deny_list | severity_eq | High |
+
+The signal_type vocabulary is the same as Step 3a (\`bracketed_title\`, \`cve\`, \`component\`, \`severity_only\`, \`criteria_json\`, \`opaque\`) plus the new types from rego parsing: \`severity_eq\`, \`severity_gte\`, \`title_regex\`, \`refid_eq\`, \`reftype_cve\`, \`occurrence_gte\`.
+
+5. CRITICAL: if you can extract structured filters from the rego, the candidate set IS the result of applying those filters to pipeline_security_issue. **Do not include any issue that doesn't match the extracted filters.** Severity-only is acceptable here BECAUSE we read it from the rego, not from a deny message.
+
+6. If the rego does not match the canonical template (e.g. customer-authored rego with custom logic), fall back to the no-correlation flow: print the rego source for the user to read, ask them which issues to exempt, do not guess.
+
+### 3a. MANDATORY: print the extracted deny signals before correlating
+
+Before doing any matching, print a markdown table titled **"Extracted OPA deny signals"** with one row per kept EvaluatedPolicy:
+
+| policy_set | policy | deny_message (raw) | extracted_signal_type | extracted_signal_value |
+|---|---|---|---|---|
+
+Where extracted_signal_type ∈ { bracketed_title, cve, component, severity_only, criteria_json, opaque }.
+
+This table is NON-OPTIONAL. It is the audit trail for the user. If you cannot show this table you must not proceed — instead stop and tell the user exactly what you found in evaluation.details.
+
+If the ONLY signal_type you can extract across every row is "severity_only" or "opaque", treat the run as low-confidence and go to the no-correlation fallback in step 5 — do NOT silently bulk-exempt by severity.
+
+HARD GATE: you are forbidden from asking the user ANY question (including "which issues should I exempt?", scope-confirmation questions, or severity-pick menus) until this Step 3a table has been printed. If you have not extracted deny signals, you have no basis to offer choices — the only legal output is the error message from Step 3 above. NEVER present menu options of the form "exempt all High" / "exempt all High + Medium + Low" / "exempt every active issue" — those options are categorically banned, regardless of how the user phrases their request, because they bypass correlation entirely.
+
+## 4. Pull execution context (scan steps + Pipeline Security issues)
+
+Call:
+  harness_list(resource_type="pipeline_security_step",
+               filters={ execution_id: "${executionId}" }${scope})
+
+- Capture the list of scan steps (Trivy, Semgrep, Snyk, …) for diagnostic attribution and possible scanner-based narrowing.
+
+Then call:
+  harness_list(resource_type="pipeline_security_issue",
+               filters={
+                 execution_id: "${executionId}",
+                 include_exempted: false,
+                 status: "ACTIVE,PENDING_EXEMPTION",
+                 page_size_existing: 100,
+                 page_size_new: 100${extra_filters ? `,
+                 ...${JSON.stringify(extra_filters).replace(/[{}]/g, "").trim()}` : ""}
+               }${scope})
+
+Pagination note: this endpoint uses DIFF pagination — \`page_existing\`/\`page_size_existing\` and \`page_new\`/\`page_size_new\` are independent counters for the two partitions, NOT a single \`page\`/\`size\`. If \`existing_total > 100\` or \`new_total > 100\` after the first call, paginate each partition independently by incrementing its respective \`page_*\` while keeping its \`page_size_*\` constant. For most chat-driven cases the first call with size 100 is sufficient.
+
+- If the list is empty, stop and tell the user "no active, unexempted issues remain for this execution — nothing to exempt."
+
+## 5. Correlate deny signals → candidate issue_ids
+
+This is the LLM-mediated step. For every deny_signal collected in step 3, try these shortcuts FIRST (deterministic where possible):
+
+  Shortcut 1 — Issue ID in EvaluatedPolicy.output.deny:
+    For each kept policy, inspect output.deny[]. Issue IDs are typically 22-char URL-safe base64 strings (regex: /^[A-Za-z0-9_-]{22}$/). If any entry matches and that ID is present in the pipeline_security_issue list, use it directly (zero-correlation path).
+
+  Shortcut 2 — Issue ID in Evaluation.input (USUALLY WORKS for the Harness STO+OPA pattern):
+    The Evaluation.input is whatever the customer's pipeline YAML fed into the OPA step. For the CANONICAL Harness pattern (STO scan step → OPA Evaluation step referencing <+steps.scan_x.output.outputVariables.Issues>), the input contains the response of sto-core's GET /api/v2/scans/{scanId}/issues. Crucially, IDs in that response come from the SAME IssueID type as pipeline_security_issue.id, so a deterministic join is possible.
+
+    KNOWN INPUT SHAPES (do NOT give up after checking only one):
+      Shape A — pipeline-service "aggregator" wrapping (very common for SecurityTests stage Policy steps):
+          [
+            { "name": "securityTestData",
+              "outcome": { "issues": [ { "id": "abc...22", "title": "...", "severityCode": "High", ... }, ... ] } },
+            ...
+          ]
+          The Rego identifies its own step block via input[i].name == "securityTestData", then reads input[i].outcome.issues[j].
+      Shape B — direct passthrough (less common):
+          { "issues": [ { "id": "abc...22", ... }, ... ]  }
+      Shape C — Custom Stage policy where the customer wired the payload by hand:
+          fully custom; could be anything.
+
+    Strategy:
+      1. Walk Evaluation.input RECURSIVELY (objects + arrays at any depth).
+      2. Collect every object that has an "id" field matching /^[A-Za-z0-9_-]{22}$/ AND at least one other STO-like field (title, severityCode, scanId, key) — this filters out unrelated 22-char IDs.
+      3. Intersect those .id values with the pipeline_security_issue list (match on .id).
+      4. Any matches are deterministic candidates — use them directly.
+
+    This works out of the box for customers who wire STO output variables into the Policy step the standard way. It does NOT work when:
+      - The customer transforms the payload (e.g. extracts only counts / CVE strings before passing to OPA).
+      - The customer feeds raw scanner JSON instead of going through STO output variables.
+      - The OPA step is a Custom Stage policy step evaluating unrelated data.
+
+    On no match, fall through silently to the fuzzy path below — do NOT raise an error.
+
+If neither shortcut yields matches, fall back to fuzzy extraction from deny_messages and (when present) policy.rego. Extract signals in this priority order:
+
+  (a) Bracketed/quoted substrings inside the deny message — these are usually the issue title.
+      Common Harness deny-list template format:
+        "Vulnerability ['<issue.title>'] matches the following item found on the deny list '<criteria>'"
+      Regex: /\\['([^']+)'\\]|"([^"]+)"/g  — collect every captured substring.
+      Match each captured substring against pipeline_security_issue.title (case-insensitive substring match).
+      This is the SINGLE BIGGEST signal for the deny-list policy template; do NOT skip this step.
+  (b) CVE pattern: /CVE-\\d{4}-\\d{4,}/   — match against pipeline_security_issue.key (IssueSummary has .key, NOT .cve).
+  (c) Severity keyword: Critical / High / Medium / Low / Info   — match against pipeline_security_issue.severityCode.
+      ⚠️ Severity-only is the WEAKEST signal and is the #1 source of over-exemption. Apply it ONLY when ALL of the following hold:
+        - the deny message contains NO bracketed title, NO CVE, NO component name, and no parseable criteria JSON, AND
+        - the deny message explicitly names a severity (e.g. "High severity vulnerabilities are not allowed"), AND
+        - the severity-filtered candidate count is reasonable relative to the number of failing policies (a single deny message should not justify exempting dozens of unrelated issues).
+      Do NOT infer "OPA probably denies on High+" from the policy name or rego — that is a guess, not a signal. If the deny message itself does not name a severity, this rule does not apply.
+  (d) Issue type keyword: SAST / DAST / SCA / IAC / SECRET / MISCONFIG / EXTERNAL_POLICY   — match against pipeline_security_issue.type.
+  (e) Target / variant identifier (e.g. image tag, repo name)   — match against pipeline_security_issue.targetVariantName.
+  (f) Component / library name (e.g. "log4j", "openssl") not already captured by (a)   — fuzzy substring match against pipeline_security_issue.title.
+
+  Note on the deny-list rule criteria (the second '%s' in the message — Harness deny-list template): the criteria string contains structured key-value pairs like:
+    - {"severity": {"value": "High", "operator": "=="}}         → severity filter (exact / range)
+    - {"title":    {"value": "log4j", "operator": "~"}}         → title is a REGEX (operator "~"); use as a case-insensitive title regex filter
+    - {"refId":    {"value": "CVE-2021-44228", "operator": "=="}} → match against pipeline_security_issue.key
+    - {"refType":  {"value": "cve", "operator": "=="}}          → narrows the kind of identifier
+    - {"year":     {"value": 2021, "operator": ">="}}            → CVE year range (applies to refType="cve")
+    - {"maxOccurrences": {"value": 5, "operator": ">="}}        → match against pipeline_security_issue.numOccurrences
+
+  Operators: "==" exact, "!" not, "~" regex, "<=" "<" ">=" ">" numeric/semver ranges. Parse what you can and translate to pipeline_security_issue filters. For policies that emit ONE deny per matching issue, the bracketed title from signal (a) is usually enough on its own; the criteria parse is a useful cross-check.
+
+For SCANNER-based narrowing, IssueSummary itself does NOT carry a scanner name. Use the matching_steps array returned alongside the issue list (each entry is { stageId, stepId }), or cross-reference the pipeline_security_step list from step 4 (each step has a productName / scanner identifier). If the deny message clearly implicates one scanner, re-list with steps="stageId.stepId" to tighten:
+  harness_list(resource_type="pipeline_security_issue",
+               filters={ execution_id, include_exempted=false, status="ACTIVE,PENDING_EXEMPTION", steps: "<stageId>.<stepId>" }${scope})
+
+If after all of the above NO candidates are found, do NOT silently assume "exempt everything" and do NOT propose "exempt all N" as a default. Instead:
+  1. Print the deny_signals table (from step 3a) AND the full pipeline_security_issue list as two separate tables.
+  2. Ask the user verbatim: "I could not deterministically correlate the OPA deny signals above to specific issues in this execution. Please reply with the issue_ids (or a filter like severity=High) you want exempted. I will NOT default to exempting all issues."
+  3. Wait for an explicit issue list or filter. Do not proceed otherwise.
+
+### 5a. Sanity check the candidate set BEFORE step 6
+
+Before rendering the candidate table, verify ALL of the following. If ANY check fails, stop and surface the discrepancy to the user instead of proceeding:
+
+  - Every candidate issue_id was produced by AT LEAST ONE deny_signal from step 3a — record which signal in a \`matched_deny\` field. Issues with no matched signal MUST NOT be candidates.
+  - The candidate count is plausible given the deny messages. Rough heuristic: for deny-list-template policies (one deny per matching issue), expect \`candidates ≈ deny_messages.length\`. If candidates exceeds deny_messages.length by more than 2× AND the extra issues were added by severity-only matching, drop the severity-only-only candidates and re-check.
+  - You did NOT pull in issues whose only relationship to the deny signal is sharing a severity with the failing policies' rego — that is a guess.
+
+If the candidate count differs substantially from the number of deny messages, state this explicitly in your reply (e.g. "3 deny messages → 3 candidates" or "3 deny messages but 17 candidates — flagging mismatch").
+
+## 6. Present the candidate table
+
+Render a markdown table with one row per candidate issue:
+
+| issue_id | severity | cve / key | component / title | scanStep | partition | matched_deny |
+|---|---|---|---|---|---|---|
+
+Also print summary lines:
+- "Denied by policy_set(s): <names from step 3>"
+- "Total candidates: N"
+- "Already exempted (will skip): M"
+- "Created on this run: 0 (pending confirmation)"
+
+## 7. Confirmation gate
+
+If \`exemption_type\` or \`reason\` was NOT provided at invocation time, ask for them HERE (after the candidate table has been shown) with a single combined question:
+  "Found <N> candidate exemption(s). To create them I need:
+   - exemption_type: one of 'Compensating Controls' | 'Acceptable Use' | 'Acceptable Risk' | 'False Positive' | 'Fix Unavailable' | 'Other'
+   - reason: a one-line justification
+   - duration_days: number (default 30)
+   Reply with these, or 'cancel' to abort."
+
+Otherwise (both were provided), ask EXACTLY once:
+  "Confirm creating <N> exemption(s) with type='${exemption_type ?? "<to be supplied>"}', reason='${reason ?? "<to be supplied>"}'${duration_days ? `, duration_days=${duration_days}` : ", duration_days=30 (default)"}? Reply 'yes' to proceed or list the issue_ids to keep."
+
+DO NOT proceed without an affirmative reply AND a populated exemption_type + reason. If dry_run was true at the top of this run, STOP HERE and do not create anything regardless of the reply.
+
+## 8. Bulk create exemptions
+
+For every confirmed issue_id call:
+  harness_create(
+    resource_type="security_exemption"${scope},
+    body={
+      issue_id: "<issue_id>",
+      type: "${exemption_type}",
+      reason: "${reason}"${duration_days ? `,
+      duration_days: ${duration_days}` : ""}${link ? `,
+      link: "${link}"` : ""}${expiration ? `,
+      expiration: ${expiration}` : ""}
+    }
+  )
+
+DO NOT send requester_id. DO NOT send exempt_future_occurrences. The server enforces both.
+
+## 9. Final summary
+
+Render a results table:
+
+| issue_id | status | exemption_id | failure_reason |
+|---|---|---|---|
+
+Where status is "created" | "skipped (already exempt)" | "failed".
+
+Then totals:
+- Total candidates: <N>
+- Created: <created>
+- Skipped: <skipped>
+- Failed: <failed>
+
+## 10. Suggested next steps
+
+Append a section titled "## Suggested next steps" with 3–5 personalized, send-as-is sentences. Use real human-readable values (CVE / component / policy_set name); NEVER raw UUIDs in the visible text. Examples (shape only — use real values):
+
+- Retry pipeline execution <execId> now that the blocking issues are exempted.
+- Promote these exemptions to ORG scope so other projects benefit from the same waiver.
+- Review the newly created Pending exemptions with the security-exemption-review prompt.
+- Inspect the OPA policy_set <name> to consider tightening or relaxing its rules.
+
+Rules:
+- Bold imperative sentences only, one per bullet.
+- Maximum 5 suggestions.
+- Omit the section entirely if NOTHING was created and NOTHING is actionable.
+
+---
+
+Guardrails (must hold throughout):
+
+1. NEVER create an exemption without an explicit affirmative reply from the user (or dry_run=true bypass — and dry_run=true means: stop, do not create).
+2. NEVER collect deny signals from EvaluatedPolicy entries unless BOTH status == "error" AND policy_severity == "Error & Exit". A policy configured as "Warn & Continue" does not fail the pipeline even when its rego returns error — collecting from such policies over-exempts.
+3. NEVER use harness_list(resource_type="security_issue") for this skill — that is the cross-execution Issues page. Use pipeline_security_issue (execution-scoped) only.
+4. NEVER send requester_id or exempt_future_occurrences in the exemption body.
+5. If correlation yields 0 candidates, ASK with an explicit issue-id / filter request — NEVER propose "exempt all N", "exempt all High", or any severity-bucket option as a menu choice. The user must supply the IDs.
+6. Every candidate row in step 6 MUST cite at least one specific deny_signal from the step 3a table. "OPA likely denies on High+", "typical pattern is denial on High/Critical", or similar inferences from the policy name/rego are NOT valid signals and must not appear as \`matched_deny\` — nor may they appear anywhere in your reasoning shown to the user.
+7. If the only signal type extracted is severity_only or opaque, you MUST go to the no-correlation fallback (step 5) and ask the user for explicit IDs — do not silently severity-filter and do not offer severity-based menu options.
+8. You are FORBIDDEN from asking the user any question before printing the Step 3a deny-signals table. If you reach a state where you want to ask "which issues should I exempt?" or similar, that is a signal you skipped Step 3 — go back and call harness_get on each evaluation_id first.
+9. Menu options of the form "All active High + Medium + Low (N issues)" or "High severity only (N issues)" are categorically banned. You may present a candidate table derived from extracted deny signals, or you may ask for explicit issue_ids — nothing else.`,
+          },
+        }],
+      };
+    },
+  );
+}

--- a/src/prompts/exempt-opa-failed-issues.ts
+++ b/src/prompts/exempt-opa-failed-issues.ts
@@ -28,7 +28,7 @@ export function registerExemptOpaFailedIssuesPrompt(server: McpServer): void {
         + "execution's Pipeline Security issues + scan steps, correlates the deny signals to "
         + "specific issue_ids, asks for confirmation, then bulk-creates exemptions.",
       argsSchema: {
-        executionId: z.string().describe("Pipeline plan execution ID (e.g. 'ehsPKtczTRO5CUDAt-NR'). Accepts a Harness UI execution URL too — extract the executionId segment."),
+        executionId: z.string().describe("Pipeline plan execution ID (e.g. 'ehsPKtczTRO5CUDAt-NR'), OR any Harness UI URL that contains '/executions/<executionId>/' in its path. Examples: the pipeline execution page, the Security Tests / vulnerabilities tab, the Policy Evaluations tab. If a URL is pasted, the prompt extracts the executionId segment automatically. orgId and projectId are also extracted from the URL if present."),
         projectId: z.string().describe("Project identifier (optional; defaults to configured project)").optional(),
         orgId: z.string().describe("Organization identifier (optional; defaults to configured org)").optional(),
         exemption_type: z.string().describe("Exemption type to apply: 'Compensating Controls' | 'Acceptable Use' | 'Acceptable Risk' | 'False Positive' | 'Fix Unavailable' | 'Other'. Optional — if omitted, the prompt will ask after showing the candidate table.").optional(),
@@ -79,7 +79,14 @@ Inputs for this run:
 ${exemption_type ? `- exemption_type: "${exemption_type}"` : "- exemption_type: (NOT PROVIDED — ask the user at the confirmation gate)"}
 ${reason ? `- reason: "${reason}"` : "- reason: (NOT PROVIDED — ask the user at the confirmation gate)"}${duration_days ? `\n- duration_days: ${duration_days}` : "\n- duration_days: 30 (default — confirm with user)"}${link ? `\n- link: ${link}` : ""}${expiration ? `\n- expiration: ${expiration}` : ""}${extraFiltersHint}${dryRunHint}
 
-If executionId looks like a URL, extract the plan-execution ID segment (typically a 20+ character base64-ish token) before any further calls.
+## 0. Normalize the input
+
+The \`executionId\` argument may be either a raw ID or a full Harness UI URL. Before any other step:
+
+- If the value contains \`/executions/\`, extract the segment immediately after it as the executionId. Example: \`https://app.harness.io/ng/account/<acct>/all/orgs/<org>/projects/<proj>/pipelines/<pid>/executions/drWLj24BRQCHZYeIuaquEQ/pipeline?stage=...\` → executionId = \`drWLj24BRQCHZYeIuaquEQ\`. The same shape covers the Security Tests / vulnerabilities tab, the Policy Evaluations tab, and the default pipeline view — they all have \`/executions/<id>/\` in the path.
+- If the URL also contains \`/orgs/<orgId>/\` and/or \`/projects/<projectId>/\` and the corresponding argument was NOT provided, use the URL values for scope.
+- If the value is already a bare ID (no \`/\` in it), use it as-is.
+- Print the normalized values back to the user in one line before continuing: \`Resolved: executionId=<id>, orgId=<...>, projectId=<...>\`. Do not proceed if executionId is empty after extraction — ask the user to paste a valid ID or URL.
 
 ═══════════════════════════════════════════════════════════════════
 🛑 CRITICAL RULES — READ FIRST, OBEY ABSOLUTELY 🛑

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -28,6 +28,7 @@ import { registerSbomCompliancePrompt } from "./sbom-compliance.js";
 import { registerSupplyChainAuditPrompt } from "./supply-chain-audit.js";
 import { registerExemptionReviewPrompt } from "./exemption-review.js";
 import { registerBulkExemptionCreatePrompt } from "./bulk-exemption-create.js";
+import { registerExemptOpaFailedIssuesPrompt } from "./exempt-opa-failed-issues.js";
 import { registerAccessControlAuditPrompt } from "./access-control-audit.js";
 
 // Harness Code prompts
@@ -76,6 +77,7 @@ export function registerAllPrompts(server: McpServer): void {
   registerSupplyChainAuditPrompt(server);
   registerExemptionReviewPrompt(server);
   registerBulkExemptionCreatePrompt(server);
+  registerExemptOpaFailedIssuesPrompt(server);
   registerAccessControlAuditPrompt(server);
 
   // Harness Code

--- a/src/registry/toolsets/governance.ts
+++ b/src/registry/toolsets/governance.ts
@@ -273,7 +273,17 @@ export const governanceToolset: ToolsetDefinition = {
           defaultQueryParams: {
             created_date_from: "0",
           },
-          responseExtractor: v1ListExtract(),
+          responseExtractor: (raw: unknown) => {
+            const result = v1ListExtract()(raw);
+            // Remap `id` → `evaluation_id` so compact mode preserves it.
+            // The compactor's IDENTIFIER_PATTERN matches `_id$` but not bare `id`.
+            result.items = result.items.map(item => {
+              if (typeof item !== "object" || item === null || !("id" in item)) return item;
+              const r = item as Record<string, unknown>;
+              return { ...r, evaluation_id: r.id };
+            });
+            return result;
+          },
           description: "List OPA policy evaluation results. Covers BOTH pipeline-governance onrun evaluations AND STO scan-step onstep enforcement evaluations (type=securityTests). Filter by execution_id to find evaluations for a specific pipeline run.",
         },
         get: {

--- a/src/registry/toolsets/governance.ts
+++ b/src/registry/toolsets/governance.ts
@@ -241,12 +241,12 @@ export const governanceToolset: ToolsetDefinition = {
       deepLinkTemplate: "/ng/account/{accountId}/all/orgs/{orgIdentifier}/projects/{projectIdentifier}/settings/governance/evaluation/{id}",
       listFilterFields: [
         { name: "entity", description: "Filter by entity identifier" },
-        { name: "type", description: "Filter by entity type. Matches the evaluated policy_set's type — for SBOM/SSCA enforcement use 'sbom' (NOT 'sbom_enforcement'; that is the policy-level type, not the evaluation-level type).", enum: ["sbom", "pipeline", "connector", "service", "environment", "secret", "template", "infrastructure"] },
-        { name: "action", description: "Filter by enforcement action. SBOM enforcement uses 'onstep'. Other values: onrun (pipeline), onsave, onpush, onstepstart.", enum: ["onrun", "onsave", "onpush", "onstep", "onstepstart"] },
-        { name: "status", description: "Filter by evaluation status" },
-        { name: "execution_id", description: "Filter by pipeline execution ID" },
-        { name: "created_date_from", description: "Filter evaluations created after this date (ISO 8601)" },
-        { name: "created_date_to", description: "Filter evaluations created before this date (ISO 8601)" },
+        { name: "type", description: "Filter by entity type. Matches the evaluated policy_set's type — for SBOM/SSCA enforcement use 'sbom' (NOT 'sbom_enforcement'; that is the policy-level type, not the evaluation-level type). For STO scan-step enforcement use 'securityTests'.", enum: ["sbom", "securityTests", "pipeline", "connector", "service", "environment", "secret", "template", "infrastructure", "custom"] },
+        { name: "action", description: "Filter by enforcement action. SBOM enforcement and STO scan-step (Semgrep/Trivy etc. with enforce.policySets) both use 'onstep'. Pipeline governance uses 'onrun'.", enum: ["onrun", "onsave", "onpush", "onstep", "onstepstart"] },
+        { name: "status", description: "Filter by evaluation status. Pass 'error' to find failing evaluations." },
+        { name: "execution_id", description: "Filter by pipeline plan execution ID (e.g. 'drWLj24BRQCHZYeIuaquEQ'). Returns the OPA evaluation(s) that ran for that execution, including STO onstep enforcement evaluations." },
+        { name: "created_date_from", description: "Filter evaluations created after this epoch-millis timestamp. ⚠️ IMPORTANT: when omitted, the upstream policy-mgmt API silently defaults to 'past 7 days', which hides older executions. This resource overrides that default to 0 (no lower bound) so execution_id lookups work for arbitrarily old runs. Pass an explicit value only if you want to narrow the window." },
+        { name: "created_date_to", description: "Filter evaluations created before this epoch-millis timestamp" },
         { name: "include_child_scopes", description: "Include evaluations from child scopes", type: "boolean" },
       ],
       operations: {
@@ -266,8 +266,15 @@ export const governanceToolset: ToolsetDefinition = {
             created_date_to: "created_date_to",
             include_child_scopes: "includeChildScopes",
           },
+          // Defeat policy-mgmt's silent 7-day default window. Without this, listing by
+          // execution_id silently returns 0 items for executions older than 7 days
+          // (see policy-mgmt internal/handlers/evaluations/list.go:44-48). Callers can
+          // still override by passing their own created_date_from.
+          defaultQueryParams: {
+            created_date_from: "0",
+          },
           responseExtractor: v1ListExtract(),
-          description: "List OPA policy evaluation results",
+          description: "List OPA policy evaluation results. Covers BOTH pipeline-governance onrun evaluations AND STO scan-step onstep enforcement evaluations (type=securityTests). Filter by execution_id to find evaluations for a specific pipeline run.",
         },
         get: {
           method: "GET",

--- a/src/registry/toolsets/sto.ts
+++ b/src/registry/toolsets/sto.ts
@@ -121,6 +121,195 @@ export const stoToolset: ToolsetDefinition = {
       },
     },
 
+    // ── Pipeline Security Issues (per-execution view) ─────────────────
+    {
+      resourceType: "pipeline_security_issue",
+      displayName: "Pipeline Security Issue",
+      description:
+        "Security issues from STO's per-execution **Pipeline Security view** — the issues shown on a "
+        + "specific pipeline execution's Security tab. Keyed by REQUIRED `execution_id`. Use this "
+        + "(not `security_issue`, which is the cross-execution Issues page) when the user asks about "
+        + "issues that caused a specific pipeline run to fail, or when correlating to a policy "
+        + "evaluation. Response merges `existing` + `new` issue summaries into a single `items[]` "
+        + "(each row tagged with `_partition`) and exposes per-partition counts + matching-step "
+        + "metadata as side-channels. PAGINATION: this endpoint uses DIFF pagination — not standard "
+        + "`page`/`size`. Use `page_existing` / `page_size_existing` (for the 'existing' partition) "
+        + "and `page_new` / `page_size_new` (for the 'new' partition) independently. Each defaults to "
+        + "page 0, size 50 (max 100). For most chat-driven workflows, calling once with both sizes "
+        + "set to 100 returns the full page of each partition.",
+      searchAliases: ["pipeline security", "execution issues", "security tab", "issues for execution", "issues that failed pipeline"],
+      relatedResources: [
+        { resourceType: "pipeline_security_step", relationship: "sibling", description: "List the STO scan steps (Trivy, Semgrep, …) that ran in this execution. Required to attribute an issue to its source scanner." },
+        { resourceType: "security_exemption", relationship: "child", description: "Create exemptions for issues from this view (one per issue_id)." },
+        { resourceType: "policy_evaluation", relationship: "sibling", description: "Find OPA policy evaluations that ran on the same execution_id to learn why the pipeline was denied." },
+      ],
+      toolset: "sto",
+      scope: "project",
+      scopeParams: STO_SCOPE,
+      identifierFields: ["issue_id"],
+      listFilterFields: [
+        { name: "execution_id", description: "REQUIRED. Pipeline plan execution ID (e.g. 'ehsPKtczTRO5CUDAt-NR'). Identifies which execution's Pipeline Security view to read.", required: true },
+        { name: "stages", description: "Comma-separated stage identifiers (or parent.stage). Narrows issues to specific pipeline stages." },
+        { name: "steps", description: "Comma-separated step identifiers as 'stage.step' or 'parent.stage.step'. Narrows issues to specific scan steps (Trivy / Semgrep / …)." },
+        { name: "target_ids", description: "Comma-separated 22-char target IDs." },
+        { name: "target_types", description: "Comma-separated target types.", enum: ["repository", "container", "instance", "configuration"] },
+        { name: "product_names", description: "Comma-separated scanner product names (e.g. 'owasp,zap')." },
+        { name: "severity_codes", description: "Comma-separated severities.", enum: ["Critical", "High", "Medium", "Low", "Info"] },
+        { name: "include_exempted", type: "boolean", description: "Include already-exempted issues. Defaults to true on the API; pass false when looking for unexempted candidates." },
+        { name: "search", description: "Free-text search across issue title / CWE / CVE." },
+        { name: "issue_types", description: "Comma-separated issue types.", enum: ["SAST", "DAST", "SCA", "IAC", "SECRET", "MISCONFIG", "BUG_SMELLS", "CODE_SMELLS", "CODE_COVERAGE", "EXTERNAL_POLICY", "UNKNOWN"] },
+        { name: "status", description: "Comma-separated issue statuses.", enum: ["ACTIVE", "REMEDIATED", "PENDING_EXEMPTION", "EXEMPTED", "PARTIALLY_EXEMPTED", "REJECTED"] },
+        { name: "origins", description: "Comma-separated origin layers.", enum: ["app", "base", "no_layer"] },
+        { name: "origin_statuses", description: "Comma-separated origin statuses.", enum: ["approved", "unapproved"] },
+        { name: "epss", description: "EPSS probability bucket (single select).", enum: ["all", "gte_15", "gte_5", "gte_1", "na"] },
+        { name: "epss_percentile", description: "EPSS percentile bucket (single select).", enum: ["all", "gte_99", "gte_90", "gte_80", "na"] },
+        { name: "severity_overridden", description: "Filter by whether severity was manually overridden.", enum: ["Yes", "No"] },
+        { name: "reachability", description: "Reachability filter.", enum: ["reachable", "unknown-reachability"] },
+        { name: "exploitability", description: "Exploitability filter.", enum: ["yes", "no"] },
+        // Diff pagination — this endpoint paginates `existing` and `new` partitions independently.
+        // See DiffPaginationRequestParams in sto-core/design/frontend.go.
+        { name: "page_existing", type: "number", description: "0-indexed page number for the 'existing' issue partition (defaults to 0). The endpoint paginates existing and new issues independently — NOT a single combined cursor." },
+        { name: "page_size_existing", type: "number", description: "Page size for the 'existing' partition (1–100, default 50)." },
+        { name: "page_new", type: "number", description: "0-indexed page number for the 'new' issue partition (defaults to 0)." },
+        { name: "page_size_new", type: "number", description: "Page size for the 'new' partition (1–100, default 50)." },
+      ],
+      deepLinkTemplate: "/ng/account/{accountId}/all/orgs/{orgIdentifier}/projects/{projectIdentifier}/sto/executions/{executionId}/pipeline",
+      operations: {
+        list: {
+          method: "GET",
+          path: "/sto/api/v2/frontend/pipeline-security/issues",
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          queryParams: {
+            execution_id: "executionId",
+            stages: "stages",
+            steps: "steps",
+            target_ids: "targetIds",
+            target_types: "targetTypes",
+            product_names: "productNames",
+            severity_codes: "severityCodes",
+            include_exempted: "includeExempted",
+            search: "search",
+            issue_types: "issueTypes",
+            status: "status",
+            origins: "origins",
+            origin_statuses: "originStatuses",
+            epss: "epss",
+            epss_percentile: "epssPercentile",
+            severity_overridden: "severityOverridden",
+            reachability: "reachability",
+            exploitability: "exploitability",
+            // Diff pagination — NOT standard page/pageSize. This endpoint splits
+            // pagination between the 'existing' and 'new' partitions.
+            page_existing: "pageExisting",
+            page_size_existing: "pageSizeExisting",
+            page_new: "pageNew",
+            page_size_new: "pageSizeNew",
+          },
+          responseExtractor: (raw: unknown): unknown => {
+            // Pipeline Security endpoint (sto-core PipelineSecurityIssuesResult) returns:
+            //   { existing: { issues: [...], pagination: { totalItems, ... } },
+            //     new:      { issues: [...], pagination: { totalItems, ... } },
+            //     counts: {...}, matchingSteps: [...] }
+            // NOTE: the partition payload key is `issues` (not `items`) and totals live
+            // under `pagination.totalItems` (not a top-level `totalItems`). We flatten
+            // existing+new into a single items[] for prompt consumption and preserve
+            // the partitioned counts + matchingSteps as side-channels.
+            if (raw === null || raw === undefined || typeof raw !== "object") return raw;
+            type Partition = {
+              issues?: unknown[];
+              items?: unknown[]; // defensive: handle older or alternate shapes
+              pagination?: { totalItems?: number };
+              totalItems?: number; // defensive
+            };
+            const r = raw as {
+              existing?: Partition;
+              new?: Partition;
+              counts?: unknown;
+              matchingSteps?: unknown;
+            };
+            const partitionItems = (p: Partition | undefined): unknown[] => {
+              if (!p) return [];
+              if (Array.isArray(p.issues)) return p.issues;
+              if (Array.isArray(p.items)) return p.items;
+              return [];
+            };
+            const partitionTotal = (p: Partition | undefined, fallback: number): number => {
+              if (!p) return fallback;
+              if (typeof p.pagination?.totalItems === "number") return p.pagination.totalItems;
+              if (typeof p.totalItems === "number") return p.totalItems;
+              return fallback;
+            };
+            const existingItems = partitionItems(r.existing);
+            const newItems = partitionItems(r.new);
+            // Tag each row so the prompt can tell which partition it came from.
+            const tagged = [
+              ...existingItems.map(it => (typeof it === "object" && it !== null ? { ...it, _partition: "existing" } : it)),
+              ...newItems.map(it => (typeof it === "object" && it !== null ? { ...it, _partition: "new" } : it)),
+            ];
+            const existingTotal = partitionTotal(r.existing, existingItems.length);
+            const newTotal = partitionTotal(r.new, newItems.length);
+            return {
+              items: tagged,
+              total: existingTotal + newTotal,
+              existing_total: existingTotal,
+              new_total: newTotal,
+              counts: r.counts,
+              matching_steps: r.matchingSteps,
+            };
+          },
+          skipCompact: true,
+          description: "List the security issues shown on a specific pipeline execution's Security tab. Requires execution_id. Flattens existing + new partitions into items[]; each item is tagged with _partition.",
+        },
+      },
+    },
+
+    // ── Pipeline Security Steps (scan steps for an execution) ─────────
+    {
+      resourceType: "pipeline_security_step",
+      displayName: "Pipeline Security Scan Step",
+      description:
+        "STO scan steps (Trivy / Semgrep / Snyk / …) that ran inside a specific pipeline execution. "
+        + "Use to attribute Pipeline Security issues to their source scanner, or to narrow a "
+        + "`pipeline_security_issue` query by `steps`. Keyed by REQUIRED `execution_id`. Response also "
+        + "carries `reachabilityFlag` / `exploitabilityFlag` indicating whether reachability or "
+        + "exploitability analysis is available for this execution.",
+      searchAliases: ["scan steps", "sto steps", "pipeline scan steps", "execution scan steps"],
+      relatedResources: [
+        { resourceType: "pipeline_security_issue", relationship: "sibling", description: "List issues for the same execution; filter by 'steps' to scope to one scanner." },
+      ],
+      toolset: "sto",
+      scope: "project",
+      scopeParams: STO_SCOPE,
+      identifierFields: [],
+      listFilterFields: [
+        { name: "execution_id", description: "REQUIRED. Pipeline plan execution ID.", required: true },
+      ],
+      operations: {
+        list: {
+          method: "GET",
+          path: "/sto/api/v2/frontend/pipeline-security/steps",
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          queryParams: {
+            execution_id: "executionId",
+          },
+          responseExtractor: (raw: unknown): unknown => {
+            // Response: { steps: [...], reachabilityFlag: bool, exploitabilityFlag: bool }
+            if (raw === null || raw === undefined || typeof raw !== "object") return raw;
+            const r = raw as { steps?: unknown[]; reachabilityFlag?: boolean; exploitabilityFlag?: boolean };
+            const steps = Array.isArray(r.steps) ? r.steps : [];
+            return {
+              items: steps,
+              total: steps.length,
+              reachability_flag: r.reachabilityFlag ?? false,
+              exploitability_flag: r.exploitabilityFlag ?? false,
+            };
+          },
+          skipCompact: true,
+          description: "List STO scan steps that ran in a given pipeline execution. Use to map issues back to their source scanner.",
+        },
+      },
+    },
+
     // ── Security Exemptions ────────────────────────────────────────────
     {
       resourceType: "security_exemption",

--- a/src/utils/compact.ts
+++ b/src/utils/compact.ts
@@ -8,7 +8,7 @@ const TIMESTAMP_PATTERN = /(?:At|Ts|Time|Date)$/;
 
 /** Fields to always keep when compacting list items. */
 const IDENTITY_FIELDS = new Set([
-  "identifier", "identity", "name", "displayName", "description", "slug",
+  "id", "identifier", "identity", "name", "displayName", "description", "slug",
   "versionLabel", "sha", "title", "message",
 ]);
 

--- a/src/utils/compact.ts
+++ b/src/utils/compact.ts
@@ -8,7 +8,7 @@ const TIMESTAMP_PATTERN = /(?:At|Ts|Time|Date)$/;
 
 /** Fields to always keep when compacting list items. */
 const IDENTITY_FIELDS = new Set([
-  "id", "identifier", "identity", "name", "displayName", "description", "slug",
+  "identifier", "identity", "name", "displayName", "description", "slug",
   "versionLabel", "sha", "title", "message",
 ]);
 


### PR DESCRIPTION
## Description
<!-- What does this PR do? -->
- src/prompts/exempt-opa-failed-issues.ts (new, 316 lines) — the skill itself: arg schema accepting executionId or url, programmatic URL pre-resolution via the shared parseHarnessUrl utility (handles /executions/, /deployments/, and vanity domains uniformly), and the full prompt template covering the deterministic title-join algorithm (evaluation.input.outcome.issues[].title → issue_id mapped against output.deny_list_violations[].issue.title), the candidate-table presentation, the batch-confirmation gate, and hardened refusal paths for non-OPA failures, pipeline-governance pre-run blocks, SBOM enforcement, warning-only policies, and non-canonical rego.

- src/prompts/index.ts — registers the new prompt with the MCP server.

- src/registry/toolsets/governance.ts — modifies the existing policy_evaluation resource's list operation. Two functional changes: (1) defaultQueryParams: { created_date_from: "0" } defeats policy-mgmt's silent 7-day default window that would otherwise hide older executions when filtering by execution_id; (2) a custom responseExtractor wraps v1ListExtract() and remaps each item's id → evaluation_id so the compactor (whose IDENTIFIER_PATTERN matches fields ending in _id, not bare id) preserves the evaluation identifier in compact mode. Also rewrites the type / action / status / execution_id / created_date_from filter descriptions to accurately reflect upstream domain semantics (STO scan-step uses onstep+securityTests, pipeline governance uses onrun, dates are epoch-millis not ISO 8601) and explicitly warns about the 7-day default window.

- src/registry/toolsets/sto.ts — adds two new resources the skill depends on: pipeline_security_issue (execution-scoped issue listing with diff-pagination handling for the existing/new partitions) and pipeline_security_step (per-execution scan step metadata for issue attribution). Also adds a relatedResources link from pipeline_security_issue to the existing security_exemption resource.

- README.md — documents the new skill in the prompts table.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] Tests pass
- [x] Typecheck passes
