### PR TITLE
fix: allow write operations on clients without elicitation support

### DIFF
--- a/src/tools/harness-create.ts
+++ b/src/tools/harness-create.ts
@@ -28,6 +28,7 @@ export function registerCreateTool(server: McpServer, registry: Registry, client
         resource_scope: resourceScopeSchema,
         org_id: z.string().describe("Organization identifier (overrides default)").optional(),
         project_id: z.string().describe("Project identifier (overrides default)").optional(),
+        confirm: z.boolean().describe("Set to true to confirm the operation. Required when the client does not support interactive confirmation prompts (e.g. managed MCP).").optional(),
         params: z.record(z.string(), z.unknown()).describe("Additional parameters. For external Git pipelines: store_type='REMOTE', connector_ref, repo_name, branch, file_path, commit_msg. For Harness Code pipelines: store_type='REMOTE', is_harness_code_repo=true, repo_name, branch, file_path.").optional(),
       },
       outputSchema: createOutputSchema,
@@ -41,7 +42,7 @@ export function registerCreateTool(server: McpServer, registry: Registry, client
     },
     async (args) => {
       try {
-        const { params, body, ...rest } = args;
+        const { params, body, confirm: _confirm, ...rest } = args;
         const coercedBody = typeof body === "string" ? (coerceRecord(body) ?? body) : body;
         const input = applyUrlDefaults({ ...rest, body: coercedBody } as Record<string, unknown>, args.url);
         const coercedParams = coerceRecord(params);
@@ -63,9 +64,12 @@ export function registerCreateTool(server: McpServer, registry: Registry, client
           message: `Create ${args.resource_type}?\n\n${bodyPreview}`,
           risk,
           autoApproveRisk: config?.HARNESS_AUTO_APPROVE_RISK,
+          callerConfirmed: args.confirm === true,
         });
         if (!elicit.proceed) {
-          return errorResult(`Operation ${elicit.reason} by user.`);
+          return errorResult(
+            `Operation ${elicit.reason} by user. Hint: if your client does not support interactive confirmation, pass confirm: true to proceed.`,
+          );
         }
 
         const result = await registry.dispatch(client, args.resource_type, "create", input, { tool: "harness_create", confirmation: elicit.method });

--- a/src/tools/harness-delete.ts
+++ b/src/tools/harness-delete.ts
@@ -25,6 +25,7 @@ export function registerDeleteTool(server: McpServer, registry: Registry, client
         resource_scope: resourceScopeSchema,
         org_id: z.string().describe("Organization identifier (overrides default)").optional(),
         project_id: z.string().describe("Project identifier (overrides default)").optional(),
+        confirm: z.boolean().describe("Set to true to confirm the destructive operation. Required when the client does not support interactive confirmation prompts (e.g. managed MCP).").optional(),
         params: z.record(z.string(), z.unknown()).describe("Additional identifiers for nested resources (e.g. pipeline_id for triggers/input sets, environment_id for infrastructure).").optional(),
       },
       outputSchema: deleteOutputSchema,
@@ -50,11 +51,14 @@ export function registerDeleteTool(server: McpServer, registry: Registry, client
           message: `Delete ${args.resource_type} "${args.resource_id}"?\n\nThis is destructive and cannot be undone.`,
           risk: "destructive",
           autoApproveRisk: config?.HARNESS_AUTO_APPROVE_RISK,
+          callerConfirmed: args.confirm === true,
         });
         if (!elicit.proceed) {
-          return errorResult(`Operation ${elicit.reason} by user.`);
+          return errorResult(
+            `Operation ${elicit.reason} by user. Hint: if your client does not support interactive confirmation, pass confirm: true to proceed.`,
+          );
         }
-        const { params, ...rest } = args;
+        const { params, confirm: _confirm, ...rest } = args;
         const input = applyUrlDefaults(rest as Record<string, unknown>, args.url);
         const coercedParams = coerceRecord(params);
         if (coercedParams) Object.assign(input, coercedParams);

--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -65,6 +65,7 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
         input_set_ids: z.array(z.string()).describe("Input set IDs for complex pipelines. List available: harness_list(resource_type='input_set', filters={pipeline_id: '...'}).").optional(),
         body: z.record(z.string(), z.unknown()).describe("Additional body payload for the action").optional(),
         params: z.record(z.string(), z.unknown()).describe("Action-specific parameters. Call harness_describe for available fields per resource_type.").optional(),
