### PR TITLE
fix: mark harness_update and harness_execute as destructive

### DIFF
--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -73,7 +73,7 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
       annotations: {
         title: "Execute Harness Action",
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: false,
         openWorldHint: true,
       },

--- a/src/tools/harness-update.ts
+++ b/src/tools/harness-update.ts
@@ -34,7 +34,7 @@ export function registerUpdateTool(server: McpServer, registry: Registry, client
       annotations: {
         title: "Update Harness Resource",
         readOnlyHint: false,
-        destructiveHint: false,
+        destructiveHint: true,
         idempotentHint: true,
         openWorldHint: true,
       },


### PR DESCRIPTION
## Summary
- Sets `destructiveHint: true` on `harness_update` (can full-replace resources, overwriting omitted fields)
- Sets `destructiveHint: true` on `harness_execute` (can revoke tokens, reject approvals, interrupt executions, kill/restore feature flags, run chaos experiments)

Unblocks correct `chatgpt-app-submission.json` generation from source annotations.

## Test plan
- [x] `pnpm test` passes (annotation assertion test validates explicit boolean values)
- [x] Verify via MCP Inspector that both tools report `destructiveHint: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)