### PR TITLE
[codex] Fix SAT account ID extraction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,14 @@
 # Deployment mode: single-user (default) or multi-user.
 # single-user — HARNESS_API_KEY required, used for all sessions.
 # multi-user  — HTTP only; sessions provide credentials via x-harness-api-key
-#               and x-harness-account-id headers. HARNESS_API_KEY must NOT be set.
+#               and, when not embedded in the key, x-harness-account-id headers.
+#               HARNESS_API_KEY must NOT be set.
 HARNESS_MCP_MODE=single-user
 
 # Required in single-user mode. Must NOT be set in multi-user mode.
 HARNESS_API_KEY=pat.xxxxx.xxxxx.xxxxx
-# Required in single-user mode (or auto-extracted from PAT). Optional in multi-user
-# mode (sessions provide their own via x-harness-account-id header).
+# Required in single-user mode unless auto-extracted from PAT/SAT. Optional in
+# multi-user mode when sessions provide or embed their own account ID.
 HARNESS_ACCOUNT_ID=your-account-id
 
 # Optional — defaults shown

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This server is built differently:
 - **Multi-project workflows out of the box.** Agents discover organizations and projects dynamically — no hardcoded env vars needed. Ask "show failed executions across all projects" and the agent can navigate the full account hierarchy.
 - **32 prompt templates.** Pre-built prompts for common workflows: build & deploy apps end-to-end, debug failed pipelines, review DORA metrics, triage vulnerabilities, optimize cloud costs, audit access control, plan feature flag rollouts, review pull requests, approve pending pipelines, and more.
 - **Works everywhere.** Stdio transport for local clients (Claude Desktop, Cursor, Windsurf), HTTP transport for remote/shared deployments, Docker and Kubernetes ready.
-- **Zero-config start.** Just provide a Harness API key. Account ID is auto-extracted from PAT tokens, org/project defaults are optional, and toolset filtering lets you expose only what you need.
+- **Zero-config start.** Just provide a Harness API key. Account ID is auto-extracted from PAT and SAT tokens, org/project defaults are optional, and toolset filtering lets you expose only what you need.
 - **Extensible by design.** Adding a new Harness resource means adding a declarative data file — no new tool registration, no schema changes, no prompt updates.
 
 ## Prerequisites
