### PR TITLE
feat: [IAC-6857]: add iacm ansible support to MCP server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,13 +66,14 @@ HARNESS_PIPELINE_VERSION=0
 HARNESS_MCP_LOG_FILE=
 
 # Toolset filtering — comma-separated list of enabled toolsets
-# If unset, all default toolsets are enabled. The iacm toolset is opt-in; use
-# +iacm to add it alongside defaults, or HARNESS_TOOLSETS=iacm for an explicit
-# IaCM-only allowlist. Use -name to remove defaults. The legacy name
+# If unset, all default toolsets are enabled. Two toolsets are opt-in (not loaded
+# by default): iacm and ansible. Use +name to add alongside defaults, or list
+# explicitly for an allowlist. Use -name to remove defaults. The legacy name
 # agent-pipelines is accepted as agents.
-# Available: pipelines,agents,services,environments,infrastructure,connectors,secrets,logs,audit,delegates,repositories,registries,templates,dashboards,idp,pull-requests,feature-flags,gitops,chaos,ccm,sei,scs,sto,dbops,access_control,settings,platform,visualizations,governance,freeze,overrides,ai-evals,iacm
-# IaCM (opt-in): project-scoped APIs require HARNESS_ORG and HARNESS_PROJECT,
-# or explicit org_id/project_id per tool call.
+# Available: pipelines,agents,services,environments,infrastructure,connectors,secrets,logs,audit,delegates,repositories,registries,templates,dashboards,idp,pull-requests,feature-flags,gitops,chaos,ccm,sei,scs,sto,dbops,access_control,settings,platform,visualizations,governance,freeze,overrides,ai-evals,iacm,ansible
+# Opt-in toolsets (require HARNESS_ORG and HARNESS_PROJECT, or explicit org_id/project_id per call):
+#   iacm    — Terraform workspaces, resources, modules, costs, activity diffs
+#   ansible — Ansible inventories, playbooks, hosts, and activity history
 HARNESS_TOOLSETS=
 
 # Audit sinks — all optional

--- a/README.md
+++ b/README.md
@@ -1510,7 +1510,10 @@ Inline PNG chart visualizations rendered from Harness data. These are metadata-o
 
 ## Toolset Filtering
 
-By default, 32 of 33 toolsets are enabled. The `iacm` toolset is opt-in because Harness IaCM APIs are project-scoped and add Terraform workspace/module concepts that many users do not need. The `ai-evals` toolset is default-enabled.
+By default, 32 of 34 toolsets are enabled. Two toolsets are opt-in and excluded from the defaults:
+
+- **`iacm`** — Harness IaCM (Terraform workspaces, modules, resources). Opt-in because it is project-scoped and adds concepts many users do not need.
+- **`ansible`** — Harness Ansible (inventories, playbooks, hosts, activity). Opt-in for the same reason.
 
 ### Adding toolsets with `+` prefix
 
@@ -1519,6 +1522,12 @@ Use the `+` prefix to explicitly include opt-in toolsets alongside all defaults:
 ```bash
 # Explicitly include IaCM alongside all defaults
 HARNESS_TOOLSETS=+iacm
+
+# Explicitly include Ansible alongside all defaults
+HARNESS_TOOLSETS=+ansible
+
+# Include both
+HARNESS_TOOLSETS=+iacm,+ansible
 ```
 
 ### Removing default toolsets
@@ -1584,6 +1593,7 @@ Available toolset names:
 | `visualizations`        | visual_timeline, visual_stage_flow, visual_health_dashboard, visual_pie_chart, visual_bar_chart, visual_timeseries, visual_architecture                                                                                                                                                         |
 | `ai-evals`              | eval_dataset, eval_dataset_item, evaluation, eval_run, eval_run_item, eval_run_by_eval, eval_metric, eval_metric_set, eval_metric_set_entry, eval_suite, eval_suite_evaluation, eval_suite_run, eval_target, eval_model, eval_annotation, eval_analytics, eval_git_settings, eval_registry_item |
 | `iacm` *(opt-in)*       | iacm_workspace, iacm_resource, iacm_module, iacm_workspace_costs, iacm_activity_resource_change                                                                                                                                                                                                 |
+| `ansible` *(opt-in)*    | ansible_inventory, ansible_playbook, ansible_host, ansible_host_activity, ansible_activity                                                                                                                                                                                                      |
 
 
 ## Architecture

--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -83,6 +83,10 @@ Unlike traditional MCP servers with one tool per API endpoint, this server uses 
 - Opt-in toolset for Terraform workspaces, resources, module registry entries, workspace costs, and activity resource changes
 - Enable with `HARNESS_TOOLSETS=+iacm`; IaCM APIs require org/project scope
 
