### PR TITLE
fix: preserve caller-provided FME auth

### DIFF
--- a/src/client/harness-client.ts
+++ b/src/client/harness-client.ts
@@ -155,9 +155,13 @@ export class HarnessClient {
   }
 
   private applyDefaultAuth(headers: Record<string, string>, isFme: boolean): void {
+    // Hosted/internal MCP wrappers may already provide service-to-service auth.
+    // Preserve it instead of layering the configured PAT/SAT on top.
     if (headers["Authorization"]) return;
 
     if (isFme) {
+      // FME/Split Admin APIs expect Bearer auth. Drop x-api-key here so hosted
+      // placeholder credentials are never forwarded to api.split.io.
       const headerApiKey = headers["x-api-key"]?.trim();
       delete headers["x-api-key"];
 
@@ -185,6 +189,7 @@ export class HarnessClient {
       return;
     }
 
+    // Non-FME Harness services continue to use the standard API-key header.
     if (!headers["x-api-key"]) {
       headers["x-api-key"] = this.token;
     }

--- a/src/client/harness-client.ts
+++ b/src/client/harness-client.ts
@@ -155,14 +155,14 @@ export class HarnessClient {
   }
 
   private applyDefaultAuth(headers: Record<string, string>, isFme: boolean): void {
-    // Preserve caller-provided auth instead of layering fallback credentials on top.
-    if (headers["Authorization"]) return;
-
     if (isFme) {
       // FME/Split Admin APIs expect Bearer auth. Drop x-api-key here so
       // placeholder credentials are never forwarded to api.split.io.
       const headerApiKey = headers["x-api-key"]?.trim();
       delete headers["x-api-key"];
+
+      // Preserve caller-provided auth instead of layering fallback credentials on top.
+      if (headers["Authorization"]) return;
 
       const fmeApiKey = headerApiKey && !isPlaceholderCredential(headerApiKey)
         ? headerApiKey
@@ -187,6 +187,9 @@ export class HarnessClient {
       headers["Authorization"] = `Bearer ${fmeApiKey}`;
       return;
     }
+
+    // Preserve caller-provided auth instead of layering fallback credentials on top.
+    if (headers["Authorization"]) return;
 
     // Non-FME Harness services continue to use the standard API-key header.
     if (!headers["x-api-key"]) {

--- a/src/client/harness-client.ts
+++ b/src/client/harness-client.ts
@@ -155,12 +155,11 @@ export class HarnessClient {
   }
 
   private applyDefaultAuth(headers: Record<string, string>, isFme: boolean): void {
-    // Hosted/internal MCP wrappers may already provide service-to-service auth.
-    // Preserve it instead of layering the configured PAT/SAT on top.
+    // Preserve caller-provided auth instead of layering fallback credentials on top.
     if (headers["Authorization"]) return;
 
     if (isFme) {
-      // FME/Split Admin APIs expect Bearer auth. Drop x-api-key here so hosted
+      // FME/Split Admin APIs expect Bearer auth. Drop x-api-key here so
       // placeholder credentials are never forwarded to api.split.io.
       const headerApiKey = headers["x-api-key"]?.trim();
       delete headers["x-api-key"];
@@ -173,13 +172,13 @@ export class HarnessClient {
         const remediation = this.mcpMode === "multi-user"
           ? "Ensure the session x-harness-api-key is an FME-entitled Harness PAT/SAT. " +
             "Do not configure HARNESS_FME_API_KEY in multi-user mode."
-          : "Ask your Harness administrator to configure an FME/Split Admin credential for hosted MCP, " +
+          : "Configure an FME/Split Admin credential, " +
             "or set HARNESS_FME_API_KEY to a legacy Split admin key or FME-entitled Harness PAT/SAT. " +
-            "Self-hosted sessions may also provide a non-placeholder HARNESS_API_KEY.";
+            "A non-placeholder HARNESS_API_KEY may also be used when it is FME-entitled.";
         throw new HarnessApiError(
           "FME is not configured or authorized for this MCP session. " +
           `${remediation} ` +
-          "Hosted OAuth placeholders such as \"dummy\" are not sent to api.split.io.",
+          "Placeholder credentials such as \"dummy\" are not sent to api.split.io.",
           401,
           "FME_AUTH_MISSING",
         );

--- a/src/client/harness-client.ts
+++ b/src/client/harness-client.ts
@@ -1,4 +1,4 @@
-import type { Config } from "../config.js";
+import { type Config, isPlaceholderCredential, resolveFmeApiKey } from "../config.js";
 import type { RequestOptions } from "./types.js";
 import { HarnessApiError } from "../utils/errors.js";
 import { RateLimiter } from "../utils/rate-limiter.js";
@@ -115,6 +115,8 @@ export class HarnessClient {
   private readonly maxRetries: number;
   private readonly rateLimiter: RateLimiter;
   private readonly logUnsafeBodies: boolean;
+  private readonly fmeApiKey: string | undefined;
+  private readonly mcpMode: Config["HARNESS_MCP_MODE"];
   private accountIdResolver?: AccountIdResolver;
   private currentUserId?: string;
   private currentUserPromise?: Promise<string>;
@@ -127,6 +129,8 @@ export class HarnessClient {
     this.maxRetries = config.HARNESS_MAX_RETRIES;
     this.rateLimiter = new RateLimiter(config.HARNESS_RATE_LIMIT_RPS);
     this.logUnsafeBodies = config.HARNESS_LOG_UNSAFE_BODIES;
+    this.fmeApiKey = resolveFmeApiKey(config);
+    this.mcpMode = config.HARNESS_MCP_MODE;
   }
 
   /**
@@ -148,6 +152,42 @@ export class HarnessClient {
 
   get baseURL(): string {
     return this.baseUrl;
+  }
+
+  private applyDefaultAuth(headers: Record<string, string>, isFme: boolean): void {
+    if (headers["Authorization"]) return;
+
+    if (isFme) {
+      const headerApiKey = headers["x-api-key"]?.trim();
+      delete headers["x-api-key"];
+
+      const fmeApiKey = headerApiKey && !isPlaceholderCredential(headerApiKey)
+        ? headerApiKey
+        : this.fmeApiKey;
+
+      if (!fmeApiKey) {
+        const remediation = this.mcpMode === "multi-user"
+          ? "Ensure the session x-harness-api-key is an FME-entitled Harness PAT/SAT. " +
+            "Do not configure HARNESS_FME_API_KEY in multi-user mode."
+          : "Ask your Harness administrator to configure an FME/Split Admin credential for hosted MCP, " +
+            "or set HARNESS_FME_API_KEY to a legacy Split admin key or FME-entitled Harness PAT/SAT. " +
+            "Self-hosted sessions may also provide a non-placeholder HARNESS_API_KEY.";
+        throw new HarnessApiError(
+          "FME is not configured or authorized for this MCP session. " +
+          `${remediation} ` +
+          "Hosted OAuth placeholders such as \"dummy\" are not sent to api.split.io.",
+          401,
+          "FME_AUTH_MISSING",
+        );
+      }
+
+      headers["Authorization"] = `Bearer ${fmeApiKey}`;
+      return;
+    }
+
+    if (!headers["x-api-key"]) {
+      headers["x-api-key"] = this.token;
+    }
   }
 
   /**
@@ -198,13 +238,11 @@ export class HarnessClient {
       ...options.headers,
     };
 
-    // Only inject x-api-key when the caller hasn't already set auth.
+    // Only inject default auth when the caller hasn't already set auth.
     // When service-routing handles auth (bearer-jwt, remote-mcp), it sets
     // Authorization directly — sending x-api-key alongside would cause
     // downstream services to attempt API-key validation on the dummy token.
-    if (!headers["Authorization"] && !headers["x-api-key"]) {
-      headers["x-api-key"] = this.token;
-    }
+    this.applyDefaultAuth(headers, isFme);
 
     if (hasExplicitBody(options.body)) {
       if (isFormDataBody(options.body)) {
@@ -375,9 +413,7 @@ export class HarnessClient {
     };
 
     // Same auth-header guard as request() — see comment there.
-    if (!headers["Authorization"] && !headers["x-api-key"]) {
-      headers["x-api-key"] = this.token;
-    }
+    this.applyDefaultAuth(headers, isFme);
 
     if (hasExplicitBody(options.body)) {
       if (isFormDataBody(options.body)) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -200,9 +200,8 @@ export const ConfigSchema = RawConfigSchema.transform((data) => {
 export type Config = z.infer<typeof ConfigSchema>;
 
 /**
- * Hosted/internal MCP deployments use literal placeholder credentials (for
- * example "dummy") while platform auth is handled by service routing. Those
- * placeholders are not valid external Split/FME API credentials.
+ * Some integrations use literal placeholder credentials (for example "dummy").
+ * Those placeholders are not valid external Split/FME API credentials.
  */
 export function isPlaceholderCredential(value: string | undefined): boolean {
   const normalized = value?.trim().toLowerCase();
@@ -212,8 +211,8 @@ export function isPlaceholderCredential(value: string | undefined): boolean {
 
 /**
  * Resolve the token used for Split/FME product APIs.
- * FME talks directly to api.split.io, so hosted OAuth/proxy auth for Harness
- * platform APIs cannot be reused there.
+ * FME talks directly to api.split.io, so a Harness platform auth placeholder
+ * cannot be reused there.
  */
 export function resolveFmeApiKey(
   config: Pick<Config, "HARNESS_MCP_MODE" | "HARNESS_FME_API_KEY" | "HARNESS_API_KEY">,

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { type Config, resolveFmeApiKey, resolveProductBaseUrl } from "../config.js";
+import { type Config, resolveProductBaseUrl } from "../config.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import { HarnessApiError } from "../utils/errors.js";
 import type { ResourceDefinition, ToolsetDefinition, ToolsetName, OperationName, EndpointSpec, FilterFieldSpec, ResourceScope } from "./types.js";
@@ -722,25 +722,6 @@ export class Registry {
     const product = def.product ?? "harness";
     const baseUrl = resolveProductBaseUrl(this.config, product);
     const productHeaders: Record<string, string> = { ...spec.headers };
-    if (product === "fme") {
-      const fmeApiKey = resolveFmeApiKey(this.config);
-      if (!fmeApiKey) {
-        const remediation = this.config.HARNESS_MCP_MODE === "multi-user"
-          ? "Ensure the session x-harness-api-key is an FME-entitled Harness PAT/SAT. " +
-            "Do not configure HARNESS_FME_API_KEY in multi-user mode."
-          : "Ask your Harness administrator to configure an FME/Split Admin credential for hosted MCP, " +
-            "or set HARNESS_FME_API_KEY to a legacy Split admin key or FME-entitled Harness PAT/SAT. " +
-            "Self-hosted sessions may also provide a non-placeholder HARNESS_API_KEY.";
-        throw new HarnessApiError(
-          "FME is not configured or authorized for this MCP session. " +
-          `${remediation} ` +
-          "Hosted OAuth placeholders such as \"dummy\" are not sent to api.split.io.",
-          401,
-          "FME_AUTH_MISSING",
-        );
-      }
-      productHeaders["Authorization"] = `Bearer ${fmeApiKey}`;
-    }
 
     const requestOpts = {
       method: resolvedMethod,

--- a/tests/client/harness-client.test.ts
+++ b/tests/client/harness-client.test.ts
@@ -285,7 +285,7 @@ describe("HarnessClient", () => {
       expect(headers.has("x-api-key")).toBe(false);
     });
 
-    it("fails before sending hosted placeholder credentials to Split.io", async () => {
+    it("fails before sending placeholder credentials to Split.io", async () => {
       const client = new HarnessClient(makeConfig({
         HARNESS_API_KEY: "pat.internal.internal.dummy",
         HARNESS_FME_API_KEY: undefined,
@@ -293,7 +293,7 @@ describe("HarnessClient", () => {
 
       await expect(
         client.request({ path: "/internal/api/v2/workspaces", product: "fme" }),
-      ).rejects.toThrow("Hosted OAuth placeholders");
+      ).rejects.toThrow("Placeholder credentials");
 
       expect(fetchSpy).not.toHaveBeenCalled();
     });

--- a/tests/client/harness-client.test.ts
+++ b/tests/client/harness-client.test.ts
@@ -285,6 +285,28 @@ describe("HarnessClient", () => {
       expect(headers.has("x-api-key")).toBe(false);
     });
 
+    it("drops x-api-key when preserving caller-provided Authorization for FME requests", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      const client = new HarnessClient(makeConfig({
+        HARNESS_API_KEY: "pat.internal.internal.dummy",
+        HARNESS_FME_API_KEY: undefined,
+      }));
+
+      await client.request({
+        path: "/internal/api/v2/workspaces",
+        product: "fme",
+        headers: {
+          Authorization: "PlatformService service-jwt",
+          "x-api-key": "pat.internal.internal.dummy",
+        },
+      });
+
+      const init = fetchSpy.mock.calls[0][1] as RequestInit;
+      const headers = new Headers(init.headers);
+      expect(headers.get("Authorization")).toBe("PlatformService service-jwt");
+      expect(headers.has("x-api-key")).toBe(false);
+    });
+
     it("fails before sending placeholder credentials to Split.io", async () => {
       const client = new HarnessClient(makeConfig({
         HARNESS_API_KEY: "pat.internal.internal.dummy",

--- a/tests/client/harness-client.test.ts
+++ b/tests/client/harness-client.test.ts
@@ -5,6 +5,7 @@ import type { Config } from "../../src/config.js";
 
 function makeConfig(overrides: Partial<Config> = {}): Config {
   return {
+    HARNESS_MCP_MODE: "single-user",
     HARNESS_API_KEY: "pat.test-account.token.secret",
     HARNESS_ACCOUNT_ID: "test-account",
     HARNESS_BASE_URL: "https://app.harness.io",
@@ -16,6 +17,8 @@ function makeConfig(overrides: Partial<Config> = {}): Config {
     HARNESS_RATE_LIMIT_RPS: 1000, // high limit so rate limiter doesn't interfere
     HARNESS_MAX_BODY_SIZE_MB: 10,
     HARNESS_READ_ONLY: false,
+    HARNESS_FME_API_KEY: undefined,
+    HARNESS_FME_BASE_URL: "https://api.split.io",
     ...overrides,
   };
 }
@@ -233,6 +236,66 @@ describe("HarnessClient", () => {
       const url = new URL(fetchSpy.mock.calls[0][0] as string);
       expect(url.searchParams.has("accountIdentifier")).toBe(false);
       expect(url.searchParams.has("routingId")).toBe(false);
+    });
+
+    it("uses bearer auth from a non-placeholder HARNESS_API_KEY for FME requests", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      const client = new HarnessClient(makeConfig());
+
+      await client.request({ path: "/internal/api/v2/workspaces", product: "fme" });
+
+      const init = fetchSpy.mock.calls[0][1] as RequestInit;
+      const headers = new Headers(init.headers);
+      expect(headers.get("Authorization")).toBe("Bearer pat.test-account.token.secret");
+      expect(headers.has("x-api-key")).toBe(false);
+      expect(headers.has("Harness-Account")).toBe(false);
+    });
+
+    it("prefers HARNESS_FME_API_KEY over HARNESS_API_KEY for FME requests", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      const client = new HarnessClient(makeConfig({
+        HARNESS_API_KEY: "pat.internal.internal.dummy",
+        HARNESS_FME_API_KEY: "fme-admin-key",
+      }));
+
+      await client.request({ path: "/internal/api/v2/workspaces", product: "fme" });
+
+      const init = fetchSpy.mock.calls[0][1] as RequestInit;
+      const headers = new Headers(init.headers);
+      expect(headers.get("Authorization")).toBe("Bearer fme-admin-key");
+      expect(headers.has("x-api-key")).toBe(false);
+    });
+
+    it("preserves host-provided Authorization for FME requests", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      const client = new HarnessClient(makeConfig({
+        HARNESS_API_KEY: "pat.internal.internal.dummy",
+        HARNESS_FME_API_KEY: undefined,
+      }));
+
+      await client.request({
+        path: "/internal/api/v2/workspaces",
+        product: "fme",
+        headers: { Authorization: "PlatformService service-jwt" },
+      });
+
+      const init = fetchSpy.mock.calls[0][1] as RequestInit;
+      const headers = new Headers(init.headers);
+      expect(headers.get("Authorization")).toBe("PlatformService service-jwt");
+      expect(headers.has("x-api-key")).toBe(false);
+    });
+
+    it("fails before sending hosted placeholder credentials to Split.io", async () => {
+      const client = new HarnessClient(makeConfig({
+        HARNESS_API_KEY: "pat.internal.internal.dummy",
+        HARNESS_FME_API_KEY: undefined,
+      }));
+
+      await expect(
+        client.request({ path: "/internal/api/v2/workspaces", product: "fme" }),
+      ).rejects.toThrow("Hosted OAuth placeholders");
+
+      expect(fetchSpy).not.toHaveBeenCalled();
     });
 
     it("uses resolved account ID for routingId", async () => {

--- a/tests/registry/feature-flags.test.ts
+++ b/tests/registry/feature-flags.test.ts
@@ -126,8 +126,8 @@ describe("FME registry metadata", () => {
   });
 });
 
-describe("FME auth", () => {
-  it("uses bearer auth from a non-placeholder HARNESS_API_KEY fallback", async () => {
+describe("FME request routing", () => {
+  it("marks FME requests for product-specific client auth and base URL handling", async () => {
     const registry = new Registry(makeConfig());
     const mockRequest = vi.fn().mockResolvedValue({ objects: [], totalCount: 0, offset: 0, limit: 20 });
     const client = makeClient(mockRequest);
@@ -137,47 +137,10 @@ describe("FME auth", () => {
     const call = firstRequest(mockRequest);
     expect(call.product).toBe("fme");
     expect(call.baseUrl).toBe("https://api.split.io");
-    expect(call.headers).toMatchObject({ Authorization: "Bearer pat.test" });
-    expect(call.headers).not.toHaveProperty("x-api-key");
+    expect(call.headers).toBeUndefined();
   });
 
-  it("prefers explicit HARNESS_FME_API_KEY over a hosted placeholder HARNESS_API_KEY", async () => {
-    const registry = new Registry(makeConfig({
-      HARNESS_API_KEY: "dummy",
-      HARNESS_FME_API_KEY: "fme-admin-key",
-    }));
-    const mockRequest = vi.fn().mockResolvedValue({ objects: [], totalCount: 0, offset: 0, limit: 20 });
-    const client = makeClient(mockRequest);
-
-    await registry.dispatch(client, "fme_workspace", "list", {});
-
-    const call = firstRequest(mockRequest);
-    expect(call.headers).toMatchObject({ Authorization: "Bearer fme-admin-key" });
-    expect(call.headers).not.toHaveProperty("x-api-key");
-  });
-
-  it("fails before sending hosted placeholder credentials to Split.io", async () => {
-    const registry = new Registry(makeConfig({
-      HARNESS_API_KEY: "dummy",
-      HARNESS_FME_API_KEY: undefined,
-    }));
-    const mockRequest = vi.fn().mockResolvedValue({ objects: [], totalCount: 0, offset: 0, limit: 20 });
-    const client = makeClient(mockRequest);
-
-    try {
-      await registry.dispatch(client, "fme_workspace", "list", {});
-      expect.fail("expected FME auth guard to throw");
-    } catch (err) {
-      const message = (err as Error).message;
-      expect(message).toContain("FME is not configured or authorized for this MCP session");
-      expect(message).toContain("Ask your Harness administrator to configure an FME/Split Admin credential");
-      expect(message).toContain("legacy Split admin key or FME-entitled Harness PAT/SAT");
-    }
-
-    expect(mockRequest).not.toHaveBeenCalled();
-  });
-
-  it("fails before sending dotted internal placeholders to Split.io", async () => {
+  it("passes static FME headers through to the client without adding auth", async () => {
     const registry = new Registry(makeConfig({
       HARNESS_API_KEY: "pat.internal.internal.dummy",
       HARNESS_FME_API_KEY: undefined,
@@ -185,33 +148,12 @@ describe("FME auth", () => {
     const mockRequest = vi.fn().mockResolvedValue({ objects: [], totalCount: 0, offset: 0, limit: 20 });
     const client = makeClient(mockRequest);
 
-    await expect(
-      registry.dispatch(client, "fme_workspace", "list", {}),
-    ).rejects.toThrow("Hosted OAuth placeholders");
+    await registry.dispatch(client, "fme_workspace", "list", {});
 
-    expect(mockRequest).not.toHaveBeenCalled();
-  });
-
-  it("uses multi-user remediation when session FME auth is missing", async () => {
-    const registry = new Registry(makeConfig({
-      HARNESS_MCP_MODE: "multi-user",
-      HARNESS_API_KEY: "dummy",
-      HARNESS_FME_API_KEY: undefined,
-    }));
-    const mockRequest = vi.fn().mockResolvedValue({ objects: [], totalCount: 0, offset: 0, limit: 20 });
-    const client = makeClient(mockRequest);
-
-    try {
-      await registry.dispatch(client, "fme_workspace", "list", {});
-      expect.fail("expected FME auth guard to throw");
-    } catch (err) {
-      const message = (err as Error).message;
-      expect(message).toContain("Ensure the session x-harness-api-key is an FME-entitled Harness PAT/SAT");
-      expect(message).toContain("Do not configure HARNESS_FME_API_KEY in multi-user mode");
-      expect(message).not.toContain("or set HARNESS_FME_API_KEY");
-    }
-
-    expect(mockRequest).not.toHaveBeenCalled();
+    const call = firstRequest(mockRequest);
+    expect(call.product).toBe("fme");
+    expect(call.baseUrl).toBe("https://api.split.io");
+    expect(call.headers).toBeUndefined();
   });
 });
 
@@ -244,8 +186,7 @@ describe("fme_identity create", () => {
     expect(call.path).toBe("/internal/api/v2/trafficTypes/tt-user/environments/env-prod/identities");
     expect(call.baseUrl).toBe("https://api.split.io");
     expect(call.product).toBe("fme");
-    expect(call.headers).toMatchObject({ Authorization: "Bearer pat.test" });
-    expect(call.headers).not.toHaveProperty("x-api-key");
+    expect(call.headers).toBeUndefined();
     expect(call.body).toEqual([
       { key: "user-1", values: { name: "Ada", company: "Acme" } },
       { key: "user-2", values: { name: "Grace" } },


### PR DESCRIPTION
## Summary
- Move FME default authentication from the registry layer into `HarnessClient`, so caller-provided `Authorization` can be preserved before fallback auth is applied.
- Avoid sending placeholder API keys such as `dummy` or `pat.*.*.dummy` to Split/FME.
- Keep standalone behavior working by falling back to a non-placeholder request `x-api-key`, `HARNESS_FME_API_KEY`, or an FME-entitled `HARNESS_API_KEY` for FME calls.
- Leave non-FME Harness toolsets on the existing `x-api-key` default auth path.

## Why
FME/Split Admin APIs use Bearer auth, while the rest of the Harness APIs commonly use `x-api-key`. Keeping FME auth at the registry layer made it harder for callers to supply their own `Authorization` header. Moving fallback auth into the client makes the behavior consistent: explicit auth wins, FME fallback credentials are normalized to Bearer, and placeholder credentials are blocked before any request is sent to Split/FME.

## Behavior Covered
- FME requests with caller-provided `Authorization` are passed through unchanged.
- FME requests with a valid non-placeholder API key are sent as `Authorization: Bearer <key>`.
- FME requests with only placeholder credentials fail before making a network call.
- Regular Harness requests continue to receive `x-api-key` when no auth header is supplied.

## Test Plan
- [x] `pnpm test tests/client/harness-client.test.ts tests/registry/feature-flags.test.ts`
- [x] Local smoke test with QA FME token against `https://api.split-stage.io/internal/api/v2/workspaces` returned 200.
- [x] Local MCP `harness_list` for `fme_workspace` returned workspace data through the updated config.
