### PR TITLE
fix: translate pr_comment inline line numbers to upstream Code API fields

### DIFF
--- a/src/registry/toolsets/pull-requests.ts
+++ b/src/registry/toolsets/pull-requests.ts
@@ -269,19 +269,35 @@ export const pullRequestsToolset: ToolsetDefinition = {
             repo_id: "repoIdentifier",
             pr_number: "prNumber",
           },
-          bodyBuilder: (input) => input.body,
+          bodyBuilder: (input) => {
+            const b = { ...(input.body as Record<string, unknown>) };
+            if (typeof b.line_new === "number") {
+              b.line_start = b.line_new;
+              b.line_end = b.line_new;
+              b.line_start_new = true;
+              b.line_end_new = true;
+              delete b.line_new;
+            } else if (typeof b.line_old === "number") {
+              b.line_start = b.line_old;
+              b.line_end = b.line_old;
+              b.line_start_new = false;
+              b.line_end_new = false;
+              delete b.line_old;
+            }
+            return b;
+          },
           responseExtractor: passthrough,
           description:
-            "Add a comment to a pull request. Body fields: text (required). For inline code comments, also include: path, line_new/line_old, source_commit_sha, target_commit_sha.",
+            "Add a comment to a pull request. Body fields: text (required). For inline code comments, also include: path, line_new OR line_old (line number on the new or old side of the diff), source_commit_sha, target_commit_sha.",
           bodySchema: {
             description: "PR comment content",
             fields: [
               { name: "text", type: "string", required: true, description: "Comment text (markdown supported)" },
               { name: "path", type: "string", required: false, description: "File path for inline code comment" },
-              { name: "line_new", type: "number", required: false, description: "Line number in new file for inline comment" },
-              { name: "line_old", type: "number", required: false, description: "Line number in old file for inline comment" },
-              { name: "source_commit_sha", type: "string", required: false, description: "Source commit SHA for code comment context" },
-              { name: "target_commit_sha", type: "string", required: false, description: "Target commit SHA for code comment context" },
+              { name: "line_new", type: "number", required: false, description: "Line number in the new file version for inline comment (mutually exclusive with line_old)" },
+              { name: "line_old", type: "number", required: false, description: "Line number in the old file version for inline comment (mutually exclusive with line_new)" },
+              { name: "source_commit_sha", type: "string", required: false, description: "Source commit SHA (HEAD of source branch) for code comment context" },
+              { name: "target_commit_sha", type: "string", required: false, description: "Target/merge-base commit SHA for code comment context" },
             ],
           },
         },

--- a/tests/registry/pull-requests.test.ts
+++ b/tests/registry/pull-requests.test.ts
@@ -101,3 +101,85 @@ describe("pull_request registry mappings", () => {
     }));
   });
 });
+
+describe("pr_comment bodyBuilder translation", () => {
+  it("translates line_new to line_start/line_end with line_start_new=true", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pull-requests" }));
+    const mockRequest = vi.fn().mockResolvedValue({ data: { id: 1 } });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "pr_comment", "create", {
+      repo_id: "my_repo",
+      pr_number: "5",
+      body: {
+        text: "inline comment",
+        path: "main.ts",
+        line_new: 8,
+        source_commit_sha: "abc123",
+        target_commit_sha: "def456",
+      },
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith(expect.objectContaining({
+      method: "POST",
+      path: "/code/api/v1/repos/my_repo/pullreq/5/comments",
+      body: {
+        text: "inline comment",
+        path: "main.ts",
+        line_start: 8,
+        line_end: 8,
+        line_start_new: true,
+        line_end_new: true,
+        source_commit_sha: "abc123",
+        target_commit_sha: "def456",
+      },
+    }));
+  });
+
+  it("translates line_old to line_start/line_end with line_start_new=false", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pull-requests" }));
+    const mockRequest = vi.fn().mockResolvedValue({ data: { id: 2 } });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "pr_comment", "create", {
+      repo_id: "my_repo",
+      pr_number: "5",
+      body: {
+        text: "old side comment",
+        path: "removed.ts",
+        line_old: 12,
+        source_commit_sha: "abc123",
+        target_commit_sha: "def456",
+      },
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith(expect.objectContaining({
+      body: {
+        text: "old side comment",
+        path: "removed.ts",
+        line_start: 12,
+        line_end: 12,
+        line_start_new: false,
+        line_end_new: false,
+        source_commit_sha: "abc123",
+        target_commit_sha: "def456",
+      },
+    }));
+  });
+
+  it("passes general comments through without translation", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pull-requests" }));
+    const mockRequest = vi.fn().mockResolvedValue({ data: { id: 3 } });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "pr_comment", "create", {
+      repo_id: "my_repo",
+      pr_number: "5",
+      body: { text: "general comment" },
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith(expect.objectContaining({
+      body: { text: "general comment" },
+    }));
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes inline PR code comments returning HTTP 400 (`Code comments require line numbers`) when using `harness_create(resource_type="pr_comment", ...)`
- The `bodyBuilder` now translates agent-friendly `line_new`/`line_old` into the upstream Code API's expected `line_start`, `line_end`, `line_start_new`, `line_end_new` fields
- General (non-inline) comments are unaffected — pass-through behavior preserved

## Test plan
- [x] Unit tests added for `line_new` translation (new-file side)
- [x] Unit tests added for `line_old` translation (old-file side)
- [x] Unit test confirms general comments pass through unchanged
- [x] Full test suite passes (1756 tests)
- [ ] Manual validation with MCP Inspector against a real Harness Code PR

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)