### PR TITLE
feat: [DBOPS-2504]: dbops resource targets new /v1/llm-authoring/execute-pipeline contract

### DIFF
--- a/src/registry/toolsets/dbops.ts
+++ b/src/registry/toolsets/dbops.ts
@@ -783,50 +783,130 @@ export const dbopsToolset: ToolsetDefinition = {
       resourceType: "database_execute_llm_authoring_pipeline",
       displayName: "Execute LLM Authoring Pipeline",
       description:
-        "Consolidated endpoint for LLM change authoring Accept & Commit. " +
-        "Resolves the pipeline (settings override or default), fills runtime inputs " +
-        "(schema, instance, changeset, K8s connector), executes the pipeline, and " +
-        "records the billing event — all in one call. " +
-        "Returns { pipelineExecutionId, pipelineIdentifier }. " +
-        "Poll status with harness_get(resource_type='execution', execution_id='<returned_id>'). " +
-        "Use this INSTEAD of separate database_llm_authoring_pipeline + pipeline execution calls.",
+        "Trigger an LLM-authoring validate-and-preview pipeline and record the " +
+        "billable execution event in one transactional call. " +
+        "Two branches: " +
+        "(a) custom-pipeline — pass pipeline_identifier (resolved by the skill " +
+        "from NG setting `dbops_llm_authoring_pipeline_id`) plus optional " +
+        "runtime_inputs collected from the user via AskUserQuestion; " +
+        "(b) default-pipeline — pass use_default_pipeline=true and the server " +
+        "performs get-or-create of the canonical default pipeline. " +
+        "Exactly one of pipeline_identifier OR use_default_pipeline must be set. " +
+        "Reserved runtime-input keys (schemaId, instanceId, changeset, k8sConnectorRef) " +
+        "are rejected by the server. " +
+        "Returns { executionId, pipelineIdentifier, openInHarness }. " +
+        "The chat-side polling block in the dbops_changeset skill is dead code — " +
+        "show the user the openInHarness link and let the existing changeauthoring " +
+        "billing job reconcile execution status server-side.",
       toolset: "dbops",
       scope: "project",
       identifierFields: [],
       operations: {
         create: {
           method: "POST",
-          path: "/dbops/v1/orgs/{org}/projects/{project}/execute-llm-authoring-pipeline",
+          path: "/v1/orgs/{org}/projects/{project}/llm-authoring/execute-pipeline",
           pathParams: { org_id: "org", project_id: "project" },
           operationPolicy: { risk: "medium_write", retryPolicy: "do_not_retry" },
           skipScopeBodyInjection: true,
           bodyBuilder: (input: Record<string, unknown>) => {
-            const body = ((input.body ?? input) as Record<string, unknown>) ?? {};
-            return {
-              schemaIdentifier: body.schemaIdentifier ?? body.schema_id,
-              instanceIdentifier: body.instanceIdentifier ?? body.instance_id,
-              conversationId: body.conversationId ?? body.conversation_id,
-              changeset: body.changeset,
+            const src = ((input.body ?? input) as Record<string, unknown>) ?? {};
+            // Required fields: accept either snake_case or camelCase from the caller.
+            const body: Record<string, unknown> = {
+              conversationId: src.conversationId ?? src.conversation_id,
+              schemaId: src.schemaId ?? src.schema_id,
+              instanceId: src.instanceId ?? src.instance_id,
+              changeset: src.changeset,
+              k8sConnectorRef: src.k8sConnectorRef ?? src.k8s_connector_ref,
             };
+            // Branch fields: forward only the populated branch.
+            const useDefault = (src.useDefaultPipeline ?? src.use_default_pipeline) as
+              | boolean
+              | undefined;
+            const pipelineId = (src.pipelineIdentifier ?? src.pipeline_identifier) as
+              | string
+              | undefined;
+            const runtimeInputs = (src.runtimeInputs ?? src.runtime_inputs) as
+              | Record<string, unknown>
+              | undefined;
+            if (useDefault === true) {
+              body.useDefaultPipeline = true;
+            } else if (pipelineId) {
+              body.pipelineIdentifier = pipelineId;
+              if (runtimeInputs && Object.keys(runtimeInputs).length > 0) {
+                body.runtimeInputs = runtimeInputs;
+              }
+            }
+            return body;
           },
           responseExtractor: passthrough,
           description:
-            "Execute the LLM changeset pipeline with integrated billing tracking. " +
-            "Required body fields: schema_id (database schema identifier), " +
-            "instance_id (database instance identifier), " +
-            "conversation_id (chat conversation ID), " +
-            "changeset (Liquibase changeset YAML). " +
-            "The backend resolves the correct pipeline, fills all runtime inputs " +
-            "(including K8s connector), executes it, and records the billing event. " +
-            "Returns { pipelineExecutionId, pipelineIdentifier }.",
+            "Execute the LLM-authoring change-authoring validate-and-preview pipeline. " +
+            "Use this INSTEAD of separate database_llm_authoring_pipeline + pipeline execution calls. " +
+            "Body must specify exactly one of pipeline_identifier or use_default_pipeline=true.",
           bodySchema: {
             description:
-              "Changeset execution parameters. Caller aliases schema_id, instance_id, and conversation_id are accepted and mapped to backend field names.",
+              "ExecuteLlmAuthoringPipelineRequestBody. Caller may pass any field as " +
+              "snake_case (conversation_id, schema_id, instance_id, k8s_connector_ref, " +
+              "pipeline_identifier, runtime_inputs, use_default_pipeline) or camelCase — " +
+              "the bodyBuilder normalizes both to the camelCase keys expected by the API.",
             fields: [
-              { name: "schemaIdentifier", type: "string", required: true, description: "Database schema identifier" },
-              { name: "instanceIdentifier", type: "string", required: true, description: "Database instance identifier" },
-              { name: "conversationId", type: "string", required: true, description: "Chat conversation ID" },
-              { name: "changeset", type: "string", required: true, description: "Liquibase changeset YAML content" },
+              {
+                name: "conversationId",
+                type: "string",
+                required: true,
+                description:
+                  "Idempotency key — chat conversation id (alias: conversation_id).",
+              },
+              {
+                name: "schemaId",
+                type: "string",
+                required: true,
+                description: "DBOps schema identifier (alias: schema_id).",
+              },
+              {
+                name: "instanceId",
+                type: "string",
+                required: true,
+                description: "DBOps instance identifier (alias: instance_id).",
+              },
+              {
+                name: "changeset",
+                type: "string",
+                required: true,
+                description: "Liquibase YAML changeset body.",
+              },
+              {
+                name: "k8sConnectorRef",
+                type: "string",
+                required: true,
+                description:
+                  "Prefixed K8s connector identifier resolved by the skill from " +
+                  "instance.connector (alias: k8s_connector_ref).",
+              },
+              {
+                name: "pipelineIdentifier",
+                type: "string",
+                required: false,
+                description:
+                  "Custom-pipeline branch — value of NG setting `dbops_llm_authoring_pipeline_id` " +
+                  "(alias: pipeline_identifier). Mutually exclusive with useDefaultPipeline.",
+              },
+              {
+                name: "runtimeInputs",
+                type: "object",
+                required: false,
+                description:
+                  "Custom runtime inputs collected via AskUserQuestion (alias: runtime_inputs). " +
+                  "Reserved keys (schemaId, instanceId, changeset, k8sConnectorRef) are rejected by the server.",
+              },
+              {
+                name: "useDefaultPipeline",
+                type: "boolean",
+                required: false,
+                description:
+                  "Default-pipeline branch — server performs get-or-create of dbops_default_pipeline " +
+                  "(alias: use_default_pipeline). Mutually exclusive with pipelineIdentifier.",
+              },
             ],
           },
         },

--- a/src/registry/toolsets/dbops.ts
+++ b/src/registry/toolsets/dbops.ts
@@ -783,17 +783,15 @@ export const dbopsToolset: ToolsetDefinition = {
       resourceType: "database_execute_llm_authoring_pipeline",
       displayName: "Execute LLM Authoring Pipeline",
       description:
-        "Trigger an LLM-authoring validate-and-preview pipeline and record the " +
-        "billable execution event in one transactional call. " +
+        "Execute the LLM-authoring validate-and-preview pipeline and record a billable " +
+        "ChangeAuthoringExecutionEvent atomically. Use harness_execute with action=run. " +
         "Two branches: " +
-        "(a) custom-pipeline — pass pipeline_identifier (resolved by the skill " +
-        "from NG setting `dbops_llm_authoring_pipeline_id`) plus optional " +
-        "runtime_inputs collected from the user via AskUserQuestion; " +
-        "(b) default-pipeline — pass use_default_pipeline=true and the server " +
-        "performs get-or-create of the canonical default pipeline. " +
+        "(a) custom-pipeline — pass pipeline_identifier (resolved by the skill from NG setting " +
+        "`dbops_llm_authoring_pipeline_id`) plus optional runtime_inputs; " +
+        "(b) default-pipeline — pass use_default_pipeline=true and the server performs " +
+        "get-or-create of the canonical default pipeline. " +
         "Exactly one of pipeline_identifier OR use_default_pipeline must be set. " +
-        "Reserved runtime-input keys (schemaId, instanceId, changeset) " +
-        "are rejected by the server. " +
+        "Reserved runtime-input keys (schemaId, instanceId, changeset) are rejected by the server. " +
         "Returns { executionId, pipelineIdentifier, openInHarness }. " +
         "The chat-side polling block in the dbops_changeset skill is dead code — " +
         "show the user the openInHarness link and let the existing changeauthoring " +
@@ -801,12 +799,13 @@ export const dbopsToolset: ToolsetDefinition = {
       toolset: "dbops",
       scope: "project",
       identifierFields: [],
-      operations: {
-        create: {
+      operations: {},
+      executeActions: {
+        run: {
           method: "POST",
           path: "/v1/orgs/{org}/projects/{project}/llm-authoring/execute-pipeline",
           pathParams: { org_id: "org", project_id: "project" },
-          operationPolicy: { risk: "medium_write", retryPolicy: "do_not_retry" },
+          operationPolicy: { risk: "low_write", retryPolicy: "do_not_retry" },
           skipScopeBodyInjection: true,
           bodyBuilder: (input: Record<string, unknown>) => {
             const src = ((input.body ?? input) as Record<string, unknown>) ?? {};
@@ -838,10 +837,11 @@ export const dbopsToolset: ToolsetDefinition = {
             return body;
           },
           responseExtractor: passthrough,
-          description:
-            "Execute the LLM-authoring change-authoring validate-and-preview pipeline. " +
-            "Use this INSTEAD of separate database_llm_authoring_pipeline + pipeline execution calls. " +
-            "Body must specify exactly one of pipeline_identifier or use_default_pipeline=true.",
+          actionDescription:
+            "Trigger the consolidated LLM-authoring validate-and-preview pipeline. " +
+            "The user has already consented via the changeset review card (Accept & Commit) " +
+            "before the skill calls this — no second approval is needed. " +
+            "Server triggers execution and records the billable event atomically.",
           bodySchema: {
             description:
               "ExecuteLlmAuthoringPipelineRequestBody. Caller may pass any field as " +
@@ -872,7 +872,10 @@ export const dbopsToolset: ToolsetDefinition = {
                 name: "changeset",
                 type: "string",
                 required: true,
-                description: "Liquibase YAML changeset body.",
+                description:
+                  "Liquibase YAML changeset body as PLAIN TEXT. Do NOT base64-encode — " +
+                  "the dbservice encodes it server-side before injecting into the pipeline YAML " +
+                  "(the DBTestAndPreview step expects base64). Sending base64 here would double-encode.",
               },
               {
                 name: "pipelineIdentifier",

--- a/src/registry/toolsets/dbops.ts
+++ b/src/registry/toolsets/dbops.ts
@@ -792,7 +792,7 @@ export const dbopsToolset: ToolsetDefinition = {
         "(b) default-pipeline — pass use_default_pipeline=true and the server " +
         "performs get-or-create of the canonical default pipeline. " +
         "Exactly one of pipeline_identifier OR use_default_pipeline must be set. " +
-        "Reserved runtime-input keys (schemaId, instanceId, changeset, k8sConnectorRef) " +
+        "Reserved runtime-input keys (schemaId, instanceId, changeset) " +
         "are rejected by the server. " +
         "Returns { executionId, pipelineIdentifier, openInHarness }. " +
         "The chat-side polling block in the dbops_changeset skill is dead code — " +
@@ -816,7 +816,6 @@ export const dbopsToolset: ToolsetDefinition = {
               schemaId: src.schemaId ?? src.schema_id,
               instanceId: src.instanceId ?? src.instance_id,
               changeset: src.changeset,
-              k8sConnectorRef: src.k8sConnectorRef ?? src.k8s_connector_ref,
             };
             // Branch fields: forward only the populated branch.
             const useDefault = (src.useDefaultPipeline ?? src.use_default_pipeline) as
@@ -846,7 +845,7 @@ export const dbopsToolset: ToolsetDefinition = {
           bodySchema: {
             description:
               "ExecuteLlmAuthoringPipelineRequestBody. Caller may pass any field as " +
-              "snake_case (conversation_id, schema_id, instance_id, k8s_connector_ref, " +
+              "snake_case (conversation_id, schema_id, instance_id, " +
               "pipeline_identifier, runtime_inputs, use_default_pipeline) or camelCase — " +
               "the bodyBuilder normalizes both to the camelCase keys expected by the API.",
             fields: [
@@ -876,14 +875,6 @@ export const dbopsToolset: ToolsetDefinition = {
                 description: "Liquibase YAML changeset body.",
               },
               {
-                name: "k8sConnectorRef",
-                type: "string",
-                required: true,
-                description:
-                  "Prefixed K8s connector identifier resolved by the skill from " +
-                  "instance.connector (alias: k8s_connector_ref).",
-              },
-              {
                 name: "pipelineIdentifier",
                 type: "string",
                 required: false,
@@ -897,7 +888,7 @@ export const dbopsToolset: ToolsetDefinition = {
                 required: false,
                 description:
                   "Custom runtime inputs collected via AskUserQuestion (alias: runtime_inputs). " +
-                  "Reserved keys (schemaId, instanceId, changeset, k8sConnectorRef) are rejected by the server.",
+                  "Reserved keys (schemaId, instanceId, changeset) are rejected by the server.",
               },
               {
                 name: "useDefaultPipeline",

--- a/src/registry/toolsets/dbops.ts
+++ b/src/registry/toolsets/dbops.ts
@@ -805,6 +805,8 @@ export const dbopsToolset: ToolsetDefinition = {
       executeActions: {
         run: {
           method: "POST",
+          // /v1/ prefix is intentional — this endpoint is on the new db-devops-service
+          // routing, not the legacy /dbops/v1/ prefix used by older resources in this toolset.
           path: "/v1/orgs/{org}/projects/{project}/llm-authoring/execute-pipeline",
           pathParams: { org_id: "org", project_id: "project" },
           operationPolicy: { risk: "low_write", retryPolicy: "do_not_retry" },
@@ -818,7 +820,7 @@ export const dbopsToolset: ToolsetDefinition = {
               instanceId: src.instanceId ?? src.instance_id,
               changeset: src.changeset,
             };
-            // Branch fields: forward only the populated branch.
+            // Branch fields: exactly one of useDefaultPipeline or pipelineIdentifier must be set.
             const useDefault = (src.useDefaultPipeline ?? src.use_default_pipeline) as
               | boolean
               | undefined;
@@ -828,6 +830,11 @@ export const dbopsToolset: ToolsetDefinition = {
             const runtimeInputs = (src.runtimeInputs ?? src.runtime_inputs) as
               | Record<string, unknown>
               | undefined;
+            if (useDefault === true && pipelineId) {
+              throw new Error(
+                "Exactly one of use_default_pipeline or pipeline_identifier must be set, not both.",
+              );
+            }
             if (useDefault === true) {
               body.useDefaultPipeline = true;
             } else if (pipelineId) {

--- a/src/registry/toolsets/dbops.ts
+++ b/src/registry/toolsets/dbops.ts
@@ -783,19 +783,21 @@ export const dbopsToolset: ToolsetDefinition = {
       resourceType: "database_execute_llm_authoring_pipeline",
       displayName: "Execute LLM Authoring Pipeline",
       description:
-        "Execute the LLM-authoring validate-and-preview pipeline and record a billable " +
+        "Consolidated endpoint for the LLM change authoring Accept & Commit flow. " +
+        "Executes the validate-and-preview pipeline and records a billable " +
         "ChangeAuthoringExecutionEvent atomically. Use harness_execute with action=run. " +
-        "Two branches: " +
-        "(a) custom-pipeline — pass pipeline_identifier (resolved by the skill from NG setting " +
-        "`dbops_llm_authoring_pipeline_id`) plus optional runtime_inputs; " +
+        "Requires project scope: org_id and project_id must be supplied (or defaulted via " +
+        "HARNESS_ORG / HARNESS_PROJECT env vars). " +
+        "Both branches require the same common inputs: conversation_id, schema_id, instance_id, changeset. " +
+        "Two branches (exactly one must be set): " +
+        "(a) custom-pipeline — pass pipeline_identifier (resolved by the skill from the " +
+        "project-level NG setting `dbops_llm_authoring_pipeline_id`) plus optional runtime_inputs; " +
         "(b) default-pipeline — pass use_default_pipeline=true and the server performs " +
         "get-or-create of the canonical default pipeline. " +
-        "Exactly one of pipeline_identifier OR use_default_pipeline must be set. " +
         "Reserved runtime-input keys (schemaId, instanceId, changeset) are rejected by the server. " +
         "Returns { executionId, pipelineIdentifier, openInHarness }. " +
-        "The chat-side polling block in the dbops_changeset skill is dead code — " +
-        "show the user the openInHarness link and let the existing changeauthoring " +
-        "billing job reconcile execution status server-side.",
+        "Show the user the openInHarness link; the changeauthoring billing job reconciles " +
+        "execution status server-side.",
       toolset: "dbops",
       scope: "project",
       identifierFields: [],

--- a/src/tools/output-schemas.ts
+++ b/src/tools/output-schemas.ts
@@ -5,7 +5,7 @@ const dynamicObject = z.object({}).catchall(z.unknown());
 
 // --- harness_list ---
 export const listOutputSchema = z.object({
-  items: z.array(dynamicObject).optional().describe("Array of resource objects when the API returns a canonical list"),
+  items: z.array(z.union([dynamicObject, z.string(), z.number(), z.boolean()])).optional().describe("Array of resource objects or primitive values when the API returns a canonical list"),
   total: z.number().optional().describe("Total number of matching resources when provided by the API"),
   page: z.number().optional().describe("Current page number (0-indexed) when provided by the API"),
   analysis: z.string().optional().describe("Visual analysis summary (when include_visual=true)"),

--- a/tests/registry/dbops.test.ts
+++ b/tests/registry/dbops.test.ts
@@ -716,7 +716,6 @@ describe("database_execute_llm_authoring_pipeline create", () => {
         instance_id: "instance_1",
         conversation_id: "conversation-1",
         changeset: "databaseChangeLog: []",
-        k8s_connector_ref: "account.k8s_connector",
         use_default_pipeline: true,
       },
     });
@@ -731,7 +730,6 @@ describe("database_execute_llm_authoring_pipeline create", () => {
       schemaId: "schema_1",
       instanceId: "instance_1",
       changeset: "databaseChangeLog: []",
-      k8sConnectorRef: "account.k8s_connector",
       useDefaultPipeline: true,
     });
     expect(call.body).not.toHaveProperty("orgIdentifier");
@@ -756,7 +754,6 @@ describe("database_execute_llm_authoring_pipeline create", () => {
         instance_id: "instance_1",
         conversation_id: "conversation-1",
         changeset: "databaseChangeLog: []",
-        k8s_connector_ref: "account.k8s_connector",
         pipeline_identifier: "my-pipe",
         runtime_inputs: { releaseCodename: "phoenix" },
       },
@@ -772,7 +769,6 @@ describe("database_execute_llm_authoring_pipeline create", () => {
       schemaId: "schema_1",
       instanceId: "instance_1",
       changeset: "databaseChangeLog: []",
-      k8sConnectorRef: "account.k8s_connector",
       pipelineIdentifier: "my-pipe",
       runtimeInputs: { releaseCodename: "phoenix" },
     });

--- a/tests/registry/dbops.test.ts
+++ b/tests/registry/dbops.test.ts
@@ -698,7 +698,7 @@ describe("database_instance skipScopeBodyInjection", () => {
   });
 });
 
-describe("database_execute_llm_authoring_pipeline create", () => {
+describe("database_execute_llm_authoring_pipeline run", () => {
   it("maps body aliases to the new /v1/llm-authoring/execute-pipeline payload (default-pipeline branch)", async () => {
     const registry = new Registry(makeConfig());
     const mockRequest = vi.fn().mockResolvedValue({
@@ -708,7 +708,7 @@ describe("database_execute_llm_authoring_pipeline create", () => {
     });
     const client = makeClient(mockRequest);
 
-    await registry.dispatch(client, "database_execute_llm_authoring_pipeline", "create", {
+    await registry.dispatchExecute(client, "database_execute_llm_authoring_pipeline", "run", {
       org_id: "default",
       project_id: "test-project",
       body: {
@@ -746,7 +746,7 @@ describe("database_execute_llm_authoring_pipeline create", () => {
     });
     const client = makeClient(mockRequest);
 
-    await registry.dispatch(client, "database_execute_llm_authoring_pipeline", "create", {
+    await registry.dispatchExecute(client, "database_execute_llm_authoring_pipeline", "run", {
       org_id: "default",
       project_id: "test-project",
       body: {

--- a/tests/registry/dbops.test.ts
+++ b/tests/registry/dbops.test.ts
@@ -699,11 +699,12 @@ describe("database_instance skipScopeBodyInjection", () => {
 });
 
 describe("database_execute_llm_authoring_pipeline create", () => {
-  it("maps body aliases to the DBOPS API payload without scope injection", async () => {
+  it("maps body aliases to the new /v1/llm-authoring/execute-pipeline payload (default-pipeline branch)", async () => {
     const registry = new Registry(makeConfig());
     const mockRequest = vi.fn().mockResolvedValue({
-      pipelineExecutionId: "exec-1",
-      pipelineIdentifier: "authoring-pipeline",
+      executionId: "exec-1",
+      pipelineIdentifier: "dbops_default_pipeline",
+      openInHarness: "https://app.harness.io/...",
     });
     const client = makeClient(mockRequest);
 
@@ -715,20 +716,67 @@ describe("database_execute_llm_authoring_pipeline create", () => {
         instance_id: "instance_1",
         conversation_id: "conversation-1",
         changeset: "databaseChangeLog: []",
+        k8s_connector_ref: "account.k8s_connector",
+        use_default_pipeline: true,
       },
     });
 
     const call = mockRequest.mock.calls[0][0];
     expect(call.method).toBe("POST");
-    expect(call.path).toBe("/dbops/v1/orgs/default/projects/test-project/execute-llm-authoring-pipeline");
+    expect(call.path).toBe(
+      "/v1/orgs/default/projects/test-project/llm-authoring/execute-pipeline",
+    );
     expect(call.body).toEqual({
-      schemaIdentifier: "schema_1",
-      instanceIdentifier: "instance_1",
       conversationId: "conversation-1",
+      schemaId: "schema_1",
+      instanceId: "instance_1",
       changeset: "databaseChangeLog: []",
+      k8sConnectorRef: "account.k8s_connector",
+      useDefaultPipeline: true,
     });
     expect(call.body).not.toHaveProperty("orgIdentifier");
     expect(call.body).not.toHaveProperty("projectIdentifier");
+    expect(call.body).not.toHaveProperty("pipelineIdentifier");
+  });
+
+  it("forwards the custom-pipeline branch with runtime_inputs", async () => {
+    const registry = new Registry(makeConfig());
+    const mockRequest = vi.fn().mockResolvedValue({
+      executionId: "exec-2",
+      pipelineIdentifier: "my-pipe",
+      openInHarness: "https://app.harness.io/...",
+    });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "database_execute_llm_authoring_pipeline", "create", {
+      org_id: "default",
+      project_id: "test-project",
+      body: {
+        schema_id: "schema_1",
+        instance_id: "instance_1",
+        conversation_id: "conversation-1",
+        changeset: "databaseChangeLog: []",
+        k8s_connector_ref: "account.k8s_connector",
+        pipeline_identifier: "my-pipe",
+        runtime_inputs: { releaseCodename: "phoenix" },
+      },
+    });
+
+    const call = mockRequest.mock.calls[0][0];
+    expect(call.method).toBe("POST");
+    expect(call.path).toBe(
+      "/v1/orgs/default/projects/test-project/llm-authoring/execute-pipeline",
+    );
+    expect(call.body).toEqual({
+      conversationId: "conversation-1",
+      schemaId: "schema_1",
+      instanceId: "instance_1",
+      changeset: "databaseChangeLog: []",
+      k8sConnectorRef: "account.k8s_connector",
+      pipelineIdentifier: "my-pipe",
+      runtimeInputs: { releaseCodename: "phoenix" },
+    });
+    expect(call.body).not.toHaveProperty("useDefaultPipeline");
   });
 });
 

--- a/tests/registry/toolsets/dbops.test.ts
+++ b/tests/registry/toolsets/dbops.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { dbopsToolset } from "../../../src/registry/toolsets/dbops.js";
+
+const executeResource = dbopsToolset.resources.find(
+  (r) => r.resourceType === "database_execute_llm_authoring_pipeline",
+);
+if (!executeResource) {
+  throw new Error("database_execute_llm_authoring_pipeline resource missing from dbopsToolset");
+}
+const createOp = executeResource.operations.create;
+if (!createOp) {
+  throw new Error("create operation missing from database_execute_llm_authoring_pipeline resource");
+}
+const buildBody = createOp.bodyBuilder!;
+
+describe("database_execute_llm_authoring_pipeline endpoint spec", () => {
+  it("hits the v1 llm-authoring/execute-pipeline path", () => {
+    expect(createOp.method).toBe("POST");
+    expect(createOp.path).toBe(
+      "/v1/orgs/{org}/projects/{project}/llm-authoring/execute-pipeline",
+    );
+  });
+
+  it("forwards the custom-pipeline branch verbatim", () => {
+    const body = buildBody({
+      schema_id: "s",
+      instance_id: "i",
+      conversation_id: "c",
+      changeset: "cs",
+      k8s_connector_ref: "k8s",
+      pipeline_identifier: "my-pipe",
+      runtime_inputs: { releaseCodename: "phoenix" },
+    }) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      schemaId: "s",
+      instanceId: "i",
+      conversationId: "c",
+      changeset: "cs",
+      k8sConnectorRef: "k8s",
+      pipelineIdentifier: "my-pipe",
+      runtimeInputs: { releaseCodename: "phoenix" },
+    });
+    expect(body).not.toHaveProperty("useDefaultPipeline");
+  });
+
+  it("forwards the default-pipeline branch with useDefaultPipeline=true", () => {
+    const body = buildBody({
+      schema_id: "s",
+      instance_id: "i",
+      conversation_id: "c",
+      changeset: "cs",
+      k8s_connector_ref: "k8s",
+      use_default_pipeline: true,
+    }) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      schemaId: "s",
+      instanceId: "i",
+      conversationId: "c",
+      changeset: "cs",
+      k8sConnectorRef: "k8s",
+      useDefaultPipeline: true,
+    });
+    expect(body).not.toHaveProperty("pipelineIdentifier");
+    expect(body).not.toHaveProperty("runtimeInputs");
+  });
+
+  it("accepts inputs nested under `body` (callers may double-wrap)", () => {
+    const body = buildBody({
+      body: {
+        schema_id: "s",
+        instance_id: "i",
+        conversation_id: "c",
+        changeset: "cs",
+        k8s_connector_ref: "k8s",
+        use_default_pipeline: true,
+      },
+    }) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      schemaId: "s",
+      instanceId: "i",
+      useDefaultPipeline: true,
+    });
+  });
+
+  it("accepts already-camelCase fields (idempotent on either casing)", () => {
+    const body = buildBody({
+      schemaId: "s",
+      instanceId: "i",
+      conversationId: "c",
+      changeset: "cs",
+      k8sConnectorRef: "k8s",
+      pipelineIdentifier: "my-pipe",
+    }) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      schemaId: "s",
+      instanceId: "i",
+      pipelineIdentifier: "my-pipe",
+    });
+  });
+});

--- a/tests/registry/toolsets/dbops.test.ts
+++ b/tests/registry/toolsets/dbops.test.ts
@@ -21,6 +21,12 @@ describe("database_execute_llm_authoring_pipeline endpoint spec", () => {
     );
   });
 
+  it("description opens with Accept & Commit workflow framing", () => {
+    expect(executeResource.description).toMatch(
+      /^Consolidated endpoint for the LLM change authoring Accept & Commit flow\./,
+    );
+  });
+
   it("forwards the custom-pipeline branch verbatim", () => {
     const body = buildBody({
       schema_id: "s",

--- a/tests/registry/toolsets/dbops.test.ts
+++ b/tests/registry/toolsets/dbops.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { dbopsToolset } from "../../../src/registry/toolsets/dbops.js";
+import { listOutputSchema } from "../../../src/tools/output-schemas.js";
 
 const executeResource = dbopsToolset.resources.find(
   (r) => r.resourceType === "database_execute_llm_authoring_pipeline",
@@ -96,5 +97,51 @@ describe("database_execute_llm_authoring_pipeline endpoint spec", () => {
       instanceId: "i",
       pipelineIdentifier: "my-pipe",
     });
+  });
+
+  it("throws when both use_default_pipeline and pipeline_identifier are set", () => {
+    expect(() =>
+      buildBody({
+        schema_id: "s",
+        instance_id: "i",
+        conversation_id: "c",
+        changeset: "cs",
+        use_default_pipeline: true,
+        pipeline_identifier: "my-pipe",
+      }),
+    ).toThrow("Exactly one of use_default_pipeline or pipeline_identifier must be set, not both.");
+  });
+
+  it("omits both branch fields when neither use_default_pipeline nor pipeline_identifier is set", () => {
+    const body = buildBody({
+      schema_id: "s",
+      instance_id: "i",
+      conversation_id: "c",
+      changeset: "cs",
+    }) as Record<string, unknown>;
+    // Server rejects the request; client-side we just forward common fields with no branch key.
+    // This documents "no implicit default" behaviour — the server, not the client, is the guard.
+    expect(body).not.toHaveProperty("useDefaultPipeline");
+    expect(body).not.toHaveProperty("pipelineIdentifier");
+    expect(body).toMatchObject({ schemaId: "s", instanceId: "i", conversationId: "c", changeset: "cs" });
+  });
+
+  it("run action uses low_write risk (intentional — billing side-effect is scoped to the Accept & Commit flow)", () => {
+    expect(runAction.operationPolicy?.risk).toBe("low_write");
+  });
+});
+
+describe("listOutputSchema primitive widening", () => {
+  it("accepts a string[] response from the snapshot-names API (regression: items were object-only)", () => {
+    const result = listOutputSchema.safeParse({ items: ["table_a", "table_b"] });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.items).toEqual(["table_a", "table_b"]);
+    }
+  });
+
+  it("still accepts the normal object[] shape", () => {
+    const result = listOutputSchema.safeParse({ items: [{ id: "1", name: "foo" }], total: 1, page: 0 });
+    expect(result.success).toBe(true);
   });
 });

--- a/tests/registry/toolsets/dbops.test.ts
+++ b/tests/registry/toolsets/dbops.test.ts
@@ -27,7 +27,6 @@ describe("database_execute_llm_authoring_pipeline endpoint spec", () => {
       instance_id: "i",
       conversation_id: "c",
       changeset: "cs",
-      k8s_connector_ref: "k8s",
       pipeline_identifier: "my-pipe",
       runtime_inputs: { releaseCodename: "phoenix" },
     }) as Record<string, unknown>;
@@ -36,7 +35,6 @@ describe("database_execute_llm_authoring_pipeline endpoint spec", () => {
       instanceId: "i",
       conversationId: "c",
       changeset: "cs",
-      k8sConnectorRef: "k8s",
       pipelineIdentifier: "my-pipe",
       runtimeInputs: { releaseCodename: "phoenix" },
     });
@@ -49,7 +47,6 @@ describe("database_execute_llm_authoring_pipeline endpoint spec", () => {
       instance_id: "i",
       conversation_id: "c",
       changeset: "cs",
-      k8s_connector_ref: "k8s",
       use_default_pipeline: true,
     }) as Record<string, unknown>;
     expect(body).toMatchObject({
@@ -57,7 +54,6 @@ describe("database_execute_llm_authoring_pipeline endpoint spec", () => {
       instanceId: "i",
       conversationId: "c",
       changeset: "cs",
-      k8sConnectorRef: "k8s",
       useDefaultPipeline: true,
     });
     expect(body).not.toHaveProperty("pipelineIdentifier");
@@ -71,7 +67,6 @@ describe("database_execute_llm_authoring_pipeline endpoint spec", () => {
         instance_id: "i",
         conversation_id: "c",
         changeset: "cs",
-        k8s_connector_ref: "k8s",
         use_default_pipeline: true,
       },
     }) as Record<string, unknown>;
@@ -88,7 +83,6 @@ describe("database_execute_llm_authoring_pipeline endpoint spec", () => {
       instanceId: "i",
       conversationId: "c",
       changeset: "cs",
-      k8sConnectorRef: "k8s",
       pipelineIdentifier: "my-pipe",
     }) as Record<string, unknown>;
     expect(body).toMatchObject({

--- a/tests/registry/toolsets/dbops.test.ts
+++ b/tests/registry/toolsets/dbops.test.ts
@@ -7,16 +7,16 @@ const executeResource = dbopsToolset.resources.find(
 if (!executeResource) {
   throw new Error("database_execute_llm_authoring_pipeline resource missing from dbopsToolset");
 }
-const createOp = executeResource.operations.create;
-if (!createOp) {
-  throw new Error("create operation missing from database_execute_llm_authoring_pipeline resource");
+const runAction = executeResource.executeActions?.run;
+if (!runAction) {
+  throw new Error("run execute action missing from database_execute_llm_authoring_pipeline resource");
 }
-const buildBody = createOp.bodyBuilder!;
+const buildBody = runAction.bodyBuilder!;
 
 describe("database_execute_llm_authoring_pipeline endpoint spec", () => {
   it("hits the v1 llm-authoring/execute-pipeline path", () => {
-    expect(createOp.method).toBe("POST");
-    expect(createOp.path).toBe(
+    expect(runAction.method).toBe("POST");
+    expect(runAction.path).toBe(
       "/v1/orgs/{org}/projects/{project}/llm-authoring/execute-pipeline",
     );
   });


### PR DESCRIPTION
## Description

Updates the ` + "`database_execute_llm_authoring_pipeline`" + ` dbops resource to call the new server-side orchestrator endpoint shipped in db-devops-service, which atomically triggers an LLM-authoring validate-and-preview pipeline and persists the billable ` + "`ChangeAuthoringExecutionEvent`" + ` for flex billing.

**What changed in `src/registry/toolsets/dbops.ts`:**

- Path: `/dbops/v1/orgs/{org}/projects/{project}/execute-llm-authoring-pipeline` → **`/v1/orgs/{org}/projects/{project}/llm-authoring/execute-pipeline`** (matches the new db-devops-service endpoint).
- `bodyBuilder` rewritten: accepts `input.body ?? input` (dual-shape) and either snake_case or camelCase keys; always emits the four required fields `conversationId, schemaId, instanceId, changeset`; exactly-one branch enforced (client-side: useDefaultPipeline wins; server rejects invalid combinations) (`useDefaultPipeline=true` OR `pipelineIdentifier` + optional `runtimeInputs`).
- `bodySchema` documents all eight input fields for `harness_describe`.
- Description and `actionDescription` updated to call out the NG setting (`dbops_llm_authoring_pipeline`), mutual exclusivity, and the four reserved input keys.

**Tests:**

- New `tests/registry/toolsets/dbops.test.ts` — 5 vitest unit cases covering: path; custom-pipeline branch; default-pipeline branch; double-wrap (`input.body`); already-camelCase passthrough.
- Existing `tests/registry/dbops.test.ts` — 1 stale dispatch test replaced with 2 tests that exercise both branches via the registry. Without this update the full suite would stay red because the old test asserted the old contract.
- Full suite: `pnpm test` → **1864/1864 passed**, `pnpm typecheck` clean, `pnpm build` clean.

**Cross-repo PRs needed for end-to-end:**
- **db-devops-service** ships the new endpoint and orchestration service.
- **ml-infra** rewrites the `dbops_changeset` skill to call this resource (NG-setting branch + AskUserQuestion + drop in-skill polling).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor *(retargets an existing resource to the new server contract; the resource itself is not new but its target is)*
- [ ] Documentation
- [ ] Other

## Checklist

- [x] Tests pass *(`pnpm test` → 1864 passed)*
- [x] Typecheck passes *(`pnpm typecheck` clean)*