### PR TITLE
feat: add outputSchema + structuredContent to all MCP tools

### DIFF
--- a/src/tools/harness-create.ts
+++ b/src/tools/harness-create.ts
@@ -9,6 +9,7 @@ import { confirmViaElicitation } from "../utils/elicitation.js";
 import { applyUrlDefaults } from "../utils/url-parser.js";
 import { coerceRecord } from "../utils/type-guards.js";
 import { resourceTypeSchema } from "./input-schemas.js";
+import { createOutputSchema } from "./output-schemas.js";
 
 export function registerCreateTool(server: McpServer, registry: Registry, client: HarnessClient, config?: Config): void {
   const creatableTypes = registry.getTypesForOperation("create");
@@ -28,6 +29,7 @@ export function registerCreateTool(server: McpServer, registry: Registry, client
         project_id: z.string().describe("Project identifier (overrides default)").optional(),
         params: z.record(z.string(), z.unknown()).describe("Additional parameters. For external Git pipelines: store_type='REMOTE', connector_ref, repo_name, branch, file_path, commit_msg. For Harness Code pipelines: store_type='REMOTE', is_harness_code_repo=true, repo_name, branch, file_path.").optional(),
       },
+      outputSchema: createOutputSchema,
       annotations: {
         title: "Create Harness Resource",
         readOnlyHint: false,

--- a/src/tools/harness-delete.ts
+++ b/src/tools/harness-delete.ts
@@ -9,6 +9,7 @@ import { confirmViaElicitation } from "../utils/elicitation.js";
 import { applyUrlDefaults } from "../utils/url-parser.js";
 import { coerceRecord } from "../utils/type-guards.js";
 import { resourceTypeSchema } from "./input-schemas.js";
+import { deleteOutputSchema } from "./output-schemas.js";
 
 export function registerDeleteTool(server: McpServer, registry: Registry, client: HarnessClient, config?: Config): void {
   const deletableTypes = registry.getTypesForOperation("delete");
@@ -25,6 +26,7 @@ export function registerDeleteTool(server: McpServer, registry: Registry, client
         project_id: z.string().describe("Project identifier (overrides default)").optional(),
         params: z.record(z.string(), z.unknown()).describe("Additional identifiers for nested resources (e.g. pipeline_id for triggers/input sets, environment_id for infrastructure).").optional(),
       },
+      outputSchema: deleteOutputSchema,
       annotations: {
         title: "Delete Harness Resource",
         readOnlyHint: false,

--- a/src/tools/harness-describe.ts
+++ b/src/tools/harness-describe.ts
@@ -4,6 +4,7 @@ import type { Registry } from "../registry/index.js";
 import type { InputExpansionRule } from "../registry/types.js";
 import { jsonResult } from "../utils/response-formatter.js";
 import { getExamplesForResource } from "../data/examples/index.js";
+import { describeOutputSchema } from "./output-schemas.js";
 
 export function registerDescribeTool(server: McpServer, registry: Registry): void {
   const allTypes = registry.getAllResourceTypes() as [string, ...string[]];
@@ -18,6 +19,7 @@ export function registerDescribeTool(server: McpServer, registry: Registry): voi
         toolset: z.enum(allToolsets).describe("Filter to a specific toolset").optional(),
         search_term: z.string().describe("Search for resource types by keyword (matches type name, display name, toolset, description)").optional(),
       },
+      outputSchema: describeOutputSchema,
       annotations: {
         title: "Describe Harness Resources",
         readOnlyHint: true,

--- a/src/tools/harness-diagnose.ts
+++ b/src/tools/harness-diagnose.ts
@@ -15,6 +15,7 @@ import { pipelineHandler } from "./diagnose/pipeline.js";
 import { connectorHandler } from "./diagnose/connector.js";
 import { delegateHandler } from "./diagnose/delegate.js";
 import { gitopsApplicationHandler } from "./diagnose/gitops-application.js";
+import { diagnoseOutputSchema } from "./output-schemas.js";
 
 const logDiag = createLogger("diagnose");
 
@@ -45,6 +46,7 @@ export function registerDiagnoseTool(server: McpServer, registry: Registry, clie
         project_id: z.string().describe("Project identifier (overrides default)").optional(),
         options: z.record(z.string(), z.unknown()).describe("Resource-specific diagnostic options. Pipeline: execution_id, pipeline_id, summary, include_yaml, include_logs, log_snippet_lines, max_failed_steps, include_visual (boolean, include PNG image inline), visual_type ('timeline'|'flow'|'architecture', default 'timeline' — 'architecture' renders full pipeline YAML as multi-level diagram with stages, step groups, steps, rollback), visual_width (number, default 900). When a Harness URL contains ?step=<nodeExecutionId>, setting include_logs:true fetches that specific step's log regardless of pass/fail status and returns it as requested_step_log alongside any failed_step_logs. GitOps: agent_id. Call harness_describe for details.").optional(),
       },
+      outputSchema: diagnoseOutputSchema,
       annotations: {
         title: "Diagnose Harness Resource",
         readOnlyHint: true,

--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -15,6 +15,7 @@ import { materializeInputSetsToRuntimeYaml } from "../utils/materialize-input-se
 import { resourceTypeSchema } from "./input-schemas.js";
 import { pollExecutionToTerminal, FAILURE_STATUSES, AbortError } from "../utils/poll-execution.js";
 import { sendProgress } from "../utils/progress.js";
+import { executeOutputSchema } from "./output-schemas.js";
 
 const log = createLogger("execute");
 
@@ -68,6 +69,7 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
         wait_timeout_seconds: z.number().min(10).max(7200).describe("Max seconds to wait when wait=true. Default 600 (10 min). Max 7200 (2 h). When the timeout fires, returns execution_timed_out=true with the last observed status.").optional(),
         wait_poll_interval_seconds: z.number().min(2).max(60).describe("Initial poll interval when wait=true (seconds). Default 3. Backoff multiplier 1.5x, capped at 30s.").optional(),
       },
+      outputSchema: executeOutputSchema,
       annotations: {
         title: "Execute Harness Action",
         readOnlyHint: false,

--- a/src/tools/harness-get.ts
+++ b/src/tools/harness-get.ts
@@ -9,6 +9,7 @@ import { asString, coerceRecord } from "../utils/type-guards.js";
 import { resolveLogContent } from "../utils/log-resolver.js";
 import { buildLogPrefixFromExecution } from "../utils/log-prefix.js";
 import { resourceTypeSchema } from "./input-schemas.js";
+import { getOutputSchema } from "./output-schemas.js";
 
 export function registerGetTool(server: McpServer, registry: Registry, client: HarnessClient): void {
   const gettableTypes = registry.getTypesForOperation("get");
@@ -26,6 +27,7 @@ export function registerGetTool(server: McpServer, registry: Registry, client: H
         project_id: z.string().describe("Project identifier (overrides default)").optional(),
         params: z.record(z.string(), z.unknown()).describe("Additional identifiers for nested resources. Call harness_describe for fields per resource_type.").optional(),
       },
+      outputSchema: getOutputSchema,
       annotations: {
         title: "Get Harness Resource",
         readOnlyHint: true,

--- a/src/tools/harness-list.ts
+++ b/src/tools/harness-list.ts
@@ -11,6 +11,7 @@ import { renderListVisual } from "../utils/svg/list-visuals.js";
 import type { ListVisualType } from "../utils/svg/list-visuals.js";
 import { createLogger } from "../utils/logger.js";
 import { resourceTypeSchema } from "./input-schemas.js";
+import { listOutputSchema } from "./output-schemas.js";
 
 const log = createLogger("list");
 
@@ -42,6 +43,7 @@ export function registerListTool(server: McpServer, registry: Registry, client: 
         include_visual: z.boolean().describe("Include an inline PNG chart of the results (default false). Supported for execution resource_type. Use when user asks for a visualization, chart, or graph.").default(false).optional(),
         visual_type: z.enum(["timeseries", "bar", "pie"]).describe("Chart type when include_visual=true. 'timeseries' = daily execution counts, 'pie' = breakdown by status, 'bar' = breakdown by pipeline. Default 'pie'.").default("pie").optional(),
       },
+      outputSchema: listOutputSchema,
       annotations: {
         title: "List Harness Resources",
         readOnlyHint: true,

--- a/src/tools/harness-schema.ts
+++ b/src/tools/harness-schema.ts
@@ -5,6 +5,7 @@ import { createLogger } from "../utils/logger.js";
 import { SCHEMAS, VALID_SCHEMAS } from "../data/schemas/index.js";
 import type { SchemaEntry } from "../data/schemas/types.js";
 import { getExample, searchExamples, getExamplesForResource } from "../data/examples/index.js";
+import { schemaOutputSchema } from "./output-schemas.js";
 
 const log = createLogger("tool:harness-schema");
 
@@ -176,6 +177,7 @@ export function registerSchemaTool(
           .optional()
           .describe("Search examples by keyword. Returns matching example names and descriptions. Optionally combine with resource_type to filter."),
       },
+      outputSchema: schemaOutputSchema,
       annotations: {
         title: "Harness YAML Schema",
         readOnlyHint: true,

--- a/src/tools/harness-search.ts
+++ b/src/tools/harness-search.ts
@@ -9,6 +9,7 @@ import { createLogger } from "../utils/logger.js";
 import { sendProgress, sendLog } from "../utils/progress.js";
 import { applyUrlDefaults } from "../utils/url-parser.js";
 import type { ResourceScope } from "../registry/types.js";
+import { searchOutputSchema } from "./output-schemas.js";
 
 const log = createLogger("search");
 const RESOURCE_SCOPES: readonly ResourceScope[] = ["account", "org", "project"];
@@ -60,6 +61,7 @@ export function registerSearchTool(server: McpServer, registry: Registry, client
         max_per_type: z.number().describe("Max results per type").default(5).optional(),
         compact: z.boolean().describe("Strip verbose metadata (default true)").default(true).optional(),
       },
+      outputSchema: searchOutputSchema,
       annotations: {
         title: "Search Harness Resources",
         readOnlyHint: true,

--- a/src/tools/harness-status.ts
+++ b/src/tools/harness-status.ts
@@ -11,6 +11,7 @@ import { createLogger } from "../utils/logger.js";
 import { sendProgress } from "../utils/progress.js";
 import { applyUrlDefaults } from "../utils/url-parser.js";
 import { asString } from "../utils/type-guards.js";
+import { statusOutputSchema } from "./output-schemas.js";
 
 const log = createLogger("status");
 
@@ -80,6 +81,7 @@ export function registerStatusTool(
         limit: z.number().describe("Max items per section (default 5, max 20)").default(5).optional(),
         include_visual: z.boolean().describe("Include visual health dashboard image (default false)").default(false).optional(),
       },
+      outputSchema: statusOutputSchema,
       annotations: {
         title: "Project Health Status",
         readOnlyHint: true,

--- a/src/tools/harness-update.ts
+++ b/src/tools/harness-update.ts
@@ -9,6 +9,7 @@ import { confirmViaElicitation } from "../utils/elicitation.js";
 import { applyUrlDefaults } from "../utils/url-parser.js";
 import { asString, isRecord, coerceRecord } from "../utils/type-guards.js";
 import { resourceTypeSchema } from "./input-schemas.js";
+import { updateOutputSchema } from "./output-schemas.js";
 
 export function registerUpdateTool(server: McpServer, registry: Registry, client: HarnessClient, config?: Config): void {
   const updatableTypes = registry.getTypesForOperation("update");
@@ -29,6 +30,7 @@ export function registerUpdateTool(server: McpServer, registry: Registry, client
         project_id: z.string().describe("Project identifier (overrides default)").optional(),
         params: z.record(z.string(), z.unknown()).describe("Additional identifiers (e.g. pipeline_id for triggers/input sets, version_label for templates).").optional(),
       },
+      outputSchema: updateOutputSchema,
       annotations: {
         title: "Update Harness Resource",
         readOnlyHint: false,

--- a/src/tools/output-schemas.ts
+++ b/src/tools/output-schemas.ts
@@ -1,26 +1,15 @@
 import * as z from "zod/v4";
 
-/**
- * Envelope output schemas for MCP tools.
- *
- * These define the structuredContent shape returned by each tool.
- * They describe the existing response shapes — no new wrappers.
- *
- * For tools with dynamic shapes (varying by resource_type), we use
- * z.object({}).catchall(z.unknown()) which passes through all fields
- * while satisfying the SDK's normalizeObjectSchema requirement for
- * an object schema type.
- */
-
+// Dynamic-shape passthrough: satisfies SDK's normalizeObjectSchema without constraining response fields.
 const dynamicObject = z.object({}).catchall(z.unknown());
 
 // --- harness_list ---
-export const listOutputSchema = {
+export const listOutputSchema = z.object({
   items: z.array(dynamicObject).describe("Array of resource objects"),
   total: z.number().describe("Total number of matching resources").optional(),
   page: z.number().describe("Current page number (0-indexed)").optional(),
   analysis: z.string().describe("Visual analysis summary (when include_visual=true)").optional(),
-};
+});
 
 // --- harness_get ---
 export const getOutputSchema = z.object({}).catchall(z.unknown()).describe("Resource object — shape varies by resource_type");
@@ -32,11 +21,11 @@ export const createOutputSchema = z.object({}).catchall(z.unknown()).describe("C
 export const updateOutputSchema = z.object({}).catchall(z.unknown()).describe("Updated resource object");
 
 // --- harness_delete ---
-export const deleteOutputSchema = {
+export const deleteOutputSchema = z.object({
   deleted: z.boolean().describe("Whether the resource was successfully deleted"),
   resource_type: z.string().describe("The type of resource that was deleted"),
   resource_id: z.string().describe("The ID of the deleted resource"),
-};
+});
 
 // --- harness_execute ---
 export const executeOutputSchema = z.object({}).catchall(z.unknown()).describe("Execution result — shape varies by action and resource_type");
@@ -45,7 +34,7 @@ export const executeOutputSchema = z.object({}).catchall(z.unknown()).describe("
 export const diagnoseOutputSchema = z.object({}).catchall(z.unknown()).describe("Diagnostic data — shape varies by resource_type");
 
 // --- harness_search ---
-export const searchOutputSchema = {
+export const searchOutputSchema = z.object({
   query: z.string().describe("The search query that was executed"),
   total_matches: z.number().describe("Total number of matching results"),
   searched_types: z.number().describe("Number of resource types searched"),
@@ -54,13 +43,13 @@ export const searchOutputSchema = {
     match_count: z.number().describe("Number of matches in this type"),
     items: z.array(dynamicObject).describe("Matching resources"),
   }).catchall(z.unknown())).describe("Search results grouped by resource type"),
-};
+});
 
 // --- harness_describe ---
 export const describeOutputSchema = z.object({}).catchall(z.unknown()).describe("Resource type metadata, toolset info, or registry summary");
 
 // --- harness_status ---
-export const statusOutputSchema = {
+export const statusOutputSchema = z.object({
   project: z.object({
     org: z.string().describe("Organization identifier"),
     project: z.string().describe("Project identifier"),
@@ -75,7 +64,7 @@ export const statusOutputSchema = {
   running_executions: z.array(dynamicObject).describe("Currently running executions"),
   recent_activity: z.array(dynamicObject).describe("Recent execution activity"),
   openInHarness: z.string().describe("Deep link to project in Harness UI").optional(),
-};
+});
 
 // --- harness_schema ---
 export const schemaOutputSchema = z.object({}).catchall(z.unknown()).describe("Schema data — shape varies by query mode");

--- a/src/tools/output-schemas.ts
+++ b/src/tools/output-schemas.ts
@@ -1,0 +1,81 @@
+import * as z from "zod/v4";
+
+/**
+ * Envelope output schemas for MCP tools.
+ *
+ * These define the structuredContent shape returned by each tool.
+ * They describe the existing response shapes — no new wrappers.
+ *
+ * For tools with dynamic shapes (varying by resource_type), we use
+ * z.object({}).catchall(z.unknown()) which passes through all fields
+ * while satisfying the SDK's normalizeObjectSchema requirement for
+ * an object schema type.
+ */
+
+const dynamicObject = z.object({}).catchall(z.unknown());
+
+// --- harness_list ---
+export const listOutputSchema = {
+  items: z.array(dynamicObject).describe("Array of resource objects"),
+  total: z.number().describe("Total number of matching resources").optional(),
+  page: z.number().describe("Current page number (0-indexed)").optional(),
+  analysis: z.string().describe("Visual analysis summary (when include_visual=true)").optional(),
+};
+
+// --- harness_get ---
+export const getOutputSchema = z.object({}).catchall(z.unknown()).describe("Resource object — shape varies by resource_type");
+
+// --- harness_create ---
+export const createOutputSchema = z.object({}).catchall(z.unknown()).describe("Created resource object");
+
+// --- harness_update ---
+export const updateOutputSchema = z.object({}).catchall(z.unknown()).describe("Updated resource object");
+
+// --- harness_delete ---
+export const deleteOutputSchema = {
+  deleted: z.boolean().describe("Whether the resource was successfully deleted"),
+  resource_type: z.string().describe("The type of resource that was deleted"),
+  resource_id: z.string().describe("The ID of the deleted resource"),
+};
+
+// --- harness_execute ---
+export const executeOutputSchema = z.object({}).catchall(z.unknown()).describe("Execution result — shape varies by action and resource_type");
+
+// --- harness_diagnose ---
+export const diagnoseOutputSchema = z.object({}).catchall(z.unknown()).describe("Diagnostic data — shape varies by resource_type");
+
+// --- harness_search ---
+export const searchOutputSchema = {
+  query: z.string().describe("The search query that was executed"),
+  total_matches: z.number().describe("Total number of matching results"),
+  searched_types: z.number().describe("Number of resource types searched"),
+  results: z.array(z.object({
+    resource_type: z.string().describe("Resource type"),
+    match_count: z.number().describe("Number of matches in this type"),
+    items: z.array(dynamicObject).describe("Matching resources"),
+  }).catchall(z.unknown())).describe("Search results grouped by resource type"),
+};
+
+// --- harness_describe ---
+export const describeOutputSchema = z.object({}).catchall(z.unknown()).describe("Resource type metadata, toolset info, or registry summary");
+
+// --- harness_status ---
+export const statusOutputSchema = {
+  project: z.object({
+    org: z.string().describe("Organization identifier"),
+    project: z.string().describe("Project identifier"),
+  }).catchall(z.unknown()).describe("Project scope"),
+  summary: z.object({
+    total_failed: z.number().describe("Count of failed executions"),
+    total_running: z.number().describe("Count of running executions"),
+    total_recent: z.number().describe("Count of recent executions"),
+    health: z.enum(["healthy", "degraded", "failing"]).describe("Overall project health"),
+  }).describe("Execution health summary"),
+  failed_executions: z.array(dynamicObject).describe("Recent failed executions"),
+  running_executions: z.array(dynamicObject).describe("Currently running executions"),
+  recent_activity: z.array(dynamicObject).describe("Recent execution activity"),
+  openInHarness: z.string().describe("Deep link to project in Harness UI").optional(),
+};
+
+// --- harness_schema ---
+export const schemaOutputSchema = z.object({}).catchall(z.unknown()).describe("Schema data — shape varies by query mode");

--- a/src/utils/response-formatter.ts
+++ b/src/utils/response-formatter.ts
@@ -22,6 +22,7 @@ export interface ToolResult {
 export function jsonResult(data: unknown): ToolResult {
   return {
     content: [{ type: "text", text: JSON.stringify(data) }],
+    // MCP structuredContent must be an object; arrays and primitives are intentionally excluded.
     ...(data !== null && typeof data === "object" && !Array.isArray(data)
       ? { structuredContent: data as Record<string, unknown> }
       : {}),
@@ -55,6 +56,7 @@ export async function mixedResult(data: unknown, svgString: string, options?: Mi
       { type: "text", text: JSON.stringify(data) },
       { type: "image", data: imageData, mimeType: "image/png" },
     ],
+    // MCP structuredContent must be an object; arrays and primitives are intentionally excluded.
     ...(data !== null && typeof data === "object" && !Array.isArray(data)
       ? { structuredContent: data as Record<string, unknown> }
       : {}),

--- a/src/utils/response-formatter.ts
+++ b/src/utils/response-formatter.ts
@@ -16,11 +16,15 @@ export interface ToolResult {
   [key: string]: unknown;
   content: ContentItem[];
   isError?: boolean;
+  structuredContent?: Record<string, unknown>;
 }
 
 export function jsonResult(data: unknown): ToolResult {
   return {
     content: [{ type: "text", text: JSON.stringify(data) }],
+    ...(data !== null && typeof data === "object" && !Array.isArray(data)
+      ? { structuredContent: data as Record<string, unknown> }
+      : {}),
   };
 }
 
@@ -51,5 +55,8 @@ export async function mixedResult(data: unknown, svgString: string, options?: Mi
       { type: "text", text: JSON.stringify(data) },
       { type: "image", data: imageData, mimeType: "image/png" },
     ],
+    ...(data !== null && typeof data === "object" && !Array.isArray(data)
+      ? { structuredContent: data as Record<string, unknown> }
+      : {}),
   };
 }

--- a/tests/registry/registry.test.ts
+++ b/tests/registry/registry.test.ts
@@ -183,6 +183,25 @@ describe("Registry", () => {
         }
       }
     });
+
+    it("registers every tool with an outputSchema", () => {
+      const registry = new Registry(makeConfig());
+      const server = {
+        registerTool: vi.fn(),
+      };
+
+      registerAllTools(
+        server as never,
+        registry,
+        makeClient(),
+        makeConfig(),
+      );
+
+      for (const [toolName, definition] of server.registerTool.mock.calls) {
+        const outputSchema = (definition as { outputSchema?: unknown }).outputSchema;
+        expect(outputSchema, `${toolName} should define outputSchema`).toBeDefined();
+      }
+    });
   });
 
   describe("getResource", () => {

--- a/tests/utils/response-formatter.test.ts
+++ b/tests/utils/response-formatter.test.ts
@@ -2,26 +2,30 @@ import { describe, it, expect } from "vitest";
 import { jsonResult, errorResult, imageResult, mixedResult } from "../../src/utils/response-formatter.js";
 
 describe("jsonResult", () => {
-  it("wraps data as text content", () => {
+  it("wraps data as text content with structuredContent", () => {
     const result = jsonResult({ count: 42 });
     expect(result).toEqual({
       content: [{ type: "text", text: JSON.stringify({ count: 42 }) }],
+      structuredContent: { count: 42 },
     });
   });
 
-  it("handles arrays", () => {
+  it("handles arrays without structuredContent", () => {
     const result = jsonResult([1, 2, 3]);
     expect(result.content[0].text).toBe(JSON.stringify([1, 2, 3]));
+    expect(result.structuredContent).toBeUndefined();
   });
 
-  it("handles null", () => {
+  it("handles null without structuredContent", () => {
     const result = jsonResult(null);
     expect(result.content[0].text).toBe("null");
+    expect(result.structuredContent).toBeUndefined();
   });
 
-  it("handles strings", () => {
+  it("handles strings without structuredContent", () => {
     const result = jsonResult("hello");
     expect(result.content[0].text).toBe('"hello"');
+    expect(result.structuredContent).toBeUndefined();
   });
 
   it("does not set isError", () => {
@@ -70,7 +74,7 @@ describe("imageResult", () => {
 });
 
 describe("mixedResult", () => {
-  it("returns text first, then PNG image", { timeout: 15_000 }, async () => {
+  it("returns text first, then PNG image, with structuredContent", { timeout: 15_000 }, async () => {
     const data = { count: 5 };
     const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect width="100" height="100" fill="blue"/></svg>';
     const result = await mixedResult(data, svg);
@@ -83,5 +87,6 @@ describe("mixedResult", () => {
     expect(img.mimeType).toBe("image/png");
     const buf = Buffer.from(img.data, "base64");
     expect(buf[0]).toBe(0x89); // PNG signature
+    expect(result.structuredContent).toEqual({ count: 5 });
   });
 });


### PR DESCRIPTION
## Summary
- Adds MCP `outputSchema` declarations to all 11 tools for OpenAI ChatGPT app compatibility
- `jsonResult()` and `mixedResult()` now automatically include `structuredContent` when returning object data — zero changes to tool handlers
- New `src/tools/output-schemas.ts` defines typed envelope schemas using `z.object({}).catchall(z.unknown())` for dynamic shapes (SDK-safe passthrough)
- Test coverage: asserts all registered tools have `outputSchema`, validates `structuredContent` presence/absence

## Context
OpenAI's ChatGPT app requires MCP tools to declare `outputSchema` and return `structuredContent` in responses. This PR adds minimal, non-breaking support by:
1. Defining common envelope schemas per tool (not per-resource-type — avoids 150+ schemas)
2. Using Zod's `catchall(z.unknown())` pattern which satisfies the SDK's `normalizeObjectSchema` without constraining dynamic response shapes

## Test plan
- [x] `pnpm build` — clean
- [x] `pnpm test` — 1393 tests pass (59 files)
- [x] `pnpm docs:check` — README up to date
- [x] `node scripts/smoke-test.js` — 3/3 pass
- [x] Manual stdio verification: `tools/list` includes `outputSchema`, `tools/call` returns `structuredContent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)