+        confirm: z.boolean().describe("Set to true to confirm the operation. Required when the client does not support interactive confirmation prompts (e.g. managed MCP).").optional(),
         wait: z.boolean().describe("For pipeline run/retry actions: block until the execution reaches a terminal status (Success/Failed/Aborted/Errored/Expired). Server-side polling — a single tool call gives the agent the final outcome instead of an LLM polling loop. Ignored for other actions.").optional(),
         wait_timeout_seconds: z.number().min(10).max(7200).describe("Max seconds to wait when wait=true. Default 600 (10 min). Max 7200 (2 h). When the timeout fires, returns execution_timed_out=true with the last observed status.").optional(),
         wait_poll_interval_seconds: z.number().min(2).max(60).describe("Initial poll interval when wait=true (seconds). Default 3. Backoff multiplier 1.5x, capped at 30s.").optional(),
@@ -80,7 +81,7 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
     },
     async (args, extra) => {
       try {
-        const { params, wait, wait_timeout_seconds, wait_poll_interval_seconds, ...rest } = args;
+        const { params, wait, wait_timeout_seconds, wait_poll_interval_seconds, confirm: _confirm, ...rest } = args;
         const input = applyUrlDefaults(rest as Record<string, unknown>, args.url);
         const coercedParams = coerceRecord(params);
         if (coercedParams) Object.assign(input, coercedParams);
@@ -107,9 +108,12 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
           message: `Execute "${args.action}" on ${resourceType}${resourceId ? ` "${resourceId}"` : ""}?`,
           risk,
           autoApproveRisk: config?.HARNESS_AUTO_APPROVE_RISK,
+          callerConfirmed: args.confirm === true,
         });
         if (!elicit.proceed) {
-          return errorResult(`Operation ${elicit.reason} by user.`);
+          return errorResult(
+            `Operation ${elicit.reason} by user. Hint: if your client does not support interactive confirmation, pass confirm: true to proceed.`,
+          );
         }
 
         // Map resource_id → identifierFields[0] (the documented primary field).

--- a/src/tools/harness-update.ts
+++ b/src/tools/harness-update.ts
@@ -29,6 +29,7 @@ export function registerUpdateTool(server: McpServer, registry: Registry, client
         ]).describe("The updated resource definition body. For pipelines: pass a YAML string directly, or an object with yamlPipeline (YAML string) or pipeline (JSON object)"),
         org_id: z.string().describe("Organization identifier (overrides default)").optional(),
         project_id: z.string().describe("Project identifier (overrides default)").optional(),
+        confirm: z.boolean().describe("Set to true to confirm the operation. Required when the client does not support interactive confirmation prompts (e.g. managed MCP).").optional(),
         params: z.record(z.string(), z.unknown()).describe("Additional identifiers (e.g. pipeline_id for triggers/input sets, version_label for templates).").optional(),
       },
       outputSchema: updateOutputSchema,
@@ -58,11 +59,14 @@ export function registerUpdateTool(server: McpServer, registry: Registry, client
           message: `Update ${args.resource_type} "${args.resource_id}"?\n\n${bodyPreview}`,
           risk,
           autoApproveRisk: config?.HARNESS_AUTO_APPROVE_RISK,
+          callerConfirmed: args.confirm === true,
         });
         if (!elicit.proceed) {
-          return errorResult(`Operation ${elicit.reason} by user.`);
+          return errorResult(
+            `Operation ${elicit.reason} by user. Hint: if your client does not support interactive confirmation, pass confirm: true to proceed.`,
+          );
         }
-        const { params, body, ...rest } = args;
+        const { params, body, confirm: _confirm, ...rest } = args;
         const coercedBody = typeof body === "string" ? (coerceRecord(body) ?? body) : body;
         const input = applyUrlDefaults({ ...rest, body: coercedBody } as Record<string, unknown>, args.url);
         const coercedParams = coerceRecord(params);

