### PR TITLE
fix(iacm): fix iacm_resource output validation and iacm_module pagination

### DIFF
--- a/src/registry/toolsets/iacm.ts
+++ b/src/registry/toolsets/iacm.ts
@@ -52,7 +52,7 @@ const iacmResourcesExtract = (raw: unknown): unknown => {
   const has_more = r.hasMore ?? false;
   const page_count = resources.length;
   return {
-    resources,
+    items: resources,
     outputs: r.outputs ?? [],
     data_sources: r.data_sources ?? [],
     page_count,
@@ -389,6 +389,7 @@ export const iacmToolset: ToolsetDefinition = {
             page: "page",
             size: "size",
           },
+          pageOneIndexed: true,
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           responseExtractor: moduleListExtract,
           description:

--- a/tests/registry/iacm.test.ts
+++ b/tests/registry/iacm.test.ts
@@ -226,7 +226,7 @@ describe("iacmResourcesExtract", () => {
     return getOp("iacm_resource", "list").responseExtractor!(raw) as Record<string, unknown>;
   }
 
-  it("extracts resources, outputs, data_sources sections", () => {
+  it("extracts resources as items, outputs, data_sources sections", () => {
     const raw = {
       resources: [{ name: "aws_instance.main" }],
       outputs: [{ name: "vpc_id", value: "vpc-123" }],
@@ -235,7 +235,7 @@ describe("iacmResourcesExtract", () => {
       totalItems: 1,
     };
     const result = extract(raw);
-    expect((result.resources as unknown[]).length).toBe(1);
+    expect((result.items as unknown[]).length).toBe(1);
     expect((result.outputs as unknown[]).length).toBe(1);
     expect(result.total_items).toBe(1);
     expect(result.has_more).toBe(false);
@@ -249,6 +249,17 @@ describe("iacmResourcesExtract", () => {
   it("has_more reflects hasMore from API", () => {
     const result = extract({ resources: Array(30).fill({}), hasMore: true });
     expect(result.has_more).toBe(true);
+  });
+
+  it("returns items (not resources) to satisfy listOutputSchema", () => {
+    const result = extract({ resources: [{ name: "x" }] });
+    expect(result.items).toBeDefined();
+    expect(result).not.toHaveProperty("resources");
+  });
+
+  it("returns empty items array when API returns null/undefined resources", () => {
+    const result = extract({});
+    expect(result.items).toEqual([]);
   });
 });
 
@@ -320,6 +331,22 @@ describe("activityChangesExtract", () => {
     const summary = result.summary as Record<string, unknown>;
     expect(summary.total_added).toBe(0);
     expect(summary.total_destroyed).toBe(0);
+  });
+});
+
+// ─── pageOneIndexed ──────────────────────────────────────────────────────────
+
+describe("pageOneIndexed", () => {
+  it("all list operations with page queryParam have pageOneIndexed: true", () => {
+    for (const resource of iacmToolset.resources) {
+      const listOp = resource.operations.list;
+      if (listOp?.queryParams && "page" in listOp.queryParams) {
+        expect(
+          listOp.pageOneIndexed,
+          `${resource.resourceType}.list has page queryParam but missing pageOneIndexed: true`,
+        ).toBe(true);
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## Description

Fixes two related bugs in the IaCM toolset (introduced in v3.0.5, PR #233):

1. **`iacm_resource` list fails with output validation error** (#240): The `iacmResourcesExtract` function returned a `resources` field, but the `listOutputSchema` requires `items`. Renamed the field to `items` so structured output validation passes. The `outputs` and `data_sources` fields remain as additional context alongside the standard `items` array.

2. **`iacm_module` list fails with "page must be >= 1"** (#241): The `iacm_module` list operation was missing `pageOneIndexed: true`, causing the framework's default `page=0` to be sent directly to the IaCM API which requires 1-based pagination.

### Reproduction

Both bugs verified against a live Harness account (`harness-mcp-v2@3.0.5` with `HARNESS_TOOLSETS=+iacm`):
- `iacm_resource`: Call `harness_list` on a workspace with no Terraform state → output validation error
- `iacm_module`: Call `harness_list` without explicit page filter → "page must be >= 1"

### Changes

- `src/registry/toolsets/iacm.ts`: Rename `resources` → `items` in `iacmResourcesExtract`; add `pageOneIndexed: true` to `iacm_module` list
- `tests/registry/iacm.test.ts`: Update assertion to check `items` instead of `resources`

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] Tests pass (`pnpm test` — 1432 tests, 60 files)
- [x] Typecheck passes (`pnpm build` clean)

Fixes #240, Fixes #241