### PR TITLE
feat: Add CRUD support for db instance dbops

### DIFF
--- a/README.md
+++ b/README.md
@@ -1196,7 +1196,7 @@ Template operations use the Harness Template service paths (`/template/api/templ
 | Resource Type                     | List | Get | Create | Update | Delete | Execute Actions |
 | --------------------------------- | ---- | --- | ------ | ------ | ------ | --------------- |
 | `database_schema`                 | x    | x   | x      | x      | x      |                 |
-| `database_instance`               | x    | x   |        |        |        |                 |
+| `database_instance`               | x    | x   | x      | x      | x      |                 |
 | `database_snapshot_object`        | x    | x   |        |        |        |                 |
 | `database_llm_authoring_pipeline` |      | x   |        |        |        |                 |
 

--- a/src/registry/toolsets/dbops.ts
+++ b/src/registry/toolsets/dbops.ts
@@ -201,7 +201,8 @@ const databaseSchemaUpdateSchema = {
 };
 
 // ── Body Schema Fields for Database Instance ────────────────────────────────
-// Note: Per OpenAPI spec DBInstanceIn, only identifier and connector are required for create.
+// Note: OpenAPI DBInstanceIn marks only identifier and connector in `required`, but server-side
+// validation enforces name as well. We mark all three as required here for safer agent behavior.
 // Update has all fields optional.
 
 const databaseInstanceCreateSchema = {

--- a/src/registry/toolsets/dbops.ts
+++ b/src/registry/toolsets/dbops.ts
@@ -200,6 +200,119 @@ const databaseSchemaUpdateSchema = {
   ] as BodyFieldSpec[],
 };
 
+// ── Body Schema Fields for Database Instance ────────────────────────────────
+// Note: Per OpenAPI spec DBInstanceIn, only identifier and connector are required for create.
+// Update has all fields optional.
+
+const databaseInstanceCreateSchema = {
+  description:
+    "Database instance definition. Links a schema's migration scripts to a specific database via a JDBC connector. " +
+    "The connector determines the database engine type and connection details.",
+  fields: [
+    {
+      name: "identifier",
+      type: "string",
+      required: true,
+      description:
+        "Unique instance identifier. Must start with letter/underscore, " +
+        "may contain letters, numbers, underscores, and $. Max 128 chars. " +
+        "Pattern: ^[a-zA-Z_][0-9a-zA-Z_$]{0,127}$",
+    },
+    {
+      name: "name",
+      type: "string",
+      required: false,
+      description: "Instance display name (max 128 chars). If omitted, defaults to identifier.",
+    },
+    {
+      name: "connector",
+      type: "string",
+      required: true,
+      description:
+        "JDBC connector identifier (required). The connector defines the database engine type (MySQL, PostgreSQL, etc.) " +
+        "and connection details including the target database. " +
+        "Use harness_list(resource_type='connector', filters={type: 'Jdbc'}) to find available JDBC connectors.",
+    },
+    {
+      name: "branch",
+      type: "string",
+      required: false,
+      description:
+        "Git branch for this instance. **REQUIRED for Repository/Git-based schemas** (type='Repository'). " +
+        "Specifies which branch to pull migration scripts from. Not needed for Script-based schemas.",
+    },
+    {
+      name: "context",
+      type: "string",
+      required: false,
+      description:
+        "Liquibase/Flyway context filter. Allows you to filter which changesets run for this instance. " +
+        "For example, 'dev', 'staging', 'release' — only changesets tagged with matching contexts will execute. " +
+        "Leave empty to run all changesets.",
+    },
+    {
+      name: "tags",
+      type: "object",
+      required: false,
+      description:
+        "Optional key-value pairs for tagging/labeling the instance. Format: { \"key1\": \"value1\", \"key2\": \"value2\" }",
+    },
+    {
+      name: "substituteProperties",
+      type: "object",
+      required: false,
+      description:
+        "Optional key-value pairs for Liquibase property substitution. These values replace ${property} placeholders in changesets. " +
+        "Format: { \"schemaName\": \"myschema\", \"tablespace\": \"users_ts\" }",
+    },
+  ] as BodyFieldSpec[],
+};
+
+// Update schema: all fields optional for partial updates
+const databaseInstanceUpdateSchema = {
+  description:
+    "Database instance update. Identifier cannot be changed (comes from path). " +
+    "All fields are optional — only include fields you want to update.",
+  fields: [
+    {
+      name: "name",
+      type: "string",
+      required: false,
+      description: "Instance display name",
+    },
+    {
+      name: "connector",
+      type: "string",
+      required: false,
+      description: "JDBC connector identifier",
+    },
+    {
+      name: "branch",
+      type: "string",
+      required: false,
+      description: "Git branch for Repository-type schemas",
+    },
+    {
+      name: "context",
+      type: "string",
+      required: false,
+      description: "Liquibase/Flyway context filter",
+    },
+    {
+      name: "tags",
+      type: "object",
+      required: false,
+      description: "Key-value pairs for tagging/labeling",
+    },
+    {
+      name: "substituteProperties",
+      type: "object",
+      required: false,
+      description: "Liquibase property substitution values",
+    },
+  ] as BodyFieldSpec[],
+};
+
 export const dbopsToolset: ToolsetDefinition = {
   name: "dbops",
   displayName: "Database DevOps",
@@ -328,8 +441,8 @@ export const dbopsToolset: ToolsetDefinition = {
       resourceType: "database_instance",
       displayName: "Database Instance",
       description:
-        "A database instance linked to a schema. Connects the schema's migration scripts " +
-        "to a specific database via a Harness connector. " +
+        "A database instance linked to a schema — supports full CRUD (list, get, create, update, delete). " +
+        "Connects the schema's migration scripts to a specific database via a Harness JDBC connector. " +
         "The 'connector' field holds the connector identifier — the DB engine type " +
         "(MySQL, PostgreSQL, etc.) is determined by that connector. " +
         "Use the connectors toolset to look up the connector when you need the exact engine type or JDBC details.",
@@ -360,7 +473,8 @@ export const dbopsToolset: ToolsetDefinition = {
       ],
       diagnosticHint:
         "If listing fails with 400 or 404, verify the schema identifier (dbschema_id) is correct " +
-        "by first calling harness_list(resource_type='database_schema').",
+        "by first calling harness_list(resource_type='database_schema'). " +
+        "All instance operations require dbschema_id to identify the parent schema.",
       operations: {
         list: {
           method: "POST",
@@ -394,6 +508,62 @@ export const dbopsToolset: ToolsetDefinition = {
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           responseExtractor: passthrough,
           description: "Get a single database instance by identifier",
+        },
+        create: {
+          method: "POST",
+          path: "/dbops/v1/orgs/{org}/projects/{project}/dbschema/{dbschema}/instance",
+          pathParams: {
+            org_id: "org",
+            project_id: "project",
+            dbschema_id: "dbschema",
+          },
+          operationPolicy: { risk: "low_write", retryPolicy: "do_not_retry" },
+          skipScopeBodyInjection: true,
+          // DBOPS API expects flat DBInstanceIn shape at root (no wrapper object)
+          bodyBuilder: (input) => input.body,
+          responseExtractor: passthrough,
+          description:
+            "Create a new database instance under a schema. Links the schema's migration scripts to a specific database. " +
+            "Required: name, identifier, connector (JDBC connector ID). " +
+            "For Repository-type schemas, branch is REQUIRED to specify the git branch. " +
+            "Optional: context (Liquibase context filter), tags, substituteProperties. " +
+            "The dbschema_id must be provided in params to specify the parent schema.",
+          bodySchema: databaseInstanceCreateSchema,
+        },
+        update: {
+          method: "PUT",
+          path: "/dbops/v1/orgs/{org}/projects/{project}/dbschema/{dbschema}/instance/{dbinstance}",
+          pathParams: {
+            org_id: "org",
+            project_id: "project",
+            dbschema_id: "dbschema",
+            dbinstance_id: "dbinstance",
+          },
+          operationPolicy: { risk: "low_write", retryPolicy: "safe" },
+          skipScopeBodyInjection: true,
+          // DBOPS API expects flat DBInstanceUpdateRequest shape at root (no wrapper object)
+          bodyBuilder: (input) => input.body,
+          responseExtractor: passthrough,
+          description:
+            "Update an existing database instance. All fields are optional — only include what you want to change. " +
+            "Identifier cannot be changed (comes from dbinstance_id in path).",
+          bodySchema: databaseInstanceUpdateSchema,
+        },
+        delete: {
+          method: "DELETE",
+          path: "/dbops/v1/orgs/{org}/projects/{project}/dbschema/{dbschema}/instance/{dbinstance}",
+          pathParams: {
+            org_id: "org",
+            project_id: "project",
+            dbschema_id: "dbschema",
+            dbinstance_id: "dbinstance",
+          },
+          operationPolicy: { risk: "destructive", retryPolicy: "do_not_retry" },
+          responseExtractor: passthrough,
+          description:
+            "Delete a database instance. WARNING: This removes the instance and its migration execution history. " +
+            "The underlying database is NOT affected — only Harness's record of applied migrations. " +
+            "This action cannot be undone.",
         },
       },
     },

--- a/src/registry/toolsets/dbops.ts
+++ b/src/registry/toolsets/dbops.ts
@@ -221,8 +221,8 @@ const databaseInstanceCreateSchema = {
     {
       name: "name",
       type: "string",
-      required: false,
-      description: "Instance display name (max 128 chars). If omitted, defaults to identifier.",
+      required: true,
+      description: "Instance display name (max 128 chars).",
     },
     {
       name: "connector",
@@ -238,8 +238,9 @@ const databaseInstanceCreateSchema = {
       type: "string",
       required: false,
       description:
-        "Git branch for this instance. **REQUIRED for Repository/Git-based schemas** (type='Repository'). " +
-        "Specifies which branch to pull migration scripts from. Not needed for Script-based schemas.",
+        "Git branch for this instance. **REQUIRED when parent schema uses GIT or Harness Code source**. " +
+        "Specifies which branch to pull migration scripts from. Not needed for Script-based schemas. " +
+        "Check the parent schema's source type via harness_get before creating the instance.",
     },
     {
       name: "context",
@@ -474,7 +475,9 @@ export const dbopsToolset: ToolsetDefinition = {
       diagnosticHint:
         "If listing fails with 400 or 404, verify the schema identifier (dbschema_id) is correct " +
         "by first calling harness_list(resource_type='database_schema'). " +
-        "All instance operations require dbschema_id to identify the parent schema.",
+        "All instance operations require dbschema_id to identify the parent schema. " +
+        "For create: if the API returns 400 about 'branch', the parent schema uses GIT/Harness Code source — " +
+        "call harness_get on the schema to check its source type, then retry with branch specified.",
       operations: {
         list: {
           method: "POST",
@@ -524,9 +527,10 @@ export const dbopsToolset: ToolsetDefinition = {
           responseExtractor: passthrough,
           description:
             "Create a new database instance under a schema. Links the schema's migration scripts to a specific database. " +
-            "Required: name, identifier, connector (JDBC connector ID). " +
-            "For Repository-type schemas, branch is REQUIRED to specify the git branch. " +
+            "Required: identifier, name, connector (JDBC connector ID). " +
+            "For Git-based schemas (GIT or Harness Code source), branch is REQUIRED. " +
             "Optional: context (Liquibase context filter), tags, substituteProperties. " +
+            "TIP: Call harness_get on the parent schema first to check its source type and determine if branch is needed. " +
             "The dbschema_id must be provided in params to specify the parent schema.",
           bodySchema: databaseInstanceCreateSchema,
         },

--- a/tests/registry/dbops.test.ts
+++ b/tests/registry/dbops.test.ts
@@ -573,12 +573,12 @@ describe("database_instance create bodySchema", () => {
     const fields = spec.bodySchema!.fields;
     const fieldMap = Object.fromEntries(fields.map((f) => [f.name, f]));
 
-    // Required fields per OpenAPI: only identifier and connector
+    // Required fields: identifier, name, connector
     expect(fieldMap.identifier.required).toBe(true);
+    expect(fieldMap.name.required).toBe(true);
     expect(fieldMap.connector.required).toBe(true);
 
-    // Optional fields per OpenAPI
-    expect(fieldMap.name.required).toBe(false);
+    // Optional fields
     expect(fieldMap.branch.required).toBe(false);
     expect(fieldMap.context.required).toBe(false);
     expect(fieldMap.tags.required).toBe(false);
@@ -592,12 +592,13 @@ describe("database_instance create bodySchema", () => {
     expect(idField!.description).toContain("^[a-zA-Z_][0-9a-zA-Z_$]{0,127}$");
   });
 
-  it("branch description mentions it is required for Repository-type schemas", () => {
+  it("branch description mentions it is required for GIT/Harness Code schemas", () => {
     const spec = getOp("database_instance", "create");
     const branchField = spec.bodySchema!.fields.find((f) => f.name === "branch");
 
     expect(branchField!.description).toContain("REQUIRED");
-    expect(branchField!.description).toContain("Repository");
+    expect(branchField!.description).toContain("GIT");
+    expect(branchField!.description).toContain("Harness Code");
   });
 });
 
@@ -628,6 +629,7 @@ describe("database_instance update bodySchema", () => {
     expect(fieldNames).toContain("context");
     expect(fieldNames).toContain("tags");
     expect(fieldNames).toContain("substituteProperties");
+    // NOTE: OpenAPI has 'version' but it's a no-op in the backend — not exposed to agents
   });
 });
 

--- a/tests/registry/dbops.test.ts
+++ b/tests/registry/dbops.test.ts
@@ -491,7 +491,170 @@ describe("database_instance CRUD operations", () => {
     expect(call.path).toBe("/dbops/v1/orgs/default/projects/test-project/dbschema/my_schema/instance/my_instance");
   });
 
-  // NOTE: database_instance create/update/delete tests are in the feat/dbinstance branch
+  it("create: uses POST and passes flat body through without scope injection", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ identifier: "new_instance" });
+    const client = makeClient(mockRequest);
+
+    const body = {
+      identifier: "new_instance",
+      name: "New Instance",
+      connector: "jdbc_connector",
+      branch: "main",
+    };
+
+    await registry.dispatch(client, "database_instance", "create", {
+      dbschema_id: "my_schema",
+      project_id: "test-project",
+      org_id: "default",
+      body,
+    });
+
+    const call = mockRequest.mock.calls[0][0];
+    expect(call.method).toBe("POST");
+    expect(call.path).toBe("/dbops/v1/orgs/default/projects/test-project/dbschema/my_schema/instance");
+    // Use immutable literal to catch mutation bugs — body must stay flat without scope injection
+    expect(call.body).toEqual({
+      identifier: "new_instance",
+      name: "New Instance",
+      connector: "jdbc_connector",
+      branch: "main",
+    });
+    // Explicitly verify no scope fields were injected
+    expect(call.body).not.toHaveProperty("orgIdentifier");
+    expect(call.body).not.toHaveProperty("projectIdentifier");
+  });
+
+  it("update: uses PUT with dbinstance_id in path without scope injection", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ identifier: "my_instance" });
+    const client = makeClient(mockRequest);
+
+    const body = { name: "Updated Instance", tags: { env: "staging" } };
+
+    await registry.dispatch(client, "database_instance", "update", {
+      dbschema_id: "my_schema",
+      dbinstance_id: "my_instance",
+      project_id: "test-project",
+      org_id: "default",
+      body,
+    });
+
+    const call = mockRequest.mock.calls[0][0];
+    expect(call.method).toBe("PUT");
+    expect(call.path).toBe("/dbops/v1/orgs/default/projects/test-project/dbschema/my_schema/instance/my_instance");
+    // Use immutable literal to catch mutation bugs
+    expect(call.body).toEqual({ name: "Updated Instance", tags: { env: "staging" } });
+    // Explicitly verify no scope fields were injected
+    expect(call.body).not.toHaveProperty("orgIdentifier");
+    expect(call.body).not.toHaveProperty("projectIdentifier");
+  });
+
+  it("delete: uses DELETE with dbinstance_id in path", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({});
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "database_instance", "delete", {
+      dbschema_id: "my_schema",
+      dbinstance_id: "my_instance",
+      project_id: "test-project",
+      org_id: "default",
+    });
+
+    const call = mockRequest.mock.calls[0][0];
+    expect(call.method).toBe("DELETE");
+    expect(call.path).toBe("/dbops/v1/orgs/default/projects/test-project/dbschema/my_schema/instance/my_instance");
+  });
+});
+
+describe("database_instance create bodySchema", () => {
+  it("has correct required and optional fields per OpenAPI DBInstanceIn", () => {
+    const spec = getOp("database_instance", "create");
+    expect(spec.bodySchema).toBeDefined();
+
+    const fields = spec.bodySchema!.fields;
+    const fieldMap = Object.fromEntries(fields.map((f) => [f.name, f]));
+
+    // Required fields per OpenAPI: only identifier and connector
+    expect(fieldMap.identifier.required).toBe(true);
+    expect(fieldMap.connector.required).toBe(true);
+
+    // Optional fields per OpenAPI
+    expect(fieldMap.name.required).toBe(false);
+    expect(fieldMap.branch.required).toBe(false);
+    expect(fieldMap.context.required).toBe(false);
+    expect(fieldMap.tags.required).toBe(false);
+    expect(fieldMap.substituteProperties.required).toBe(false);
+  });
+
+  it("identifier has pattern description from OpenAPI", () => {
+    const spec = getOp("database_instance", "create");
+    const idField = spec.bodySchema!.fields.find((f) => f.name === "identifier");
+
+    expect(idField!.description).toContain("^[a-zA-Z_][0-9a-zA-Z_$]{0,127}$");
+  });
+
+  it("branch description mentions it is required for Repository-type schemas", () => {
+    const spec = getOp("database_instance", "create");
+    const branchField = spec.bodySchema!.fields.find((f) => f.name === "branch");
+
+    expect(branchField!.description).toContain("REQUIRED");
+    expect(branchField!.description).toContain("Repository");
+  });
+});
+
+describe("database_instance update bodySchema", () => {
+  it("has all fields optional (no identifier)", () => {
+    const spec = getOp("database_instance", "update");
+    expect(spec.bodySchema).toBeDefined();
+
+    const fields = spec.bodySchema!.fields;
+    const fieldNames = fields.map((f) => f.name);
+
+    // identifier should NOT be in update schema
+    expect(fieldNames).not.toContain("identifier");
+
+    // All fields should be optional
+    for (const field of fields) {
+      expect(field.required, `${field.name} should be optional`).toBe(false);
+    }
+  });
+
+  it("contains all expected update fields", () => {
+    const spec = getOp("database_instance", "update");
+    const fieldNames = spec.bodySchema!.fields.map((f) => f.name);
+
+    expect(fieldNames).toContain("name");
+    expect(fieldNames).toContain("connector");
+    expect(fieldNames).toContain("branch");
+    expect(fieldNames).toContain("context");
+    expect(fieldNames).toContain("tags");
+    expect(fieldNames).toContain("substituteProperties");
+  });
+});
+
+describe("database_instance operationPolicy", () => {
+  it("create: low_write risk, do_not_retry", () => {
+    const spec = getOp("database_instance", "create");
+    expect(spec.operationPolicy).toEqual({
+      risk: "low_write",
+      retryPolicy: "do_not_retry",
+    });
+  });
+
+  it("update: low_write risk, safe retryPolicy (idempotent PUT)", () => {
+    const spec = getOp("database_instance", "update");
+    expect(spec.operationPolicy).toEqual({
+      risk: "low_write",
+      retryPolicy: "safe",
+    });
+  });
+
+  it("delete: destructive risk, do_not_retry", () => {
+    const spec = getOp("database_instance", "delete");
+    expect(spec.operationPolicy).toEqual({
+      risk: "destructive",
+      retryPolicy: "do_not_retry",
+    });
+  });
 });
 
 describe("database_instance resource metadata", () => {
@@ -501,10 +664,33 @@ describe("database_instance resource metadata", () => {
     expect(res.identifierFields).toContain("dbinstance_id");
   });
 
+  it("description mentions CRUD operations", () => {
+    const res = findResource("database_instance");
+    expect(res.description).toContain("CRUD");
+  });
+
+  it("delete description warns about migration history deletion", () => {
+    const spec = getOp("database_instance", "delete");
+    expect(spec.description).toContain("migration");
+    expect(spec.description).toContain("cannot be undone");
+  });
+
   it("has dbschema_id as required listFilterField", () => {
     const res = findResource("database_instance");
     const schemaFilter = res.listFilterFields?.find((f) => f.name === "dbschema_id");
     expect(schemaFilter).toBeDefined();
     expect(schemaFilter!.required).toBe(true);
+  });
+});
+
+describe("database_instance skipScopeBodyInjection", () => {
+  it("create has skipScopeBodyInjection enabled", () => {
+    const spec = getOp("database_instance", "create");
+    expect(spec.skipScopeBodyInjection).toBe(true);
+  });
+
+  it("update has skipScopeBodyInjection enabled", () => {
+    const spec = getOp("database_instance", "update");
+    expect(spec.skipScopeBodyInjection).toBe(true);
   });
 });


### PR DESCRIPTION

Adds full CRUD (Create, Update, Delete) support for `database_instance` resource in the DBOps toolset.
| Operation | Method | Path | Risk | Retry |
|-----------|--------|------|------|-------|
| Create | `POST` | `/dbschema/{dbschema}/instance` | `low_write` | `do_not_retry` |
| Update | `PUT` | `/dbschema/{dbschema}/instance/{dbinstance}` | `low_write` | `safe` |
| Delete | `DELETE` | `/dbschema/{dbschema}/instance/{dbinstance}` | `destructive` | `do_not_retry` |
## What's Changed
### New Instance Operations
- **Create**: Supports all fields from OpenAPI `DBInstanceIn` schema
- **Update**: Partial updates with all fields optional per `DBInstanceUpdateRequest`
- **Delete**: Includes warning about migration history deletion
### Body Schema Alignment
**Create**
- Required: `identifier`, `connector`
- Optional: `name`, `branch`, `context`, `tags`, `substituteProperties`
**Update**
- All fields optional: `name`, `connector`, `branch`, `context`, `tags`, `substituteProperties`
### Technical Details
- `skipScopeBodyInjection: true` — DBOPS API expects flat payloads without `orgIdentifier`/`projectIdentifier`
- `retryPolicy: "safe"` for update — PUT is idempotent
- `risk: "destructive"` for delete — warns about cascading data loss

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] Tests pass
- [x] Typecheck passes
