### PR TITLE
fix: [AIPLAT-692]: add log download URL option

### DIFF
--- a/src/registry/toolsets/logs.ts
+++ b/src/registry/toolsets/logs.ts
@@ -9,7 +9,7 @@ export const logsToolset: ToolsetDefinition = {
     {
       resourceType: "execution_log",
       displayName: "Execution Log",
-      description: "Pipeline execution logs. Returns readable log text (not just a URL). Accepts a raw Harness logBaseKey prefix, or an execution_id to auto-resolve the real log key from the execution graph. When a Harness execution URL includes step/stage query params, the MCP uses them to resolve the matching step log key. Use harness_diagnose with include_logs=true for the best failure analysis experience.",
+      description: "Pipeline execution logs. Returns readable log text by default for backward compatibility. Set return_download_url=true to return only a signed download URL without downloading log content. Accepts a raw Harness logBaseKey prefix, or an execution_id to auto-resolve the real log key from the execution graph. When a Harness execution URL includes step/stage query params, the MCP uses them to resolve the matching step log key. Use harness_diagnose with include_logs=true for the best failure analysis experience.",
       toolset: "logs",
       scope: "project",
       identifierFields: ["prefix"],
@@ -25,7 +25,7 @@ export const logsToolset: ToolsetDefinition = {
             prefix: "prefix",
           },
           responseExtractor: passthrough,
-          description: "Download and return execution log content by prefix",
+          description: "Download and return execution log content by prefix, or return a signed download URL when return_download_url=true",
         },
       },
     },

--- a/src/tools/harness-get.ts
+++ b/src/tools/harness-get.ts
@@ -6,10 +6,14 @@ import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { isUserError, isUserFixableApiError, toMcpError, enrichErrorWithHint, HarnessApiError } from "../utils/errors.js";
 import { applyUrlDefaults } from "../utils/url-parser.js";
 import { asString, coerceRecord } from "../utils/type-guards.js";
-import { resolveLogContent } from "../utils/log-resolver.js";
+import { resolveLogContent, resolveLogDownloadUrl } from "../utils/log-resolver.js";
 import { buildLogPrefixFromExecution } from "../utils/log-prefix.js";
 import { resourceTypeSchema } from "./input-schemas.js";
 import { getOutputSchema } from "./output-schemas.js";
+
+function isTrue(value: unknown): boolean {
+  return value === true || value === "true";
+}
 
 export function registerGetTool(server: McpServer, registry: Registry, client: HarnessClient): void {
   const gettableTypes = registry.getTypesForOperation("get");
@@ -79,7 +83,7 @@ export function registerGetTool(server: McpServer, registry: Registry, client: H
           delete input.global;
         }
 
-        // execution_log: resolve full log content instead of returning a download URL
+        // execution_log: preserve legacy content by default; opt into URL-only mode with return_download_url=true.
         if (resourceType === "execution_log") {
           try {
             let prefix = asString(input.prefix);
@@ -91,11 +95,15 @@ export function registerGetTool(server: McpServer, registry: Registry, client: H
               }
               prefix = await buildLogPrefixFromExecution(client, registry, executionId, input);
             }
+            if (isTrue(input.return_download_url)) {
+              const downloadUrl = await resolveLogDownloadUrl(client, prefix);
+              return jsonResult({ download_url: downloadUrl });
+            }
             const logText = await resolveLogContent(client, prefix);
             return jsonResult({ log_content: logText });
           } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
-            return errorResult(`Failed to fetch execution logs: ${msg}. Try harness_diagnose with include_logs=true for better failure analysis.`);
+            return errorResult(`Failed to resolve execution logs: ${msg}. Try harness_diagnose with include_logs=true for better failure analysis.`);
           }
         }
 

