### PR TITLE
fix(ai-evals): correct bugs, add discoverability, and online eval resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Harness MCP Server 2.0
 
-An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 201 resource types.
+An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 202 resource types.
 
 ## Why Use This MCP Server
 
@@ -8,7 +8,7 @@ Most MCP servers map one tool per API endpoint. For a platform as broad as Harne
 
 This server is built differently:
 
-- **11 tools, 201 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
+- **11 tools, 202 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
 - **Full platform coverage.** 33 default toolsets spanning CI/CD, GitOps, Feature Flags, Cloud Cost Management, Security Testing, Chaos Engineering, Database DevOps, Internal Developer Portal, Software Supply Chain, Infrastructure as Code Management, Governance, Service Overrides, Visualizations, and more. Opt-in Ansible coverage is available when you need inventory and playbook data.
 - **Multi-project workflows out of the box.** Agents discover organizations and projects dynamically — no hardcoded env vars needed. Ask "show failed executions across all projects" and the agent can navigate the full account hierarchy.
 - **32 prompt templates.** Pre-built prompts for common workflows: build & deploy apps end-to-end, debug failed pipelines, review DORA metrics, triage vulnerabilities, optimize cloud costs, audit access control, plan feature flag rollouts, review pull requests, approve pending pipelines, and more.
@@ -1041,7 +1041,7 @@ Harness pipelines can be stored in three ways:
 
 ## Resource Types
 
-201 resource types organized across 33 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
+202 resource types organized across 33 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
 
 ### Platform
 
@@ -1605,7 +1605,7 @@ Available toolset names:
                  +--------v---------+
                 |    Registry       |  <-- Declarative resource definitions
                 |  33 Toolsets      |      (data files, not code)
-                |  201 Resource Types|
+                |  202 Resource Types|
                  +--------+---------+
                           |
                  +--------v---------+

--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -1,6 +1,6 @@
 # Harness MCP Server — Gemini CLI Context
 
-This extension connects Gemini CLI to the Harness Platform through 11 consolidated MCP tools that cover 201 resource types across 33 default toolsets.
+This extension connects Gemini CLI to the Harness Platform through 11 consolidated MCP tools that cover 202 resource types across 33 default toolsets.
 
 ## How This Server Works
 

--- a/src/registry/toolsets/ai-evals.ts
+++ b/src/registry/toolsets/ai-evals.ts
@@ -43,7 +43,7 @@ const createDatasetSchema: BodySchema = {
     },
     { name: "metadata", type: "object", required: false, description: "Arbitrary metadata" },
     { name: "storage_type", type: "string", required: false, description: "managed (default) | git" },
-    { name: "git_source", type: "object", required: false, description: "Git location (required when storage_type='git'): { connector_ref?, repo?, branch?, file_path }" },
+    { name: "git_source", type: "object", required: false, description: "Git location (required when storage_type='git'): { connector_ref?, repo?, branch?, file_path (required) }" },
   ],
 };
 
@@ -62,7 +62,7 @@ const updateDatasetSchema: BodySchema = {
     },
     { name: "metadata", type: "object", required: false, description: "Metadata" },
     { name: "storage_type", type: "string", required: false, description: "managed | git (switches storage mode)" },
-    { name: "git_source", type: "object", required: false, description: "Git location (required when switching to storage_type='git'): { connector_ref?, repo?, branch?, file_path }" },
+    { name: "git_source", type: "object", required: false, description: "Git location (required when switching to storage_type='git'): { connector_ref?, repo?, branch?, file_path (required) }" },
   ],
 };
 
@@ -112,7 +112,7 @@ const createEvalSchema: BodySchema = {
     { name: "cost_limit_usd", type: "number", required: false, description: "Max cost in USD" },
     { name: "timeout_per_item_ms", type: "number", required: false, description: "Per-item timeout ms (default 30000, min 1000)" },
     { name: "storage_type", type: "string", required: false, description: "managed (default) | git" },
-    { name: "git_source", type: "object", required: false, description: "Git location (required when storage_type='git'): { connector_ref?, repo?, branch?, file_path }" },
+    { name: "git_source", type: "object", required: false, description: "Git location (required when storage_type='git'): { connector_ref?, repo?, branch?, file_path (required) }" },
   ],
 };
 
@@ -132,7 +132,7 @@ const updateEvalSchema: BodySchema = {
     { name: "cost_limit_usd", type: "number", required: false, description: "Max cost in USD" },
     { name: "timeout_per_item_ms", type: "number", required: false, description: "Per-item timeout ms (min 1000)" },
     { name: "storage_type", type: "string", required: false, description: "managed | git (switches storage mode)" },
-    { name: "git_source", type: "object", required: false, description: "Git location (required when switching to storage_type='git'): { connector_ref?, repo?, branch?, file_path }" },
+    { name: "git_source", type: "object", required: false, description: "Git location (required when switching to storage_type='git'): { connector_ref?, repo?, branch?, file_path (required) }" },
   ],
 };
 
@@ -289,7 +289,7 @@ const createSuiteSchema: BodySchema = {
     { name: "triggered_by", type: "string", required: false, description: "Who created the suite" },
     { name: "schedule", type: "object", required: false, description: "Cron schedule: { cron: string, timezone?: string (default UTC), enabled?: boolean (default true) }" },
     { name: "storage_type", type: "string", required: false, description: "managed (default) | git" },
-    { name: "git_source", type: "object", required: false, description: "Git location (required when storage_type='git'): { connector_ref?, repo?, branch?, file_path }" },
+    { name: "git_source", type: "object", required: false, description: "Git location (required when storage_type='git'): { connector_ref?, repo?, branch?, file_path (required) }" },
   ],
 };
 
@@ -304,7 +304,7 @@ const updateSuiteSchema: BodySchema = {
     { name: "is_blocking", type: "boolean", required: false, description: "Blocking suite" },
     { name: "schedule", type: "object", required: false, description: "Cron schedule: { cron, timezone?, enabled? } — set null to remove" },
     { name: "storage_type", type: "string", required: false, description: "managed | git (switches storage mode)" },
-    { name: "git_source", type: "object", required: false, description: "Git location (required when switching to storage_type='git'): { connector_ref?, repo?, branch?, file_path }" },
+    { name: "git_source", type: "object", required: false, description: "Git location (required when switching to storage_type='git'): { connector_ref?, repo?, branch?, file_path (required) }" },
   ],
 };
 
