### PR TITLE
feat: execute llm authoring pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Harness MCP Server 2.0
 
-An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 195 resource types.
+An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 196 resource types.
 
 ## Why Use This MCP Server
 
@@ -8,7 +8,7 @@ Most MCP servers map one tool per API endpoint. For a platform as broad as Harne
 
 This server is built differently:
 
-- **11 tools, 195 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
+- **11 tools, 196 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
 - **Full platform coverage.** 32 default toolsets spanning CI/CD, GitOps, Feature Flags, Cloud Cost Management, Security Testing, Chaos Engineering, Database DevOps, Internal Developer Portal, Software Supply Chain, Governance, Service Overrides, Visualizations, and more. Opt-in IaCM coverage is available when you need Terraform workspace and module data.
 - **Multi-project workflows out of the box.** Agents discover organizations and projects dynamically — no hardcoded env vars needed. Ask "show failed executions across all projects" and the agent can navigate the full account hierarchy.
 - **32 prompt templates.** Pre-built prompts for common workflows: build & deploy apps end-to-end, debug failed pipelines, review DORA metrics, triage vulnerabilities, optimize cloud costs, audit access control, plan feature flag rollouts, review pull requests, approve pending pipelines, and more.
@@ -1040,7 +1040,7 @@ Harness pipelines can be stored in three ways:
 
 ## Resource Types
 
-195 resource types organized across 32 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
+196 resource types organized across 32 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
 
 ### Platform
 
@@ -1601,7 +1601,7 @@ Available toolset names:
                  +--------v---------+
                 |    Registry       |  <-- Declarative resource definitions
                 |  32 Toolsets      |      (data files, not code)
-                |  195 Resource Types|
+                |  196 Resource Types|
                  +--------+---------+
                           |
                  +--------v---------+

--- a/src/registry/toolsets/dbops.ts
+++ b/src/registry/toolsets/dbops.ts
@@ -358,8 +358,7 @@ export const dbopsToolset: ToolsetDefinition = {
         "(schema, instance, changeset, K8s connector), executes the pipeline, and " +
         "records the billing event — all in one call. " +
         "Returns { pipelineExecutionId, pipelineIdentifier }. " +
-        "Poll status with harness_get(resource_type='pipeline_execution_status', " +
-        "pipeline_execution_id='<returned_id>', pipeline_id='<returned_pipelineIdentifier>'). " +
+        "Poll status with harness_get(resource_type='execution', execution_id='<returned_id>'). " +
         "Use this INSTEAD of separate database_llm_authoring_pipeline + pipeline execution calls.",
       toolset: "dbops",
       scope: "project",
@@ -382,7 +381,7 @@ export const dbopsToolset: ToolsetDefinition = {
             "Required body fields: schema_id (database schema identifier), " +
             "instance_id (database instance identifier), " +
             "conversation_id (chat conversation ID), " +
-            "changeset (base64-encoded Liquibase changeset YAML). " +
+            "changeset (Liquibase changeset YAML). " +
             "The backend resolves the correct pipeline, fills all runtime inputs " +
             "(including K8s connector), executes it, and records the billing event. " +
             "Returns { pipelineExecutionId, pipelineIdentifier }.",
@@ -392,7 +391,7 @@ export const dbopsToolset: ToolsetDefinition = {
               { name: "schema_id", type: "string", required: true, description: "Database schema identifier" },
               { name: "instance_id", type: "string", required: true, description: "Database instance identifier" },
               { name: "conversation_id", type: "string", required: true, description: "Chat conversation ID" },
-              { name: "changeset", type: "string", required: true, description: "Base64-encoded Liquibase changeset YAML" },
+              { name: "changeset", type: "string", required: true, description: "Liquibase changeset YAML content" },
             ],
           },
         },

--- a/src/registry/toolsets/dbops.ts
+++ b/src/registry/toolsets/dbops.ts
@@ -347,5 +347,56 @@ export const dbopsToolset: ToolsetDefinition = {
         },
       },
     },
+
+    // ── Execute LLM Authoring Pipeline (consolidated endpoint) ────────────
+    {
+      resourceType: "database_execute_llm_authoring_pipeline",
+      displayName: "Execute LLM Authoring Pipeline",
+      description:
+        "Consolidated endpoint for LLM change authoring Accept & Commit. " +
+        "Resolves the pipeline (settings override or default), fills runtime inputs " +
+        "(schema, instance, changeset, K8s connector), executes the pipeline, and " +
+        "records the billing event — all in one call. " +
+        "Returns { pipelineExecutionId, pipelineIdentifier }. " +
+        "Poll status with harness_get(resource_type='pipeline_execution_status', " +
+        "pipeline_execution_id='<returned_id>', pipeline_id='<returned_pipelineIdentifier>'). " +
+        "Use this INSTEAD of separate database_llm_authoring_pipeline + pipeline execution calls.",
+      toolset: "dbops",
+      scope: "project",
+      identifierFields: [],
+      operations: {
+        create: {
+          method: "POST",
+          path: "/dbops/v1/orgs/{org}/projects/{project}/execute-llm-authoring-pipeline",
+          pathParams: { org_id: "org", project_id: "project" },
+          operationPolicy: { risk: "medium_write", retryPolicy: "do_not_retry" },
+          bodyBuilder: (input: Record<string, unknown>) => ({
+            schemaIdentifier: input.schema_id,
+            instanceIdentifier: input.instance_id,
+            conversationId: input.conversation_id,
+            changeset: input.changeset,
+          }),
+          responseExtractor: passthrough,
+          description:
+            "Execute the LLM changeset pipeline with integrated billing tracking. " +
+            "Required body fields: schema_id (database schema identifier), " +
+            "instance_id (database instance identifier), " +
+            "conversation_id (chat conversation ID), " +
+            "changeset (base64-encoded Liquibase changeset YAML). " +
+            "The backend resolves the correct pipeline, fills all runtime inputs " +
+            "(including K8s connector), executes it, and records the billing event. " +
+            "Returns { pipelineExecutionId, pipelineIdentifier }.",
+          bodySchema: {
+            description: "Changeset execution parameters",
+            fields: [
+              { name: "schema_id", type: "string", required: true, description: "Database schema identifier" },
+              { name: "instance_id", type: "string", required: true, description: "Database instance identifier" },
+              { name: "conversation_id", type: "string", required: true, description: "Chat conversation ID" },
+              { name: "changeset", type: "string", required: true, description: "Base64-encoded Liquibase changeset YAML" },
+            ],
+          },
+        },
+      },
+    },
   ],
 };


### PR DESCRIPTION
## Description
Added a new resource database_execute_llm_authoring_pipeline to the dbops toolset in src/registry/toolsets/dbops.ts. This
  registers the consolidated endpoint so the LLM agent can call it via harness_create.

  What it does:
  - resourceType: "database_execute_llm_authoring_pipeline"
  - operation: create (POST to /dbops/v1/orgs/{org}/projects/{project}/execute-llm-authoring-pipeline)
  - operationPolicy: medium_write, do_not_retry
  - bodyBuilder: maps agent-friendly field names (schema_id, instance_id, conversation_id, changeset) to the API contract
  (schemaIdentifier, instanceIdentifier, conversationId, changeset)

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] Tests pass
- [x] Typecheck passes