--- a/src/utils/log-resolver.ts
+++ b/src/utils/log-resolver.ts
@@ -493,23 +493,15 @@ async function downloadBlobContent(
 
 // ─── Public API ─────────────────────────────────────────────────────────────
 
-/**
- * Resolve execution log content from the Harness log-service.
- *
- * Full pipeline: initiate blob download → poll until ready → download zip →
- * extract → parse JSON log entries → return clean text.
- */
-export async function resolveLogContent(
+async function requestLogBlobLink(
   client: HarnessClient,
   prefix: string,
   options?: LogResolveOptions,
 ): Promise<string> {
   const maxAttempts = options?.maxPollAttempts ?? DEFAULT_POLL_ATTEMPTS;
   const pollInterval = options?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
-  const maxBytes = options?.maxLogSizeBytes ?? DEFAULT_MAX_LOG_BYTES;
   const signal = options?.signal;
 
-  // Step 1 & 2: Initiate and poll until status is "success"
   let blob: BlobResponse | undefined;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     if (signal?.aborted) throw new Error("Log download cancelled");
@@ -523,7 +515,7 @@ export async function resolveLogContent(
     });
 
     if (blob?.status === "success" && blob.link) {
-      break;
+      return blob.link;
     }
 
     if (attempt < maxAttempts - 1) {
@@ -532,18 +524,65 @@ export async function resolveLogContent(
     }
   }
 
-  if (!blob?.link) {
-    throw new Error(
-      `Log blob not ready after ${maxAttempts} attempts (status: ${blob?.status ?? "unknown"}). Logs may still be processing or have expired.`,
-    );
+  throw new Error(
+    `Log blob not ready after ${maxAttempts} attempts (status: ${blob?.status ?? "unknown"}). Logs may still be processing or have expired.`,
+  );
+}
+
+function rewriteDownloadUrlIfNeeded(client: HarnessClient, blobLink: string): string {
+  const blobUrl = safeParseUrl(blobLink);
+  if (!blobUrl || isExternalStorageHost(blobUrl.hostname)) {
+    return blobLink;
   }
+
+  if (isPresignedUrl(blobUrl) && isHarnessHost(blobUrl.hostname) && blobUrl.pathname.startsWith("/storage/")) {
+    const baseUrl = safeParseUrl(client.baseURL);
+    if (!baseUrl) {
+      throw new Error(`Cannot rewrite Harness CDN blob URL: HARNESS_BASE_URL "${client.baseURL}" is not a valid URL`);
+    }
+    if (signedHeadersIncludeHost(blobUrl) && blobUrl.hostname === baseUrl.hostname) {
+      return blobLink;
+    }
+    blobUrl.hostname = baseUrl.hostname;
+    blobUrl.protocol = baseUrl.protocol;
+    blobUrl.port = baseUrl.port;
+    return blobUrl.toString();
+  }
+
+  return blobLink;
+}
+
+export async function resolveLogDownloadUrl(
+  client: HarnessClient,
+  prefix: string,
+  options?: LogResolveOptions,
+): Promise<string> {
+  const blobLink = await requestLogBlobLink(client, prefix, options);
+  return rewriteDownloadUrlIfNeeded(client, blobLink);
+}
+
+/**
+ * Resolve execution log content from the Harness log-service.
+ *
+ * Full pipeline: initiate blob download → poll until ready → download zip →
+ * extract → parse JSON log entries → return clean text.
+ */
+export async function resolveLogContent(
+  client: HarnessClient,
+  prefix: string,
+  options?: LogResolveOptions,
+): Promise<string> {
+  const maxBytes = options?.maxLogSizeBytes ?? DEFAULT_MAX_LOG_BYTES;
+  const signal = options?.signal;
+
+  const blobLink = await requestLogBlobLink(client, prefix, options);
 
   // Step 3: Download the zip/gzip from the signed URL
   const downloadSignal = signal
     ? AbortSignal.any([signal, AbortSignal.timeout(DEFAULT_DOWNLOAD_TIMEOUT_MS)])
     : AbortSignal.timeout(DEFAULT_DOWNLOAD_TIMEOUT_MS);
 
-  const response = await downloadBlobContent(client, blob.link, prefix, downloadSignal);
+  const response = await downloadBlobContent(client, blobLink, prefix, downloadSignal);
   if (!response.ok) {
     const errBody = await response.text().catch(() => "");
     throw new Error(`Log download failed: HTTP ${response.status} — ${errBody.slice(0, 200)}`);


### PR DESCRIPTION
## Summary
- Preserve existing execution log behavior by returning log content by default.
- Add `return_download_url=true` for `execution_log` to return a signed log download URL without downloading the blob.
- Update log resource descriptions to document the opt-in URL mode.

## Test plan
- `pnpm typecheck`