+### Ansible
+- Opt-in toolset for Ansible inventories, playbooks, hosts, and activity history
+- Enable with `HARNESS_TOOLSETS=+ansible`; Ansible APIs require org/project scope
+
 ### Access Control
 - Manage users, user groups, service accounts
 - Create and assign roles, resource groups, permissions
@@ -154,4 +158,4 @@ Multi-scope resources such as connectors, services, environments, infrastructure
 **Toolset filtering:**
 - Set `HARNESS_TOOLSETS=pipelines,services,connectors` in `.env` to limit which resource types are available
 - Leave empty to enable all default toolsets
-- Add opt-in IaCM alongside defaults with `HARNESS_TOOLSETS=+iacm`
+- Add opt-in toolsets alongside defaults: `HARNESS_TOOLSETS=+iacm`, `HARNESS_TOOLSETS=+ansible`, or `HARNESS_TOOLSETS=+iacm,+ansible`

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -43,6 +43,7 @@ import { freezeToolset } from "./toolsets/freeze.js";
 import { overridesToolset } from "./toolsets/overrides.js";
 import { aiEvalsToolset } from "./toolsets/ai-evals.js";
 import { iacmToolset } from "./toolsets/iacm.js";
+import { ansibleToolset } from "./toolsets/ansible.js";
 
 const log = createLogger("registry");
 
@@ -152,6 +153,7 @@ const ALL_TOOLSETS: ToolsetDefinition[] = [
   overridesToolset,
   aiEvalsToolset,
   iacmToolset,
+  ansibleToolset,
 ];
 
 /** All available toolset names — used by docs generation to discover opt-in toolsets. */

