### PR TITLE
fix: url parser accepts path-only Harness UI URLs

### DIFF
--- a/src/utils/url-parser.ts
+++ b/src/utils/url-parser.ts
@@ -101,6 +101,16 @@ const STRUCTURAL = new Set([
 ]);
 
 /**
+ * Placeholder base used only to satisfy `new URL()` when the input is a path-only
+ * string like `/ng/account/<id>/...`. parseHarnessUrl never reads `url.host` /
+ * `url.origin` / `url.protocol`; it walks `url.pathname` and `url.searchParams`
+ * only. Using an explicitly fake host makes it clear in code review that the
+ * host is not consulted and the parser is cluster-agnostic (prod0 / eu1 /
+ * harness0 / self-managed / vanity hosts all parse identically).
+ */
+const PLACEHOLDER_BASE = "https://harness.invalid";
+
+/**
  * Parse a Harness UI URL and extract identifiers.
  *
  * Handles patterns like:
@@ -110,9 +120,11 @@ const STRUCTURAL = new Set([
  * - .../all/cd/orgs/{org}/projects/{project}/...
  * - .../all/settings/connectors/{id}
  * - Vanity domains (e.g. ancestry.harness.io)
+ * - Path-only URLs (e.g. `/ng/account/<id>/...`) — the Harness UI's copy-link
+ *   actions sometimes produce these.
  */
 export function parseHarnessUrl(urlStr: string): ParsedHarnessUrl {
-  const url = new URL(urlStr);
+  const url = new URL(urlStr, PLACEHOLDER_BASE);
   const segments = url.pathname.split("/").filter(Boolean);
 
   const result: ParsedHarnessUrl = { account_id: "" };

--- a/tests/utils/url-parser.test.ts
+++ b/tests/utils/url-parser.test.ts
@@ -201,6 +201,66 @@ describe("parseHarnessUrl", () => {
     expect(result.pipeline_id).toBe("My Pipeline"); // resource IDs are decoded
     expect(result.resource_type).toBe("pipeline");
   });
+
+  // Regression tests for path-only URLs.
+  // Background: the Harness UI's "Copy Link" / address-bar fragment frequently
+  // yields a path-only URL (no scheme/host). Previously `new URL(urlStr)` threw,
+  // `applyUrlDefaults` silently caught and dropped every URL-derived field, and
+  // URL-aware tools (harness_diagnose, harness_get, harness_execute, ...) failed
+  // with "execution_id or pipeline_id is required" -- the highest-volume agent
+  // error in production. Using `new URL(urlStr, base)` resolves path-only inputs
+  // against a placeholder host that the parser never reads.
+
+  it("parses a path-only execution URL (no scheme/host)", () => {
+    const result = parseHarnessUrl(
+      "/ng/account/MTEyYzc0MTctMzIyYi00ZT/module/ci/orgs/merdeploy/projects/econn/pipelines/build_jdk11_github_clickops/executions/2QvnKmYBRK2H5oC37YjdMQ/pipeline?connectorRef=org.org_ghec_con&repoName=harn-merdeploy&branch=vk_sandbox&storeType=REMOTE",
+    );
+    expect(result.account_id).toBe("MTEyYzc0MTctMzIyYi00ZT");
+    expect(result.module).toBe("ci");
+    expect(result.org_id).toBe("merdeploy");
+    expect(result.project_id).toBe("econn");
+    expect(result.resource_type).toBe("execution");
+    expect(result.pipeline_id).toBe("build_jdk11_github_clickops");
+    expect(result.execution_id).toBe("2QvnKmYBRK2H5oC37YjdMQ");
+    expect(result.resource_id).toBe("2QvnKmYBRK2H5oC37YjdMQ");
+  });
+
+  it("parses a path-only pipeline-studio URL", () => {
+    const result = parseHarnessUrl(
+      "/ng/account/NjU5NDczNGEtMTE1My00Mz/all/orgs/default/projects/ItsnotyouItstheskill/pipelines/slack_channel_summarizer_pipeline/pipeline-studio/?storeType=INLINE",
+    );
+    expect(result.account_id).toBe("NjU5NDczNGEtMTE1My00Mz");
+    expect(result.org_id).toBe("default");
+    expect(result.project_id).toBe("ItsnotyouItstheskill");
+    expect(result.resource_type).toBe("pipeline");
+    expect(result.pipeline_id).toBe("slack_channel_summarizer_pipeline");
+    expect(result.resource_id).toBe("slack_channel_summarizer_pipeline");
+  });
+
+  it("parses a path-only URL with stage_id query param", () => {
+    const result = parseHarnessUrl(
+      "/ng/account/7i5sLmXBSne4D8bPq52bSw/all/orgs/et/projects/nabserv/pipelines/haproxyflag/executions/dqx6P6SZQbaLj2Qpdg3eLA/pipeline?stage=41EbIRIoRimtbDmHQL-T4A",
+    );
+    expect(result.execution_id).toBe("dqx6P6SZQbaLj2Qpdg3eLA");
+    expect(result.pipeline_id).toBe("haproxyflag");
+    expect(result.stage_id).toBe("41EbIRIoRimtbDmHQL-T4A");
+  });
+
+  it("is host-agnostic: absolute URL from a non-app.harness.io cluster parses identically to its path-only form", () => {
+    const path =
+      "/ng/account/abc123/all/orgs/default/projects/myProject/pipelines/myPipeline/executions/exec123/pipeline";
+    const absoluteAlt = `https://app.eu1.harness.io${path}`;
+    const absoluteSelfManaged = `https://harness.acmecorp.com${path}`;
+
+    const fromPath = parseHarnessUrl(path);
+    const fromAlt = parseHarnessUrl(absoluteAlt);
+    const fromSelfManaged = parseHarnessUrl(absoluteSelfManaged);
+
+    expect(fromPath).toEqual(fromAlt);
+    expect(fromPath).toEqual(fromSelfManaged);
+    expect(fromPath.execution_id).toBe("exec123");
+    expect(fromPath.pipeline_id).toBe("myPipeline");
+  });
 });
 
 describe("applyUrlDefaults", () => {
@@ -268,10 +328,28 @@ describe("applyUrlDefaults", () => {
     expect(result).toEqual(args);
   });
 
-  it("returns args unchanged for invalid URL", () => {
+  it("returns args unchanged for an unparseable / non-Harness URL", () => {
+    // `parseHarnessUrl` now uses a placeholder base host so path-only inputs
+    // succeed (see parseHarnessUrl regression tests). A truly unparseable input
+    // like "not-a-url" still yields no mergeable fields -- the input becomes a
+    // single-segment path with no `orgs` / `projects` / resource markers -- so
+    // args come back unchanged.
     const args = { resource_type: "pipeline" };
     const result = applyUrlDefaults(args as Record<string, unknown>, "not-a-url");
     expect(result).toEqual(args);
+  });
+
+  it("merges URL-derived values from a path-only URL (no scheme/host)", () => {
+    const args = {};
+    const result = applyUrlDefaults(
+      args as Record<string, unknown>,
+      "/ng/account/abc/all/orgs/myOrg/projects/myProject/pipelines/myPipeline/executions/exec123/pipeline",
+    );
+    expect(result.org_id).toBe("myOrg");
+    expect(result.project_id).toBe("myProject");
+    expect(result.resource_type).toBe("execution");
+    expect(result.execution_id).toBe("exec123");
+    expect(result.pipeline_id).toBe("myPipeline");
   });
 
   it("does not mutate the original args object", () => {


### PR DESCRIPTION
## Description

`parseHarnessUrl(urlStr)` previously called `new URL(urlStr)` directly, which throws `TypeError: Invalid URL` whenever the input lacks a scheme and host (e.g. `/ng/account/<id>/.../executions/<id>/pipeline`). The exception is caught in `applyUrlDefaults` and silently swallowed, so every URL-derived field is dropped. The downstream tool (most visibly `harness_diagnose`, but also any other tool that wires `applyUrlDefaults`) then fails with `"execution_id or pipeline_id is required"` even though the agent supplied a valid Harness URL.

In production this is the single highest-volume agent failure mode.

### Evidence

An audit of **293 distinct failing `harness_diagnose` URLs** from one week of prod0 chat traces (May 12 → May 21, 2026; ~488 failures, 433 unique conversations) run through the actual compiled parser:

| Bucket | Count | Reason |
|---|---:|---|
| Path-only URL — would parse if a base were supplied | **292 (99.7%)** | `parseHarnessUrl` throws on `new URL(input)` |
| Path-only URL, no execution segment | 1 | `pipeline-studio` URL, legitimately has no execution_id |

Example failing input (real prod log):

```
/ng/account/MTEyYzc0MTctMzIyYi00ZT/module/ci/orgs/merdeploy/projects/econn/pipelines/build_jdk11_github_clickops/executions/2QvnKmYBRK2H5oC37YjdMQ/pipeline?connectorRef=...&storeType=REMOTE
```

After this fix, the same input parses to:

```json
{
  "account_id": "MTEyYzc0MTctMzIyYi00ZT",
  "module": "ci",
  "org_id": "merdeploy",
  "project_id": "econn",
  "resource_type": "execution",
  "pipeline_id": "build_jdk11_github_clickops",
  "execution_id": "2QvnKmYBRK2H5oC37YjdMQ",
  "resource_id": "2QvnKmYBRK2H5oC37YjdMQ"
}
```

## Fix

Pass a placeholder base (`https://harness.invalid`) to `new URL(input, base)`.

The base is consulted only when `input` is relative; for absolute URLs (`https://app.harness.io/...`, `https://app.eu1.harness.io/...`, vanity domains like `ancestry.harness.io`, self-managed hosts) it is ignored entirely. The parser never reads `url.host`, `url.origin`, or `url.protocol` — it walks `url.pathname` and `url.searchParams` only — so the placeholder has **no operational effect** and the parser remains cluster-agnostic. The fake-host string (`harness.invalid`, per RFC 2606) makes it explicit at the call site that the host is not consulted.

## Blast radius

Every URL-aware `harness_*` tool benefits: `harness_diagnose`, `harness_list`, `harness_get`, `harness_update`, `harness_create`, `harness_delete`, `harness_execute`, `harness_search`, `harness_status`. The fix is a single line.

## Tests

- Three regression cases for path-only URLs covering the common `pipelines/<id>/executions/<id>/pipeline` shape (with and without `/module/<m>/` prefix), `pipeline-studio` URLs, and `stage_id` preservation from query params.
- Host-agnostic test asserting that path-only, prod0, eu1, and self-managed-host variants of the same path parse identically.
- Existing `applyUrlDefaults` "invalid URL" test reworded to reflect the new contract: unparseable inputs that have no Harness path structure still yield no mergeable fields and args are returned unchanged.

All **1437** tests still pass.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] Tests pass (`pnpm test` — 1437/1437)
- [x] Typecheck passes (`pnpm typecheck`)
- [x] Build passes (`pnpm build`)

Made with [Cursor](https://cursor.com)