### PR TITLE
Preserve Harness URL Git context

### DIFF
--- a/src/utils/url-parser.ts
+++ b/src/utils/url-parser.ts
@@ -23,6 +23,10 @@ export interface ParsedHarnessUrl {
   step_id?: string;
   stage_id?: string;
   stage_execution_id?: string;
+  branch?: string;
+  store_type?: string;
+  connector_ref?: string;
+  repo_name?: string;
 }
 
 /** Union of ParsedHarnessUrl fields that RESOURCE_SEGMENTS can write to. */
@@ -224,6 +228,18 @@ export function parseHarnessUrl(urlStr: string): ParsedHarnessUrl {
   const commentId = url.searchParams.get("commentId");
   if (commentId) result.comment_id = commentId;
 
+  const branch = url.searchParams.get("branch");
+  if (branch) result.branch = branch;
+
+  const storeType = url.searchParams.get("storeType");
+  if (storeType) result.store_type = storeType;
+
+  const connectorRef = url.searchParams.get("connectorRef");
+  if (connectorRef) result.connector_ref = connectorRef;
+
+  const repoName = url.searchParams.get("repoName");
+  if (repoName) result.repo_name = repoName;
+
   return result;
 }
 
@@ -246,6 +262,10 @@ const MERGEABLE_FIELDS: (keyof ParsedHarnessUrl)[] = [
   "step_id",
   "stage_id",
   "stage_execution_id",
+  "branch",
+  "store_type",
+  "connector_ref",
+  "repo_name",
 ];
 
 export interface ApplyUrlDefaultsOptions {

--- a/tests/utils/url-parser.test.ts
+++ b/tests/utils/url-parser.test.ts
@@ -223,6 +223,10 @@ describe("parseHarnessUrl", () => {
     expect(result.pipeline_id).toBe("build_jdk11_github_clickops");
     expect(result.execution_id).toBe("2QvnKmYBRK2H5oC37YjdMQ");
     expect(result.resource_id).toBe("2QvnKmYBRK2H5oC37YjdMQ");
+    expect(result.connector_ref).toBe("org.org_ghec_con");
+    expect(result.repo_name).toBe("harn-merdeploy");
+    expect(result.branch).toBe("vk_sandbox");
+    expect(result.store_type).toBe("REMOTE");
   });
 
   it("parses a path-only pipeline-studio URL", () => {
@@ -235,6 +239,7 @@ describe("parseHarnessUrl", () => {
     expect(result.resource_type).toBe("pipeline");
     expect(result.pipeline_id).toBe("slack_channel_summarizer_pipeline");
     expect(result.resource_id).toBe("slack_channel_summarizer_pipeline");
+    expect(result.store_type).toBe("INLINE");
   });
 
   it("parses a path-only URL with stage_id query param", () => {
@@ -350,6 +355,39 @@ describe("applyUrlDefaults", () => {
     expect(result.resource_type).toBe("execution");
     expect(result.execution_id).toBe("exec123");
     expect(result.pipeline_id).toBe("myPipeline");
+  });
+
+  it("merges remote Git query params from a Harness URL", () => {
+    const result = applyUrlDefaults(
+      {},
+      "https://app.harness.io/ng/account/abc/module/ci/orgs/myOrg/projects/myProject/pipelines/myPipeline/executions/exec123/pipeline?connectorRef=account.git_connector&repoName=ExampleOrg%2Fexample-service&branch=feature-branch&storeType=REMOTE",
+    );
+
+    expect(result.pipeline_id).toBe("myPipeline");
+    expect(result.execution_id).toBe("exec123");
+    expect(result.connector_ref).toBe("account.git_connector");
+    expect(result.repo_name).toBe("ExampleOrg/example-service");
+    expect(result.branch).toBe("feature-branch");
+    expect(result.store_type).toBe("REMOTE");
+  });
+
+  it("preserves explicit remote Git params over URL-derived defaults", () => {
+    const result = applyUrlDefaults(
+      {
+        branch: "explicit-branch",
+        store_type: "INLINE",
+        connector_ref: "explicit.connector",
+        repo_name: "explicit/repo",
+      },
+      "https://app.harness.io/ng/account/abc/module/ci/orgs/myOrg/projects/myProject/pipelines/myPipeline/executions/exec123/pipeline?connectorRef=url.connector&repoName=url%2Frepo&branch=url-branch&storeType=REMOTE",
+    );
+
+    expect(result.branch).toBe("explicit-branch");
+    expect(result.store_type).toBe("INLINE");
+    expect(result.connector_ref).toBe("explicit.connector");
+    expect(result.repo_name).toBe("explicit/repo");
+    expect(result.pipeline_id).toBe("myPipeline");
+    expect(result.execution_id).toBe("exec123");
   });
 
   it("does not mutate the original args object", () => {


### PR DESCRIPTION
## Summary

- preserve Git context query parameters from Harness execution URLs: branch, storeType, connectorRef, and repoName
- include those parsed fields in URL/context merging so URL-only tool calls fetch remote pipeline YAML from the correct branch/repository context
- add regression coverage for Harness execution URLs carrying branch and remote repository query parameters

## Testing

- pnpm install --frozen-lockfile
- pnpm test tests/utils/url-parser.test.ts
- pnpm build
- pnpm typecheck
- pnpm docs:check
- pnpm test
- node scripts/smoke-test.js

## Manual validation

- verified with MCP Inspector that a URL-only harness_get call against a remote Harness execution URL preserved the URL branch context when retrieving pipeline YAML
