### PR TITLE
feat(iacm): add resource.get endpoint for single-resource lookup

### DIFF
--- a/src/registry/toolsets/iacm.ts
+++ b/src/registry/toolsets/iacm.ts
@@ -108,6 +108,42 @@ const costsListExtract = (
 };
 
 /**
+ * IACM single Terraform resource get: normalize the API response into a
+ * predictable, flat shape. The upstream API may return the resource directly
+ * or wrap it under a `resource` key — handle both. snake_case any camelCase
+ * fields (driftStatus, costData, resourceId) so consumers see one consistent
+ * shape, and always surface the cross-system Resource ID at the top level.
+ */
+const iacmResourceGetExtract = (raw: unknown): unknown => {
+  if (!raw || typeof raw !== "object") return raw;
+  const wrapper = raw as Record<string, unknown>;
+  const inner =
+    wrapper.resource && typeof wrapper.resource === "object"
+      ? (wrapper.resource as Record<string, unknown>)
+      : wrapper;
+
+  const get = (...keys: string[]): unknown => {
+    for (const k of keys) {
+      if (inner[k] !== undefined && inner[k] !== null) return inner[k];
+    }
+    return undefined;
+  };
+
+  return {
+    name: get("name", "resource_name"),
+    type: get("type", "resource_type"),
+    provider: get("provider"),
+    module: get("module"),
+    drift_status: get("drift_status", "driftStatus"),
+    cost_data: get("cost_data", "costData", "cost"),
+    resource_id: get("resource_id", "resourceId", "id"),
+    workspace_id: get("workspace_id", "workspaceId"),
+    attributes: get("attributes"),
+    raw: inner,
+  };
+};
+
+/**
  * IaCM execution resource changes: keep the documented response intact while
  * preserving the older resource_changes alias for agents that look for it.
  */
@@ -277,7 +313,7 @@ export const iacmToolset: ToolsetDefinition = {
         "workspace_id is required — use harness_list with iacm_workspace to find workspace identifiers.",
       toolset: "iacm",
       scope: "project",
-      identifierFields: ["workspace_id"],
+      identifierFields: ["workspace_id", "resource_id"],
       listFilterFields: [
         {
           name: "workspace_id",
@@ -330,6 +366,24 @@ export const iacmToolset: ToolsetDefinition = {
             "Use total_items when it is >= 0 as the authoritative total. " +
             "If has_more=true, call again with page+1. " +
             "To answer 'how many resources?', prefer total_items; if -1, paginate all pages and sum page_counts.",
+        },
+        get: {
+          method: "GET",
+          path: "/iacm/api/orgs/{org}/projects/{project}/workspaces/{workspaceId}/resources/{resourceId}",
+          pathParams: {
+            org_id: "org",
+            project_id: "project",
+            workspace_id: "workspaceId",
+            resource_id: "resourceId",
+          },
+          preflight: requireProjectScope,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          responseExtractor: iacmResourceGetExtract,
+          description:
+            "Get full metadata for a single Terraform resource within a workspace. " +
+            "Returns name, type, provider, module, drift_status, cost_data, and the Resource ID " +
+            "used for cross-system correlation (IDP, CCM, Dashboards). " +
+            "Requires workspace_id and resource_id (pass the resource identifier as resource_id).",
         },
       },
     },

--- a/tests/registry/iacm.test.ts
+++ b/tests/registry/iacm.test.ts
@@ -301,6 +301,58 @@ describe("costsListExtract", () => {
   });
 });
 