--- a/src/registry/toolsets/ansible.ts
+++ b/src/registry/toolsets/ansible.ts
@@ -1,0 +1,396 @@
+import type { ToolsetDefinition, PreflightContext } from "../types.js";
+
+// ─── Response extractors ─────────────────────────────────────────────────────
+
+/** Must match harness_list tool default size (src/tools/harness-list.ts). */
+const ANSIBLE_PAGE_SIZE = 20;
+
+/**
+ * All Ansible list endpoints return a raw JSON array.
+ * `page_count` = items on THIS page only (never the real total).
+ * `has_more`   = true when the page is full (another page likely exists).
+ */
+const ansibleListExtract = (
+  raw: unknown,
+  input?: Record<string, unknown>,
+): { items: unknown[]; page_count: number; has_more: boolean; pagination_note: string } => {
+  if (!Array.isArray(raw)) {
+    throw new Error(
+      `Ansible list endpoint returned unexpected payload shape: expected a JSON array, got ${raw === null ? "null" : typeof raw}. ` +
+        `Payload: ${JSON.stringify(raw)}`,
+    );
+  }
+  const items = raw;
+  const requestedSize = typeof input?.["size"] === "number" ? input["size"] : ANSIBLE_PAGE_SIZE;
+  const has_more = items.length >= requestedSize;
+  return {
+    items,
+    page_count: items.length,
+    has_more,
+    pagination_note: has_more
+      ? `Only ${items.length} items returned (page is full). Call again with page+1 to fetch the next batch. Do NOT report ${items.length} as the total count.`
+      : `All items on this page returned (${items.length} items). has_more=false means this is the last page.`,
+  };
+};
+
+// ─── Preflight guards ────────────────────────────────────────────────────────
+
+const requireProjectScope = async (ctx: PreflightContext): Promise<void> => {
+  const cfg = (ctx.registry as unknown as { config: { HARNESS_ORG?: string; HARNESS_PROJECT?: string } }).config ?? {};
+  const orgId = ctx.input["org_id"] ?? cfg.HARNESS_ORG;
+  const projectId = ctx.input["project_id"] ?? cfg.HARNESS_PROJECT;
+  const missing: string[] = [];
+  if (!orgId) missing.push("org_id");
+  if (!projectId) missing.push("project_id");
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required field(s) for this Ansible operation: ${missing.join(", ")}. ` +
+        "Both org_id and project_id must be supplied — Ansible APIs are project-scoped.",
+    );
+  }
+};
+
+// ─── Toolset definition ─────────────────────────────────────────────────────
+
+export const ansibleToolset: ToolsetDefinition = {
+  name: "ansible",
+  displayName: "Ansible",
+  description:
+    "Harness Ansible — manage Ansible inventories (static, dynamic, plugin), playbooks, " +
+    "hosts, and activity history. Use ansible_inventory to manage host inventories, " +
+    "ansible_playbook to manage playbooks backed by Git repositories, " +
+    "ansible_host to inspect individual hosts and their last run status, " +
+    "and ansible_activity to review past Ansible execution activity.",
+  optIn: true,
+  resources: [
+    // ─── Inventory ──────────────────────────────────────────────────────────
+    {
+      resourceType: "ansible_inventory",
+      displayName: "Ansible Inventory",
+      description:
+        "An Ansible inventory managed by Harness. Inventories can be static (manual), " +
+        "dynamic (script-based), or plugin-based. Each inventory has an identifier, name, " +
+        "type (manual|dynamic|plugin), and a data payload describing hosts and groups. " +
+        "Use harness_list to list inventories and harness_get with inventory_id for full details. " +
+        "See also: ansible_host for individual host status, ansible_activity for run history.",
+      toolset: "ansible",
+      scope: "project",
+      identifierFields: ["inventory_id"],
+      listFilterFields: [
+        {
+          name: "search_term",
+          description: "Filter inventories by name (partial match).",
+          type: "string",
+        },
+        {
+          name: "page",
+          description: "Page number (0-based). Default: 0.",
+          type: "number",
+        },
+        {
+          name: "size",
+          description: "Number of inventories per page. Default: 20.",
+          type: "number",
+        },
+      ],
+      relatedResources: [
+        {
+          resourceType: "ansible_host",
+          relationship: "contains",
+          description: "Hosts belonging to this inventory",
+        },
+        {
+          resourceType: "ansible_activity",
+          relationship: "activity in",
+          description: "Ansible runs that used this inventory",
+        },
+      ],
+      operations: {
+        list: {
+          method: "GET",
+          path: "/iacm/api/orgs/{org}/projects/{project}/ansible/inventory",
+          pathParams: { org_id: "org", project_id: "project" },
+          queryParams: { search_term: "searchTerm", size: "limit", page: "page" },
+          pageOneIndexed: true,
+          skipCompact: true,
+          preflight: requireProjectScope,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          responseExtractor: ansibleListExtract,
+          description: "List Ansible inventories in the project.",
+        },
+        get: {
+          method: "GET",
+          path: "/iacm/api/orgs/{org}/projects/{project}/ansible/inventory/{inventoryId}",
+          pathParams: { org_id: "org", project_id: "project", inventory_id: "inventoryId" },
+          preflight: requireProjectScope,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          responseExtractor: (raw: unknown) => raw,
+          description: "Get full details for a specific Ansible inventory.",
+        },
+      },
+    },
+
+    // ─── Playbook ────────────────────────────────────────────────────────────
+    {
+      resourceType: "ansible_playbook",
+      displayName: "Ansible Playbook",
+      description:
+        "An Ansible playbook managed by Harness, backed by a Git repository. " +
+        "Each playbook has an identifier, name, repository connection details " +
+        "(repository, repository_branch, repository_connector, repository_path), " +
+        "and optional Ansible Galaxy support. " +
+        "Use harness_list to browse playbooks and harness_get for full details. " +
+        "See also: ansible_activity for run history.",
+      toolset: "ansible",
+      scope: "project",
+      identifierFields: ["playbook_id"],
+      listFilterFields: [
+        {
+          name: "search_term",
+          description: "Filter playbooks by name (partial match).",
+          type: "string",
+        },
+        {
+          name: "page",
+          description: "Page number (0-based). Default: 0.",
+          type: "number",
+        },
+        {
+          name: "size",
+          description: "Number of playbooks per page. Default: 20.",
+          type: "number",
+        },
+      ],
+      relatedResources: [
+        {
+          resourceType: "ansible_activity",
+          relationship: "activity in",
+          description: "Ansible runs that executed this playbook",
+        },
+        {
+          resourceType: "ansible_inventory",
+          relationship: "runs against",
+          description: "Inventories used when running this playbook",
+        },
+      ],
+      operations: {
+        list: {
+          method: "GET",
+          path: "/iacm/api/orgs/{org}/projects/{project}/ansible/playbook",
+          pathParams: { org_id: "org", project_id: "project" },
+          queryParams: { search_term: "searchTerm", size: "limit", page: "page" },
+          pageOneIndexed: true,
+          skipCompact: true,
+          preflight: requireProjectScope,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          responseExtractor: ansibleListExtract,
+          description: "List Ansible playbooks in the project.",
+        },
+        get: {
+          method: "GET",
+          path: "/iacm/api/orgs/{org}/projects/{project}/ansible/playbook/{playbookId}",
+          pathParams: { org_id: "org", project_id: "project", playbook_id: "playbookId" },
+          preflight: requireProjectScope,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          responseExtractor: (raw: unknown) => raw,
+          description: "Get full details for a specific Ansible playbook.",
+        },
+      },
+    },
+
+    // ─── Host ────────────────────────────────────────────────────────────────
+    {
+      resourceType: "ansible_host",
+      displayName: "Ansible Host",
+      description:
+        "An individual host managed by Harness Ansible. Each host has a host_address, " +
+        "a list of inventories it belongs to, and last_activity details (status, playbooks run, timestamp). " +
+        "Hosts are read-only — manage them through ansible_inventory. " +
+        "Use harness_list to browse all hosts, harness_get with host_id for full details including stats.",
+      toolset: "ansible",
+      scope: "project",
+      identifierFields: ["host_id"],
+      listFilterFields: [
+        {
+          name: "search_term",
+          description: "Filter hosts by address (partial match).",
+          type: "string",
+        },
+        {
+          name: "page",
+          description: "Page number (0-based). Default: 0.",
+          type: "number",
+        },
+        {
+          name: "size",
+          description: "Number of hosts per page. Default: 20.",
+          type: "number",
+        },
+      ],
+      relatedResources: [
+        {
+          resourceType: "ansible_inventory",
+          relationship: "member of",
+          description: "Inventories this host belongs to",
+        },
+        {
+          resourceType: "ansible_activity",
+          relationship: "activity for",
+          description: "Ansible runs that targeted this host",
+        },
+      ],
+      operations: {
+        list: {
+          method: "GET",
+          path: "/iacm/api/orgs/{org}/projects/{project}/ansible/hosts",
+          pathParams: { org_id: "org", project_id: "project" },
+          queryParams: { search_term: "searchTerm", size: "limit", page: "page" },
+          pageOneIndexed: true,
+          skipCompact: true,
+          preflight: requireProjectScope,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          responseExtractor: ansibleListExtract,
+          description: "List all Ansible hosts across inventories in the project. Supports search_term to filter by host address.",
+        },
+        get: {
+          method: "GET",
+          path: "/iacm/api/orgs/{org}/projects/{project}/ansible/hosts/{hostId}",
+          pathParams: { org_id: "org", project_id: "project", host_id: "hostId" },
+          preflight: requireProjectScope,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          responseExtractor: (raw: unknown) => raw,
+          description: "Get full details for a specific Ansible host including last_activity and stats.",
+        },
+      },
+    },
+
+    // ─── Activity ────────────────────────────────────────────────────────────
+    {
+      resourceType: "ansible_activity",
+      displayName: "Ansible Activity",
+      description:
+        "A record of an Ansible execution (playbook run) in Harness. Each activity tracks " +
+        "which inventories and playbooks were used, the pipeline execution that triggered it, " +
+        "git context (repo, branch, commit), and metrics (total_hosts, total_tasks, duration_ms, " +
+        "host_ok, host_failed, host_unreachable). " +
+        "Activities are read-only records of past runs.",
+      toolset: "ansible",
+      scope: "project",
+      identifierFields: ["activity_id"],
+      listFilterFields: [
+        {
+          name: "page",
+          description: "Page number (0-based). Default: 0.",
+          type: "number",
+        },
+        {
+          name: "size",
+          description: "Number of activities per page. Default: 20.",
+          type: "number",
+        },
+      ],
+      relatedResources: [
+        {
+          resourceType: "ansible_inventory",
+          relationship: "used inventory",
+          description: "Inventory used in this activity",
+        },
+        {
+          resourceType: "ansible_playbook",
+          relationship: "ran playbook",
+          description: "Playbook executed in this activity",
+        },
+        {
+          resourceType: "ansible_host",
+          relationship: "targeted hosts",
+          description: "Hosts targeted in this activity",
+        },
+      ],
+      operations: {
+        list: {
+          method: "GET",
+          path: "/iacm/api/orgs/{org}/projects/{project}/ansible/activities",
+          pathParams: { org_id: "org", project_id: "project" },
+          queryParams: { size: "limit", page: "page" },
+          pageOneIndexed: true,
+          skipCompact: true,
+          preflight: requireProjectScope,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          responseExtractor: ansibleListExtract,
+          description: "List Ansible activity records (playbook run history) for the project.",
+        },
+        get: {
+          method: "GET",
+          path: "/iacm/api/orgs/{org}/projects/{project}/ansible/activities/{activityId}",
+          pathParams: { org_id: "org", project_id: "project", activity_id: "activityId" },
+          preflight: requireProjectScope,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          responseExtractor: (raw: unknown) => raw,
+          description: "Get full details for a specific Ansible activity including metrics and git context.",
+        },
+      },
+    },
+
+    // ─── Host Activity ───────────────────────────────────────────────────────
+    {
+      resourceType: "ansible_host_activity",
+      displayName: "Ansible Host Activity",
+      description:
+        "Activity history for a specific Ansible host — the list of playbook runs that targeted it. " +
+        "Each entry includes the playbooks and inventories used, pipeline context, git info, " +
+        "per-task breakdown (name, action, status, changed, duration_ms), and run-level stats " +
+        "(ok, changed, failures, unreachable, skipped). " +
+        "host_id is required — use harness_list with ansible_host to find it.",
+      toolset: "ansible",
+      scope: "project",
+      identifierFields: ["host_id"],
+      listFilterFields: [
+        {
+          name: "host_id",
+          required: true,
+          description: "The host UUID. Use harness_list with ansible_host to find it.",
+          type: "string",
+        },
+        {
+          name: "page",
+          description: "Page number (0-based). Default: 0.",
+          type: "number",
+        },
+        {
+          name: "size",
+          description: "Number of activities per page. Default: 20.",
+          type: "number",
+        },
+      ],
+      relatedResources: [
+        {
+          resourceType: "ansible_host",
+          relationship: "activity for",
+          description: "The host whose activity history this shows",
+        },
+        {
+          resourceType: "ansible_playbook",
+          relationship: "ran playbook",
+          description: "Playbooks executed in these activities",
+        },
+      ],
+      operations: {
+        list: {
+          method: "GET",
+          path: "/iacm/api/orgs/{org}/projects/{project}/ansible/hosts/{hostId}/activities",
+          pathParams: { org_id: "org", project_id: "project", host_id: "hostId" },
+          queryParams: { size: "limit", page: "page" },
+          pageOneIndexed: true,
+          skipCompact: true,
+          preflight: requireProjectScope,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          responseExtractor: ansibleListExtract,
+          description:
+            "List activity history for a specific Ansible host. " +
+            "Returns per-task breakdowns including name, action, status, changed flag, and duration_ms. " +
+            "Requires host_id.",
+        },
+      },
+    },
+  ],
+};

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -138,7 +138,8 @@ export type ToolsetName =
   | "freeze"
   | "overrides"
   | "ai-evals"
-  | "iacm";
+  | "iacm"
+  | "ansible";
 
 export type ProductName = "harness" | "fme";
 

--- a/tests/registry/ansible.test.ts
+++ b/tests/registry/ansible.test.ts
@@ -1,0 +1,398 @@
+import { describe, it, expect, vi } from "vitest";
+import { ansibleToolset } from "../../src/registry/toolsets/ansible.js";
+import { Registry } from "../../src/registry/index.js";
+import type { Config } from "../../src/config.js";
+import type { HarnessClient } from "../../src/client/harness-client.js";
+import type { ResourceDefinition, EndpointSpec, PreflightContext } from "../../src/registry/types.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    HARNESS_API_KEY: "pat.test",
+    HARNESS_ACCOUNT_ID: "test-account",
+    HARNESS_BASE_URL: "https://app.harness.io",
+    HARNESS_ORG: "default",
+    HARNESS_PROJECT: "stephenAnsible",
+    HARNESS_API_TIMEOUT_MS: 30000,
+    HARNESS_MAX_RETRIES: 3,
+    LOG_LEVEL: "info",
+    HARNESS_MAX_BODY_SIZE_MB: 10,
+    HARNESS_RATE_LIMIT_RPS: 10,
+    HARNESS_READ_ONLY: false,
+    HARNESS_SKIP_ELICITATION: false,
+    HARNESS_AUTO_APPROVE_RISK: "none",
+    HARNESS_ALLOW_HTTP: false,
+    HARNESS_FME_BASE_URL: "https://api.split.io",
+    HARNESS_LOG_UNSAFE_BODIES: false,
+    HARNESS_AUDIT_WEBHOOK_BATCH_SIZE: 10,
+    HARNESS_AUDIT_WEBHOOK_FLUSH_MS: 5000,
+    ...overrides,
+  } as Config;
+}
+
+function makeClient(requestFn?: (...args: unknown[]) => unknown): HarnessClient {
+  return {
+    request: requestFn ?? vi.fn().mockResolvedValue([]),
+    account: "test-account",
+  } as unknown as HarnessClient;
+}
+
+function findResource(type: string): ResourceDefinition {
+  const res = ansibleToolset.resources.find((r) => r.resourceType === type);
+  if (!res) throw new Error(`Resource type "${type}" not found in ansibleToolset`);
+  return res;
+}
+
+function getOp(type: string, op: "list" | "get"): EndpointSpec {
+  const res = findResource(type);
+  const spec = res.operations[op];
+  if (!spec) throw new Error(`Operation "${op}" not found on "${type}"`);
+  return spec;
+}
+
+// ─── Toolset structure ────────────────────────────────────────────────────────
+
+describe("ansibleToolset structure", () => {
+  it("has name 'ansible'", () => {
+    expect(ansibleToolset.name).toBe("ansible");
+  });
+
+  it("is opt-in (not loaded by default)", () => {
+    expect(ansibleToolset.optIn).toBe(true);
+  });
+
+  it("registers all 5 resource types", () => {
+    const types = ansibleToolset.resources.map((r) => r.resourceType);
+    expect(types).toContain("ansible_inventory");
+    expect(types).toContain("ansible_playbook");
+    expect(types).toContain("ansible_host");
+    expect(types).toContain("ansible_activity");
+    expect(types).toContain("ansible_host_activity");
+    expect(types).toHaveLength(5);
+  });
+
+  it("all resources are project-scoped", () => {
+    for (const resource of ansibleToolset.resources) {
+      expect(resource.scope, `${resource.resourceType} should be project-scoped`).toBe("project");
+    }
+  });
+
+  it("all endpoint specs have operationPolicy with risk=read", () => {
+    for (const resource of ansibleToolset.resources) {
+      for (const [opName, spec] of Object.entries(resource.operations)) {
+        expect(
+          spec.operationPolicy,
+          `${resource.resourceType}.${opName} is missing operationPolicy`,
+        ).toBeDefined();
+        expect(
+          spec.operationPolicy!.risk,
+          `${resource.resourceType}.${opName} should be read risk`,
+        ).toBe("read");
+      }
+    }
+  });
+
+  it("all list operations have skipCompact=true", () => {
+    for (const resource of ansibleToolset.resources) {
+      const listSpec = resource.operations["list"];
+      if (listSpec) {
+        expect(
+          listSpec.skipCompact,
+          `${resource.resourceType}.list should have skipCompact=true`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("all list operations have pageOneIndexed=true", () => {
+    for (const resource of ansibleToolset.resources) {
+      const listSpec = resource.operations["list"];
+      if (listSpec) {
+        expect(
+          listSpec.pageOneIndexed,
+          `${resource.resourceType}.list should have pageOneIndexed=true`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("ansible_inventory and ansible_playbook are read-only (no create/update/delete)", () => {
+    for (const type of ["ansible_inventory", "ansible_playbook"]) {
+      const res = findResource(type);
+      expect(res.operations["create"], `${type} should not have create`).toBeUndefined();
+      expect(res.operations["update"], `${type} should not have update`).toBeUndefined();
+      expect(res.operations["delete"], `${type} should not have delete`).toBeUndefined();
+    }
+  });
+
+  it("ansible_host and ansible_activity are read-only (no write operations)", () => {
+    for (const type of ["ansible_host", "ansible_activity", "ansible_host_activity"]) {
+      const res = findResource(type);
+      expect(res.operations["create"], `${type} should not have create`).toBeUndefined();
+      expect(res.operations["update"], `${type} should not have update`).toBeUndefined();
+      expect(res.operations["delete"], `${type} should not have delete`).toBeUndefined();
+    }
+  });
+});
+
+// ─── Registry opt-in behaviour ────────────────────────────────────────────────
+
+describe("ansible opt-in with Registry", () => {
+  it("is NOT present when HARNESS_TOOLSETS is unset (all defaults)", () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: undefined }));
+    expect(registry.getAllResourceTypes()).not.toContain("ansible_inventory");
+    expect(registry.getAllResourceTypes()).not.toContain("ansible_playbook");
+  });
+
+  it("IS present when explicitly enabled with HARNESS_TOOLSETS=ansible", () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ansible" }));
+    const types = registry.getAllResourceTypes();
+    expect(types).toContain("ansible_inventory");
+    expect(types).toContain("ansible_playbook");
+    expect(types).toContain("ansible_host");
+    expect(types).toContain("ansible_activity");
+    expect(types).toContain("ansible_host_activity");
+  });
+
+  it("IS present when enabled with +ansible modifier", () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "+ansible" }));
+    expect(registry.getAllResourceTypes()).toContain("ansible_inventory");
+  });
+
+  it("can be combined with other toolsets (+ansible alongside defaults)", () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "+ansible" }));
+    const types = registry.getAllResourceTypes();
+    expect(types).toContain("ansible_inventory");
+    expect(types).toContain("pipeline"); // default toolset still present
+  });
+});
+
+// ─── requireProjectScope preflight ───────────────────────────────────────────
+
+describe("requireProjectScope preflight", () => {
+  const preflight = getOp("ansible_inventory", "list").preflight!;
+
+  it("passes when both org_id and project_id are provided in input", async () => {
+    const ctx: PreflightContext = {
+      input: { org_id: "default", project_id: "stephenAnsible" },
+      client: makeClient(),
+      registry: new Registry(makeConfig({ HARNESS_TOOLSETS: "ansible" })),
+    };
+    await expect(preflight(ctx)).resolves.toBeUndefined();
+  });
+
+  it("passes when org_id and project_id come from config defaults", async () => {
+    const ctx: PreflightContext = {
+      input: {},
+      client: makeClient(),
+      registry: new Registry(makeConfig({ HARNESS_TOOLSETS: "ansible", HARNESS_ORG: "default", HARNESS_PROJECT: "stephenAnsible" })),
+    };
+    await expect(preflight(ctx)).resolves.toBeUndefined();
+  });
+
+  it("throws when org_id is missing from both input and config", async () => {
+    const ctx: PreflightContext = {
+      input: { project_id: "stephenAnsible" },
+      client: makeClient(),
+      registry: new Registry(makeConfig({ HARNESS_TOOLSETS: "ansible", HARNESS_ORG: "" })),
+    };
+    await expect(preflight(ctx)).rejects.toThrow("org_id");
+  });
+
+  it("throws when project_id is missing from both input and config", async () => {
+    const ctx: PreflightContext = {
+      input: { org_id: "default" },
+      client: makeClient(),
+      registry: new Registry(makeConfig({ HARNESS_TOOLSETS: "ansible", HARNESS_PROJECT: undefined })),
+    };
+    await expect(preflight(ctx)).rejects.toThrow("project_id");
+  });
+
+  it("throws when both are missing", async () => {
+    const ctx: PreflightContext = {
+      input: {},
+      client: makeClient(),
+      registry: new Registry(makeConfig({ HARNESS_TOOLSETS: "ansible", HARNESS_ORG: "", HARNESS_PROJECT: undefined })),
+    };
+    await expect(preflight(ctx)).rejects.toThrow("org_id");
+    await expect(preflight(ctx)).rejects.toThrow("project_id");
+  });
+
+  it("preflight is present on all list operations", () => {
+    for (const type of ["ansible_inventory", "ansible_playbook", "ansible_host", "ansible_activity"]) {
+      const spec = getOp(type, "list");
+      expect(spec.preflight, `${type}.list is missing preflight`).toBeDefined();
+    }
+  });
+});
+
+// ─── ansibleListExtract ───────────────────────────────────────────────────────
+
+describe("ansibleListExtract", () => {
+  function extract(raw: unknown, input?: Record<string, unknown>) {
+    return getOp("ansible_inventory", "list").responseExtractor!(raw, input) as Record<string, unknown>;
+  }
+
+  it("wraps array into { items, page_count, has_more, pagination_note }", () => {
+    const items = [{ identifier: "inv1" }, { identifier: "inv2" }];
+    const result = extract(items);
+    expect(result.items).toEqual(items);
+    expect(result.page_count).toBe(2);
+    expect(result.has_more).toBe(false);
+    expect(typeof result.pagination_note).toBe("string");
+  });
+
+  it("does not set a total field (avoids fake total)", () => {
+    const result = extract([{ identifier: "inv1" }]);
+    expect(result.total).toBeUndefined();
+  });
+
+  it("has_more=true when items.length >= requested size", () => {
+    const items = Array.from({ length: 20 }, (_, i) => ({ identifier: `inv${i}` }));
+    const result = extract(items, { size: 20 });
+    expect(result.has_more).toBe(true);
+  });
+
+  it("has_more=false when items.length < requested size", () => {
+    const items = Array.from({ length: 5 }, (_, i) => ({ identifier: `inv${i}` }));
+    const result = extract(items, { size: 20 });
+    expect(result.has_more).toBe(false);
+  });
+
+  it("has_more=false when size=100 and only 22 items returned", () => {
+    const items = Array.from({ length: 22 }, (_, i) => ({ identifier: `inv${i}` }));
+    const result = extract(items, { size: 100 });
+    expect(result.has_more).toBe(false);
+  });
+
+  it("uses default page size (20) when input has no size", () => {
+    const items = Array.from({ length: 20 }, (_, i) => ({ identifier: `inv${i}` }));
+    const result = extract(items);
+    expect(result.has_more).toBe(true);
+  });
+
+  it("throws on non-array payload (fail loudly)", () => {
+    expect(() => extract(null)).toThrow("expected a JSON array");
+    expect(() => extract({ items: [] })).toThrow("expected a JSON array");
+    expect(() => extract("string")).toThrow("expected a JSON array");
+  });
+
+  it("pagination_note warns about page count on full page", () => {
+    const items = Array.from({ length: 20 }, (_, i) => ({ identifier: `inv${i}` }));
+    const result = extract(items, { size: 20 });
+    expect(result.pagination_note as string).toContain("page+1");
+    expect(result.pagination_note as string).toContain("Do NOT report");
+  });
+
+  it("pagination_note confirms last page when has_more=false", () => {
+    const result = extract([{ identifier: "inv1" }], { size: 20 });
+    expect(result.pagination_note as string).toContain("last page");
+  });
+
+  it("same extractor is used by all list operations", () => {
+    for (const type of ["ansible_inventory", "ansible_playbook", "ansible_host", "ansible_activity", "ansible_host_activity"]) {
+      const spec = getOp(type, "list");
+      expect(spec.responseExtractor, `${type}.list is missing responseExtractor`).toBeDefined();
+    }
+  });
+});
+
+// ─── Endpoint paths ───────────────────────────────────────────────────────────
+
+describe("endpoint paths", () => {
+  it("ansible_inventory list path", () => {
+    expect(getOp("ansible_inventory", "list").path).toBe(
+      "/iacm/api/orgs/{org}/projects/{project}/ansible/inventory",
+    );
+  });
+
+  it("ansible_inventory get path", () => {
+    expect(getOp("ansible_inventory", "get").path).toBe(
+      "/iacm/api/orgs/{org}/projects/{project}/ansible/inventory/{inventoryId}",
+    );
+  });
+
+  it("ansible_playbook list path", () => {
+    expect(getOp("ansible_playbook", "list").path).toBe(
+      "/iacm/api/orgs/{org}/projects/{project}/ansible/playbook",
+    );
+  });
+
+  it("ansible_host list path uses /hosts (plural)", () => {
+    expect(getOp("ansible_host", "list").path).toBe(
+      "/iacm/api/orgs/{org}/projects/{project}/ansible/hosts",
+    );
+  });
+
+  it("ansible_activity list path", () => {
+    expect(getOp("ansible_activity", "list").path).toBe(
+      "/iacm/api/orgs/{org}/projects/{project}/ansible/activities",
+    );
+  });
+
+  it("ansible_host_activity list path includes hostId", () => {
+    expect(getOp("ansible_host_activity", "list").path).toBe(
+      "/iacm/api/orgs/{org}/projects/{project}/ansible/hosts/{hostId}/activities",
+    );
+  });
+});
+
+// ─── Registry dispatch integration ───────────────────────────────────────────
+
+describe("ansible registry dispatch", () => {
+  it("dispatches ansible_inventory list with org/project path params", async () => {
+    const mockRequest = vi.fn().mockResolvedValue([]);
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ansible" }));
+
+    await registry.dispatch(makeClient(mockRequest), "ansible_inventory", "list", {
+      org_id: "default",
+      project_id: "stephenAnsible",
+    });
+
+    const request = mockRequest.mock.calls[0]![0] as { path: string };
+    expect(request.path).toBe("/iacm/api/orgs/default/projects/stephenAnsible/ansible/inventory");
+  });
+
+  it("dispatches ansible_playbook get with identifier", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ identifier: "GoldenPlaybook" });
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ansible" }));
+
+    await registry.dispatch(makeClient(mockRequest), "ansible_playbook", "get", {
+      org_id: "default",
+      project_id: "stephenAnsible",
+      playbook_id: "GoldenPlaybook",
+    });
+
+    const request = mockRequest.mock.calls[0]![0] as { path: string };
+    expect(request.path).toBe("/iacm/api/orgs/default/projects/stephenAnsible/ansible/playbook/GoldenPlaybook");
+  });
+
+  it("dispatches ansible_host_activity list with hostId in path", async () => {
+    const mockRequest = vi.fn().mockResolvedValue([]);
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ansible" }));
+
+    await registry.dispatch(makeClient(mockRequest), "ansible_host_activity", "list", {
+      org_id: "default",
+      project_id: "stephenAnsible",
+      host_id: "abc-123",
+    });
+
+    const request = mockRequest.mock.calls[0]![0] as { path: string };
+    expect(request.path).toBe("/iacm/api/orgs/default/projects/stephenAnsible/ansible/hosts/abc-123/activities");
+  });
+
+  it("falls back to config org/project when not in input", async () => {
+    const mockRequest = vi.fn().mockResolvedValue([]);
+    const registry = new Registry(makeConfig({
+      HARNESS_TOOLSETS: "ansible",
+      HARNESS_ORG: "default",
+      HARNESS_PROJECT: "stephenAnsible",
+    }));
+
+    await registry.dispatch(makeClient(mockRequest), "ansible_inventory", "list", {});
+
+    const request = mockRequest.mock.calls[0]![0] as { path: string };
+    expect(request.path).toBe("/iacm/api/orgs/default/projects/stephenAnsible/ansible/inventory");
+  });
+});


### PR DESCRIPTION
## Description
Add support for ansible resources to MCP server:

- playbooks
- inventories
- hosts
- host activities

This functionality is currently beta so will leave it opt in for testing until we GA 

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [ ] Tests pass
- [ ] Typecheck passes
