### PR TITLE
fix: map git query params for remote v0 template get/create/update

### DIFF
--- a/src/registry/toolsets/templates.ts
+++ b/src/registry/toolsets/templates.ts
@@ -170,7 +170,7 @@ const templateV1ListFilterFields = [
 
 const templateV0CreateSchema: BodySchema = {
   description:
-    "Classic (v0) template YAML for NG API create. Root key `template` with identifier, name, versionLabel, type, and spec.",
+    "Classic (v0) template YAML for NG API create. Root key `template` with identifier, name, versionLabel, type, and spec. Storage options via params: Inline (default), External Git (store_type='REMOTE', connector_ref, repo_name, branch, file_path), Harness Code (store_type='REMOTE', is_harness_code_repo=true, repo_name, branch, file_path).",
   fields: [
     {
       name: "template_yaml",
@@ -187,7 +187,8 @@ const templateV0CreateSchema: BodySchema = {
 };
 
 const templateV0UpdateSchema: BodySchema = {
-  description: "Classic (v0) template YAML for NG API update (full version replacement).",
+  description:
+    "Classic (v0) template YAML for NG API update (full version replacement). For remote templates, pass store_type='REMOTE' with git details via params (branch, connector_ref, repo_name, file_path) and last_object_id/last_commit_id from the GET response's gitDetails for conflict detection.",
   fields: [
     {
       name: "template_yaml",
@@ -289,9 +290,14 @@ export const templatesToolset: ToolsetDefinition = {
           queryParams: {
             version_label: "versionLabel",
             account_id: "accountIdentifier",
+            branch: "branch",
+            store_type: "storeType",
+            connector_ref: "connectorRef",
+            repo_name: "repoName",
           },
           responseExtractor: ngExtract,
-          description: "Get template details and YAML. Use global=true for global templates account.",
+          description:
+            "Get template details and YAML. Use global=true for global templates account. For remote/git-backed templates, pass branch to specify which branch to read from. The response gitDetails.objectId and gitDetails.commitId are needed as last_object_id/last_commit_id when updating a remote template.",
         },
         create: {
           method: "POST",
@@ -303,12 +309,21 @@ export const templatesToolset: ToolsetDefinition = {
             is_stable: "setDefaultTemplate",
             is_new_template: "isNewTemplate",
             enable_dag: "enableDAG",
+            store_type: "storeType",
+            connector_ref: "connectorRef",
+            repo_name: "repoName",
+            branch: "branch",
+            file_path: "filePath",
+            base_branch: "baseBranch",
+            commit_msg: "commitMsg",
+            is_new_branch: "isNewBranch",
+            is_harness_code_repo: "isHarnessCodeRepo",
           },
           bodyBuilder: (input) => buildTemplateYamlBody(input),
           bodySchema: templateV0CreateSchema,
           responseExtractor: ngExtract,
           description:
-            "Create a v0 template via NG API. Body is raw YAML (application/yaml). Scope via org_id/project_id query params; omit both for account scope.",
+            "Create a v0 template via NG API. Body is raw YAML (application/yaml). Scope via org_id/project_id query params; omit both for account scope. For external Git: store_type='REMOTE' + connector_ref, repo_name, branch, file_path. For Harness Code: store_type='REMOTE' + is_harness_code_repo=true, repo_name, branch, file_path.",
         },
         update: {
           method: "PUT",
@@ -319,12 +334,23 @@ export const templatesToolset: ToolsetDefinition = {
           queryParams: {
             comments: "comments",
             is_stable: "setDefaultTemplate",
+            store_type: "storeType",
+            connector_ref: "connectorRef",
+            repo_name: "repoName",
+            branch: "branch",
+            file_path: "filePath",
+            base_branch: "baseBranch",
+            commit_msg: "commitMsg",
+            is_new_branch: "isNewBranch",
+            is_harness_code_repo: "isHarnessCodeRepo",
+            last_object_id: "lastObjectId",
+            last_commit_id: "lastCommitId",
           },
           bodyBuilder: (input) => buildTemplateYamlBody(input),
           bodySchema: templateV0UpdateSchema,
           responseExtractor: ngExtract,
           description:
-            "Update a v0 template version via NG API. Requires template_id and version_label. Body is full v0 template YAML.",
+            "Update a v0 template version via NG API. Requires template_id and version_label. Body is full v0 template YAML. For remote/git-backed templates, pass store_type='REMOTE' with git details (branch, connector_ref, repo_name, file_path) and last_object_id/last_commit_id from the GET response's gitDetails (objectId/commitId) — without branch the API fails with 'No branch provided for modifying the file'. For Harness Code: add is_harness_code_repo=true (no connector_ref needed).",
         },
         delete: {
           method: "DELETE",

--- a/tests/registry/templates.test.ts
+++ b/tests/registry/templates.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Config } from "../../src/config.js";
+import type { HarnessClient } from "../../src/client/harness-client.js";
+import { Registry } from "../../src/registry/index.js";
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    HARNESS_API_KEY: "pat.test",
+    HARNESS_ACCOUNT_ID: "test-account",
+    HARNESS_BASE_URL: "https://app.harness.io",
+    HARNESS_ORG: "default",
+    HARNESS_PROJECT: "test-project",
+    HARNESS_API_TIMEOUT_MS: 30000,
+    HARNESS_MAX_RETRIES: 3,
+    HARNESS_MAX_BODY_SIZE_MB: 10,
+    HARNESS_RATE_LIMIT_RPS: 10,
+    HARNESS_READ_ONLY: false,
+    HARNESS_SKIP_ELICITATION: false,
+    HARNESS_ALLOW_HTTP: false,
+    HARNESS_FME_BASE_URL: "https://api.split.io",
+    LOG_LEVEL: "info",
+    ...overrides,
+  };
+}
+
+function makeClient(requestFn: (...args: unknown[]) => unknown): HarnessClient {
+  return {
+    request: requestFn,
+    account: "test-account",
+  } as unknown as HarnessClient;
+}
+
+describe("v0 template git query-param mapping", () => {
+  // Regression: remote (git-backed) v0 template update previously dropped all git
+  // query params, so the Harness API rejected the write with
+  // "No branch provided for modifying the file." The update op must map the same
+  // git params as pipelines.ts (branch/store_type/last_object_id/...).
+  it("maps git params on update so branch reaches the API", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "templates" }));
+    const mockRequest = vi.fn().mockResolvedValue({ data: { identifier: "tmpl" } });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "template", "update", {
+      template_id: "steptemplateremote",
+      version_label: "steptemplate",
+      org_id: "default",
+      project_id: "revanthcstesting",
+      store_type: "REMOTE",
+      branch: "main",
+      connector_ref: "gitconn",
+      repo_name: "revanth-cr",
+      file_path: ".harness/template.yaml",
+      commit_msg: "update via mcp",
+      last_object_id: "d88858596768b6c4717b067e885302ba50b99aa7",
+      last_commit_id: "44de290e4b7c1990cb0f6f3f0e65551d3242cbe2",
+      body: "template:\n  identifier: steptemplateremote\n  versionLabel: steptemplate\n",
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "PUT",
+        path: "/template/api/templates/update/steptemplateremote/steptemplate",
+        params: expect.objectContaining({
+          storeType: "REMOTE",
+          branch: "main",
+          connectorRef: "gitconn",
+          repoName: "revanth-cr",
+          filePath: ".harness/template.yaml",
+          commitMsg: "update via mcp",
+          lastObjectId: "d88858596768b6c4717b067e885302ba50b99aa7",
+          lastCommitId: "44de290e4b7c1990cb0f6f3f0e65551d3242cbe2",
+        }),
+      }),
+    );
+  });
+
+  it("maps git read params on get so a specific branch can be fetched", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "templates" }));
+    const mockRequest = vi.fn().mockResolvedValue({ data: { identifier: "tmpl" } });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "template", "get", {
+      template_id: "steptemplateremote",
+      version_label: "steptemplate",
+      org_id: "default",
+      project_id: "revanthcstesting",
+      branch: "feature/x",
+      store_type: "REMOTE",
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "GET",
+        path: "/template/api/templates/steptemplateremote",
+        params: expect.objectContaining({
+          versionLabel: "steptemplate",
+          branch: "feature/x",
+          storeType: "REMOTE",
+        }),
+      }),
+    );
+  });
+
+  it("maps git write params on create for remote templates", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "templates" }));
+    const mockRequest = vi.fn().mockResolvedValue({ data: { identifier: "tmpl" } });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "template", "create", {
+      org_id: "default",
+      project_id: "revanthcstesting",
+      store_type: "REMOTE",
+      branch: "main",
+      connector_ref: "gitconn",
+      repo_name: "revanth-cr",
+      file_path: ".harness/template.yaml",
+      is_new_branch: true,
+      commit_msg: "create via mcp",
+      body: "template:\n  identifier: newtmpl\n  versionLabel: v1\n",
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        path: "/template/api/templates",
+        params: expect.objectContaining({
+          storeType: "REMOTE",
+          branch: "main",
+          connectorRef: "gitconn",
+          repoName: "revanth-cr",
+          filePath: ".harness/template.yaml",
+          isNewBranch: true,
+          commitMsg: "create via mcp",
+        }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Remote (git-backed) v0 template writes failed with "No branch provided for modifying the file" because the template resource never mapped the Git Experience query params (branch, store_type, last_object_id, etc.) the way pipelines.ts does. Mirror that mapping on get/create/update so branch and conflict-detection IDs reach the NG template API.

Add request-shape contract tests covering the git param mapping.

## Description
The v0 `template` resource (`src/registry/toolsets/templates.ts`) only mapped `comments` and `is_stable` as query params on its write operations. Unlike `pipelines.ts`, it never mapped the Git Experience params, so for git-backed (REMOTE) templates the `branch` (and conflict-detection IDs) never reached the API — causing both full-body and patch updates to fail identically with `No branch provided for modifying the file`.

This PR mirrors the `pipelines.ts` git-param mapping on the v0 `template` operations:
- **`update`** — adds `store_type`, `connector_ref`, `repo_name`, `branch`, `file_path`, `base_branch`, `commit_msg`, `is_new_branch`, `is_harness_code_repo`, `last_object_id`, `last_commit_id` (the actual bug fix).
- **`get`** — adds `branch`, `store_type`, `connector_ref`, `repo_name` so a specific branch can be read and its `gitDetails` feed `last_object_id`/`last_commit_id` into the update.
- **`create`** — adds the git write params for parity (new remote templates).
- Updates the operation and `bodySchema` descriptions to document remote/git usage.

Verified end-to-end against the live Harness API through the built `Registry.dispatch` path: the previously-failing remote template update now succeeds.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] Tests pass
- [x] Typecheck passes

Made with [Cursor](https://cursor.com)