### PR TITLE
fix(list): normalize array list payloads for MCP structured output

### DIFF
--- a/src/tools/harness-list.ts
+++ b/src/tools/harness-list.ts
@@ -2,7 +2,7 @@ import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
-import { jsonResult, errorResult, mixedResult } from "../utils/response-formatter.js";
+import { jsonResult, errorResult, mixedResult, normalizeHarnessListPayload } from "../utils/response-formatter.js";
 import { isUserError, isUserFixableApiError, toMcpError, enrichErrorWithHint, HarnessApiError } from "../utils/errors.js";
 import { compactItems } from "../utils/compact.js";
 import { applyUrlDefaults } from "../utils/url-parser.js";
@@ -68,7 +68,9 @@ export function registerListTool(server: McpServer, registry: Registry, client: 
         if (resourceType === "template" && input.template_list_type === undefined) {
           input.template_list_type = "All";
         }
-        const result = await registry.dispatch(client, resourceType, "list", input);
+        const rawResult = await registry.dispatch(client, resourceType, "list", input);
+        const page = typeof args.page === "number" ? args.page : 0;
+        const result = normalizeHarnessListPayload(rawResult, { page });
 
         // Apply compact mode — strip verbose metadata from list items.
         // Skip when the endpoint spec has opted out via `skipCompact` (marker
@@ -89,7 +91,7 @@ export function registerListTool(server: McpServer, registry: Registry, client: 
               const vt = (args.visual_type ?? "pie") as ListVisualType;
               const visual = renderListVisual(resourceType, items, vt);
               if (visual) {
-                (result as Record<string, unknown>).analysis = visual.analysis;
+                result.analysis = visual.analysis;
                 return await mixedResult(result, visual.svg);
               }
             } catch (err) {

--- a/src/utils/response-formatter.ts
+++ b/src/utils/response-formatter.ts
@@ -19,6 +19,48 @@ export interface ToolResult {
   structuredContent?: Record<string, unknown>;
 }
 
+/**
+ * Coerce registry list payloads into the `{ items, total?, page? }` shape expected by
+ * `harness_list`'s output schema and MCP `structuredContent` (objects only — raw arrays
+ * cannot be sent as structured content).
+ *
+ * Harness Code endpoints such as `pr_activity` return a top-level JSON array; without
+ * this step, clients that require structured output fail with output validation errors.
+ */
+export function normalizeHarnessListPayload(
+  result: unknown,
+  options?: { page?: number },
+): unknown {
+  const page = options?.page;
+  if (Array.isArray(result)) {
+    return {
+      items: result,
+      total: result.length,
+      ...(page !== undefined ? { page } : {}),
+    };
+  }
+  if (result !== null && typeof result === "object" && !Array.isArray(result)) {
+    const r = result as Record<string, unknown>;
+    if (!Array.isArray(r.items)) {
+      for (const key of ["body", "content", "data", "objects", "features"] as const) {
+        const arr = r[key];
+        if (Array.isArray(arr)) {
+          const total = typeof r.total === "number" ? r.total : arr.length;
+          return {
+            ...r,
+            items: arr,
+            total,
+            ...(page !== undefined && r.page === undefined ? { page } : {}),
+          };
+        }
+      }
+    } else if (Array.isArray(r.items) && r.total === undefined) {
+      return { ...r, total: r.items.length };
+    }
+  }
+  return result;
+}
+
 export function jsonResult(data: unknown): ToolResult {
   return {
     content: [{ type: "text", text: JSON.stringify(data) }],

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,14 @@
 # Harness MCP Server — Task Tracking
 
+## harness_list structured output for array APIs (2026-05-22)
+- [x] Root cause: Harness Code `pr_activity` returns a top-level JSON array; `jsonResult` only sets `structuredContent` for objects, so strict MCP clients (Cursor) fail with output schema validation (-32602).
+- [x] Add `normalizeHarnessListPayload` and call it from `harness_list` after dispatch; unit tests in `response-formatter.test.ts`.
+- [x] Typecheck and focused tests
+- [x] Commit, push, PR
+
+### Review
+- Normalizes top-level arrays to `{ items, total, page }` and hoists common wrapper keys (`body`, `content`, `data`, …) when `items` is missing; fills `total` when `items` exists without `total`.
+
 ## GPT App Tool Annotation Compliance (2026-05-20)
 - [x] Add explicit `destructiveHint: false` to all non-destructive read-only MCP tools flagged by the GPT App form
 - [x] Add regression coverage that every registered tool sets `readOnlyHint`, `openWorldHint`, and `destructiveHint` to explicit booleans with value assertions

--- a/tests/utils/response-formatter.test.ts
+++ b/tests/utils/response-formatter.test.ts
@@ -1,5 +1,31 @@
 import { describe, it, expect } from "vitest";
-import { jsonResult, errorResult, imageResult, mixedResult } from "../../src/utils/response-formatter.js";
+import { jsonResult, errorResult, imageResult, mixedResult, normalizeHarnessListPayload } from "../../src/utils/response-formatter.js";
+
+describe("normalizeHarnessListPayload", () => {
+  it("wraps a top-level array into { items, total, page } for MCP structured output", () => {
+    const activities = [{ id: 1 }, { id: 2 }];
+    const normalized = normalizeHarnessListPayload(activities, { page: 0 });
+    expect(normalized).toEqual({ items: activities, total: 2, page: 0 });
+    const tool = jsonResult(normalized);
+    expect(tool.structuredContent).toEqual({ items: activities, total: 2, page: 0 });
+  });
+
+  it("hoists a list array from body when items is absent", () => {
+    const body = [{ x: 1 }];
+    const normalized = normalizeHarnessListPayload({ body, meta: "keep" }, { page: 1 });
+    expect(normalized).toEqual({ body, meta: "keep", items: body, total: 1, page: 1 });
+  });
+
+  it("fills total from items length when items exists but total is missing", () => {
+    const items = [{ a: 1 }];
+    expect(normalizeHarnessListPayload({ items })).toEqual({ items, total: 1 });
+  });
+
+  it("leaves already-shaped list objects unchanged", () => {
+    const shaped = { items: [{ a: 1 }], total: 99, page: 0 };
+    expect(normalizeHarnessListPayload(shaped)).toBe(shaped);
+  });
+});
 
 describe("jsonResult", () => {
   it("wraps data as text content with structuredContent", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes MCP output validation error `-32602` ("Tool harness_list has an output schema but no structured content was provided") when listing PR activity and other list endpoints that return a **top-level JSON array**.

Harness Code `GET .../pullreq/{n}/activities` returns an array (documented in `docs/testing/pr_activity/test_report.md`). `jsonResult` only attaches `structuredContent` for non-array objects, so strict clients (e.g. Cursor) rejected successful responses.

`normalizeHarnessListPayload` wraps top-level arrays into `{ items, total, page }`, hoists common wrapper keys when `items` is missing, and fills `total` when only `items` is present.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] Tests pass (`vitest run tests/utils/response-formatter.test.ts`, `tool-handlers.test.ts`)
- [x] Typecheck passes (`pnpm typecheck`)

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://harness.slack.com/archives/C08SYT1FWJD/p1779426626103899?thread_ts=1779426626.103899&cid=C08SYT1FWJD)

<div><a href="https://cursor.com/agents/bc-5decbcdb-0034-517f-8e27-f167e633217e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5decbcdb-0034-517f-8e27-f167e633217e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

