### PR TITLE
fix(iacm): use activity resource changes endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,13 +66,13 @@ HARNESS_PIPELINE_VERSION=0
 HARNESS_MCP_LOG_FILE=
 
 # Toolset filtering — comma-separated list of enabled toolsets
-# If unset, all default toolsets are enabled. Two toolsets are opt-in (not loaded
-# by default): iacm and ansible. Use +name to add alongside defaults, or list
+# If unset, all default toolsets are enabled. One toolset is opt-in (not loaded
+# by default): ansible. Use +name to add alongside defaults, or list
 # explicitly for an allowlist. Use -name to remove defaults. The legacy name
 # agent-pipelines is accepted as agents.
 # Available: pipelines,agents,services,environments,infrastructure,connectors,secrets,logs,audit,delegates,repositories,registries,templates,dashboards,idp,pull-requests,feature-flags,gitops,chaos,ccm,sei,scs,sto,dbops,access_control,settings,platform,visualizations,governance,freeze,overrides,ai-evals,iacm,ansible
-# Opt-in toolsets (require HARNESS_ORG and HARNESS_PROJECT, or explicit org_id/project_id per call):
-#   iacm    — Terraform workspaces, resources, modules, costs, activity diffs
+# Project-scoped IaCM/Ansible calls require HARNESS_ORG and HARNESS_PROJECT,
+# or explicit org_id/project_id per call. Opt-in toolsets:
 #   ansible — Ansible inventories, playbooks, hosts, and activity history
 HARNESS_TOOLSETS=
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Harness MCP Server 2.0
 
-An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 196 resource types.
+An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 201 resource types.
 
 ## Why Use This MCP Server
 
@@ -8,8 +8,8 @@ Most MCP servers map one tool per API endpoint. For a platform as broad as Harne
 
 This server is built differently:
 
-- **11 tools, 196 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
-- **Full platform coverage.** 32 default toolsets spanning CI/CD, GitOps, Feature Flags, Cloud Cost Management, Security Testing, Chaos Engineering, Database DevOps, Internal Developer Portal, Software Supply Chain, Governance, Service Overrides, Visualizations, and more. Opt-in IaCM coverage is available when you need Terraform workspace and module data.
+- **11 tools, 201 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
+- **Full platform coverage.** 33 default toolsets spanning CI/CD, GitOps, Feature Flags, Cloud Cost Management, Security Testing, Chaos Engineering, Database DevOps, Internal Developer Portal, Software Supply Chain, Infrastructure as Code Management, Governance, Service Overrides, Visualizations, and more. Opt-in Ansible coverage is available when you need inventory and playbook data.
 - **Multi-project workflows out of the box.** Agents discover organizations and projects dynamically — no hardcoded env vars needed. Ask "show failed executions across all projects" and the agent can navigate the full account hierarchy.
 - **32 prompt templates.** Pre-built prompts for common workflows: build & deploy apps end-to-end, debug failed pipelines, review DORA metrics, triage vulnerabilities, optimize cloud costs, audit access control, plan feature flag rollouts, review pull requests, approve pending pipelines, and more.
 - **Works everywhere.** Stdio transport for local clients (Claude Desktop, Cursor, Windsurf), HTTP transport for remote/shared deployments, Docker and Kubernetes ready.
@@ -1041,7 +1041,7 @@ Harness pipelines can be stored in three ways:
 
 ## Resource Types
 
-196 resource types organized across 32 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
+201 resource types organized across 33 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
 
 ### Platform
 
@@ -1510,24 +1510,17 @@ Inline PNG chart visualizations rendered from Harness data. These are metadata-o
 
 ## Toolset Filtering
 
-By default, 32 of 34 toolsets are enabled. Two toolsets are opt-in and excluded from the defaults:
+By default, 33 of 34 toolsets are enabled. One toolset is opt-in and excluded from the defaults:
 
-- **`iacm`** — Harness IaCM (Terraform workspaces, modules, resources). Opt-in because it is project-scoped and adds concepts many users do not need.
-- **`ansible`** — Harness Ansible (inventories, playbooks, hosts, activity). Opt-in for the same reason.
+- **`ansible`** — Harness Ansible (inventories, playbooks, hosts, activity). Opt-in because it is project-scoped and adds concepts many users do not need.
 
 ### Adding toolsets with `+` prefix
 
 Use the `+` prefix to explicitly include opt-in toolsets alongside all defaults:
 
 ```bash
-# Explicitly include IaCM alongside all defaults
-HARNESS_TOOLSETS=+iacm
-
 # Explicitly include Ansible alongside all defaults
 HARNESS_TOOLSETS=+ansible
-
-# Include both
-HARNESS_TOOLSETS=+iacm,+ansible
 ```
 
 ### Removing default toolsets