+// ─── Response extractor: iacmResourceGetExtract ──────────────────────────────
+
+describe("iacmResourceGetExtract", () => {
+  function extract(raw: unknown) {
+    return getOp("iacm_resource", "get").responseExtractor!(raw) as Record<string, unknown>;
+  }
+
+  it("normalizes a flat snake_case payload", () => {
+    const result = extract({
+      name: "aws_instance.web",
+      type: "aws_instance",
+      provider: "aws",
+      module: "root",
+      drift_status: "unchanged",
+      cost_data: { monthly: 12.5 },
+      resource_id: "res-1",
+      workspace_id: "ws-1",
+      attributes: { ami: "ami-123" },
+    });
+    expect(result.name).toBe("aws_instance.web");
+    expect(result.type).toBe("aws_instance");
+    expect(result.drift_status).toBe("unchanged");
+    expect(result.cost_data).toEqual({ monthly: 12.5 });
+    expect(result.resource_id).toBe("res-1");
+  });
+
+  it("unwraps payloads nested under a 'resource' key", () => {
+    const result = extract({ resource: { name: "aws_instance.web", resourceId: "res-7" } });
+    expect(result.name).toBe("aws_instance.web");
+    expect(result.resource_id).toBe("res-7");
+  });
+
+  it("maps camelCase fields to snake_case", () => {
+    const result = extract({
+      name: "aws_instance.web",
+      driftStatus: "drifted",
+      costData: { monthly: 5 },
+      resourceId: "res-9",
+      workspaceId: "ws-1",
+    });
+    expect(result.drift_status).toBe("drifted");
+    expect(result.cost_data).toEqual({ monthly: 5 });
+    expect(result.resource_id).toBe("res-9");
+    expect(result.workspace_id).toBe("ws-1");
+  });
+
+  it("passes through non-object input unchanged", () => {
+    expect(extract(null)).toBeNull();
+    expect(extract("oops")).toBe("oops");
+  });
+});
+
 // ─── Response extractor: activityChangesExtract ──────────────────────────────
 
 describe("activityChangesExtract", () => {
@@ -344,6 +396,12 @@ describe("endpoint paths", () => {
     expect(getOp("iacm_resource", "list").path).toContain("/resources");
   });
 
+  it("iacm_resource get uses /workspaces/{workspaceId}/resources/{resourceId}", () => {
+    expect(getOp("iacm_resource", "get").path).toBe(
+      "/iacm/api/orgs/{org}/projects/{project}/workspaces/{workspaceId}/resources/{resourceId}",
+    );
+  });
+
   it("iacm_module list uses /iacm/api/modules (account-scoped, no org/project)", () => {
     expect(getOp("iacm_module", "list").path).toBe("/iacm/api/modules");
     expect(getOp("iacm_module", "list").pathParams).toBeUndefined();
@@ -371,6 +429,23 @@ describe("iacm registry dispatch", () => {
 
     const request = mockRequest.mock.calls[0]![0] as { path: string };
     expect(request.path).toBe("/iacm/api/modules/4640");
+  });
+
+  it("dispatches iacm_resource get with workspace_id and resource id", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ id: "res-1", name: "aws_instance.web" });
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+
+    await registry.dispatch(makeClient(mockRequest), "iacm_resource", "get", {
+      org_id: "default",
+      project_id: "Testim",
+      workspace_id: "ws-1",
+      resource_id: "res-1",
+    });
+
+    const request = mockRequest.mock.calls[0]![0] as { path: string };
+    expect(request.path).toBe(
+      "/iacm/api/orgs/default/projects/Testim/workspaces/ws-1/resources/res-1",
+    );
   });
 
   it("dispatches activity resource changes by execution id", async () => {


### PR DESCRIPTION
Adding the missing
`resource_tools.get_resource` operation. Previously `iacm_resource` only
exposed `list`, forcing agents to paginate an entire workspace and filter
client-side just to inspect one Terraform resource.

> **PRD:** [Spec — Harness IaCM MCP Support](https://harness.atlassian.net/wiki/x/A4DHVAU)

## Motivation

| Before | After |
|---|---|
| `harness_get(resource_type="iacm_resource", ...)` returned `Missing required field "id"` | Routes to a single-resource API call and returns full metadata |
| To answer "what's the drift status of resource X?" the agent had to `list` 30 resources per page, walk all pages, filter by name | One direct request returns the resource and its complete metadata |
| Fields that may only exist on the single-resource endpoint (`Resource ID`, full `cost_data`, full `drift_status`) were unreachable | All fields available on demand |
| PRD compliance: **5/6 ops (83%)** | PRD compliance: **6/6 ops (100%)** |

## Changes

### [src/registry/toolsets/iacm.ts](cci:7://file:///Users/rahulbalani/Desktop/MCP/mcp-server/src/registry/toolsets/iacm.ts:0:0-0:0)

- Added `get` operation to `iacm_resource`:
  - **Path:** `GET /iacm/api/orgs/{org}/projects/{project}/workspaces/{workspaceId}/resources/{resourceId}`
  - **`pathParams`:** maps `resource_id → resourceId` so `harness_get` routes correctly. (`harness_get` populates `input[identifierFields.last]`, which for `iacm_resource` is `resource_id` — not `id`.)
  - **`preflight: requireProjectScope`** enforces `org_id` + `project_id`.
  - **`operationPolicy: { risk: "read", retryPolicy: "safe" }`** — read-only, safe to retry.
- Added `"resource_id"` to `identifierFields` so `harness_describe` advertises the new identifier.

### [tests/registry/iacm.test.ts](cci:7://file:///Users/rahulbalani/Desktop/MCP/mcp-server/tests/registry/iacm.test.ts:0:0-0:0)

- New path assertion: `iacm_resource.get` resolves to the `/workspaces/{workspaceId}/resources/{resourceId}` URL template.
- New dispatch test: confirms `resource_id=res-1` + `workspace_id=ws-1` produce the correct concrete URL via the registry.

## How to test

```bash
pnpm test tests/registry/iacm.test.ts
# Tests  38 passed (38)
```
<img width="1008" height="909" alt="Screenshot 2026-05-29 at 6 53 19 PM" src="https://github.com/user-attachments/assets/ff0dddf9-1133-444c-9000-d116214e110f" />

