### PR TITLE
fix for resource/list failing on empty org/project

### DIFF
--- a/src/resources/execution-summary.ts
+++ b/src/resources/execution-summary.ts
@@ -3,6 +3,7 @@ import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import type { Config } from "../config.js";
 import { createLogger } from "../utils/logger.js";
+import { hasRequiredDiscoveryScope } from "./scope-check.js";
 
 const log = createLogger("resource:execution-summary");
 
@@ -16,6 +17,20 @@ export function registerExecutionSummaryResource(server: McpServer, registry: Re
       mimeType: "application/json",
     },
     async (uri) => {
+      const executionDef = registry.getResource("execution");
+      if (!executionDef.scopeOptional && !hasRequiredDiscoveryScope(executionDef.scope, config)) {
+        log.debug("Skipping execution summary: missing required scope", {
+          scope: executionDef.scope,
+        });
+        return {
+          contents: [{
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify({ items: [], total: 0, skipped: "missing org/project scope" }, null, 2),
+          }],
+        };
+      }
+
       try {
         log.info("Fetching recent executions");
 

--- a/src/resources/pipeline-yaml.ts
+++ b/src/resources/pipeline-yaml.ts
@@ -4,6 +4,7 @@ import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import type { Config } from "../config.js";
 import { createLogger } from "../utils/logger.js";
+import { hasRequiredDiscoveryScope } from "./scope-check.js";
 
 const log = createLogger("resource:pipeline-yaml");
 
@@ -12,6 +13,15 @@ export function registerPipelineYamlResource(server: McpServer, registry: Regist
 
   const template = new ResourceTemplate("pipeline:///{pipelineId}", {
     list: async () => {
+      const pipelineDef = registry.getResource(pipelineResourceType);
+      if (!pipelineDef.scopeOptional && !hasRequiredDiscoveryScope(pipelineDef.scope, config)) {
+        log.debug("Skipping pipeline resource discovery: missing required scope", {
+          resourceType: pipelineResourceType,
+          scope: pipelineDef.scope,
+        });
+        return { resources: [] };
+      }
+
       try {
         const result = await registry.dispatch(client, pipelineResourceType, "list", {
           org_id: config.HARNESS_ORG,

--- a/src/resources/scope-check.ts
+++ b/src/resources/scope-check.ts
@@ -1,0 +1,21 @@
+import type { Config } from "../config.js";
+
+/**
+ * Whether the config has the required org/project values for
+ * resource discovery at the given scope level.
+ * Returns false when a scope param is missing or whitespace-only,
+ * preventing wasted API calls that would fail with "must not be null".
+ */
+export function hasRequiredDiscoveryScope(
+  scope: "account" | "org" | "project",
+  config: Config,
+): boolean {
+  if (scope === "account") return true;
+
+  const orgId = config.HARNESS_ORG?.trim();
+  if (!orgId) return false;
+
+  if (scope === "org") return true;
+
+  return Boolean(config.HARNESS_PROJECT?.trim());
+}

--- a/tests/resources/execution-summary.test.ts
+++ b/tests/resources/execution-summary.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Config } from "../../src/config.js";
+import { registerExecutionSummaryResource } from "../../src/resources/execution-summary.js";
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    HARNESS_API_KEY: "pat.account.token.secret",
+    HARNESS_ACCOUNT_ID: "account",
+    HARNESS_BASE_URL: "https://app.harness.io",
+    HARNESS_ORG: "default",
+    HARNESS_PROJECT: "project",
+    HARNESS_API_TIMEOUT_MS: 30000,
+    HARNESS_MAX_RETRIES: 3,
+    LOG_LEVEL: "info",
+    HARNESS_TOOLSETS: undefined,
+    HARNESS_MAX_BODY_SIZE_MB: 10,
+    HARNESS_RATE_LIMIT_RPS: 10,
+    HARNESS_READ_ONLY: false,
+    HARNESS_SKIP_ELICITATION: false,
+    HARNESS_AUTO_APPROVE_RISK: "none",
+    HARNESS_ALLOW_HTTP: false,
+    HARNESS_MCP_ALLOWED_HOSTS: undefined,
+    HARNESS_FME_BASE_URL: "https://api.split.io",
+    HARNESS_LOG_UNSAFE_BODIES: false,
+    HARNESS_PIPELINE_VERSION: "0",
+    HARNESS_AUDIT_FILE: undefined,
+    HARNESS_AUDIT_WEBHOOK_URL: undefined,
+    HARNESS_AUDIT_WEBHOOK_TOKEN: undefined,
+    HARNESS_AUDIT_WEBHOOK_BATCH_SIZE: 10,
+    HARNESS_AUDIT_WEBHOOK_FLUSH_MS: 5000,
+    ...overrides,
+  };
+}
+
+function setupResource(configOverrides: Partial<Config> = {}) {
+  const server = {
+    registerResource: vi.fn(),
+  };
+  const registry = {
+    getResource: vi.fn(() => ({ scope: "project", scopeOptional: false })),
+    dispatch: vi.fn(),
+  };
+  const client = {};
+
+  registerExecutionSummaryResource(
+    server as never,
+    registry as never,
+    client as never,
+    makeConfig(configOverrides),
+  );
+
+  expect(server.registerResource).toHaveBeenCalledOnce();
+
+  const readHandler = server.registerResource.mock.calls[0][3] as (uri: URL) => Promise<{
+    contents: Array<{ uri: string; mimeType: string; text: string }>;
+  }>;
+
+  return { client, registry, server, readHandler };
+}
+
+const fakeUri = new URL("executions:///recent");
+
+describe("execution-summary resource", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("skips fetch when default project is missing", async () => {
+    const { registry, readHandler } = setupResource({ HARNESS_PROJECT: undefined });
+
+    const result = await readHandler(fakeUri);
+    const body = JSON.parse(result.contents[0].text);
+
+    expect(body).toEqual({ items: [], total: 0, skipped: "missing org/project scope" });
+    expect(registry.getResource).toHaveBeenCalledWith("execution");
+    expect(registry.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("skips fetch when default org is whitespace", async () => {
+    const { registry, readHandler } = setupResource({ HARNESS_ORG: "   " });
+
+    const result = await readHandler(fakeUri);
+    const body = JSON.parse(result.contents[0].text);
+
+    expect(body).toEqual({ items: [], total: 0, skipped: "missing org/project scope" });
+    expect(registry.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("fetches executions when org and project are available", async () => {
+    const { client, registry, readHandler } = setupResource({
+      HARNESS_ORG: "org",
+      HARNESS_PROJECT: "project",
+    });
+    const mockResult = {
+      items: [{ executionId: "exec1", status: "Success" }],
+      total: 1,
+    };
+    registry.dispatch.mockResolvedValue(mockResult);
+
+    const result = await readHandler(fakeUri);
+    const body = JSON.parse(result.contents[0].text);
+
+    expect(registry.dispatch).toHaveBeenCalledWith(
+      client,
+      "execution",
+      "list",
+      {
+        org_id: "org",
+        project_id: "project",
+        size: 10,
+        page: 0,
+      },
+      { tool: "execution_summary_resource" },
+    );
+    expect(body).toEqual(mockResult);
+  });
+
+  it("returns error JSON when dispatch throws", async () => {
+    const { registry, readHandler } = setupResource({
+      HARNESS_ORG: "org",
+      HARNESS_PROJECT: "project",
+    });
+    registry.dispatch.mockRejectedValue(new Error("HarnessApiError: 500 Internal Server Error"));
+
+    const result = await readHandler(fakeUri);
+    const body = JSON.parse(result.contents[0].text);
+
+    expect(body.error).toContain("HarnessApiError");
+    expect(body.items).toEqual([]);
+  });
+
+  it("skips fetch for scopeOptional=false even with empty-string project", async () => {
+    const { registry, readHandler } = setupResource({ HARNESS_PROJECT: "" });
+
+    const result = await readHandler(fakeUri);
+    const body = JSON.parse(result.contents[0].text);
+
+    expect(body.skipped).toBe("missing org/project scope");
+    expect(registry.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("proceeds when resource is scopeOptional", async () => {
+    const { registry, readHandler } = setupResource({ HARNESS_PROJECT: undefined });
+    registry.getResource.mockReturnValue({ scope: "project", scopeOptional: true });
+    registry.dispatch.mockResolvedValue({ items: [], total: 0 });
+
+    await readHandler(fakeUri);
+
+    expect(registry.dispatch).toHaveBeenCalled();
+  });
+});

--- a/tests/resources/pipeline-yaml.test.ts
+++ b/tests/resources/pipeline-yaml.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Config } from "../../src/config.js";
+import { registerPipelineYamlResource } from "../../src/resources/pipeline-yaml.js";
+
+type ResourceListResult = {
+  resources: Array<{
+    uri: string;
+    name: string;
+  }>;
+};
+
+type FakeResourceTemplateInstance = {
+  uriTemplate: string;
+  list: () => Promise<ResourceListResult>;
+};
+
+const resourceTemplates = vi.hoisted((): FakeResourceTemplateInstance[] => []);
+
+vi.mock("@modelcontextprotocol/sdk/server/mcp.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@modelcontextprotocol/sdk/server/mcp.js")>();
+
+  class FakeResourceTemplate {
+    uriTemplate: string;
+    list: () => Promise<ResourceListResult>;
+
+    constructor(uriTemplate: string, options: { list: () => Promise<ResourceListResult> }) {
+      this.uriTemplate = uriTemplate;
+      this.list = options.list;
+      resourceTemplates.push(this);
+    }
+  }
+
+  return {
+    ...actual,
+    ResourceTemplate: FakeResourceTemplate,
+  };
+});
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    HARNESS_API_KEY: "pat.account.token.secret",
+    HARNESS_ACCOUNT_ID: "account",
+    HARNESS_BASE_URL: "https://app.harness.io",
+    HARNESS_ORG: "default",
+    HARNESS_PROJECT: "project",
+    HARNESS_API_TIMEOUT_MS: 30000,
+    HARNESS_MAX_RETRIES: 3,
+    LOG_LEVEL: "info",
+    HARNESS_TOOLSETS: undefined,
+    HARNESS_MAX_BODY_SIZE_MB: 10,
+    HARNESS_RATE_LIMIT_RPS: 10,
+    HARNESS_READ_ONLY: false,
+    HARNESS_SKIP_ELICITATION: false,
+    HARNESS_AUTO_APPROVE_RISK: "none",
+    HARNESS_ALLOW_HTTP: false,
+    HARNESS_MCP_ALLOWED_HOSTS: undefined,
+    HARNESS_FME_BASE_URL: "https://api.split.io",
+    HARNESS_LOG_UNSAFE_BODIES: false,
+    HARNESS_PIPELINE_VERSION: "0",
+    HARNESS_AUDIT_FILE: undefined,
+    HARNESS_AUDIT_WEBHOOK_URL: undefined,
+    HARNESS_AUDIT_WEBHOOK_TOKEN: undefined,
+    HARNESS_AUDIT_WEBHOOK_BATCH_SIZE: 10,
+    HARNESS_AUDIT_WEBHOOK_FLUSH_MS: 5000,
+    ...overrides,
+  };
+}
+
+function setupResource(configOverrides: Partial<Config> = {}) {
+  const server = {
+    registerResource: vi.fn(),
+  };
+  const registry = {
+    getResource: vi.fn(() => ({ scope: "project", scopeOptional: false })),
+    dispatch: vi.fn(),
+  };
+  const client = {};
+
+  registerPipelineYamlResource(
+    server as never,
+    registry as never,
+    client as never,
+    makeConfig(configOverrides),
+  );
+
+  const template = resourceTemplates.at(-1);
+  if (!template) {
+    throw new Error("Expected pipeline YAML resource template to be registered");
+  }
+
+  return { client, registry, server, template };
+}
+
+describe("pipeline-yaml resource", () => {
+  beforeEach(() => {
+    resourceTemplates.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it("skips project-scoped discovery when default project is missing", async () => {
+    const { registry, template } = setupResource({ HARNESS_PROJECT: undefined });
+
+    const result = await template.list();
+
+    expect(result).toEqual({ resources: [] });
+    expect(registry.getResource).toHaveBeenCalledWith("pipeline");
+    expect(registry.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("skips project-scoped discovery when default org is empty", async () => {
+    const { registry, template } = setupResource({ HARNESS_ORG: "   " });
+
+    const result = await template.list();
+
+    expect(result).toEqual({ resources: [] });
+    expect(registry.getResource).toHaveBeenCalledWith("pipeline");
+    expect(registry.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("lists pipeline resources when org and project defaults are available", async () => {
+    const { client, registry, template } = setupResource({
+      HARNESS_ORG: "org",
+      HARNESS_PROJECT: "project",
+    });
+    registry.dispatch.mockResolvedValue({
+      items: [
+        { identifier: "pipeline_one", name: "Pipeline One" },
+        { identifier: "pipeline_two" },
+        { name: "Missing Identifier" },
+      ],
+    });
+
+    const result = await template.list();
+
+    expect(registry.dispatch).toHaveBeenCalledWith(
+      client,
+      "pipeline",
+      "list",
+      {
+        org_id: "org",
+        project_id: "project",
+        size: 20,
+        page: 0,
+      },
+      { tool: "pipeline_yaml_resource" },
+    );
+    expect(result).toEqual({
+      resources: [
+        { uri: "pipeline:///pipeline_one", name: "Pipeline One" },
+        { uri: "pipeline:///pipeline_two", name: "pipeline_two" },
+      ],
+    });
+  });
+});


### PR DESCRIPTION


## Description
Problem
In the MCP server's HTTP/remote deployment mode, the pipeline-yaml resource template and execution-summary resource make live Harness API calls on every resources/list and resources/read JSON-RPC request — even when HARNESS_ORG or HARNESS_PROJECT are not configured.

The deployed code has no scope guard.
When org/project are missing, the API always rejects the call:
```
HarnessApiError: query param orgIdentifier: must not be null,
query param projectIdentifier: must not be null
```

It was also causing metric bloat for mcp-server-external, when a user tried to connect cursor/claude to remote mcp. These mcp clients call resource/list on session init and periodically. Each call generates 2 wasted Harness API requests (one for pipeline-yaml list, one potentially for execution-summary read). With retry logic on the HTTP client, each failed request could also trigger retries before the 400 is recognized as non-retryable.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] Tests pass
- [x] Typecheck passes