@@ -1542,8 +1535,8 @@ HARNESS_TOOLSETS=-chaos,-ccm
 ### Combining + and -
 
 ```bash
-# Add IaCM, remove chaos
-HARNESS_TOOLSETS=+iacm,-chaos
+# Add Ansible, remove chaos
+HARNESS_TOOLSETS=+ansible,-chaos
 ```
 
 ### Explicit allowlist
@@ -1592,7 +1585,7 @@ Available toolset names:
 | `settings`              | setting                                                                                                                                                                                                                                                                                         |
 | `visualizations`        | visual_timeline, visual_stage_flow, visual_health_dashboard, visual_pie_chart, visual_bar_chart, visual_timeseries, visual_architecture                                                                                                                                                         |
 | `ai-evals`              | eval_dataset, eval_dataset_item, evaluation, eval_run, eval_run_item, eval_run_by_eval, eval_metric, eval_metric_set, eval_metric_set_entry, eval_suite, eval_suite_evaluation, eval_suite_run, eval_target, eval_model, eval_annotation, eval_analytics, eval_git_settings, eval_registry_item |
-| `iacm` *(opt-in)*       | iacm_workspace, iacm_resource, iacm_module, iacm_workspace_costs, iacm_activity_resource_change                                                                                                                                                                                                 |
+| `iacm`                  | iacm_workspace, iacm_resource, iacm_module, iacm_workspace_costs, iacm_activity_resource_change                                                                                                                                                                                                 |
 | `ansible` *(opt-in)*    | ansible_inventory, ansible_playbook, ansible_host, ansible_host_activity, ansible_activity                                                                                                                                                                                                      |
 
 
@@ -1611,8 +1604,8 @@ Available toolset names:
                           |
                  +--------v---------+
                 |    Registry       |  <-- Declarative resource definitions
-                |  32 Toolsets      |      (data files, not code)
-                |  196 Resource Types|
+                |  33 Toolsets      |      (data files, not code)
+                |  201 Resource Types|
                  +--------+---------+
                           |
                  +--------v---------+

--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -1,6 +1,6 @@
 # Harness MCP Server — Gemini CLI Context
 
-This extension connects Gemini CLI to the Harness Platform through 11 consolidated MCP tools that cover 190 resource types across 32 default toolsets.
+This extension connects Gemini CLI to the Harness Platform through 11 consolidated MCP tools that cover 201 resource types across 33 default toolsets.
 
 ## How This Server Works
 
@@ -80,8 +80,8 @@ Unlike traditional MCP servers with one tool per API endpoint, this server uses 
 - Access custom dashboards and data exports
 
 ### Infrastructure as Code Management (IaCM)
-- Opt-in toolset for Terraform workspaces, resources, module registry entries, workspace costs, and activity resource changes
-- Enable with `HARNESS_TOOLSETS=+iacm`; IaCM APIs require org/project scope
+- Default-enabled toolset for Terraform workspaces, resources, module registry entries, workspace costs, and activity resource changes
+- IaCM APIs require org/project scope
 
 ### Ansible
 - Opt-in toolset for Ansible inventories, playbooks, hosts, and activity history
@@ -158,4 +158,4 @@ Multi-scope resources such as connectors, services, environments, infrastructure
 **Toolset filtering:**
 - Set `HARNESS_TOOLSETS=pipelines,services,connectors` in `.env` to limit which resource types are available
 - Leave empty to enable all default toolsets
-- Add opt-in toolsets alongside defaults: `HARNESS_TOOLSETS=+iacm`, `HARNESS_TOOLSETS=+ansible`, or `HARNESS_TOOLSETS=+iacm,+ansible`
+- Add opt-in toolsets alongside defaults: `HARNESS_TOOLSETS=+ansible`