@@ -365,7 +365,7 @@ const createTargetSchema: BodySchema = {
     { name: "env_secrets", type: "object", required: false, description: "Env var to Harness secret ref mapping" },
     { name: "connector_ref", type: "string", required: false, description: "Harness HTTP connector for endpoint configuration" },
     { name: "storage_type", type: "string", required: false, description: "managed (default) | git" },
-    { name: "git_source", type: "object", required: false, description: "Git location (required when storage_type='git'): { connector_ref?, repo?, branch?, file_path }" },
+    { name: "git_source", type: "object", required: false, description: "Git location (required when storage_type='git'): { connector_ref?, repo?, branch?, file_path (required) }" },
   ],
 };
 
@@ -381,7 +381,7 @@ const updateTargetSchema: BodySchema = {
     { name: "env_secrets", type: "object", required: false, description: "Env var to Harness secret ref mapping" },
     { name: "connector_ref", type: "string", required: false, description: "Harness HTTP connector for endpoint configuration" },
     { name: "storage_type", type: "string", required: false, description: "managed | git (switches storage mode)" },
-    { name: "git_source", type: "object", required: false, description: "Git location (required when switching to storage_type='git'): { connector_ref?, repo?, branch?, file_path }" },
+    { name: "git_source", type: "object", required: false, description: "Git location (required when switching to storage_type='git'): { connector_ref?, repo?, branch?, file_path (required) }" },
   ],
 };
 

--- a/src/registry/toolsets/ai-evals.ts
+++ b/src/registry/toolsets/ai-evals.ts
@@ -24,7 +24,7 @@ function base(input: Record<string, unknown>, config: PathBuilderConfig): string
   return `${AI}/orgs/${encodeURIComponent(org)}/projects/${encodeURIComponent(project)}`;
 }
 
-const listQ = { page: "page", limit: "limit" };
+const listQ = { page: "page", size: "limit" };
 
 // --- Body schemas (concise; full shapes in OpenAPI / harness_describe) ---
 