@@ -22,7 +22,7 @@ Before installing or running the server, you need a Harness API key:
 
 1. Log in to your [Harness account](https://app.harness.io)
 2. Go to **My Profile** → **API Keys** → **+ New API Key**
-3. Create a new **Token** under the API key — this generates a PAT in the format `pat.<accountId>.<tokenId>.<secret>`
+3. Create a new **Token** under the API key — this generates a PAT or SAT in the format `<prefix>.<accountId>.<tokenId>.<secret>`
 4. Save the token somewhere secure — you'll need it in the next step
 
 > For detailed instructions, see the [Harness API Quickstart](https://developer.harness.io/docs/platform/automation/api/api-quickstart/).
@@ -55,7 +55,7 @@ HARNESS_API_KEY=pat.xxx npx harness-mcp-v2
 HARNESS_API_KEY=pat.xxx npx harness-mcp-v2 http --port 8080
 ```
 
-> **Note:** The account ID is auto-extracted from PAT tokens (`pat.<accountId>.<tokenId>.<secret>`), so `HARNESS_ACCOUNT_ID` is only needed for non-PAT API keys.
+> **Note:** The account ID is auto-extracted from PAT and SAT tokens (`pat.<accountId>...` or `sat.<accountId>...`), so `HARNESS_ACCOUNT_ID` is only needed for API keys without an embedded account segment.
 
 ### Option 2: Global Install
 
@@ -141,7 +141,7 @@ Operational constraints in HTTP mode:
 Set `HARNESS_MCP_MODE=multi-user` for shared HTTP deployments where each client authenticates as a different Harness user. In this mode:
 
 - `HARNESS_API_KEY` must **not** be set in the server config — the server holds no Harness credentials.
-- Each session must provide `x-harness-api-key` and `x-harness-account-id` headers on the `initialize` request. Sessions without these headers are rejected with a 401.
+- Each session must provide `x-harness-api-key` on the `initialize` request. `x-harness-account-id` is required only when the API key does not embed an account segment.
 - Sessions may also provide `x-harness-org` and `x-harness-project` headers to set default scope for that session.
 - The Harness API key flows through to every Harness API call for that session, so the audit trail in Harness reflects the real user.
 - `HARNESS_MCP_AUTH_TOKEN` is independent and can still be used as an additional transport-layer gate.
@@ -151,7 +151,8 @@ Set `HARNESS_MCP_MODE=multi-user` for shared HTTP deployments where each client 
 curl http://localhost:3000/health
 
 # MCP initialize request (capture mcp-session-id response header)
-# In multi-user mode, x-harness-api-key and x-harness-account-id are required on initialize.
+# In multi-user mode, x-harness-api-key is required on initialize.
+# x-harness-account-id is needed only for API keys without an embedded account segment.
 curl -i -X POST http://localhost:3000/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
@@ -517,9 +518,9 @@ The server automatically loads environment variables from a `.env` file in the p
 
 | Variable                    | Required | Default                     | Description                                                                                                                                                                                                                                           |
 | --------------------------- | -------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `HARNESS_MCP_MODE`          | No       | `single-user`               | Deployment mode: `single-user` (API key in config, used for all sessions) or `multi-user` (HTTP only, per-session credentials via `x-harness-api-key` and `x-harness-account-id` headers)                                                            |
+| `HARNESS_MCP_MODE`          | No       | `single-user`               | Deployment mode: `single-user` (API key in config, used for all sessions) or `multi-user` (HTTP only, per-session credentials via `x-harness-api-key` and optional `x-harness-account-id` headers)                                                   |
 | `HARNESS_API_KEY`           | Yes*     | --                          | Harness personal access token or service account token. Required in `single-user` mode. Must NOT be set in `multi-user` mode                                                                                                                          |
-| `HARNESS_ACCOUNT_ID`        | No       | *(from PAT)*                | Harness account identifier. Auto-extracted from PAT tokens in single-user mode; sessions provide their own via `x-harness-account-id` in multi-user mode                                                                                              |
+| `HARNESS_ACCOUNT_ID`        | No       | *(from PAT/SAT)*            | Harness account identifier. Auto-extracted from PAT/SAT tokens in single-user mode; multi-user sessions can provide their own via `x-harness-account-id` when the API key does not embed one                                                          |
 | `HARNESS_BASE_URL`          | No       | `https://app.harness.io`    | Harness API/UI base URL for local stdio or self-hosted HTTP deployments. Set this to environments such as `https://harness0.harness.io` when running the server yourself. It does not affect the managed `https://mcp.harness.io/mcp` hosted endpoint |
 | `HARNESS_ORG`               | No       | --                          | Organization ID. Used when `org_id` is not specified per tool call. If omitted, `org_id` must be provided explicitly. Agents can also discover orgs dynamically via `harness_list(resource_type="organization")`                                      |
 | `HARNESS_PROJECT`           | No       | --                          | Project ID. Used when `project_id` is not specified per tool call. Agents can also discover projects dynamically via `harness_list(resource_type="project")`                                                                                          |
@@ -1877,7 +1878,7 @@ The Harness MCP server pairs well with **[Harness Skills](https://github.com/har
 
 | Symptom                                                                          | Likely Cause                                                                                         | What to Do                                                                                                                           |
 | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `HARNESS_ACCOUNT_ID is required when the API key is not a PAT...`                | API key is not in PAT format (`pat.<accountId>.<tokenId>.<secret>`) so account ID cannot be inferred | Set `HARNESS_ACCOUNT_ID` explicitly                                                                                                  |
+| `HARNESS_ACCOUNT_ID is required when the API key does not include an account ID segment...` | API key is not in a supported account-scoped format (`pat.<accountId>...` or `sat.<accountId>...`) so account ID cannot be inferred | Set `HARNESS_ACCOUNT_ID` explicitly |
 | `Unknown transport: "..."` on startup                                            | Unsupported CLI transport arg                                                                        | Use `stdio` or `http` only                                                                                                           |
 | `Invalid HARNESS_TOOLSETS: ...` on startup                                       | One or more toolset names are not recognized                                                         | Use only names from [Toolset Filtering](#toolset-filtering) (exact match)                                                            |
 | HTTP `mcp-session-id header is required...`                                      | A session request was sent without session header                                                    | Send `initialize` first, then include `mcp-session-id` on `POST/GET/DELETE /mcp`                                                     |

--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -131,7 +131,7 @@ Multi-scope resources such as connectors, services, environments, infrastructure
 2. **Configure environment variables** in the project's `.env` file:
    ```
    HARNESS_API_KEY=pat.xxxxx.xxxxx.xxxxx
-   HARNESS_ACCOUNT_ID=your_account_id   # Optional for PATs, required for non-PAT API keys
+   HARNESS_ACCOUNT_ID=your_account_id   # Optional for PAT/SAT keys with embedded account ID
    HARNESS_ORG=default
    HARNESS_PROJECT=your_project
    HARNESS_RATE_LIMIT_RPS=10            # Optional: client-side throttling

--- a/manifest.json
+++ b/manifest.json
@@ -70,7 +70,7 @@
     "HARNESS_ACCOUNT_ID": {
       "type": "string",
       "title": "Harness Account ID",
-      "description": "Harness account identifier. Optional when using a PAT because the server can extract the account ID from pat.<accountId>.<tokenId>.<secret>.",
+      "description": "Harness account identifier. Optional when using a PAT or SAT because the server can extract the account ID from pat.<accountId>.<tokenId>.<secret> or sat.<accountId>.<tokenId>.<secret>.",
       "required": false,
       "sensitive": false
     },

--- a/mcp-directory/manifest.json
+++ b/mcp-directory/manifest.json
@@ -70,7 +70,7 @@
     "HARNESS_ACCOUNT_ID": {
       "type": "string",
       "title": "Harness Account ID",
-      "description": "Harness account identifier. Optional when using a PAT because the server can extract the account ID from pat.<accountId>.<tokenId>.<secret>.",
+      "description": "Harness account identifier. Optional when using a PAT or SAT because the server can extract the account ID from pat.<accountId>.<tokenId>.<secret> or sat.<accountId>.<tokenId>.<secret>.",
       "required": false,
       "sensitive": false
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,15 +37,26 @@ function validateAllowedHosts(rawHosts: string | undefined): string | undefined 
   return hosts.join(",");
 }
 
+const ACCOUNT_SCOPED_API_KEY_PREFIXES = new Set(["pat", "sat"]);
+
 /**
- * Extract the account ID from a Harness PAT token.
- * PAT format: pat.<accountId>.<tokenId>.<secret>
- * Returns undefined if the token doesn't match the expected format.
+ * Extract the account ID from a Harness account-scoped API key.
+ * Supported formats:
+ * - pat.<accountId>.<tokenId>.<secret>
+ * - sat.<accountId>.<tokenId>.<secret>
+ * Returns undefined if the token doesn't match a supported format.
  */
 export function extractAccountIdFromToken(apiKey: string): string | undefined {
   const parts = apiKey.split(".");
+  const prefix = parts[0]?.toLowerCase();
   const accountId = parts[1];
-  if (parts.length >= 3 && parts[0] === "pat" && accountId && accountId.length > 0) {
+  if (
+    parts.length >= 3 &&
+    prefix &&
+    ACCOUNT_SCOPED_API_KEY_PREFIXES.has(prefix) &&
+    accountId &&
+    accountId.length > 0
+  ) {
     return accountId;
   }
   return undefined;
@@ -117,7 +128,7 @@ export const ConfigSchema = RawConfigSchema.transform((data) => {
     accountId = data.HARNESS_ACCOUNT_ID ?? extractAccountIdFromToken(data.HARNESS_API_KEY!);
     if (!accountId) {
       throw new Error(
-        "HARNESS_ACCOUNT_ID is required when the API key is not a PAT (pat.<accountId>.<tokenId>.<secret>)",
+        "HARNESS_ACCOUNT_ID is required when the API key does not include an account ID segment (pat.<accountId>... or sat.<accountId>...)",
       );
     }
   }

--- a/src/utils/session-headers.ts
+++ b/src/utils/session-headers.ts
@@ -81,7 +81,9 @@ export function mergeConfigWithSessionHeaders(
   // Identity headers are only accepted in multi-user mode.
   // In single-user mode, the operator's config is authoritative.
   const sessionApiKey = isMultiUser ? getHeader(headers, API_KEY_HEADER) : undefined;
-  const sessionAccountId = isMultiUser ? getHeader(headers, ACCOUNT_ID_HEADER) : undefined;
+  const rawSessionAccountId = isMultiUser ? getHeader(headers, ACCOUNT_ID_HEADER) : undefined;
+  const tokenAccountId = sessionApiKey ? extractAccountIdFromToken(sessionApiKey) : undefined;
+  const sessionAccountId = rawSessionAccountId ?? tokenAccountId;
   const sessionOrg = getHeader(headers, ORG_HEADER);
   const sessionProject = getHeader(headers, PROJECT_HEADER);
 
@@ -93,10 +95,9 @@ export function mergeConfigWithSessionHeaders(
       throw new MissingSessionCredentialsError(missing);
     }
 
-    const patAccountId = extractAccountIdFromToken(sessionApiKey!);
-    if (patAccountId && patAccountId !== sessionAccountId) {
+    if (tokenAccountId && rawSessionAccountId && tokenAccountId !== rawSessionAccountId) {
       throw new MissingSessionCredentialsError([
-        `${ACCOUNT_ID_HEADER} (value "${sessionAccountId}" does not match PAT account "${patAccountId}")`,
+        `${ACCOUNT_ID_HEADER} (value "${rawSessionAccountId}" does not match API key account "${tokenAccountId}")`,
       ]);
     }
   }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,10 @@
 # Lessons Learned
 
+## Harness SAT Account Extraction
+- **Issue**: Service account tokens can use the same account-scoped segment shape as PATs, but the parser only recognized the `pat` prefix.
+- **Fix**: Extract account IDs from both `pat` and `sat` prefixes, and let multi-user HTTP sessions derive `HARNESS_ACCOUNT_ID` from either prefix when `x-harness-account-id` is omitted.
+- **Rule**: Before requiring explicit account IDs for new Harness API key types, check whether the token format embeds the account ID segment; preserve explicit account overrides and mismatch validation.
+
 ## MCP SDK v1.27+ Type Compatibility
 - **Issue**: `server.tool()` callback return type requires `[key: string]: unknown` index signature on the result object.
 - **Fix**: Add `[key: string]: unknown` to the ToolResult interface.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,29 @@
 # Harness MCP Server — Task Tracking
 
+## SAT Account Extraction (2026-05-28)
+- [x] Confirm SAT failure mode from config and session header handling
+- [x] Allow account ID extraction from SAT tokens
+- [x] Let multi-user sessions derive account ID from PAT/SAT when possible
+- [x] Update focused tests and user-facing guidance
+- [x] Run focused and full verification
+- [x] Document review results and lesson
+
+### Plan
+- Keep the token parser simple: account ID is the second dot-delimited segment for supported Harness API key prefixes.
+- Extend supported account-scoped prefixes from only `pat` to `pat` and `sat`, case-insensitively.
+- Preserve explicit account-ID overrides and continue rejecting mismatches when the token embeds an account ID.
+- Update single-user config tests, multi-user session header tests, HTTP initialize coverage, and docs.
+- Keep the PR scoped to the SAT bug.
+
+### Review
+- Updated `extractAccountIdFromToken` so supported account-scoped API key prefixes are `pat` and `sat`, case-insensitively.
+- Updated single-user config handling so `HARNESS_ACCOUNT_ID` is derived from SATs with an embedded account segment.
+- Updated multi-user HTTP session handling so `x-harness-account-id` can be omitted when `x-harness-api-key` embeds the account ID; explicit mismatched account headers still fail.
+- Updated focused tests for config parsing, session header merging, and HTTP initialize behavior.
+- Updated README, manifests, `.env.example`, and Gemini docs from PAT-only account extraction to PAT/SAT account extraction.
+- Verified the customer-provided SAT sample was not written into the repo.
+- Verification passed: `pnpm vitest run tests/config.test.ts tests/utils/session-headers.test.ts tests/integration/http-transport.test.ts`, `pnpm typecheck`, and `pnpm test` outside the sandbox for local HTTP port binding.
+
 ## Jira Feature Request Spec Automation (2026-05-25)
 - [x] Inspect current automation registry and saved schedules
 - [x] Create Jira Feature Request spec drafting automation

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -10,8 +10,16 @@ describe("extractAccountIdFromToken", () => {
     expect(extractAccountIdFromToken("pat.acct123.tokenId.secret.extra")).toBe("acct123");
   });
 
-  it("returns undefined for non-PAT tokens", () => {
-    expect(extractAccountIdFromToken("sat.acct123.tokenId.secret")).toBeUndefined();
+  it("extracts account ID from a valid SAT", () => {
+    expect(extractAccountIdFromToken("sat.acct123.tokenId.secret")).toBe("acct123");
+  });
+
+  it("extracts account ID from token prefixes case-insensitively", () => {
+    expect(extractAccountIdFromToken("SAT.acct123.tokenId.secret")).toBe("acct123");
+  });
+
+  it("returns undefined for unsupported token prefixes", () => {
+    expect(extractAccountIdFromToken("api.acct123.tokenId.secret")).toBeUndefined();
   });
 
   it("returns undefined for tokens with too few segments", () => {
@@ -63,6 +71,17 @@ describe("ConfigSchema", () => {
   it("HARNESS_ACCOUNT_ID is optional in schema", () => {
     const result = ConfigSchema.safeParse({ HARNESS_API_KEY: "pat.acct123.tok.sec" });
     expect(result.success).toBe(true);
+  });
+
+  it("extracts HARNESS_ACCOUNT_ID from service account API keys", () => {
+    const result = ConfigSchema.safeParse({
+      HARNESS_API_KEY: "sat.acct123.tokenId.secret",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.HARNESS_ACCOUNT_ID).toBe("acct123");
+    }
   });
 
   it("fails when HARNESS_API_KEY is empty", () => {
@@ -390,10 +409,17 @@ describe("loadConfig — account ID extraction", () => {
     });
   });
 
-  it("throws when HARNESS_ACCOUNT_ID missing and API key is not a PAT", () => {
-    withEnv({ HARNESS_API_KEY: "sat.notapat.tok.sec" }, () => {
+  it("extracts account ID from SAT when HARNESS_ACCOUNT_ID is not set", () => {
+    withEnv({ HARNESS_API_KEY: "sat.extracted123.tok.sec" }, () => {
+      const config = loadConfig();
+      expect(config.HARNESS_ACCOUNT_ID).toBe("extracted123");
+    });
+  });
+
+  it("throws when HARNESS_ACCOUNT_ID missing and API key has no account segment", () => {
+    withEnv({ HARNESS_API_KEY: "opaque-token" }, () => {
       expect(() => loadConfig()).toThrow(
-        "HARNESS_ACCOUNT_ID is required when the API key is not a PAT",
+        "HARNESS_ACCOUNT_ID is required when the API key does not include an account ID segment",
       );
     });
   });

--- a/tests/integration/http-transport.test.ts
+++ b/tests/integration/http-transport.test.ts
@@ -409,7 +409,7 @@ describe("HTTP /mcp route-level auth", () => {
     });
   });
 
-  it("returns 401 when PAT account ID mismatches x-harness-account-id", async () => {
+  it("returns 401 when API key account ID mismatches x-harness-account-id", async () => {
     const app = buildAuthTestApp({ multiUser: true });
     await withListeningApp(app, async (baseUrl) => {
       const res = await postMcp(baseUrl, {
@@ -424,6 +424,20 @@ describe("HTTP /mcp route-level auth", () => {
         jsonrpc: "2.0",
         error: { code: -32001 },
       });
+    });
+  });
+
+  it("succeeds with SAT account ID extraction when x-harness-account-id is omitted", async () => {
+    const app = buildAuthTestApp({ multiUser: true });
+    await withListeningApp(app, async (baseUrl) => {
+      const res = await postMcp(baseUrl, {
+        body: buildInitializeBody(),
+        headers: {
+          "x-harness-api-key": "sat.myaccount.token.secret",
+        },
+      });
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ jsonrpc: "2.0", id: 1, result: { ok: true } });
     });
   });
 

--- a/tests/utils/session-headers.test.ts
+++ b/tests/utils/session-headers.test.ts
@@ -123,29 +123,45 @@ describe("multi-user session credentials", () => {
     ).toThrow(MissingSessionCredentialsError);
   });
 
-  it("throws MissingSessionCredentialsError when account id is missing in multi-user mode", () => {
+  it("derives account ID from a PAT when x-harness-account-id is missing in multi-user mode", () => {
+    const base = makeConfig({ HARNESS_MCP_MODE: "multi-user", HARNESS_API_KEY: "", HARNESS_ACCOUNT_ID: "" });
+    const merged = mergeConfigWithSessionHeaders(base, {
+      "x-harness-api-key": "pat.user1.tok.sec",
+    });
+    expect(merged.HARNESS_ACCOUNT_ID).toBe("user1");
+  });
+
+  it("derives account ID from an SAT when x-harness-account-id is missing in multi-user mode", () => {
+    const base = makeConfig({ HARNESS_MCP_MODE: "multi-user", HARNESS_API_KEY: "", HARNESS_ACCOUNT_ID: "" });
+    const merged = mergeConfigWithSessionHeaders(base, {
+      "x-harness-api-key": "sat.user1.tok.sec",
+    });
+    expect(merged.HARNESS_ACCOUNT_ID).toBe("user1");
+  });
+
+  it("throws MissingSessionCredentialsError when account id is missing and token has no account segment", () => {
     const base = makeConfig({ HARNESS_MCP_MODE: "multi-user", HARNESS_API_KEY: "", HARNESS_ACCOUNT_ID: "" });
     expect(() =>
       mergeConfigWithSessionHeaders(base, {
-        "x-harness-api-key": "pat.user1.tok.sec",
+        "x-harness-api-key": "opaque-token",
       }),
     ).toThrow(MissingSessionCredentialsError);
   });
 
-  it("throws when PAT account ID does not match x-harness-account-id", () => {
+  it("throws when API key account ID does not match x-harness-account-id", () => {
     const base = makeConfig({ HARNESS_MCP_MODE: "multi-user", HARNESS_API_KEY: "", HARNESS_ACCOUNT_ID: "" });
     expect(() =>
       mergeConfigWithSessionHeaders(base, {
-        "x-harness-api-key": "pat.accountA.tok.sec",
+        "x-harness-api-key": "sat.accountA.tok.sec",
         "x-harness-account-id": "accountB",
       }),
     ).toThrow(MissingSessionCredentialsError);
   });
 
-  it("allows non-PAT tokens without account ID validation", () => {
+  it("allows opaque tokens without account ID validation when x-harness-account-id is provided", () => {
     const base = makeConfig({ HARNESS_MCP_MODE: "multi-user", HARNESS_API_KEY: "", HARNESS_ACCOUNT_ID: "" });
     const merged = mergeConfigWithSessionHeaders(base, {
-      "x-harness-api-key": "sat.sometoken.secret",
+      "x-harness-api-key": "opaque-token",
       "x-harness-account-id": "any-account",
     });
     expect(merged.HARNESS_ACCOUNT_ID).toBe("any-account");


### PR DESCRIPTION
## Summary
- Extract account IDs from `sat.<accountId>...` tokens in addition to PATs.
- Allow multi-user HTTP sessions to omit `x-harness-account-id` when the API key embeds the account segment.
- Update tests, docs, manifests, and task notes for PAT/SAT account extraction.

## Root Cause
SATs can carry the same account-scoped segment shape as PATs, but the parser only recognized `pat`, which forced SAT users to provide `HARNESS_ACCOUNT_ID` separately.

## Validation
- `pnpm vitest run tests/config.test.ts tests/utils/session-headers.test.ts tests/integration/http-transport.test.ts`
- `pnpm typecheck`
- `pnpm test` (rerun outside sandbox so local HTTP port binding is permitted)

## Notes
-  SAT sample was used only for analysis and was not committed.
