### PR TITLE
[codex] Bump version to 3.1.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "harness-mcp-server",
   "display_name": "Harness",
-  "version": "3.0.9",
+  "version": "3.1.0",
   "description": "Connect AI agents to Harness for CI/CD, code repositories, pull requests, services, environments, and feature flags.",
   "long_description": "The Harness MCP Server gives MCP-compatible clients access to Harness platform workflows through consolidated tools, resources, and prompts. It supports local stdio usage and can be bundled as a Node-based MCPB extension.",
   "author": {

--- a/mcp-directory/manifest.json
+++ b/mcp-directory/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "harness-mcp-server",
   "display_name": "Harness",
-  "version": "3.0.9",
+  "version": "3.1.0",
   "description": "Connect AI agents to Harness for CI/CD, code repositories, pull requests, services, environments, and feature flags.",
   "long_description": "The Harness MCP Server gives MCP-compatible clients access to Harness platform workflows through consolidated tools, resources, and prompts. It supports local stdio usage and can be bundled as a Node-based MCPB extension.",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-mcp-v2",
-  "version": "3.0.9",
+  "version": "3.1.0",
   "description": "Give AI agents full access to the Harness.io platform — manage pipelines, deployments, cloud costs, chaos engineering, feature flags, SEI, and 125+ resource types through 11 MCP tools",
   "type": "module",
   "main": "build/index.js",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,22 @@
 # Harness MCP Server — Task Tracking
 
+## Version Bump 3.1.0 (2026-05-29)
+- [x] Identify release metadata fields pinned to the previous version
+- [x] Update package and manifest versions to 3.1.0
+- [x] Update release metadata regression test
+- [x] Run verification
+- [x] Open PR
+
+### Plan
+- Keep this as a metadata-only release bump.
+- Update `package.json`, root `manifest.json`, `mcp-directory/manifest.json`, and the release metadata test expectation.
+- Do not change dependency versions or generated lockfile data unless verification shows the package manager requires it.
+
+### Review
+- Updated `package.json`, root `manifest.json`, and `mcp-directory/manifest.json` to `3.1.0`.
+- Updated `tests/release-metadata.test.ts` so package and bundle manifest versions remain locked together for the `3.1.0` release.
+- Verification passed: `pnpm vitest run tests/release-metadata.test.ts` and `pnpm typecheck`.
+
 ## PR 282 IaCM Activity Resource Changes (2026-05-29)
 - [x] Restore engineer's activity-scoped resource change endpoint
 - [x] Keep IaCM default-enabled and Ansible opt-in on current main

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -9,12 +9,12 @@ function readJson(path: string): { version: string } {
 }
 
 describe("release metadata", () => {
-  it("keeps package and bundle manifest versions in sync for the next patch release", () => {
+  it("keeps package and bundle manifest versions in sync for the next release", () => {
     const packageJson = readJson("package.json");
     const rootManifest = readJson("manifest.json");
     const directoryManifest = readJson("mcp-directory/manifest.json");
 
-    expect(packageJson.version).toBe("3.0.9");
+    expect(packageJson.version).toBe("3.1.0");
     expect(rootManifest.version).toBe(packageJson.version);
     expect(directoryManifest.version).toBe(packageJson.version);
   });


### PR DESCRIPTION
## Summary
- Bump the package version from `3.0.9` to `3.1.0`.
- Keep the root MCP manifest and MCP directory manifest in sync with the package version.
- Update the release metadata regression test for the new release version.

## Validation
- `pnpm vitest run tests/release-metadata.test.ts`
- `pnpm typecheck`