--- a/src/registry/toolsets/ai-evals.ts
+++ b/src/registry/toolsets/ai-evals.ts
@@ -103,9 +103,9 @@ const createEvalSchema: BodySchema = {
     { name: "name", type: "string", required: true, description: "Eval name" },
     { name: "description", type: "string", required: false, description: "Description" },
     { name: "tags", type: "array", required: false, description: "Tags", itemType: "string" },
-    { name: "dataset_id", type: "string", required: false, description: "Dataset UUID" },
-    { name: "target_id", type: "string", required: false, description: "Target UUID" },
-    { name: "metric_set_id", type: "string", required: false, description: "Metric set UUID" },
+    { name: "dataset_id", type: "string", required: false, description: "Dataset UUID (list with harness_list resource_type=eval_dataset)" },
+    { name: "target_id", type: "string", required: false, description: "Target UUID (list with harness_list resource_type=eval_target)" },
+    { name: "metric_set_id", type: "string", required: false, description: "Metric set UUID (list with harness_list resource_type=eval_metric_set)" },
     { name: "sampling_strategy", type: "string", required: false, description: "all | random | first_n (default all)" },
     { name: "sample_size", type: "number", required: false, description: "Sample size" },
     { name: "concurrency", type: "number", required: false, description: "Parallelism (default 5, min 1)" },
@@ -122,10 +122,10 @@ const updateEvalSchema: BodySchema = {
     { name: "name", type: "string", required: false, description: "Name" },
     { name: "description", type: "string", required: false, description: "Description" },
     { name: "tags", type: "array", required: false, description: "Tags", itemType: "string" },
-    { name: "status", type: "string", required: false, description: "draft | active | archived" },
-    { name: "dataset_id", type: "string", required: false, description: "Dataset UUID" },
-    { name: "target_id", type: "string", required: false, description: "Target UUID" },
-    { name: "metric_set_id", type: "string", required: false, description: "Metric set UUID" },
+    { name: "status", type: "string", required: false, description: "active | archived" },
+    { name: "dataset_id", type: "string", required: false, description: "Dataset UUID (list with harness_list resource_type=eval_dataset)" },
+    { name: "target_id", type: "string", required: false, description: "Target UUID (list with harness_list resource_type=eval_target)" },
+    { name: "metric_set_id", type: "string", required: false, description: "Metric set UUID (list with harness_list resource_type=eval_metric_set)" },
     { name: "sampling_strategy", type: "string", required: false, description: "all | random | first_n" },
     { name: "sample_size", type: "number", required: false, description: "Sample size" },
     { name: "concurrency", type: "number", required: false, description: "Parallelism (min 1)" },
@@ -154,52 +154,12 @@ const triggerEvalRunSchema: BodySchema = {
   ],
 };
 
-const createRunSchema: BodySchema = {
-  description: "Create run. Provide eval_id XOR suite (not both).",
-  fields: [
-    { name: "eval_id", type: "string", required: false, description: "Eval UUID (mutually exclusive with suite)" },
-    { name: "suite", type: "object", required: false, description: "Full suite definition (mutually exclusive with eval_id)" },
-    { name: "name", type: "string", required: false, description: "Run name" },
-    { name: "pass_threshold", type: "number", required: false, description: "Pass threshold" },
-    { name: "dataset_id", type: "string", required: false, description: "Dataset UUID" },
-    { name: "dataset_snapshot", type: "object", required: false, description: "Dataset snapshot (when dataset_id is omitted)" },
-    { name: "variant_id", type: "string", required: false, description: "Variant identifier" },
-    { name: "suite_run_id", type: "string", required: false, description: "Parent SuiteRun UUID (links child run to suite run)" },
-    { name: "target_id", type: "string", required: false, description: "Target UUID (for single-eval runs)" },
-    { name: "metric_set_id", type: "string", required: false, description: "MetricSet UUID (for single-eval runs)" },
-    { name: "environment", type: "string", required: false, description: "Execution environment (local, ci, prod)" },
-    { name: "metadata", type: "object", required: false, description: "Arbitrary metadata" },
-    { name: "trigger_type", type: "string", required: false, description: "manual | scheduled | api | ci (default manual)" },
-  ],
-};
-
-const updateRunSchema: BodySchema = {
-  description: "Update run (PATCH)",
-  fields: [
-    { name: "name", type: "string", required: false, description: "Run name" },
-    { name: "pass_threshold", type: "number", required: false, description: "Pass threshold" },
-    { name: "status", type: "string", required: false, description: "Status" },
-    { name: "total_items", type: "number", required: false, description: "Total item count" },
-    { name: "success_count", type: "number", required: false, description: "Successful items" },
-    { name: "failed_count", type: "number", required: false, description: "Failed items" },
-    { name: "summary_scores", type: "object", required: false, description: "Aggregated scores { metric_name: float }" },
-    { name: "git_commit_sha", type: "string", required: false, description: "Resolved commit SHA (max 64 chars, set once, ignored on subsequent updates)" },
-  ],
-};
 
 const rescoreSchema: BodySchema = {
   description: "Rescore with a different metric set",
   fields: [{ name: "metric_set_id", type: "string", required: true, description: "Metric set UUID" }],
 };
 
-const postScoresSchema: BodySchema = {
-  description: "Post scores (HarnessSink)",
-  fields: [
-    { name: "scores", type: "array", required: true, description: "HarnessScoreInput objects", itemType: "object" },
-    { name: "dataset_item_id", type: "string", required: false, description: "Dataset item UUID" },
-    { name: "eval_id", type: "string", required: false, description: "Eval UUID" },
-  ],
-};
 
 const createMetricSchema: BodySchema = {
   description: "Create custom metric",
@@ -207,8 +167,18 @@ const createMetricSchema: BodySchema = {
     { name: "name", type: "string", required: true, description: "Metric name" },
     { name: "type", type: "string", required: true, description: "heuristic | llm | embedding | code | composite" },
     { name: "description", type: "string", required: false, description: "Description" },
-    { name: "kind", type: "string", required: false, description: "harness-evals metric kind identifier (e.g. exact_match, contains, levenshtein)" },
-    { name: "config", type: "object", required: false, description: "Metric config JSON" },
+    { name: "kind", type: "string", required: false, description: "harness-evals metric kind identifier (e.g. exact_match, contains, levenshtein, json_diff, latency, rubric_judge, geval)" },
+    {
+      name: "config",
+      type: "object",
+      required: false,
+      description:
+        "Metric config — structure depends on type/kind. " +
+        "Heuristic: { kind, threshold?, case_sensitive?, ... }. " +
+        "LLM: { rubric?, criteria?, judge_model_id? (eval_model UUID) }. " +
+        "Composite: { metrics: [{ metric_id, weight }], aggregation: 'average'|'weighted_average'|'min'|'max'|'all_pass' }. " +
+        "Use harness_execute(resource_type='eval_metric', action='suggestions') to discover appropriate metrics for a target type.",
+    },
     { name: "default_threshold", type: "number", required: false, description: "Default threshold 0-1 (default 0.8)" },
     { name: "tags", type: "array", required: false, description: "Tags", itemType: "string" },
     { name: "is_active", type: "boolean", required: false, description: "Active (default true)" },
@@ -233,8 +203,16 @@ const createMetricSetSchema: BodySchema = {
     { name: "name", type: "string", required: true, description: "Name" },
     { name: "description", type: "string", required: false, description: "Description" },
     { name: "tags", type: "array", required: false, description: "Tags", itemType: "string" },
-    { name: "judge_model_id", type: "string", required: false, description: "Default judge model UUID for LLM metrics in this set" },
-    { name: "entries", type: "array", required: false, description: "Initial metric entries (AddMetricSetEntryRequest[])", itemType: "object" },
+    { name: "judge_model_id", type: "string", required: false, description: "Default judge model UUID for LLM metrics (list with harness_list resource_type=eval_model)" },
+    {
+      name: "entries",
+      type: "array",
+      required: false,
+      description:
+        "Initial metric entries. Each: { metric_id: '<eval_metric UUID>', threshold: 0-1, weight?: number, position?: number, config?: object }. " +
+        "List metrics with harness_list(resource_type=eval_metric).",
+      itemType: "object",
+    },
   ],
 };
 
@@ -244,14 +222,14 @@ const updateMetricSetSchema: BodySchema = {
     { name: "name", type: "string", required: false, description: "Name" },
     { name: "description", type: "string", required: false, description: "Description" },
     { name: "tags", type: "array", required: false, description: "Tags", itemType: "string" },
-    { name: "judge_model_id", type: "string", required: false, description: "Default judge model UUID for LLM metrics" },
+    { name: "judge_model_id", type: "string", required: false, description: "Default judge model UUID for LLM metrics (list with harness_list resource_type=eval_model)" },
   ],
 };
 
 const addMetricSetEntrySchema: BodySchema = {
   description: "Add metric to set",
   fields: [
-    { name: "metric_id", type: "string", required: true, description: "Metric UUID" },
+    { name: "metric_id", type: "string", required: true, description: "Metric UUID (list with harness_list resource_type=eval_metric)" },
     { name: "threshold", type: "number", required: true, description: "Pass threshold 0-1" },
     { name: "weight", type: "number", required: false, description: "Weight" },
     { name: "position", type: "number", required: false, description: "Order" },
@@ -311,7 +289,7 @@ const updateSuiteSchema: BodySchema = {
 const addSuiteEntrySchema: BodySchema = {
   description: "Add evaluation to suite",
   fields: [
-    { name: "evaluation_id", type: "string", required: true, description: "Eval UUID" },
+    { name: "evaluation_id", type: "string", required: true, description: "Eval UUID (list with harness_list resource_type=evaluation)" },
     { name: "is_required", type: "boolean", required: false, description: "Counts toward pass" },
     { name: "position", type: "number", required: false, description: "Order" },
   ],
@@ -358,7 +336,18 @@ const createTargetSchema: BodySchema = {
   fields: [
     { name: "name", type: "string", required: true, description: "Name" },
     { name: "type", type: "string", required: false, description: "prompt | agent | precomputed (required when storage_type='managed', omit for git)" },
-    { name: "config", type: "object", required: false, description: "Target config (required when storage_type='managed', omit for git)" },
+    {
+      name: "config",
+      type: "object",
+      required: false,
+      description:
+        "Target config (required when storage_type='managed', omit for git). " +
+        "For type='prompt': { model_id: '<eval_model UUID — list with harness_list resource_type=eval_model>', " +
+        "system_message?: string, temperature?: 0-2, max_tokens?: int, top_p?: 0-1, " +
+        "frequency_penalty?: -2 to 2, presence_penalty?: -2 to 2 }. " +
+        "For type='agent': { endpoint: '<agent HTTP URL>' }. " +
+        "For type='precomputed': { dataset_id?: string, model_name?: string, model_version?: string }.",
+    },
     { name: "description", type: "string", required: false, description: "Description" },
     { name: "tags", type: "array", required: false, description: "Tags", itemType: "string" },
     { name: "is_active", type: "boolean", required: false, description: "Active (default true)" },
@@ -375,7 +364,14 @@ const updateTargetSchema: BodySchema = {
     { name: "name", type: "string", required: false, description: "Name" },
     { name: "description", type: "string", required: false, description: "Description" },
     { name: "type", type: "string", required: false, description: "prompt | agent | precomputed" },
-    { name: "config", type: "object", required: false, description: "Config" },
+    {
+      name: "config",
+      type: "object",
+      required: false,
+      description:
+        "Target config. For type='prompt': { model_id, system_message?, temperature?, max_tokens?, top_p?, frequency_penalty?, presence_penalty? }. " +
+        "For type='agent': { endpoint }. For type='precomputed': { dataset_id?, model_name?, model_version? }.",
+    },
     { name: "tags", type: "array", required: false, description: "Tags", itemType: "string" },
     { name: "is_active", type: "boolean", required: false, description: "Active" },
     { name: "env_secrets", type: "object", required: false, description: "Env var to Harness secret ref mapping" },
@@ -501,10 +497,6 @@ const updateRegistryItemSchema: BodySchema = {
   ],
 };
 
-const createRunItemsSchema: BodySchema = {
-  description: "Append run items",
-  fields: [{ name: "items", type: "array", required: true, description: "Run item payloads", itemType: "object" }],
-};
 
 const generateDatasetItemsSchema: BodySchema = {
   description: "Generate synthetic dataset items using an LLM (synchronous)",
@@ -563,6 +555,35 @@ const bulkUpsertDatasetItemsSchema: BodySchema = {
   ],
 };
 
+const evaluateTraceSchema: BodySchema = {
+  description: "Evaluate a production trace with selected metrics",
+  fields: [
+    { name: "span_id", type: "string", required: false, description: "Specific span to evaluate (defaults to root span)" },
+    {
+      name: "metric_ids",
+      type: "array",
+      required: false,
+      description: "UUIDs of existing metrics to evaluate against (list with harness_list resource_type=eval_metric)",
+      itemType: "string",
+    },
+    {
+      name: "metrics",
+      type: "array",
+      required: false,
+      description:
+        "Inline metric definitions for ad-hoc evaluation: [{ type: 'heuristic'|'llm', kind?: string, score_name: string, config?: object, threshold?: 0-1 }]. " +
+        "At least one of metric_ids or metrics is required.",
+      itemType: "object",
+    },
+    {
+      name: "options",
+      type: "object",
+      required: false,
+      description: "Evaluation options: { include_trajectory?: boolean (default false) }",
+    },
+  ],
+};
+
 /** Merge harness_execute `body` into JSON POST body */
 function bodyFromInput(input: Record<string, unknown>): unknown {
   const b = input.body;
@@ -592,13 +613,17 @@ export const aiEvalsToolset: ToolsetDefinition = {
       scopeOptional: true,
       headerBasedScoping: true,
       identifierFields: ["dataset_id"],
+      diagnosticHint:
+        "Dataset items require 'input' as a JSON object (e.g. { messages: [{role:'user', content:'...'}] } or { prompt: '...' }). " +
+        "Optional fields depend on metric type: 'expected_output' for correctness metrics, 'context' (string array) for RAG/groundedness metrics, " +
+        "'expected_tools' for agent tool-use metrics. Items can be added inline on create or managed separately via eval_dataset_item.",
       listFilterFields: [
         { name: "search", description: "Search by name, identifier, or description" },
         { name: "target_id", description: "Filter datasets used by evals referencing this target UUID" },
       ],
       relatedResources: [
-        { resourceType: "eval_dataset_item", relationship: "contains", description: "Dataset rows" },
-        { resourceType: "evaluation", relationship: "uses", description: "Evals reference datasets" },
+        { resourceType: "eval_dataset_item", relationship: "contains", description: "Dataset rows (add/list/update individually)" },
+        { resourceType: "evaluation", relationship: "used_by", description: "Evals reference datasets via dataset_id" },
       ],
       operations: {
         list: {
@@ -774,6 +799,17 @@ export const aiEvalsToolset: ToolsetDefinition = {
       scopeOptional: true,
       headerBasedScoping: true,
       identifierFields: ["eval_id"],
+      diagnosticHint:
+        "An eval requires three components: dataset_id, target_id, and metric_set_id. " +
+        "Before creating an eval, list existing resources with harness_list for eval_dataset, eval_target, and eval_metric_set. " +
+        "Create any missing components first. The eval stays in 'draft' status until all three are set, then auto-activates. " +
+        "When storage_type='git', omit dataset_id/target_id/metric_set_id (they live in the YAML at git_source.file_path).",
+      relatedResources: [
+        { resourceType: "eval_dataset", relationship: "uses", description: "Eval references a dataset via dataset_id" },
+        { resourceType: "eval_target", relationship: "uses", description: "Eval references a target via target_id" },
+        { resourceType: "eval_metric_set", relationship: "uses", description: "Eval references a metric set via metric_set_id" },
+        { resourceType: "eval_run", relationship: "produces", description: "Eval runs are listed via eval_run_by_eval" },
+      ],
       listFilterFields: [
         {
           name: "status",
@@ -882,6 +918,8 @@ export const aiEvalsToolset: ToolsetDefinition = {
       ],
       relatedResources: [
         { resourceType: "eval_run_item", relationship: "contains", description: "Per-item results" },
+        { resourceType: "evaluation", relationship: "belongs_to", description: "Run belongs to an evaluation" },
+        { resourceType: "eval_suite_run", relationship: "belongs_to", description: "Run may be a child of a suite run via suite_run_id" },
       ],
       operations: {
         list: {
@@ -900,26 +938,6 @@ export const aiEvalsToolset: ToolsetDefinition = {
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           responseExtractor: passthrough,
           description: "Get run",
-        },
-        create: {
-          method: "POST",
-          path: "",
-          pathBuilder: (input, config) => `${base(input, config)}/runs`,
-          operationPolicy: { risk: "low_write", retryPolicy: "do_not_retry" },
-          bodyBuilder: (input) => input.body ?? {},
-          bodySchema: createRunSchema,
-          responseExtractor: passthrough,
-          description: "Create run record",
-        },
-        update: {
-          method: "PATCH",
-          path: "",
-          pathBuilder: (input, config) => `${base(input, config)}/runs/${input.run_id as string}`,
-          operationPolicy: { risk: "low_write", retryPolicy: "safe" },
-          bodyBuilder: (input) => input.body ?? {},
-          bodySchema: updateRunSchema,
-          responseExtractor: passthrough,
-          description: "Update run",
         },
       },
       executeActions: {
@@ -943,16 +961,6 @@ export const aiEvalsToolset: ToolsetDefinition = {
           responseExtractor: passthrough,
           actionDescription: "Create a new run rescored with a different metric set",
         },
-        post_scores: {
-          method: "POST",
-          path: "",
-          pathBuilder: (input, config) => `${base(input, config)}/runs/${input.run_id as string}/scores`,
-          operationPolicy: { risk: "low_write", retryPolicy: "do_not_retry" },
-          bodyBuilder: bodyFromInput,
-          bodySchema: postScoresSchema,
-          responseExtractor: passthrough,
-          actionDescription: "Ingest scores from harness-evals HarnessSink",
-        },
       },
     },
     {
@@ -975,19 +983,6 @@ export const aiEvalsToolset: ToolsetDefinition = {
           queryParams: listQ,
           responseExtractor: aiEvalsListExtract,
           description: "List run items",
-        },
-      },
-      executeActions: {
-        append_items: {
-          method: "POST",
-          path: "",
-          pathBuilder: (input, config) =>
-            `${base(input, config)}/runs/${input.run_id as string}/items`,
-          operationPolicy: { risk: "low_write", retryPolicy: "do_not_retry" },
-          bodyBuilder: bodyFromInput,
-          bodySchema: createRunItemsSchema,
-          responseExtractor: passthrough,
-          actionDescription: "Append run item results (HarnessSink / batch)",
         },
       },
     },
@@ -1018,12 +1013,19 @@ export const aiEvalsToolset: ToolsetDefinition = {
     {
       resourceType: "eval_metric",
       displayName: "AI Evals Metric",
-      description: "Custom or builtin metric definitions.",
+      description: "Custom or builtin metric definitions. Types: heuristic (deterministic), llm (LLM-as-judge), code (custom Python), composite (aggregation).",
       toolset: "ai-evals",
       scope: "project",
       scopeOptional: true,
       headerBasedScoping: true,
       identifierFields: ["metric_id"],
+      diagnosticHint:
+        "Use the 'suggestions' execute action to discover appropriate metrics for a given target type and dataset shape. " +
+        "Metrics are added to metric sets (eval_metric_set) via eval_metric_set_entry, then referenced by evaluations.",
+      relatedResources: [
+        { resourceType: "eval_metric_set_entry", relationship: "used_by", description: "Metrics are added to metric sets via entries" },
+        { resourceType: "eval_model", relationship: "uses", description: "LLM metrics can reference a judge model via config.judge_model_id" },
+      ],
       listFilterFields: [
         { name: "type", description: "Filter by metric type (e.g. heuristic, llm)" },
         { name: "search", description: "Search by metric name or description" },
@@ -1105,6 +1107,16 @@ export const aiEvalsToolset: ToolsetDefinition = {
       scopeOptional: true,
       headerBasedScoping: true,
       identifierFields: ["set_id"],
+      diagnosticHint:
+        "Before creating a metric set, list available metrics with harness_list(resource_type='eval_metric'). " +
+        "Use harness_execute(resource_type='eval_metric', action='suggestions') to discover metrics appropriate for a target type. " +
+        "If using LLM metrics (llm-as-judge), set judge_model_id to an eval_model UUID.",
+      relatedResources: [
+        { resourceType: "eval_metric_set_entry", relationship: "contains", description: "Metric membership entries with thresholds" },
+        { resourceType: "eval_metric", relationship: "uses", description: "Entries reference metrics by metric_id" },
+        { resourceType: "eval_model", relationship: "uses", description: "Optional judge model for LLM metrics via judge_model_id" },
+        { resourceType: "evaluation", relationship: "used_by", description: "Evals reference metric sets via metric_set_id" },
+      ],
       listFilterFields: [
         { name: "search", description: "Search by name or description" },
         { name: "target_id", description: "Filter metric sets used by evals referencing this target UUID" },
@@ -1201,6 +1213,10 @@ export const aiEvalsToolset: ToolsetDefinition = {
       scopeOptional: true,
       headerBasedScoping: true,
       identifierFields: ["set_id", "metric_id"],
+      relatedResources: [
+        { resourceType: "eval_metric_set", relationship: "belongs_to", description: "Entry belongs to a metric set" },
+        { resourceType: "eval_metric", relationship: "references", description: "Entry references a metric by metric_id" },
+      ],
       listFilterFields: [{ name: "set_id", description: "Metric set UUID", required: true }],
       operations: {
         list: {
@@ -1255,6 +1271,15 @@ export const aiEvalsToolset: ToolsetDefinition = {
       scopeOptional: true,
       headerBasedScoping: true,
       identifierFields: ["suite_id"],
+      diagnosticHint:
+        "A suite groups evaluations together. First create evaluations (each with dataset + target + metric set), " +
+        "then create the suite and add evaluations via eval_suite_evaluation or the replace_evaluations execute action. " +
+        "List existing evaluations with harness_list(resource_type='evaluation').",
+      relatedResources: [
+        { resourceType: "eval_suite_evaluation", relationship: "contains", description: "Suite membership entries" },
+        { resourceType: "evaluation", relationship: "uses", description: "Suite entries reference evaluations by evaluation_id" },
+        { resourceType: "eval_suite_run", relationship: "produces", description: "Suite runs" },
+      ],
       operations: {
         list: {
           method: "GET",
@@ -1357,6 +1382,10 @@ export const aiEvalsToolset: ToolsetDefinition = {
       scopeOptional: true,
       headerBasedScoping: true,
       identifierFields: ["suite_id", "evaluation_id"],
+      relatedResources: [
+        { resourceType: "eval_suite", relationship: "belongs_to", description: "Entry belongs to a suite" },
+        { resourceType: "evaluation", relationship: "references", description: "Entry references an evaluation by evaluation_id" },
+      ],
       listFilterFields: [{ name: "suite_id", description: "Suite UUID", required: true }],
       operations: {
         list: {
@@ -1393,12 +1422,16 @@ export const aiEvalsToolset: ToolsetDefinition = {
     {
       resourceType: "eval_suite_run",
       displayName: "AI Evals Suite Run",
-      description: "Suite execution. List by suite; get by suite_run_id.",
+      description: "Suite execution (status: queued | running | passed | failed | stopped). List by suite; get by suite_run_id.",
       toolset: "ai-evals",
       scope: "project",
       scopeOptional: true,
       headerBasedScoping: true,
       identifierFields: ["suite_run_id"],
+      relatedResources: [
+        { resourceType: "eval_suite", relationship: "belongs_to", description: "Suite run belongs to a suite" },
+        { resourceType: "eval_run", relationship: "contains", description: "Suite run spawns child eval runs (filter via suite_run_id on eval_run)" },
+      ],
       listFilterFields: [{ name: "suite_id", description: "Suite UUID", required: true }],
       operations: {
         list: {
@@ -1426,12 +1459,19 @@ export const aiEvalsToolset: ToolsetDefinition = {
     {
       resourceType: "eval_target",
       displayName: "AI Evals Target",
-      description: "Invocation target (prompt, agent, or precomputed).",
+      description: "Invocation target (prompt, agent, or precomputed). Prompt targets reference a registered eval_model via config.model_id.",
       toolset: "ai-evals",
       scope: "project",
       scopeOptional: true,
       headerBasedScoping: true,
       identifierFields: ["target_id"],
+      diagnosticHint:
+        "When creating a prompt target, first list available models with harness_list(resource_type='eval_model') " +
+        "so you can reference the correct model_id in config. The config.model_id must be a UUID from an existing eval_model.",
+      relatedResources: [
+        { resourceType: "eval_model", relationship: "uses", description: "Prompt targets reference a model via config.model_id" },
+        { resourceType: "evaluation", relationship: "used_by", description: "Evals reference targets via target_id" },
+      ],
       listFilterFields: [
         { name: "type", description: "prompt | agent | precomputed" },
         { name: "search", description: "Search by name or description" },
@@ -1542,12 +1582,15 @@ export const aiEvalsToolset: ToolsetDefinition = {
     {
       resourceType: "eval_model",
       displayName: "AI Evals Model",
-      description: "Registered LLM model for eval runs.",
+      description: "Registered LLM model (provider + model_id + credentials) for eval runs. Prompt targets reference models via config.model_id.",
       toolset: "ai-evals",
       scope: "project",
       scopeOptional: true,
       headerBasedScoping: true,
       identifierFields: ["model_id"],
+      relatedResources: [
+        { resourceType: "eval_target", relationship: "used_by", description: "Prompt targets reference models via config.model_id" },
+      ],
       listFilterFields: [
         { name: "active_only", description: "Only active models", type: "boolean" },
         { name: "search", description: "Search by name, provider, or model ID" },
@@ -1684,6 +1727,40 @@ export const aiEvalsToolset: ToolsetDefinition = {
           responseExtractor: passthrough,
           actionDescription: "Annotation counts over time (optional start/end ISO, granularity auto|hour|day)",
           bodySchema: { description: "No body", fields: [] },
+        },
+      },
+    },
+    {
+      resourceType: "online_eval",
+      displayName: "AI Evals Online Evaluation",
+      description: "Evaluate production traces with metrics. Scores a trace's input/output against selected metrics and creates annotations.",
+      toolset: "ai-evals",
+      scope: "project",
+      scopeOptional: true,
+      headerBasedScoping: true,
+      identifierFields: ["trace_id"],
+      diagnosticHint:
+        "Evaluate a trace from production observability data. Pass metric_ids (existing metric UUIDs) " +
+        "or inline metric definitions via 'metrics'. Results are persisted as annotations (eval_annotation). " +
+        "Get trace_id from your observability/tracing system.",
+      relatedResources: [
+        { resourceType: "eval_metric", relationship: "uses", description: "References metrics by metric_ids" },
+        { resourceType: "eval_annotation", relationship: "produces", description: "Creates annotations with scores" },
+      ],
+      operations: {},
+      executeActions: {
+        evaluate: {
+          method: "POST",
+          path: "",
+          pathBuilder: (input, config) =>
+            `${base(input, config)}/traces/${input.trace_id as string}/evaluate`,
+          operationPolicy: { risk: "low_write", retryPolicy: "do_not_retry" },
+          bodyBuilder: bodyFromInput,
+          bodySchema: evaluateTraceSchema,
+          responseExtractor: passthrough,
+          actionDescription:
+            "Evaluate a production trace with metrics. Returns scores, summary (pass_rate), and trace metadata. " +
+            "Provide at least one of metric_ids or inline metrics.",
         },
       },
     },

--- a/src/registry/toolsets/ai-evals.ts
+++ b/src/registry/toolsets/ai-evals.ts
@@ -24,7 +24,7 @@ function base(input: Record<string, unknown>, config: PathBuilderConfig): string
   return `${AI}/orgs/${encodeURIComponent(org)}/projects/${encodeURIComponent(project)}`;
 }
 
-const listQ = { page: "page", size: "limit" };
+const listQ = { page: "page", limit: "limit" };
 
 // --- Body schemas (concise; full shapes in OpenAPI / harness_describe) ---
 
@@ -507,7 +507,7 @@ const createRunItemsSchema: BodySchema = {
 };
 
 const generateDatasetItemsSchema: BodySchema = {
-  description: "Generate synthetic dataset items using an LLM (async via pipeline)",
+  description: "Generate synthetic dataset items using an LLM (synchronous)",
   fields: [
     {
       name: "strategy",
@@ -594,6 +594,7 @@ export const aiEvalsToolset: ToolsetDefinition = {
       identifierFields: ["dataset_id"],
       listFilterFields: [
         { name: "search", description: "Search by name, identifier, or description" },
+        { name: "target_id", description: "Filter datasets used by evals referencing this target UUID" },
       ],
       relatedResources: [
         { resourceType: "eval_dataset_item", relationship: "contains", description: "Dataset rows" },
@@ -605,7 +606,7 @@ export const aiEvalsToolset: ToolsetDefinition = {
           path: "",
           pathBuilder: (input, config) => `${base(input, config)}/dataset`,
           operationPolicy: { risk: "read", retryPolicy: "safe" },
-          queryParams: { ...listQ, search: "search" },
+          queryParams: { ...listQ, search: "search", target_id: "target_id" },
           responseExtractor: aiEvalsListExtract,
           description: "List datasets",
         },
@@ -681,20 +682,9 @@ export const aiEvalsToolset: ToolsetDefinition = {
           bodySchema: generateDatasetItemsSchema,
           responseExtractor: passthrough,
           actionDescription:
-            "Generate synthetic dataset items using an LLM (async). " +
+            "Generate synthetic dataset items using an LLM (synchronous). " +
             "Strategies: use_case (from description), rephrase (from seed_inputs), adversarial, complexity_ladder. " +
-            "Returns job_id — poll with poll_generate action.",
-        },
-        poll_generate: {
-          method: "GET",
-          path: "",
-          pathBuilder: (input, config) =>
-            `${base(input, config)}/dataset/${input.dataset_id as string}/generate/${input.job_id as string}`,
-          operationPolicy: { risk: "read", retryPolicy: "safe" },
-          responseExtractor: passthrough,
-          actionDescription:
-            "Poll generation job status. Pass dataset_id and job_id (from generate action response).",
-          bodySchema: { description: "No body", fields: [] },
+            "Returns generated_count and items directly.",
         },
       },
     },
@@ -839,7 +829,7 @@ export const aiEvalsToolset: ToolsetDefinition = {
           pathBuilder: (input, config) => `${base(input, config)}/evals/${input.eval_id as string}`,
           operationPolicy: { risk: "destructive", retryPolicy: "do_not_retry" },
           responseExtractor: passthrough,
-          description: "Soft-delete (archive) eval",
+          description: "Hard-delete eval and its runs (409 if referenced by a suite)",
         },
       },
       executeActions: {
@@ -1034,14 +1024,18 @@ export const aiEvalsToolset: ToolsetDefinition = {
       scopeOptional: true,
       headerBasedScoping: true,
       identifierFields: ["metric_id"],
-      listFilterFields: [{ name: "type", description: "Filter by metric type (e.g. heuristic, llm)" }],
+      listFilterFields: [
+        { name: "type", description: "Filter by metric type (e.g. heuristic, llm)" },
+        { name: "search", description: "Search by metric name or description" },
+        { name: "target_id", description: "Filter metrics used by evals referencing this target UUID" },
+      ],
       operations: {
         list: {
           method: "GET",
           path: "",
           pathBuilder: (input, config) => `${base(input, config)}/metrics`,
           operationPolicy: { risk: "read", retryPolicy: "safe" },
-          queryParams: { ...listQ, type: "type" },
+          queryParams: { ...listQ, type: "type", search: "search", target_id: "target_id" },
           responseExtractor: aiEvalsListExtract,
           description: "List metrics",
         },
@@ -1113,6 +1107,7 @@ export const aiEvalsToolset: ToolsetDefinition = {
       identifierFields: ["set_id"],
       listFilterFields: [
         { name: "search", description: "Search by name or description" },
+        { name: "target_id", description: "Filter metric sets used by evals referencing this target UUID" },
       ],
       operations: {
         list: {
@@ -1120,7 +1115,7 @@ export const aiEvalsToolset: ToolsetDefinition = {
           path: "",
           pathBuilder: (input, config) => `${base(input, config)}/metric-sets`,
           operationPolicy: { risk: "read", retryPolicy: "safe" },
-          queryParams: { ...listQ, search: "search" },
+          queryParams: { ...listQ, search: "search", target_id: "target_id" },
           responseExtractor: aiEvalsListExtract,
           description: "List metric sets",
         },

--- a/tests/registry/ai-evals.test.ts
+++ b/tests/registry/ai-evals.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for AI Evals toolset:
+ * - Pagination mapping (size → limit)
+ * - Resource presence and removed internal ops
+ * - New online_eval resource
+ * - Filter queryParams correctness
+ * - diagnosticHint presence on key entities
+ */
+import { describe, it, expect } from "vitest";
+import { aiEvalsToolset } from "../../src/registry/toolsets/ai-evals.js";
+import { aiEvalsListExtract, aiEvalsArrayExtract } from "../../src/registry/extractors.js";
+import type { ResourceDefinition } from "../../src/registry/types.js";
+
+/** Helper: find a resource definition by resourceType */
+function findResource(type: string): ResourceDefinition {
+  const res = aiEvalsToolset.resources.find((r) => r.resourceType === type);
+  if (!res) throw new Error(`Resource type "${type}" not found in aiEvalsToolset`);
+  return res;
+}
+
+// ─── Pagination mapping ─────────────────────────────────────────────────────
+
+describe("AI Evals pagination mapping", () => {
+  it("dataset list sends size as limit query param", () => {
+    const res = findResource("eval_dataset");
+    const listOp = res.operations.list!;
+    expect(listOp.queryParams).toHaveProperty("size", "limit");
+    expect(listOp.queryParams).toHaveProperty("page", "page");
+  });
+
+  it("eval_run list sends size as limit query param", () => {
+    const res = findResource("eval_run");
+    const listOp = res.operations.list!;
+    expect(listOp.queryParams).toHaveProperty("size", "limit");
+  });
+});
+
+// ─── Internal ops removed ───────────────────────────────────────────────────
+
+describe("AI Evals internal ops removed", () => {
+  it("eval_run has no create operation", () => {
+    const res = findResource("eval_run");
+    expect(res.operations.create).toBeUndefined();
+  });
+
+  it("eval_run has no update operation", () => {
+    const res = findResource("eval_run");
+    expect(res.operations.update).toBeUndefined();
+  });
+
+  it("eval_run has no post_scores execute action", () => {
+    const res = findResource("eval_run");
+    expect(res.executeActions?.post_scores).toBeUndefined();
+  });
+
+  it("eval_run_item has no append_items execute action", () => {
+    const res = findResource("eval_run_item");
+    expect(res.executeActions).toBeUndefined();
+  });
+
+  it("eval_run retains list, get, compare, rescore", () => {
+    const res = findResource("eval_run");
+    expect(res.operations.list).toBeDefined();
+    expect(res.operations.get).toBeDefined();
+    expect(res.executeActions?.compare).toBeDefined();
+    expect(res.executeActions?.rescore).toBeDefined();
+  });
+});
+
+// ─── online_eval resource ───────────────────────────────────────────────────
+
+describe("AI Evals online_eval resource", () => {
+  it("exists in the toolset", () => {
+    expect(() => findResource("online_eval")).not.toThrow();
+  });
+
+  it("has evaluate execute action with POST method", () => {
+    const res = findResource("online_eval");
+    const action = res.executeActions?.evaluate;
+    expect(action).toBeDefined();
+    expect(action!.method).toBe("POST");
+  });
+
+  it("evaluate path includes trace_id", () => {
+    const res = findResource("online_eval");
+    const action = res.executeActions!.evaluate;
+    const path = action.pathBuilder!(
+      { trace_id: "abc123", org_id: "myorg", project_id: "myproj" },
+      { HARNESS_ORG: "", HARNESS_PROJECT: "" },
+    );
+    expect(path).toContain("/traces/abc123/evaluate");
+  });
+
+  it("has diagnosticHint", () => {
+    const res = findResource("online_eval");
+    expect(res.diagnosticHint).toBeDefined();
+    expect(res.diagnosticHint).toContain("trace");
+  });
+});
+
+// ─── Filter queryParams ─────────────────────────────────────────────────────
+
+describe("AI Evals filter queryParams", () => {
+  it("dataset list has target_id filter", () => {
+    const res = findResource("eval_dataset");
+    expect(res.operations.list!.queryParams).toHaveProperty("target_id", "target_id");
+  });
+
+  it("metric list has search and target_id filters", () => {
+    const res = findResource("eval_metric");
+    const qp = res.operations.list!.queryParams!;
+    expect(qp).toHaveProperty("search", "search");
+    expect(qp).toHaveProperty("target_id", "target_id");
+  });
+
+  it("metric set list has target_id filter", () => {
+    const res = findResource("eval_metric_set");
+    expect(res.operations.list!.queryParams).toHaveProperty("target_id", "target_id");
+  });
+});
+
+// ─── diagnosticHint presence ────────────────────────────────────────────────
+
+describe("AI Evals diagnosticHint on key entities", () => {
+  const entitiesWithHints = [
+    "eval_dataset",
+    "evaluation",
+    "eval_target",
+    "eval_metric",
+    "eval_metric_set",
+    "eval_suite",
+    "online_eval",
+  ];
+
+  for (const type of entitiesWithHints) {
+    it(`${type} has a diagnosticHint`, () => {
+      const res = findResource(type);
+      expect(res.diagnosticHint).toBeDefined();
+      expect(res.diagnosticHint!.length).toBeGreaterThan(20);
+    });
+  }
+});
+
+// ─── Extractors ─────────────────────────────────────────────────────────────
+
+describe("AI Evals extractors", () => {
+  it("aiEvalsListExtract handles standard paginated response", () => {
+    const result = aiEvalsListExtract({ data: [{ id: "1" }, { id: "2" }], total_elements: 5 });
+    expect(result).toEqual({ items: [{ id: "1" }, { id: "2" }], total: 5 });
+  });
+
+  it("aiEvalsListExtract handles empty response", () => {
+    const result = aiEvalsListExtract({});
+    expect(result).toEqual({ items: [], total: 0 });
+  });
+
+  it("aiEvalsArrayExtract handles bare array", () => {
+    const result = aiEvalsArrayExtract([{ id: "a" }, { id: "b" }]);
+    expect(result).toEqual({ items: [{ id: "a" }, { id: "b" }], total: 2 });
+  });
+
+  it("aiEvalsArrayExtract handles non-array", () => {
+    const result = aiEvalsArrayExtract("unexpected");
+    expect(result).toEqual({ items: [], total: 0 });
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug fixes**: Remove phantom `poll_generate` action (404), fix `size`→`limit` param naming, correct eval delete description (hard-delete not soft-delete), clarify `file_path` required in `git_source`
- **Missing filters**: Add `target_id` to dataset/metric/metric-set list; add `search` to metric list
- **Discoverability**: Add `diagnosticHint` and `relatedResources` to all major entities (dataset, evaluation, target, metric, metric_set, suite) guiding AI through creation workflows and cross-resource navigation
- **Body schema improvements**: Expand config descriptions with per-type shapes (target configs, metric configs), add UUID discovery hints
- **New resource**: `online_eval` — `POST /traces/{trace_id}/evaluate` for scoring production traces
- **Remove internal ops**: `eval_run` create/update, `post_scores`, `eval_run_item` append_items (CLI/HarnessSink-only endpoints)

## Test plan

- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Test target creation (prompt, agent, precomputed, git-backed) via MCP
- [ ] Test eval creation workflow (list datasets/targets/metric-sets → create eval → trigger run)
- [ ] Test online eval: `harness_execute(resource_type='online_eval', action='evaluate', params={trace_id:'...'}, body={metric_ids:[...]})`
- [ ] Verify removed internal operations no longer appear in `harness_describe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)