--- a/src/registry/toolsets/iacm.ts
+++ b/src/registry/toolsets/iacm.ts
@@ -158,7 +158,7 @@ export const iacmToolset: ToolsetDefinition = {
     "Use iacm_workspace to list and get workspaces, iacm_resource for Terraform resources and outputs, " +
     "iacm_module for the module registry, iacm_workspace_costs for cost breakdown, " +
     "and iacm_activity_resource_change for activity diffs.",
-  optIn: true,
+  optIn: false,
   resources: [
     // ─── Workspace ─────────────────────────────────────────────────────────
     {
@@ -456,34 +456,29 @@ export const iacmToolset: ToolsetDefinition = {
       resourceType: "iacm_activity_resource_change",
       displayName: "IaCM Activity Resource Change",
       description:
-        "Resource attribute diffs from a specific IaCM pipeline execution. " +
-        "Each response can include resources, planned_changes, drift_changes, outputs, data_sources, " +
-        "and the pipeline execution/stage/workspace identifiers. activity_id is treated as the pipeline execution ID.",
+        "Resource attribute diffs from a specific IaCM activity (plan, apply, or destroy execution). " +
+        "Each entry has resource_name, resource_type, provider, action (add/change/destroy/no-op), " +
+        "and changed_attributes with before/after values. " +
+        "Response also includes summary counts: total_added, total_changed, total_destroyed, total_unchanged. " +
+        "Both activity_id and workspace_id are required. " +
+        "Activity IDs appear in the workspace execution history in the Harness UI.",
       toolset: "iacm",
       scope: "project",
-      identifierFields: ["activity_id"],
+      identifierFields: ["activity_id", "workspace_id"],
       listFilterFields: [
         {
           name: "activity_id",
           required: true,
           description:
-            "The IaCM pipeline execution ID whose resource changes should be listed.",
+            "The UUID of the IaCM activity (e.g. 'd2487e0d-a0a4-40ee-b502-7e6e8fb3fd0a'). " +
+            "Found in workspace execution history in the Harness UI.",
           type: "string",
         },
         {
-          name: "pipeline_stage_id",
-          description: "Optional pipeline stage execution ID to narrow resource changes.",
+          name: "workspace_id",
+          required: true,
+          description: "The workspace identifier the activity belongs to.",
           type: "string",
-        },
-        {
-          name: "path_id",
-          description: "Optional Terragrunt path identifier for filtering module-specific resources.",
-          type: "string",
-        },
-        {
-          name: "exclude_state",
-          description: "When true, exclude values from state in the response.",
-          type: "boolean",
         },
       ],
       relatedResources: [
@@ -501,24 +496,23 @@ export const iacmToolset: ToolsetDefinition = {
       operations: {
         list: {
           method: "GET",
-          path: "/iacm/api/orgs/{org}/projects/{project}/executions/{pipelineExecutionId}/resource-changes",
+          path: "/iacm/api/orgs/{org}/projects/{project}/activities/{activityId}/resource-changes",
           pathParams: {
             org_id: "org",
             project_id: "project",
-            activity_id: "pipelineExecutionId",
+            activity_id: "activityId",
           },
           queryParams: {
-            exclude_state: "exclude_state",
-            pipeline_stage_id: "pipeline_stage_id",
-            path_id: "path_id",
+            workspace_id: "workspace",
           },
           preflight: requireProjectScope,
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           responseExtractor: activityChangesExtract,
           description:
-            "List resource changes for a specific IaCM pipeline execution. " +
-            "Returns the documented resources, planned_changes, drift_changes, outputs, and data_sources sections. " +
-            "Requires activity_id, which is used as the pipeline_execution_id path parameter.",
+            "List resource changes for a specific IaCM activity (plan, apply, or destroy). " +
+            "Returns per-resource before/after attribute diffs, action (add/change/destroy/no-op), " +
+            "and summary counts (total_added, total_changed, total_destroyed, total_unchanged). " +
+            "Requires activity_id (path) and workspace_id (query param).",
         },
       },
     },

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,24 @@
 # Harness MCP Server — Task Tracking
 
+## PR 282 IaCM Activity Resource Changes (2026-05-29)
+- [x] Restore engineer's activity-scoped resource change endpoint
+- [x] Keep IaCM default-enabled and Ansible opt-in on current main
+- [x] Update generated docs plus config/Gemini guidance
+- [x] Run focused registry, build, and docs checks
+- [x] Push updated PR branch
+
+### Plan
+- Rebuild PR 282 on current `origin/main` so the change includes recent Ansible docs and registry updates.
+- Preserve the intended IaCM activity resource-changes contract: `/activities/{activityId}/resource-changes` with required `workspace_id`.
+- Preserve `operationPolicy` on the endpoint and keep IaCM default-enabled.
+- Update docs that previously described IaCM as opt-in.
+
+### Review
+- Updated `iacm_activity_resource_change` to use the activity-scoped endpoint and required `workspace_id` query mapping.
+- Updated IaCM registry tests for default-on loading and activity-scoped dispatch.
+- Updated README, `.env.example`, and Gemini docs so IaCM is documented as default-enabled and Ansible remains the only opt-in toolset.
+- Verification passed: `pnpm vitest run tests/registry/iacm.test.ts tests/registry/ansible.test.ts tests/registry/registry.test.ts tests/registry/structural-validation.test.ts`, `pnpm build`, and `pnpm docs:check`.
+
 ## Version Bump 3.0.9 (2026-05-28)
 - [x] Identify release metadata fields pinned to the previous version
 - [x] Update package and manifest versions to 3.0.9

--- a/tests/registry/iacm.test.ts
+++ b/tests/registry/iacm.test.ts
@@ -58,8 +58,8 @@ describe("iacmToolset structure", () => {
     expect(iacmToolset.name).toBe("iacm");
   });
 
-  it("is opt-in (not loaded by default)", () => {
-    expect(iacmToolset.optIn).toBe(true);
+  it("is loaded by default (not opt-in)", () => {
+    expect(iacmToolset.optIn).toBe(false);
   });
 
   it("registers all 5 resource types", () => {
@@ -95,12 +95,12 @@ describe("iacmToolset structure", () => {
   });
 });
 
-// ─── Registry opt-in behaviour ───────────────────────────────────────────────
+// ─── Registry default-on behaviour ───────────────────────────────────────────
 
-describe("iacm opt-in with Registry", () => {
-  it("is NOT present when HARNESS_TOOLSETS is unset (all defaults)", () => {
+describe("iacm default-on with Registry", () => {
+  it("IS present when HARNESS_TOOLSETS is unset (all defaults)", () => {
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: undefined }));
-    expect(registry.getAllResourceTypes()).not.toContain("iacm_workspace");
+    expect(registry.getAllResourceTypes()).toContain("iacm_workspace");
   });
 
   it("IS present when explicitly enabled with HARNESS_TOOLSETS=iacm", () => {
@@ -353,9 +353,9 @@ describe("endpoint paths", () => {
     expect(getOp("iacm_module", "get").path).toBe("/iacm/api/modules/{moduleId}");
   });
 
-  it("iacm_activity_resource_change list uses the execution resource-changes endpoint", () => {
+  it("iacm_activity_resource_change list uses the activity resource-changes endpoint", () => {
     expect(getOp("iacm_activity_resource_change", "list").path).toContain(
-      "/executions/{pipelineExecutionId}/resource-changes",
+      "/activities/{activityId}/resource-changes",
     );
   });
 });
@@ -373,7 +373,7 @@ describe("iacm registry dispatch", () => {
     expect(request.path).toBe("/iacm/api/modules/4640");
   });
 
-  it("dispatches activity resource changes by execution id", async () => {
+  it("dispatches activity resource changes by activity id", async () => {
     const mockRequest = vi.fn().mockResolvedValue({ planned_changes: [] });
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
 
@@ -381,10 +381,11 @@ describe("iacm registry dispatch", () => {
       org_id: "default",
       project_id: "Testim",
       activity_id: "exec-123",
+      workspace_id: "ws-1",
     });
 
     const request = mockRequest.mock.calls[0]![0] as { path: string; params: Record<string, unknown> };
-    expect(request.path).toBe("/iacm/api/orgs/default/projects/Testim/executions/exec-123/resource-changes");
-    expect(request.params.workspace).toBeUndefined();
+    expect(request.path).toBe("/iacm/api/orgs/default/projects/Testim/activities/exec-123/resource-changes");
+    expect(request.params.workspace).toBe("ws-1");
   });
 });


### PR DESCRIPTION
## Summary
- Move `iacm_activity_resource_change` to the activity-scoped endpoint: `/activities/{activityId}/resource-changes`.
- Require `workspace_id` and map it to the `workspace` query parameter for the activity resource-changes API.
- Keep `operationPolicy: { risk: "read", retryPolicy: "safe" }` on the endpoint.
- Promote the IaCM toolset to default-enabled while leaving Ansible as opt-in.
- Update README, `.env.example`, Gemini docs, and focused registry tests.

## Validation
- `pnpm vitest run tests/registry/iacm.test.ts tests/registry/ansible.test.ts tests/registry/registry.test.ts tests/registry/structural-validation.test.ts`
- `pnpm build`
- `pnpm docs:check`

## Note
We are intentionally keeping the activity-scoped resource-changes endpoint based on the newer IaCM contract.
