### PR TITLE
fix: bound diagnose log-fetch concurrency and tighten max blob size

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -86,6 +86,15 @@ const RawConfigSchema = z.object({
   HARNESS_AUDIT_WEBHOOK_TOKEN: optionalStringFromEnv,
   HARNESS_AUDIT_WEBHOOK_BATCH_SIZE: z.preprocess(emptyStringAsUndefined, z.coerce.number().min(1).default(10)),
   HARNESS_AUDIT_WEBHOOK_FLUSH_MS: z.preprocess(emptyStringAsUndefined, z.coerce.number().min(1).default(5000)),
+  // Maximum number of concurrent log-blob downloads issued by harness_diagnose
+  // when fetching logs for failed steps. Default 3 keeps peak memory bounded
+  // while still parallelising the common case (1–3 failed steps). Increase
+  // only if diagnose latency is dominated by log-fetch wall-clock and the
+  // pod has memory headroom (AIDEVOPS-2200).
+  HARNESS_DIAGNOSE_LOG_FETCH_CONCURRENCY: z.preprocess(
+    emptyStringAsUndefined,
+    z.coerce.number().min(1).max(20).default(3),
+  ),
 });
 
 export const ConfigSchema = RawConfigSchema.transform((data) => {

--- a/src/tools/diagnose/pipeline.ts
+++ b/src/tools/diagnose/pipeline.ts
@@ -582,21 +582,37 @@ export const pipelineHandler: DiagnoseHandler = {
         diagnostic.failed_steps_truncated = { shown: capped.length, total: failedNodes.length };
       }
 
-      const logEntries = await Promise.all(
-        capped.map(async (fn) => {
-          const key = `${fn.stage}/${fn.step}`;
-          const prefix = fn.log_key;
-          if (!prefix) return { key, value: { error: "No log key available for this step" } };
-          fetchedFailedLogKeys.add(prefix);
-          try {
-            const logText = await resolveLogContent(client, prefix, { signal });
-            return { key, value: truncateLog(logText, logSnippetLines) };
-          } catch (err) {
-            log.warn("Failed to fetch step logs", { step: fn.step, error: String(err) });
-            return { key, value: { error: String(err) } };
-          }
-        }),
-      );
+      // Bound concurrency. Each resolveLogContent buffers a downloaded blob
+      // (capped at maxLogSizeBytes) into the V8 heap; firing capped.length
+      // calls in parallel was a contributor to mcp-server-internal cgroup
+      // OOMs in prod2 (AIDEVOPS-2200). The default of 3 keeps p99 diagnose
+      // latency similar to before for typical 1–3 failed steps, and
+      // dramatically caps peak memory when the user passes a large
+      // max_failed_steps. Tunable via HARNESS_DIAGNOSE_LOG_FETCH_CONCURRENCY.
+      // Fall back to 3 if the config field is missing (e.g. older callers
+      // constructing Config manually in tests); Zod gives 3 in production.
+      const logFetchConcurrency = config.HARNESS_DIAGNOSE_LOG_FETCH_CONCURRENCY ?? 3;
+      const logEntries: { key: string; value: unknown }[] = [];
+      for (let i = 0; i < capped.length; i += logFetchConcurrency) {
+        signal?.throwIfAborted();
+        const batch = capped.slice(i, i + logFetchConcurrency);
+        const batchResults = await Promise.all(
+          batch.map(async (fn) => {
+            const key = `${fn.stage}/${fn.step}`;
+            const prefix = fn.log_key;
+            if (!prefix) return { key, value: { error: "No log key available for this step" } };
+            fetchedFailedLogKeys.add(prefix);
+            try {
+              const logText = await resolveLogContent(client, prefix, { signal });
+              return { key, value: truncateLog(logText, logSnippetLines) };
+            } catch (err) {
+              log.warn("Failed to fetch step logs", { step: fn.step, error: String(err) });
+              return { key, value: { error: String(err) } };
+            }
+          }),
+        );
+        logEntries.push(...batchResults);
+      }
 
       const stepLogs: Record<string, unknown> = {};
       for (const entry of logEntries) {

--- a/src/utils/log-resolver.ts
+++ b/src/utils/log-resolver.ts
@@ -6,7 +6,11 @@ const log = createLogger("log-resolver");
 
 const DEFAULT_POLL_ATTEMPTS = 3;
 const DEFAULT_POLL_INTERVAL_MS = 3000;
-const DEFAULT_MAX_LOG_BYTES = 10 * 1024 * 1024; // 10 MB
+// Tightened from 10 MB to 2 MB. Diagnose callers truncate output to a few
+// hundred lines anyway; buffering 10 MB per concurrent log fetch into the V8
+// heap was a contributor to the prod2 mcp-server-internal cgroup OOMs
+// (AIDEVOPS-2200). Callers needing more can still pass maxLogSizeBytes.
+const DEFAULT_MAX_LOG_BYTES = 2 * 1024 * 1024; // 2 MB
 const DEFAULT_DOWNLOAD_TIMEOUT_MS = 30_000;
 
 export interface LogResolveOptions {

--- a/tests/tools/diagnose/helpers.ts
+++ b/tests/tools/diagnose/helpers.ts
@@ -17,6 +17,7 @@ export function makeConfig(overrides: Partial<Config> = {}): Config {
     HARNESS_READ_ONLY: false,
     HARNESS_MAX_BODY_SIZE_MB: 10,
     HARNESS_RATE_LIMIT_RPS: 10,
+    HARNESS_DIAGNOSE_LOG_FETCH_CONCURRENCY: 3,
     ...overrides,
   } as Config;
 }

--- a/tests/tools/diagnose/pipeline.test.ts
+++ b/tests/tools/diagnose/pipeline.test.ts
@@ -978,4 +978,57 @@ describe("pipelineHandler", () => {
     expect(stepLog.error).toContain("Download timeout");
     expect(stepLog.log).toBeUndefined();
   });
+
+  it("bounds concurrent log fetches by HARNESS_DIAGNOSE_LOG_FETCH_CONCURRENCY (AIDEVOPS-2200)", async () => {
+    // Track how many resolveLogContent calls are in flight at once.
+    const { resolveLogContent } = await import("../../../src/utils/log-resolver.js");
+    const mockFn = resolveLogContent as ReturnType<typeof vi.fn>;
+    mockFn.mockClear();
+
+    let inFlight = 0;
+    let peakInFlight = 0;
+    mockFn.mockImplementation(async () => {
+      inFlight++;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      // Yield to other resolveLogContent calls so several can pile up before any resolves.
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+      return "log line 1\nlog line 2";
+    });
+
+    // 6 failed steps so concurrency=2 forces 3 batches.
+    const stepEntries: Record<string, Record<string, unknown>> = {};
+    for (let i = 1; i <= 6; i++) {
+      stepEntries[`st${i}`] = {
+        uuid: `st${i}`, identifier: `st${i}`, name: `ST${i}`,
+        baseFqn: `pipeline.stages.s1.spec.execution.steps.st${i}`,
+        status: "Failed",
+        failureInfo: { message: `err${i}` },
+        logBaseKey: `log/st${i}`,
+      };
+    }
+    const exec = makeExecution({
+      status: "Failed",
+      stages: [{
+        id: "s1", name: "S1", status: "Failed",
+        steps: Array.from({ length: 6 }, (_, i) => ({ id: `st${i + 1}`, name: `ST${i + 1}`, status: "Failed" })),
+      }],
+      nodeMapEntries: stepEntries,
+    });
+
+    const registry = makePipelineRegistry(exec);
+    const ctx = makeContext({
+      input: { execution_id: "exec-001" },
+      registry,
+      args: { summary: false, include_logs: true, max_failed_steps: 6 },
+      config: makeConfig({ HARNESS_DIAGNOSE_LOG_FETCH_CONCURRENCY: 2 }),
+    });
+
+    const result = await pipelineHandler.diagnose(ctx);
+
+    expect(mockFn).toHaveBeenCalledTimes(6);
+    expect(peakInFlight).toBeLessThanOrEqual(2);
+    expect(peakInFlight).toBeGreaterThan(0);
+    expect(Object.keys(result.failed_step_logs as Record<string, unknown>)).toHaveLength(6);
+  });
 });


### PR DESCRIPTION
## Summary

`harness_diagnose`'s failed-step log fetch fires `Promise.all` over the capped failed nodes, so a user passing `max_failed_steps=20` downloads up to 20 log blobs concurrently. Each `resolveLogContent` buffers the downloaded blob (capped at `maxLogSizeBytes`) into the V8 heap before parsing. Under modest concurrency this is a real source of memory pressure — pre-crash logs from one observed deployment showed multiple multi-MB log archives being fetched in parallel for a single failed pipeline diagnose call.

## Changes

1. **`src/utils/log-resolver.ts`**: lower `DEFAULT_MAX_LOG_BYTES` from **10 MB → 2 MB**. Diagnose callers truncate output to a few hundred lines anyway; buffering 10 MB per concurrent fetch was wasted heap. Callers that genuinely need more can still pass `maxLogSizeBytes` explicitly.

2. **`src/tools/diagnose/pipeline.ts`**: replace the `Promise.all` in the failed-step log fetch with a bounded-batch loop, gated by a new `HARNESS_DIAGNOSE_LOG_FETCH_CONCURRENCY` config knob (default **3**, max 20). Same batch-of-N idiom as `harness-search.ts`. Default keeps p99 latency similar for the common 1–3 failed-step case and dramatically caps peak memory for large `max_failed_steps`.

3. **`src/config.ts`**: declare the new env var with Zod (default 3, range 1–20).

4. **`tests/tools/diagnose/pipeline.test.ts`**: focused test that 6 failed steps with `concurrency=2` never has more than 2 `resolveLogContent` calls in flight.

5. **`tests/tools/diagnose/helpers.ts`**: thread the new field through `makeConfig` so existing test fixtures don't bypass it.

## Trade-offs

- **Latency**: for the common case (1–3 failed steps), the batching has no effect — they still all fan out in one batch. For larger `max_failed_steps`, wall-clock latency goes up roughly linearly with how many batches we need, which is the explicit trade for bounded memory.
- **Backwards compat**: callers passing their own `maxLogSizeBytes` are unchanged. Default change from 10 MB → 2 MB is the only visible behaviour shift, and only for callers that didn't override and produced logs >2 MB. They get a more aggressive size error instead of buffering 10 MB; they can opt in via the option.

## Verification

- `pnpm typecheck` → clean
- `pnpm build` → clean
- `pnpm test` → 1160 pass, 0 fail (was 1159 + new bounded-concurrency test)

## Test plan

- [ ] Confirm `harness_diagnose` against a pipeline with 5+ failed steps still returns logs for every step.
- [ ] Watch peak working-set on the consumer pod across a diagnose call with `max_failed_steps=10`; expect ≈3× one blob's heap, not ≈10×.
- [ ] Smoke-test setting `HARNESS_DIAGNOSE_LOG_FETCH_CONCURRENCY=1` to serialise log fetches; confirm correctness over latency.