### PR TITLE
fix: parse raw YAML string bodies for normalized JSON resources

### DIFF
--- a/src/utils/body-normalizer.ts
+++ b/src/utils/body-normalizer.ts
@@ -38,6 +38,12 @@ function parseYamlBody(body: string): unknown {
   }
 }
 
+function assertObjectBody(body: unknown): void {
+  if (body == null || typeof body !== "object" || Array.isArray(body)) {
+    throw new Error("body must be a JSON object or YAML object for this resource.");
+  }
+}
+
 /**
  * Options for the standardized body builder factory.
  */
@@ -62,10 +68,9 @@ export function buildBodyNormalized(opts: BodyBuilderOptions = {}): (input: Reco
 
     if (typeof body === "string") {
       body = parseYamlBody(body);
-    }
-
-    if (body !== undefined && body !== null && (typeof body !== "object" || Array.isArray(body))) {
-      throw new Error("body must be a JSON object or YAML object for this resource.");
+      assertObjectBody(body);
+    } else if (body != null && (typeof body !== "object" || Array.isArray(body))) {
+      assertObjectBody(body);
     }
 
     // Step 1a: Unwrap wrapper key if configured

--- a/src/utils/body-normalizer.ts
+++ b/src/utils/body-normalizer.ts
@@ -4,6 +4,8 @@
  * - Unwrap common wrapper keys (environment, service, connector) when APIs expect the entity at top level.
  */
 
+import { parse as parseYaml } from "yaml";
+
 /** Recursively remove null and undefined so they are omitted from JSON. */
 export function stripNulls(obj: unknown): unknown {
   if (obj === null || obj === undefined) return undefined;
@@ -27,6 +29,15 @@ export function unwrapBody(body: unknown, wrapperKey: string): unknown {
   return body;
 }
 
+function parseYamlBody(body: string): unknown {
+  try {
+    return parseYaml(body);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(`body must be a JSON object or YAML object for this resource. Failed to parse YAML body: ${detail}`);
+  }
+}
+
 /**
  * Options for the standardized body builder factory.
  */
@@ -48,6 +59,14 @@ export interface BodyBuilderOptions {
 export function buildBodyNormalized(opts: BodyBuilderOptions = {}): (input: Record<string, unknown>) => unknown {
   return (input: Record<string, unknown>) => {
     let body = input.body;
+
+    if (typeof body === "string") {
+      body = parseYamlBody(body);
+    }
+
+    if (body !== undefined && body !== null && (typeof body !== "object" || Array.isArray(body))) {
+      throw new Error("body must be a JSON object or YAML object for this resource.");
+    }
 
     // Step 1a: Unwrap wrapper key if configured
     if (opts.unwrapKey) {

--- a/tests/integration/mock-harness-api.test.ts
+++ b/tests/integration/mock-harness-api.test.ts
@@ -315,19 +315,22 @@ describe("Integration: Registry → HarnessClient → fetch", () => {
       });
     });
 
-    it("connector create rejects raw YAML string bodies that do not parse to objects", async () => {
-      const config = makeConfig();
-      const client = new HarnessClient(config);
-      const registry = new Registry(config);
+    it.each(["- just\n- a\n- list", "", "null", "~", "---", "   "])(
+      "connector create rejects invalid raw YAML string bodies (%j)",
+      async (yamlBody) => {
+        const config = makeConfig();
+        const client = new HarnessClient(config);
+        const registry = new Registry(config);
 
-      await expect(
-        registry.dispatch(client, "connector", "create", {
-          body: "- just\n- a\n- list",
-        }),
-      ).rejects.toThrow(/body must be a JSON object or YAML object/);
+        await expect(
+          registry.dispatch(client, "connector", "create", {
+            body: yamlBody,
+          }),
+        ).rejects.toThrow(/body must be a JSON object or YAML object/);
 
-      expect(fetchSpy).not.toHaveBeenCalled();
-    });
+        expect(fetchSpy).not.toHaveBeenCalled();
+      },
+    );
   });
 
   describe("execution lifecycle", () => {

--- a/tests/integration/mock-harness-api.test.ts
+++ b/tests/integration/mock-harness-api.test.ts
@@ -275,6 +275,59 @@ describe("Integration: Registry → HarnessClient → fetch", () => {
       // Body is the raw YAML string
       expect(init.body).toBe(yaml);
     });
+
+    it("connector create converts raw YAML string bodies to JSON", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({ status: "SUCCESS", data: { connector: { identifier: "k8s" } } }),
+      );
+
+      const config = makeConfig();
+      const client = new HarnessClient(config);
+      const registry = new Registry(config);
+
+      await registry.dispatch(client, "connector", "create", {
+        body: [
+          "connector:",
+          "  name: K8s",
+          "  identifier: k8s",
+          "  type: K8sCluster",
+          "  spec:",
+          "    credential:",
+          "      type: InheritFromDelegate",
+        ].join("\n"),
+      });
+
+      const [, options] = fetchSpy.mock.calls[0]!;
+      const init = options as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      expect(headers["Content-Type"]).toBe("application/json");
+      expect(JSON.parse(init.body as string)).toMatchObject({
+        connector: {
+          name: "K8s",
+          identifier: "k8s",
+          type: "K8sCluster",
+          spec: {
+            credential: {
+              type: "InheritFromDelegate",
+            },
+          },
+        },
+      });
+    });
+
+    it("connector create rejects raw YAML string bodies that do not parse to objects", async () => {
+      const config = makeConfig();
+      const client = new HarnessClient(config);
+      const registry = new Registry(config);
+
+      await expect(
+        registry.dispatch(client, "connector", "create", {
+          body: "- just\n- a\n- list",
+        }),
+      ).rejects.toThrow(/body must be a JSON object or YAML object/);
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe("execution lifecycle", () => {


### PR DESCRIPTION
Convert harness_create string bodies to objects in buildBodyNormalized before JSON API dispatch, fixing connector create HTTP 415 when agents pass raw YAML instead of body.connector JSON.

## Description
<!-- What does this PR do? -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [ ] Tests pass
- [ ] Typecheck passes
