### PR TITLE
Skip CDN host rewrite when presigned URL binds host

### DIFF
--- a/src/utils/log-resolver.ts
+++ b/src/utils/log-resolver.ts
@@ -77,6 +77,28 @@ function isPresignedUrl(url: URL): boolean {
   return false;
 }
 
+/**
+ * True when the URL's signature covers the HTTP `Host` header.
+ * Rewriting the hostname for CDN fetch would invalidate the signature (401).
+ */
+function signedHeadersIncludeHost(url: URL): boolean {
+  const goog = url.searchParams.get("X-Goog-SignedHeaders");
+  if (goog) {
+    return goog
+      .split(";")
+      .map((s) => s.trim().toLowerCase())
+      .includes("host");
+  }
+  const amz = url.searchParams.get("X-Amz-SignedHeaders");
+  if (amz) {
+    return amz
+      .split(";")
+      .map((s) => s.trim().toLowerCase())
+      .includes("host");
+  }
+  return false;
+}
+
 
 // ─── ANSI / log parsing helpers ─────────────────────────────────────────────
 
@@ -345,7 +367,7 @@ async function downloadBlobContent(
   //    The URL is publicly routable with embedded signature params; routing through
   //    the client or adding extra headers would invalidate the AWS/GCS signature.
   //
-  // 2. *.harness.io pre-signed CDN blob URLs → rewrite hostname to match
+  // 2. *.harness.io pre-signed CDN blob URLs → usually rewrite hostname to match
   //    HARNESS_BASE_URL host, then direct fetch.
   //    The Harness log-service always returns blob links pointing to app.harness.io/storage/...
   //    regardless of the configured base URL. On self-managed deployments app.harness.io is
@@ -353,6 +375,8 @@ async function downloadBlobContent(
   //    (e.g. self-managed.example.com/storage/...). The pre-signed params authenticate the request
   //    so no API key header is needed — and adding one would not help anyway since this is
   //    a CDN path, not an API gateway path (/gateway/... would 403 for /storage/... paths).
+  //    Exception: if SignedHeaders includes `host`, the signature is bound to the link's
+  //    hostname — do not rewrite; fetch the original URL (e.g. QA SaaS with qa.harness.io base).
   //
   // 3. Standard log-service paths → client.requestStream() with gateway prefix so
   //    PAT/JWT auth headers are injected by the client proxy.
@@ -374,6 +398,18 @@ async function downloadBlobContent(
     // that happen to carry pre-signed params — those must go through client.requestStream() for auth.
     // The blob link always points to app.harness.io/storage/... regardless of HARNESS_BASE_URL.
     // Rewrite to the configured host so self-managed deployments can reach it.
+    if (signedHeadersIncludeHost(blobUrl)) {
+      log.debug("Downloading log blob (direct, host-bound presigned CDN)", {
+        prefix,
+        url: blobLink.slice(0, 80),
+      });
+      try {
+        return await fetch(blobLink, { signal });
+      } catch (err) {
+        const cause = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+        throw new Error(`Log download fetch failed for ${blobUrl.hostname}: ${cause}`);
+      }
+    }
     const baseUrl = safeParseUrl(client.baseURL);
     if (!baseUrl) {
       // If baseURL is unparseable we cannot safely rewrite — throw rather than

--- a/tests/utils/log-resolver.test.ts
+++ b/tests/utils/log-resolver.test.ts
@@ -266,9 +266,9 @@ describe("resolveLogContent", () => {
     );
   });
 
-  it("STRICT: pre-signed query params are preserved exactly after host rewrite", async () => {
-    // Critical: if X-Amz-Signature or X-Amz-Expires are dropped, the CDN rejects the request.
-    // Verify the full URL including all query params reaches fetchSpy unchanged (except hostname).
+  it("STRICT: host-bound presigned CDN URL (SignedHeaders includes host) is fetched as-is — no host rewrite", async () => {
+    // When X-Amz-SignedHeaders (or X-Goog-SignedHeaders) includes `host`, the signature is tied to
+    // the link hostname. Rewriting to HARNESS_BASE_URL breaks the signature (401 in QA SaaS).
     const blobLink =
       "https://app.harness.io/storage/harness-download/logs.zip" +
       "?X-Amz-Algorithm=AWS4-HMAC-SHA256" +
@@ -286,16 +286,62 @@ describe("resolveLogContent", () => {
     await resolveLogContent(client, "prefix");
 
     const fetchUrl = fetchSpy.mock.calls[0]![0] as string;
-    // Host rewritten
-    expect(fetchUrl).toContain("self-managed.example.com");
-    expect(fetchUrl).not.toContain("app.harness.io");
-    // All pre-signed params intact
+    expect(fetchUrl).toContain("app.harness.io");
+    expect(fetchUrl).not.toContain("self-managed.example.com");
     expect(fetchUrl).toContain("X-Amz-Signature=abc123def456");
     expect(fetchUrl).toContain("X-Amz-Expires=86400");
     expect(fetchUrl).toContain("X-Amz-SignedHeaders=host");
-    // Path intact
     expect(fetchUrl).toContain("/storage/harness-download/logs.zip");
-    // No gateway prefix injected — CDN path must stay as /storage/..., not /gateway/storage/...
+    expect(fetchUrl).not.toContain("/gateway/storage");
+  });
+
+  it("STRICT: GCS host-bound presigned CDN URL is fetched as-is — no host rewrite", async () => {
+    const blobLink =
+      "https://app.harness.io/storage/harness-download/logs.zip" +
+      "?X-Goog-Algorithm=GOOG4-RSA-SHA256" +
+      "&X-Goog-SignedHeaders=host" +
+      "&X-Goog-Signature=gcs-sig" +
+      "&X-Goog-Expires=3600";
+    fetchSpy.mockResolvedValue(new Response('{"out":"gcs host-bound"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const fetchUrl = fetchSpy.mock.calls[0]![0] as string;
+    expect(fetchUrl).toContain("app.harness.io");
+    expect(fetchUrl).not.toContain("self-managed.example.com");
+    expect(fetchUrl).toContain("X-Goog-Signature=gcs-sig");
+    expect(fetchUrl).toContain("X-Goog-SignedHeaders=host");
+    expect(fetchUrl).not.toContain("/gateway/storage");
+  });
+
+  it("STRICT: pre-signed query params are preserved exactly after host rewrite when not host-bound", async () => {
+    const blobLink =
+      "https://app.harness.io/storage/harness-download/logs.zip" +
+      "?X-Amz-Algorithm=AWS4-HMAC-SHA256" +
+      "&X-Amz-Credential=GOOG1EXAMPLEKEY%2F20260516%2Fus-east-1%2Fs3%2Faws4_request" +
+      "&X-Amz-Date=20260516T040000Z" +
+      "&X-Amz-Expires=86400" +
+      "&X-Amz-SignedHeaders=content-type" +
+      "&X-Amz-Signature=abc123def456";
+    fetchSpy.mockResolvedValue(new Response('{"out":"sig preserved"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const fetchUrl = fetchSpy.mock.calls[0]![0] as string;
+    expect(fetchUrl).toContain("self-managed.example.com");
+    expect(fetchUrl).not.toContain("app.harness.io");
+    expect(fetchUrl).toContain("X-Amz-Signature=abc123def456");
+    expect(fetchUrl).toContain("X-Amz-Expires=86400");
+    expect(fetchUrl).toContain("X-Amz-SignedHeaders=content-type");
+    expect(fetchUrl).toContain("/storage/harness-download/logs.zip");
     expect(fetchUrl).not.toContain("/gateway/storage");
   });
 


### PR DESCRIPTION
GCS/S4 signed URLs that list `host` in SignedHeaders must be fetched with the original hostname; rewriting to HARNESS_BASE_URL invalidates the signature. Self-managed host rewrite is unchanged when not host-bound.

## Description
<!-- What does this PR do? -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [ ] Tests pass
- [ ] Typecheck passes