--- a/src/utils/elicitation.ts
+++ b/src/utils/elicitation.ts
@@ -49,6 +49,7 @@ export async function confirmViaElicitation({
   message,
   risk,
   autoApproveRisk,
+  callerConfirmed,
 }: {
   server: McpServer;
   toolName: string;
@@ -57,6 +58,9 @@ export async function confirmViaElicitation({
   risk: RiskLevel;
   /** Optional per-session threshold. Falls back to the process default. */
   autoApproveRisk?: AutoApproveRisk;
+  /** When true, the caller explicitly passed confirm=true — acts as confirmation
+   *  on clients that lack elicitation support (managed MCP, Cursor, etc.). */
+  callerConfirmed?: boolean;
 }): Promise<ElicitationResult> {
   const threshold = autoApproveRisk ?? _autoApproveRisk;
   if (shouldAutoApprove(risk, threshold)) {
@@ -66,6 +70,10 @@ export async function confirmViaElicitation({
 
   if (!clientSupportsElicitation(server.server)) {
     if (requiresConfirmation(risk)) {
+      if (callerConfirmed) {
+        log.info("Client lacks elicitation, proceeding via explicit confirm param", { toolName, risk });
+        return { proceed: true, method: "elicited" };
+      }
       log.warn("Client does not support elicitation, blocking operation", { toolName, risk });
       return { proceed: false, reason: "declined", method: "blocked" };
     }
@@ -94,6 +102,10 @@ export async function confirmViaElicitation({
     return { proceed: false, reason: "cancelled", method: "elicited" };
   } catch (err) {
     if (requiresConfirmation(risk)) {
+      if (callerConfirmed) {
+        log.info("Elicitation failed but proceeding via explicit confirm param", { toolName, risk, error: String(err) });
+        return { proceed: true, method: "elicited" };
+      }
       log.warn("Elicitation failed, blocking operation", {
         toolName,
         risk,

--- a/tests/utils/elicitation.test.ts
+++ b/tests/utils/elicitation.test.ts
@@ -283,4 +283,54 @@ describe("confirmViaElicitation", () => {
     expect(result).toEqual({ proceed: true, method: "auto_approved" });
     expect(mcpServer.server.elicitInput).not.toHaveBeenCalled();
   });
+
+  it("proceeds with callerConfirmed when client lacks elicitation (destructive)", async () => {
+    const mcpServer = makeServerStub(undefined);
+    const result = await confirmViaElicitation({
+      server: mcpServer,
+      toolName: "harness_delete",
+      message: "Delete pipeline?",
+      risk: "destructive",
+      callerConfirmed: true,
+    });
+    expect(result).toEqual({ proceed: true, method: "elicited" });
+    expect(mcpServer.server.elicitInput).not.toHaveBeenCalled();
+  });
+
+  it("proceeds with callerConfirmed when client lacks elicitation (medium_write)", async () => {
+    const mcpServer = makeServerStub(undefined);
+    const result = await confirmViaElicitation({
+      server: mcpServer,
+      toolName: "harness_create",
+      message: "Create repo rule?",
+      risk: "medium_write",
+      callerConfirmed: true,
+    });
+    expect(result).toEqual({ proceed: true, method: "elicited" });
+  });
+
+  it("proceeds with callerConfirmed when elicitInput throws (destructive)", async () => {
+    const mcpServer = makeServerStub({ elicitation: { form: {} } });
+    mcpServer.server.elicitInput.mockRejectedValue(new Error("not implemented"));
+    const result = await confirmViaElicitation({
+      server: mcpServer,
+      toolName: "harness_delete",
+      message: "Delete service?",
+      risk: "destructive",
+      callerConfirmed: true,
+    });
+    expect(result).toEqual({ proceed: true, method: "elicited" });
+  });
+
+  it("still blocks without callerConfirmed when client lacks elicitation (destructive)", async () => {
+    const mcpServer = makeServerStub(undefined);
+    const result = await confirmViaElicitation({
+      server: mcpServer,
+      toolName: "harness_delete",
+      message: "Delete pipeline?",
+      risk: "destructive",
+      callerConfirmed: false,
+    });
+    expect(result).toEqual({ proceed: false, reason: "declined", method: "blocked" });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #150 — `harness_delete` (and other write tools) fail with "Operation cancelled by user" on managed MCP and Cursor because these clients don't advertise MCP elicitation capability.

- Adds optional `confirm: true` parameter to `harness_delete`, `harness_create`, `harness_update`, and `harness_execute`
- When a client lacks elicitation support, passing `confirm: true` allows the operation to proceed — the client's own tool-approval UX (Cursor's "Allow" button, Claude's permission prompt) serves as the safety gate
- Without `confirm: true`, behavior is unchanged (operation is blocked with an improved error message including a hint)
- Error messages now include: `Hint: if your client does not support interactive confirmation, pass confirm: true to proceed.`

## Changes

| File | What |
|------|------|
| `src/utils/elicitation.ts` | Accept `callerConfirmed` param; bypass block when true |
| `src/tools/harness-delete.ts` | Add `confirm` input param, pass to elicitation, exclude from dispatch |
| `src/tools/harness-create.ts` | Same |
| `src/tools/harness-update.ts` | Same |
| `src/tools/harness-execute.ts` | Same |
| `tests/utils/elicitation.test.ts` | 4 new tests covering callerConfirmed behavior |

## Test plan

- [x] All 1673 tests pass (4 new)
- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] Manual: connect via managed MCP, call `harness_delete` without `confirm` → see improved error with hint
- [x] Manual: call `harness_delete` with `confirm: true` → operation proceeds
- [x] Manual: local stdio with elicitation-capable client → existing flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)