### PR TITLE
docs: add rule to avoid internal Jira IDs in external PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ The "Sunil On Demand Architecture Review" bot reviews every PR and reliably catc
 - **No silent data loss.** Body builders use `!= null` (not truthiness) so `0`/`false` survive; metadata strippers preserve meaningful empty collections but prune `{}` placeholder rows; reattached raw fields are re-stripped.
 - **Tests cover the contract, not just the request.** Add a response-shape/extractor test (envelope dropped, empty/edge cases) and a request-shape test for every new extractor and body builder — "no focused coverage" is itself a review finding.
 - **Guardrails are green locally.** Run `pnpm build` THEN `pnpm docs:generate`, plus `pnpm typecheck` and `pnpm test`, before pushing. `docs:check` reads from `build/`.
+- **No internal Jira IDs in external PRs.** This is a public OSS repo — do not put Harness-internal ticket IDs (e.g. `AIDEVOPS-1234`, `AIDEVOSP-1830`) in PR titles, descriptions, or commit messages. Describe the user-facing problem and fix instead; link internal tickets only in private channels or the internal tracker.
 
 ---
 
@@ -560,6 +561,7 @@ The MCP server exposes an `instructions` string (in `src/index.ts`) that is sent
 | Read-only / confirmation gating by tool family | Gate by the action's `operationPolicy.risk`, mirroring `registry.dispatchExecute()` — `risk: "read"` actions (e.g. a query language with no mutations) must pass in read-only mode |
 | Stripping non-empty array values, or leaving `{}` placeholder rows | Preserve explicitly-empty collections (meaningful), but prune array elements that collapse to `{}` after stripping — recurse first, then decide |
 | Truthiness checks dropping `0`/`false` from body builders | Use `!= null` checks so zero-valued options (`timeout_ms: 0`) reach the API instead of being silently rewritten |
+| Internal Jira IDs in PR title, description, or commit message | Describe the user-facing problem/fix in plain language; reserve ticket IDs for internal trackers and Slack, not the public GitHub history |
 | Running `pnpm docs:generate` without `pnpm build` first | `docs:generate` reads from `build/` — a stale build produces wrong counts and `docs:check` fails in CI. Build, then generate |
 
 ---

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -104,3 +104,8 @@
   - **List-only metadata on get-only resources misleads discovery.** `kg_related_type` (get-only) set `listFilterFields`, so `harness_describe`/`harness_list` advertised `kind`/`include_transitive` as list filters. Fix: drop `listFilterFields`; document get params via the get op's `paramsSchema`. Add local required-field validation (throw a plain `Error` from the body builder → surfaces as a clean `errorResult` via `isUserError`) so a missing id fails locally instead of sending an id-less body.
 - **Rule**: For every new/changed resource, run the **Pre-Push Architecture-Review Pass** in `AGENTS.md` §Workflow 7 before pushing, and pair every new extractor/body builder with both a response-shape test (envelope dropped, empty/edge cases) and a request-shape test. "No focused coverage" is itself a recurring review finding.
 - **Build/docs gotcha**: `pnpm docs:generate` and `docs:check` read from `build/`. Always `pnpm build` first or counts go stale and CI `docs:check` fails.
+
+## External PR Hygiene (Sunil review, PR #325)
+- **Issue**: Commit message `fix: [AIDEVOSP-1830]: …` exposed an internal Jira ID in the public `mcp-server` repo.
+- **Fix**: Use user-facing commit/PR text (e.g. `fix: skip resource discovery when org/project defaults are missing`) with no ticket prefix.
+- **Rule**: Never put Harness-internal ticket IDs in external PR titles, descriptions, or commit messages — see **Pre-Push Architecture-Review Pass** in `AGENTS.md` §Workflow 7.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Captures Sunil's review feedback on [PR #325](https://github.com/harness/mcp-server/pull/325): avoid putting Harness-internal Jira ticket IDs in public OSS PR titles, descriptions, or commit messages.

## Changes

- **`AGENTS.md` §Workflow 7 (Pre-Push Architecture-Review Pass):** New bullet requiring user-facing PR/commit text with no internal ticket IDs.
- **`AGENTS.md` Common Pitfalls table:** Matching row for quick reference.
- **`tasks/lessons.md`:** Lesson entry tied to PR #325 for future self-improvement.

## Context

PR #325's commit message used `fix: [AIDEVOSP-1830]: …`, which exposes an internal ticket in the public GitHub history. Sunil flagged this in #ai-platform-dev — internal IDs belong in private trackers/Slack, not external PR metadata.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://harness.slack.com/archives/C07DFRL656H/p1781156952992469?thread_ts=1781156952.992469&cid=C07DFRL656H)

<div><a href="https://cursor.com/agents/bc-d4a62af9-63c3-51ed-ac64-d88f748c1183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4a62af9-63c3-51ed-ac64-d88f748c1183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

