### PR TITLE
fix: always rewrite blob hostname on self-managed deployments when hosts differ

### DIFF
--- a/src/utils/log-resolver.ts
+++ b/src/utils/log-resolver.ts
@@ -352,6 +352,36 @@ const LOG_SERVICE_GATEWAY_PREFIX = "/gateway/log-service";
  * Harness-hosted URLs are routed through the client so that auth headers
  * (PAT, service JWT, or log-service token) are injected by the client or
  * any proxy installed on it (e.g. mcpServerInternal's service routing).
+ *
+ * ╔══════════════════════════════════════════════════════════════════════════╗
+ * ║  ⚠  THIS FUNCTION HAS BROKEN MULTIPLE TIMES — READ BEFORE CHANGING  ⚠  ║
+ * ╠══════════════════════════════════════════════════════════════════════════╣
+ * ║                                                                          ║
+ * ║  INVARIANT A — always rewrite when blob host ≠ base URL host            ║
+ * ║    The log-service always returns app.harness.io/storage/... in blob     ║
+ * ║    links regardless of HARNESS_BASE_URL. On self-managed deployments,   ║
+ * ║    app.harness.io is NOT reachable. Rewrite to the configured host.      ║
+ * ║    This MUST happen even when X-Amz-SignedHeaders / X-Goog-SignedHeaders ║
+ * ║    includes "host" — the original URL is blocked, so a potential 403 is  ║
+ * ║    better than a guaranteed network error.                               ║
+ * ║                                                                          ║
+ * ║  INVARIANT B — skip rewrite only when blob host = base URL host         ║
+ * ║    When the blob URL hostname already matches our base URL hostname, the  ║
+ * ║    signature is valid for direct fetch and rewriting would be a no-op.   ║
+ * ║    Skipping the rewrite in this case is safe.                            ║
+ * ║                                                                          ║
+ * ║  INVARIANT C — never call requestStream() for /storage/ CDN blobs       ║
+ * ║    Strategy 3 prepends /gateway/log-service/ which produces a 404 for   ║
+ * ║    CDN storage paths. /storage/ blobs must always be direct-fetched.     ║
+ * ║                                                                          ║
+ * ║  INVARIANT D — external S3/GCS hosts bypass all rewriting               ║
+ * ║    True external storage (amazonaws.com, googleapis.com, etc.) URLs are  ║
+ * ║    publicly routable with embedded signature params. Rewriting or adding  ║
+ * ║    auth headers invalidates the AWS/GCS signature.                       ║
+ * ║                                                                          ║
+ * ║  Tests in tests/utils/log-resolver.test.ts are labeled REGRESSION-GUARD ║
+ * ║  [A], [B], [C], [D]. ALL must stay green after any change here.         ║
+ * ╚══════════════════════════════════════════════════════════════════════════╝
  */
 async function downloadBlobContent(
   client: HarnessClient,

--- a/src/utils/log-resolver.ts
+++ b/src/utils/log-resolver.ts
@@ -398,7 +398,17 @@ async function downloadBlobContent(
     // that happen to carry pre-signed params — those must go through client.requestStream() for auth.
     // The blob link always points to app.harness.io/storage/... regardless of HARNESS_BASE_URL.
     // Rewrite to the configured host so self-managed deployments can reach it.
-    if (signedHeadersIncludeHost(blobUrl)) {
+    const baseUrl = safeParseUrl(client.baseURL);
+    if (!baseUrl) {
+      // If baseURL is unparseable we cannot safely rewrite — throw rather than
+      // direct-fetching the original app.harness.io URL (which is blocked on self-managed nets).
+      throw new Error(`Cannot rewrite Harness CDN blob URL: HARNESS_BASE_URL "${client.baseURL}" is not a valid URL`);
+    }
+    // Skip rewriting only when the signature covers the Host header AND the blob hostname
+    // already matches our base URL (rewrite would be a no-op). When hostnames differ
+    // (self-managed deployment), rewrite regardless — the original hostname (app.harness.io)
+    // may not be reachable from the client's network.
+    if (signedHeadersIncludeHost(blobUrl) && blobUrl.hostname === baseUrl.hostname) {
       log.debug("Downloading log blob (direct, host-bound presigned CDN)", {
         prefix,
         url: blobLink.slice(0, 80),
@@ -409,12 +419,6 @@ async function downloadBlobContent(
         const cause = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
         throw new Error(`Log download fetch failed for ${blobUrl.hostname}: ${cause}`);
       }
-    }
-    const baseUrl = safeParseUrl(client.baseURL);
-    if (!baseUrl) {
-      // If baseURL is unparseable we cannot safely rewrite — throw rather than
-      // direct-fetching the original app.harness.io URL (which is blocked on self-managed nets).
-      throw new Error(`Cannot rewrite Harness CDN blob URL: HARNESS_BASE_URL "${client.baseURL}" is not a valid URL`);
     }
     blobUrl.hostname = baseUrl.hostname;
     blobUrl.protocol = baseUrl.protocol;

--- a/src/utils/log-resolver.ts
+++ b/src/utils/log-resolver.ts
@@ -353,35 +353,36 @@ const LOG_SERVICE_GATEWAY_PREFIX = "/gateway/log-service";
  * (PAT, service JWT, or log-service token) are injected by the client or
  * any proxy installed on it (e.g. mcpServerInternal's service routing).
  *
- * ╔══════════════════════════════════════════════════════════════════════════╗
- * ║  ⚠  THIS FUNCTION HAS BROKEN MULTIPLE TIMES — READ BEFORE CHANGING  ⚠  ║
- * ╠══════════════════════════════════════════════════════════════════════════╣
- * ║                                                                          ║
- * ║  INVARIANT A — always rewrite when blob host ≠ base URL host            ║
- * ║    The log-service always returns app.harness.io/storage/... in blob     ║
- * ║    links regardless of HARNESS_BASE_URL. On self-managed deployments,   ║
- * ║    app.harness.io is NOT reachable. Rewrite to the configured host.      ║
- * ║    This MUST happen even when X-Amz-SignedHeaders / X-Goog-SignedHeaders ║
- * ║    includes "host" — the original URL is blocked, so a potential 403 is  ║
- * ║    better than a guaranteed network error.                               ║
- * ║                                                                          ║
- * ║  INVARIANT B — skip rewrite only when blob host = base URL host         ║
- * ║    When the blob URL hostname already matches our base URL hostname, the  ║
- * ║    signature is valid for direct fetch and rewriting would be a no-op.   ║
- * ║    Skipping the rewrite in this case is safe.                            ║
- * ║                                                                          ║
- * ║  INVARIANT C — never call requestStream() for /storage/ CDN blobs       ║
- * ║    Strategy 3 prepends /gateway/log-service/ which produces a 404 for   ║
- * ║    CDN storage paths. /storage/ blobs must always be direct-fetched.     ║
- * ║                                                                          ║
- * ║  INVARIANT D — external S3/GCS hosts bypass all rewriting               ║
- * ║    True external storage (amazonaws.com, googleapis.com, etc.) URLs are  ║
- * ║    publicly routable with embedded signature params. Rewriting or adding  ║
- * ║    auth headers invalidates the AWS/GCS signature.                       ║
- * ║                                                                          ║
- * ║  Tests in tests/utils/log-resolver.test.ts are labeled REGRESSION-GUARD ║
- * ║  [A], [B], [C], [D]. ALL must stay green after any change here.         ║
- * ╚══════════════════════════════════════════════════════════════════════════╝
+ * ### Routing invariants — please read before modifying
+ *
+ * The three strategies below have specific edge cases that are easy to get
+ * wrong. Here is the reasoning behind each constraint:
+ *
+ * **A. Always rewrite when blob host ≠ base URL host.**
+ * The log-service always returns `app.harness.io/storage/...` in blob links
+ * regardless of `HARNESS_BASE_URL`. On self-managed deployments that host is
+ * not publicly reachable, so the URL must be rewritten to the configured host.
+ * This includes cases where `X-Amz-SignedHeaders` / `X-Goog-SignedHeaders`
+ * contains `host` — a potential 403 from the CDN is preferable to a guaranteed
+ * network error on a blocked host.
+ *
+ * **B. Skip rewrite only when blob host already equals base URL host.**
+ * When the hostnames already match, the presigned signature is valid as-is and
+ * rewriting would be a no-op. In that case it is safe (and cleaner) to fetch
+ * the original URL directly.
+ *
+ * **C. Never route `/storage/` blobs through `requestStream()`.**
+ * Strategy 3 prepends `/gateway/log-service/` to the path, which produces a
+ * 404 for CDN storage paths. Blobs with a `/storage/` path must always be
+ * direct-fetched (Strategy 2).
+ *
+ * **D. External S3/GCS hosts bypass all rewriting.**
+ * True external storage URLs (amazonaws.com, googleapis.com, …) are publicly
+ * routable with embedded signature params. Adding auth headers or rewriting the
+ * host invalidates the AWS/GCS signature.
+ *
+ * Each invariant is covered by `REGRESSION-GUARD [A/B/C/D]` tests in
+ * `tests/utils/log-resolver.test.ts`. Please keep all of them green.
  */
 async function downloadBlobContent(
   client: HarnessClient,

--- a/tests/utils/log-resolver.test.ts
+++ b/tests/utils/log-resolver.test.ts
@@ -512,4 +512,214 @@ describe("resolveLogContent", () => {
       resolveLogContent(client, "prefix", { maxLogSizeBytes: 1024 }),
     ).rejects.toThrow(/too large/);
   });
+
+  // ─── REGRESSION GUARD: blob hostname rewriting (breaks repeatedly) ──────────
+  //
+  // This logic has regressed multiple times. Every strategy change in
+  // downloadBlobContent() MUST leave all tests below green. The invariants:
+  //
+  //   A) blob host ≠ base URL host  →  ALWAYS rewrite (even when host in SignedHeaders)
+  //      Rationale: original app.harness.io is unreachable on self-managed nets.
+  //   B) blob host = base URL host  →  skip rewrite when host is in SignedHeaders
+  //      Rationale: signature already valid; rewriting is a no-op anyway.
+  //   C) requestStream must NEVER be called for /storage/ CDN blob URLs.
+  //   D) External S3/GCS host URLs bypass rewriting entirely (Strategy 1).
+
+  it("REGRESSION-GUARD [A]: self-managed instance (corp.harness.example) + host in SignedHeaders → rewrites to corp host", async () => {
+    const blobLink =
+      "https://app.harness.io/storage/blob.zip" +
+      "?X-Amz-SignedHeaders=host" +
+      "&X-Amz-Signature=sig123" +
+      "&X-Amz-Expires=3600";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://corp.harness.example/gateway" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("corp.harness.example");
+    expect(url).not.toContain("app.harness.io");
+    expect(url).toContain("X-Amz-Signature=sig123");
+    expect(url).toContain("/storage/blob.zip");
+  });
+
+  it("REGRESSION-GUARD [A]: multiple headers in SignedHeaders including host → self-managed still rewrites", async () => {
+    const blobLink =
+      "https://app.harness.io/storage/blob.zip" +
+      "?X-Amz-SignedHeaders=content-type%3Bhost%3Bx-amz-date" +
+      "&X-Amz-Signature=multi123";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.corp.example/gateway" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("self-managed.corp.example");
+    expect(url).not.toContain("app.harness.io");
+    expect(url).toContain("X-Amz-Signature=multi123");
+  });
+
+  it("REGRESSION-GUARD [A]: SignedHeaders host value is case-insensitive → self-managed rewrites", async () => {
+    // The check must handle 'Host', 'HOST', 'host' — all the same
+    const blobLink =
+      "https://app.harness.io/storage/blob.zip" +
+      "?X-Amz-SignedHeaders=Host" +
+      "&X-Amz-Signature=case123";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("self-managed.example.com");
+    expect(url).not.toContain("app.harness.io");
+  });
+
+  it("REGRESSION-GUARD [B]: SaaS base URL = app.harness.io + host in SignedHeaders → no rewrite, direct fetch", async () => {
+    // Standard SaaS: blob URL host matches base URL host — no rewrite needed.
+    // If rewrite were applied it would be a no-op, but it must NOT be applied to
+    // preserve the original URL for cases where signature covers the Host header.
+    const blobLink =
+      "https://app.harness.io/storage/blob.zip" +
+      "?X-Amz-SignedHeaders=host" +
+      "&X-Amz-Signature=saas456";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://app.harness.io" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("app.harness.io");
+    expect(url).toContain("/storage/blob.zip");
+    expect(url).toContain("X-Amz-Signature=saas456");
+  });
+
+  it("REGRESSION-GUARD [B]: GCS blob, host in X-Goog-SignedHeaders, base = app.harness.io → no rewrite", async () => {
+    const blobLink =
+      "https://app.harness.io/storage/blob.zip" +
+      "?X-Goog-SignedHeaders=host" +
+      "&X-Goog-Signature=gcssaas789";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://app.harness.io" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("app.harness.io");
+    expect(url).not.toContain("self-managed");
+    expect(url).toContain("X-Goog-Signature=gcssaas789");
+  });
+
+  it("REGRESSION-GUARD [C]: requestStream is NEVER called for host-bound /storage/ CDN blob on self-managed", async () => {
+    // Strategy 2 (direct fetch with host rewrite) must handle this — not Strategy 3 (requestStream).
+    // If requestStream is called, it would prepend /gateway/log-service/ → 404.
+    const blobLink =
+      "https://app.harness.io/storage/blob.zip" +
+      "?X-Amz-SignedHeaders=host" +
+      "&X-Amz-Signature=s1";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const streamFn = vi.fn();
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway", requestStream: streamFn },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    expect(streamFn).not.toHaveBeenCalled();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("self-managed.example.com");
+  });
+
+  it("REGRESSION-GUARD [A]: network error after host rewrite surfaces rewritten hostname in error message", async () => {
+    // When the rewritten URL is also unreachable, the error must name the rewritten host —
+    // not app.harness.io — so operators know the rewrite happened and look at the right host.
+    const blobLink =
+      "https://app.harness.io/storage/blob.zip" +
+      "?X-Amz-SignedHeaders=host" +
+      "&X-Amz-Signature=err1";
+    fetchSpy.mockRejectedValue(new TypeError("fetch failed"));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway" },
+    );
+
+    await expect(resolveLogContent(client, "prefix")).rejects.toThrow("self-managed.example.com");
+  });
+
+  it("REGRESSION-GUARD [A]: self-managed with non-default port + host in SignedHeaders → rewrites with port preserved", async () => {
+    const blobLink =
+      "https://app.harness.io/storage/blob.zip" +
+      "?X-Amz-SignedHeaders=host" +
+      "&X-Amz-Signature=port1";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://corp.harness.example:8443/gateway" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("corp.harness.example:8443");
+    expect(url).not.toContain("app.harness.io");
+    expect(url).toContain("/storage/blob.zip");
+  });
+
+  it("REGRESSION-GUARD [A]: non-host-bound URL on self-managed always rewrites (unchanged baseline)", async () => {
+    // SignedHeaders that do NOT include host — rewrite must happen regardless of this fix.
+    // Guards against the fix accidentally narrowing the rewrite condition too far.
+    const blobLink =
+      "https://app.harness.io/storage/blob.zip" +
+      "?X-Amz-SignedHeaders=content-type%3Bx-amz-date" +
+      "&X-Amz-Signature=noh1";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("self-managed.example.com");
+    expect(url).not.toContain("app.harness.io");
+    expect(url).toContain("X-Amz-Signature=noh1");
+  });
+
+  it("REGRESSION-GUARD [A+C]: host-bound blob returns HTTP 403 after rewrite — error propagates, requestStream not attempted", async () => {
+    // When CDN returns 403 (e.g. host-bound signature mismatch after rewrite), the error
+    // must be surfaced immediately. Strategy 3 (requestStream) must NOT be tried as fallback.
+    const blobLink =
+      "https://app.harness.io/storage/blob.zip" +
+      "?X-Amz-SignedHeaders=host" +
+      "&X-Amz-Signature=sig403";
+    fetchSpy.mockResolvedValue(new Response("Forbidden", { status: 403 }));
+    const streamFn = vi.fn();
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway", requestStream: streamFn },
+    );
+
+    await expect(resolveLogContent(client, "prefix")).rejects.toThrow(/HTTP 403/);
+    expect(streamFn).not.toHaveBeenCalled();
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("self-managed.example.com");
+  });
 });

--- a/tests/utils/log-resolver.test.ts
+++ b/tests/utils/log-resolver.test.ts
@@ -266,9 +266,9 @@ describe("resolveLogContent", () => {
     );
   });
 
-  it("STRICT: host-bound presigned CDN URL (SignedHeaders includes host) is fetched as-is — no host rewrite", async () => {
-    // When X-Amz-SignedHeaders (or X-Goog-SignedHeaders) includes `host`, the signature is tied to
-    // the link hostname. Rewriting to HARNESS_BASE_URL breaks the signature (401 in QA SaaS).
+  it("STRICT: host-bound presigned CDN URL on self-managed instance rewrites hostname (original host unreachable)", async () => {
+    // When X-Amz-SignedHeaders includes `host` AND blob hostname differs from base URL hostname,
+    // rewrite anyway — the original app.harness.io is not reachable on self-managed networks.
     const blobLink =
       "https://app.harness.io/storage/harness-download/logs.zip" +
       "?X-Amz-Algorithm=AWS4-HMAC-SHA256" +
@@ -286,8 +286,8 @@ describe("resolveLogContent", () => {
     await resolveLogContent(client, "prefix");
 
     const fetchUrl = fetchSpy.mock.calls[0]![0] as string;
-    expect(fetchUrl).toContain("app.harness.io");
-    expect(fetchUrl).not.toContain("self-managed.example.com");
+    expect(fetchUrl).toContain("self-managed.example.com");
+    expect(fetchUrl).not.toContain("app.harness.io");
     expect(fetchUrl).toContain("X-Amz-Signature=abc123def456");
     expect(fetchUrl).toContain("X-Amz-Expires=86400");
     expect(fetchUrl).toContain("X-Amz-SignedHeaders=host");
@@ -295,7 +295,30 @@ describe("resolveLogContent", () => {
     expect(fetchUrl).not.toContain("/gateway/storage");
   });
 
-  it("STRICT: GCS host-bound presigned CDN URL is fetched as-is — no host rewrite", async () => {
+  it("STRICT: host-bound presigned CDN URL on matching-host SaaS is fetched as-is — no rewrite needed", async () => {
+    // When X-Amz-SignedHeaders includes `host` AND blob hostname already matches base URL hostname,
+    // skip rewriting — the signature is valid for direct fetch and rewrite would be a no-op.
+    const blobLink =
+      "https://app.harness.io/storage/harness-download/logs.zip" +
+      "?X-Amz-Algorithm=AWS4-HMAC-SHA256" +
+      "&X-Amz-SignedHeaders=host" +
+      "&X-Amz-Signature=abc123def456";
+    fetchSpy.mockResolvedValue(new Response('{"out":"saas direct"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://app.harness.io" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const fetchUrl = fetchSpy.mock.calls[0]![0] as string;
+    expect(fetchUrl).toContain("app.harness.io");
+    expect(fetchUrl).toContain("X-Amz-Signature=abc123def456");
+    expect(fetchUrl).toContain("X-Amz-SignedHeaders=host");
+    expect(fetchUrl).toContain("/storage/harness-download/logs.zip");
+  });
+
+  it("STRICT: GCS host-bound presigned CDN URL on self-managed instance rewrites hostname", async () => {
     const blobLink =
       "https://app.harness.io/storage/harness-download/logs.zip" +
       "?X-Goog-Algorithm=GOOG4-RSA-SHA256" +
@@ -311,8 +334,8 @@ describe("resolveLogContent", () => {
     await resolveLogContent(client, "prefix");
 
     const fetchUrl = fetchSpy.mock.calls[0]![0] as string;
-    expect(fetchUrl).toContain("app.harness.io");
-    expect(fetchUrl).not.toContain("self-managed.example.com");
+    expect(fetchUrl).toContain("self-managed.example.com");
+    expect(fetchUrl).not.toContain("app.harness.io");
     expect(fetchUrl).toContain("X-Goog-Signature=gcs-sig");
     expect(fetchUrl).toContain("X-Goog-SignedHeaders=host");
     expect(fetchUrl).not.toContain("/gateway/storage");

--- a/tests/utils/log-resolver.test.ts
+++ b/tests/utils/log-resolver.test.ts
@@ -722,4 +722,374 @@ describe("resolveLogContent", () => {
     const url = fetchSpy.mock.calls[0]![0] as string;
     expect(url).toContain("self-managed.example.com");
   });
+
+  // ─── Extended coverage: every routing branch and edge case ──────────────────
+  //
+  // Strategy 1 (external S3/GCS) — direct fetch, no rewrite, no auth headers
+  // Strategy 2 (*.harness.io /storage/ CDN) — rewrite hostname, direct fetch
+  // Strategy 3 (everything else) — requestStream via gateway prefix
+
+  // ── Strategy 1 edge cases ───────────────────────────────────────────────────
+
+  it("Strategy 1: regional S3 bucket URL is fetched directly (external host)", async () => {
+    const blobLink = "https://my-bucket.s3.us-east-1.amazonaws.com/logs/run.zip?X-Amz-Signature=s1&X-Amz-Expires=3600";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const streamFn = vi.fn();
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway", requestStream: streamFn },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    expect(streamFn).not.toHaveBeenCalled();
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("my-bucket.s3.us-east-1.amazonaws.com");
+    expect(url).not.toContain("self-managed.example.com");
+  });
+
+  it("Strategy 1: regional S3 path-style URL is fetched directly (external host)", async () => {
+    // my-bucket.s3.us-west-2.amazonaws.com matches S3_BUCKET_HOST_RE → external storage.
+    const blobLink = "https://my-bucket.s3.us-west-2.amazonaws.com/logs/run.zip?X-Amz-Signature=s2";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("s3.us-west-2.amazonaws.com");
+    expect(url).not.toContain("self-managed.example.com");
+  });
+
+  it("Strategy 1: GCS subdomain bucket URL is fetched directly (external host)", async () => {
+    const blobLink = "https://my-bucket.storage.googleapis.com/logs/run.zip?X-Goog-Signature=gcs1";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("storage.googleapis.com");
+    expect(url).not.toContain("self-managed.example.com");
+  });
+
+  it("Strategy 1 beats Strategy 2: S3 URL with host in X-Amz-SignedHeaders is still direct-fetched as external", async () => {
+    // isExternalStorageHost takes priority over the /storage/ presigned-URL path.
+    // An S3 URL must never be routed through Strategy 2 (Harness CDN rewrite).
+    const blobLink = "https://my-bucket.s3.amazonaws.com/storage/run.zip?X-Amz-Signature=s3&X-Amz-SignedHeaders=host";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const streamFn = vi.fn();
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway", requestStream: streamFn },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    expect(streamFn).not.toHaveBeenCalled();
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("s3.amazonaws.com");
+    expect(url).not.toContain("self-managed.example.com");
+  });
+
+  // ── Strategy 2 edge cases ───────────────────────────────────────────────────
+
+  it("Strategy 2: baseURL without a path suffix still rewrites hostname correctly", async () => {
+    // Covers: baseURL = "https://corp.example.com" (no /gateway path).
+    const blobLink = "https://app.harness.io/storage/blob.zip?X-Amz-Signature=np1";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://corp.example.com" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("corp.example.com");
+    expect(url).not.toContain("app.harness.io");
+    expect(url).not.toContain("/gateway");
+    expect(url).toContain("/storage/blob.zip");
+  });
+
+  it("Strategy 2: protocol is also rewritten when baseURL uses HTTP", async () => {
+    const blobLink = "https://app.harness.io/storage/blob.zip?X-Amz-Signature=http1";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "http://corp-internal.example.com/gateway" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toMatch(/^http:\/\/corp-internal\.example\.com/);
+    expect(url).not.toContain("https://app.harness.io");
+  });
+
+  it("Strategy 2: non-app.harness.io Harness host in blob URL is still host-rewritten on self-managed", async () => {
+    // qa.harness.io is a valid Harness SaaS host — isHarnessHost matches it.
+    // When baseURL points to a different self-managed host, it must be rewritten.
+    const blobLink = "https://qa.harness.io/storage/blob.zip?X-Amz-Signature=qa1";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("self-managed.example.com");
+    expect(url).not.toContain("qa.harness.io");
+  });
+
+  it("Strategy 2: GCS blob on self-managed (no host in SignedHeaders) — rewrites hostname", async () => {
+    const blobLink =
+      "https://app.harness.io/storage/blob.zip" +
+      "?X-Goog-Algorithm=GOOG4-RSA-SHA256" +
+      "&X-Goog-SignedHeaders=content-type" +
+      "&X-Goog-Signature=gcsnoh1";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("self-managed.example.com");
+    expect(url).not.toContain("app.harness.io");
+    expect(url).toContain("X-Goog-Signature=gcsnoh1");
+  });
+
+  it("Strategy 2: X-Amz-SignedHeaders with host at end of semicolon list — self-managed still rewrites", async () => {
+    // Checks the split+includes logic handles trailing position correctly.
+    const blobLink =
+      "https://app.harness.io/storage/blob.zip" +
+      "?X-Amz-SignedHeaders=x-amz-date%3Bcontent-type%3Bhost" +
+      "&X-Amz-Signature=tailhost1";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("self-managed.example.com");
+    expect(url).not.toContain("app.harness.io");
+  });
+
+  it("Strategy 2: X-Amz-SignedHeaders present but empty — treated as not including host, rewrite happens", async () => {
+    const blobLink =
+      "https://app.harness.io/storage/blob.zip" +
+      "?X-Amz-SignedHeaders=" +
+      "&X-Amz-Signature=empty1";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("self-managed.example.com");
+    expect(url).not.toContain("app.harness.io");
+  });
+
+  it("Strategy 2: presigned URL path is exactly /storage/ with no further segments — still rewritten", async () => {
+    const blobLink = "https://app.harness.io/storage/?X-Amz-Signature=root1";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("self-managed.example.com");
+    expect(url).toContain("/storage/");
+  });
+
+  it("Strategy 2 not triggered: presigned app.harness.io URL on /api/ path routes to requestStream", async () => {
+    // /api/ does not start with /storage/ — must go to Strategy 3, not Strategy 2.
+    const blobLink =
+      "https://app.harness.io/api/logs/stream" +
+      "?X-Amz-Signature=api1" +
+      "&X-Amz-SignedHeaders=host";
+    const streamFn = vi.fn().mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway", requestStream: streamFn },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(streamFn).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Strategy 3 edge cases ───────────────────────────────────────────────────
+
+  it("Strategy 3: URL already starting with /gateway/log-service/ is not double-prefixed", async () => {
+    const blobLink = "/gateway/log-service/blob/download?prefix=abc";
+    const streamFn = vi.fn().mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway", requestStream: streamFn },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const calledPath = (streamFn.mock.calls[0]![0] as { path: string }).path;
+    expect(calledPath).toMatch(/^\/gateway\/log-service\//);
+    expect(calledPath).not.toContain("/gateway/log-service/gateway/log-service/");
+  });
+
+  it("Strategy 3: non-presigned Harness URL gets /gateway/log-service/ prefix added", async () => {
+    const blobLink = "/log-service/blob/some-id";
+    const streamFn = vi.fn().mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway", requestStream: streamFn },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const calledPath = (streamFn.mock.calls[0]![0] as { path: string }).path;
+    expect(calledPath).toContain("/gateway/log-service/");
+  });
+
+  it("Strategy 3: HarnessApiError from requestStream propagates without wrapping", async () => {
+    class HarnessApiError extends Error {
+      constructor(msg: string) { super(msg); this.name = "HarnessApiError"; }
+    }
+    const blobLink = "/log-service/blob/error-id";
+    const apiErr = new HarnessApiError("401 Unauthorized");
+    const streamFn = vi.fn().mockRejectedValue(apiErr);
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway", requestStream: streamFn },
+    );
+
+    await expect(resolveLogContent(client, "prefix")).rejects.toThrow("401 Unauthorized");
+  });
+
+  // ── isPresignedUrl detection edge cases ─────────────────────────────────────
+
+  it("URL with X-Goog-Signature but no X-Amz-Signature is detected as presigned", async () => {
+    // Validates isPresignedUrl() handles GCS-only signatures correctly.
+    const blobLink =
+      "https://app.harness.io/storage/blob.zip" +
+      "?X-Goog-Signature=gcsonlysig" +
+      "&X-Goog-SignedHeaders=content-type";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("self-managed.example.com");
+  });
+
+  it("URL with neither X-Amz-Signature nor X-Goog-Signature routes to requestStream (not presigned)", async () => {
+    const blobLink = "https://app.harness.io/storage/blob.zip?some-other-param=abc";
+    const streamFn = vi.fn().mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway", requestStream: streamFn },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(streamFn).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Full decision-matrix: signedHeadersIncludeHost × hostname-match ─────────
+  //
+  // This table must stay complete. Any change to the condition
+  // `signedHeadersIncludeHost(blobUrl) && blobUrl.hostname === baseUrl.hostname`
+  // will break at least one of these four tests.
+  //
+  //  signedHeadersIncludeHost | hosts match | expected action
+  //  false                    | false       | rewrite  (covered by REGRESSION tests above)
+  //  false                    | true        | rewrite (no-op)
+  //  true                     | false       | rewrite  ← the bug fixed by this PR
+  //  true                     | true        | direct fetch, no rewrite
+
+  it("MATRIX [false×true]: SignedHeaders has no host, blob host = base host → rewrite (no-op)", async () => {
+    const blobLink =
+      "https://app.harness.io/storage/blob.zip" +
+      "?X-Amz-SignedHeaders=content-type" +
+      "&X-Amz-Signature=noh-same1";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://app.harness.io" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    // hostname unchanged (no-op rewrite), path and params intact
+    expect(url).toContain("app.harness.io");
+    expect(url).toContain("/storage/blob.zip");
+    expect(url).toContain("X-Amz-Signature=noh-same1");
+  });
+
+  it("MATRIX [true×false]: SignedHeaders has host, blob host ≠ base host → rewrite (the fixed bug)", async () => {
+    const blobLink =
+      "https://app.harness.io/storage/blob.zip" +
+      "?X-Amz-SignedHeaders=host" +
+      "&X-Amz-Signature=yh-diff1";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://self-managed.example.com/gateway" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("self-managed.example.com");
+    expect(url).not.toContain("app.harness.io");
+    expect(url).toContain("X-Amz-Signature=yh-diff1");
+  });
+
+  it("MATRIX [true×true]: SignedHeaders has host, blob host = base host → direct fetch, no rewrite", async () => {
+    const blobLink =
+      "https://app.harness.io/storage/blob.zip" +
+      "?X-Amz-SignedHeaders=host" +
+      "&X-Amz-Signature=yh-same1";
+    fetchSpy.mockResolvedValue(new Response('{"out":"ok"}', { status: 200 }));
+    const client = makeClient(
+      vi.fn().mockResolvedValue({ status: "success", link: blobLink }),
+      { baseURL: "https://app.harness.io" },
+    );
+
+    await resolveLogContent(client, "prefix");
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("app.harness.io");
+    expect(url).toContain("X-Amz-Signature=yh-same1");
+    // no rewrite → original URL fetched as-is
+    expect(url).toMatch(/^https:\/\/app\.harness\.io\/storage\/blob\.zip/);
+  });
 });


### PR DESCRIPTION
## Problem

PR #245 added a \`signedHeadersIncludeHost()\` guard in Strategy 2 of \`downloadBlobContent()\`. When \`X-Amz-SignedHeaders\` (or \`X-Goog-SignedHeaders\`) includes \`host\`, it skipped hostname rewriting and fetched the original blob URL directly.

On self-managed Harness deployments the blob URL always points to \`app.harness.io/storage/...\` regardless of \`HARNESS_BASE_URL\`. If \`app.harness.io\` is not reachable from the client network, the direct fetch fails with \`TypeError: fetch failed\`.

## Root cause

The \`signedHeadersIncludeHost\` guard was too broad. It prevented rewriting even when the blob hostname (\`app.harness.io\`) differed from the configured base URL hostname — the case where rewriting is the *only* viable path.

The guard only makes sense when the blob hostname **already matches** the base URL hostname (rewrite is a no-op; direct fetch with the valid signature is correct).

## Fix

Move \`baseUrl\` computation before the \`signedHeadersIncludeHost\` check and add a hostname equality condition. Only skip rewriting when both are true:

1. \`signedHeadersIncludeHost(blobUrl)\` — signature covers the Host header
2. \`blobUrl.hostname === baseUrl.hostname\` — rewrite would be a no-op

When hostnames differ, rewrite regardless of \`SignedHeaders\`.

## Behavior matrix

| Deployment | Blob URL | Base URL | \`host\` in SignedHeaders | Result |
|---|---|---|---|---|
| SaaS | \`app.harness.io\` | \`app.harness.io\` | yes | Direct fetch — no rewrite (correct) |
| SaaS | \`app.harness.io\` | \`app.harness.io\` | no | Rewrite (no-op) then fetch |
| Self-managed | \`app.harness.io\` | \`corp.example.com\` | yes | **Rewrite** then fetch ✅ fixed |
| Self-managed | \`app.harness.io\` | \`corp.example.com\` | no | Rewrite then fetch (unchanged) |

## ⚠️ Reviewer note — this area breaks repeatedly

The blob hostname rewriting logic in \`downloadBlobContent()\` has now broken **three times** across PRs #214, #245, and this one. Each time a change looked locally correct but violated one of the core invariants.

**Please verify all four invariants hold before approving any future change to this function:**

- **A** — blob host ≠ base URL host → always rewrite, even when \`host\` is in SignedHeaders
- **B** — blob host = base URL host → skip rewrite when \`host\` is in SignedHeaders  
- **C** — \`/storage/\` CDN blobs must never fall through to \`requestStream()\`
- **D** — External S3/GCS hosts (amazonaws.com, googleapis.com) bypass all rewriting

These invariants are documented in a warning comment block inside \`downloadBlobContent()\` and enforced by 10 \`REGRESSION-GUARD\` tests in \`tests/utils/log-resolver.test.ts\`. All must stay green.

## Tests

- Corrected 2 existing tests that encoded the wrong behavior for the self-managed case
- Added 1 test for the SaaS same-host case (no rewrite when hostnames already match)
- Added 10 \`REGRESSION-GUARD\` tests covering invariants A–D with edge cases:
  - \`host\` in \`SignedHeaders\` with multiple headers
  - Case-insensitive \`SignedHeaders\` parsing (\`Host\` vs \`host\`)
  - Non-default ports preserved after rewrite
  - Network error surfaces rewritten hostname in error message
  - HTTP 403 after rewrite propagates; \`requestStream\` not attempted as fallback
  - Non-host-bound URLs on self-managed still rewrite (baseline unchanged)