### PR TITLE
feat: add execution_inputs resource for merged input set retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Harness MCP Server 2.0
 
-An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 213 resource types.
+An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 214 resource types.
 
 ## Why Use This MCP Server
 
@@ -8,7 +8,7 @@ Most MCP servers map one tool per API endpoint. For a platform as broad as Harne
 
 This server is built differently:
 
-- **11 tools, 213 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
+- **11 tools, 214 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
 - **Full platform coverage.** 36 default toolsets spanning CI/CD, GitOps, Feature Flags, Cloud Cost Management, Security Testing, Chaos Engineering, Database DevOps, Internal Developer Portal, Software Supply Chain, Infrastructure as Code Management, Governance, Service Overrides, Knowledge Graph, Visualizations, and more. Opt-in Ansible coverage is available when you need inventory and playbook data.
 - **Multi-project workflows out of the box.** Agents discover organizations and projects dynamically — no hardcoded env vars needed. Ask "show failed executions across all projects" and the agent can navigate the full account hierarchy.
 - **32 prompt templates.** Pre-built prompts for common workflows: build & deploy apps end-to-end, debug failed pipelines, review DORA metrics, triage vulnerabilities, optimize cloud costs, audit access control, plan feature flag rollouts, review pull requests, approve pending pipelines, and more.
@@ -1082,7 +1082,7 @@ Harness pipelines can be stored in three ways:
 
 ## Resource Types
 
-213 resource types organized across 36 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
+214 resource types organized across 36 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
 
 ### Platform
 
@@ -1736,7 +1736,7 @@ Available toolset names:
                  +--------v---------+
                 |    Registry       |  <-- Declarative resource definitions
                 |  36 Toolsets      |      (data files, not code)
-                |  213 Resource Types|
+                |  214 Resource Types|
                  +--------+---------+
                           |
                  +--------v---------+

--- a/README.md
+++ b/README.md
@@ -1101,6 +1101,7 @@ Harness pipelines can be stored in three ways:
 | `pipeline`                | x    | x   | x      | x      | x      | `run`, `retry`      |
 | `pipeline_v1` **(Alpha)** | x    | x   | x      | x      | x      | `run`               |
 | `execution`               | x    | x   |        |        |        | `interrupt`         |
+| `execution_inputs`        |      | x   |        |        |        |                     |
 | `trigger`                 | x    | x   | x      | x      | x      |                     |
 | `pipeline_summary`        |      | x   |        |        |        |                     |
 | `input_set`               | x    | x   | x      | x      | x      |                     |
@@ -1682,7 +1683,7 @@ Available toolset names:
 | Toolset                 | Resource Types                                                                                                                                                                                                                                                                                  |
 | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `platform`              | organization, project                                                                                                                                                                                                                                                                           |
-| `pipelines`             | pipeline, pipeline_v1, execution, trigger, pipeline_summary, input_set, approval_instance                                                                                                                                                                                                       |
+| `pipelines`             | pipeline, pipeline_v1, execution, execution_inputs, trigger, pipeline_summary, input_set, approval_instance                                                                                                                                                                                     |
 | `agents`                | agent, agent_run                                                                                                                                                                                                                                                                                |
 | `services`              | service                                                                                                                                                                                                                                                                                         |
 | `environments`          | environment                                                                                                                                                                                                                                                                                     |

--- a/src/prompts/debug-pipeline.ts
+++ b/src/prompts/debug-pipeline.ts
@@ -37,7 +37,8 @@ Then analyze the diagnostic payload:
 - **child_pipeline section**: if present, the failure is in a chained pipeline — focus on the child's failure details
 - **failed_step_logs**: actual log output from the failed steps — look for error patterns, stack traces, and exit codes
 - **runtime input issues**: if the error mentions unresolved \`<+input>\` expressions or missing variables, check:
-  - Call harness_get with resource_type="runtime_input_template" and resource_id=<pipeline_id> to see which inputs the pipeline expects
+  - For **post-run forensics** (what values *actually* ran?): call harness_get with resource_type="execution_inputs" and execution_id=<execution_id> to see the merged input set YAML used at runtime — this is the source of truth for what the failed run received
+  - For **pre-run expectations** (what does the pipeline expect?): call harness_get with resource_type="runtime_input_template" and resource_id=<pipeline_id> to see which inputs the pipeline declares
   - Call harness_list with resource_type="input_set", pipeline_id=<pipeline_id> to see available input sets that could provide the missing values
   - Suggest the user either pass the missing values as \`inputs\` or use \`input_set_ids\` referencing a saved input set
 

--- a/src/registry/extractors.ts
+++ b/src/registry/extractors.ts
@@ -297,6 +297,44 @@ export const runtimeInputExtract = (raw: unknown): unknown => {
 };
 
 /**
+ * Extracts merged input set data for a pipeline execution from
+ * GET /pipeline/api/pipelines/execution/{planExecutionId}/inputsetV2.
+ *
+ * Projects to a stable shape: { inputSetYaml, inputSetTemplateYaml, resolvedYaml,
+ * inputSetDetails, inputSetBranchName, executionId } so the public tool boundary
+ * never leaks the NG response envelope or unrelated debug fields. `inputSetDetails`
+ * is normalized to `[{identifier, name}]` even when the upstream returns a richer
+ * object — agents only need those two fields per the spec.
+ */
+export const executionInputsExtract = (raw: unknown, input?: Record<string, unknown>): unknown => {
+  const r = raw as {
+    data?: {
+      inputSetYaml?: string;
+      inputSetTemplateYaml?: string;
+      resolvedYaml?: string;
+      inputSetDetails?: Array<{ identifier?: string; name?: string }>;
+      inputSetBranchName?: string;
+    };
+  };
+  const data = r?.data ?? {};
+  const details = Array.isArray(data.inputSetDetails)
+    ? data.inputSetDetails.map((d) => ({
+      identifier: d?.identifier ?? null,
+      name: d?.name ?? null,
+    }))
+    : [];
+  const executionId = (input?.execution_id as string | undefined) ?? null;
+  return {
+    executionId,
+    inputSetYaml: data.inputSetYaml ?? null,
+    inputSetTemplateYaml: data.inputSetTemplateYaml ?? null,
+    resolvedYaml: data.resolvedYaml ?? null,
+    inputSetDetails: details,
+    inputSetBranchName: data.inputSetBranchName ?? null,
+  };
+};
+
+/**
  * Extracts CCM list responses with views/totalCount structure.
  * Maps `data.views` → `items` and `data.totalCount` → `total`.
  * Used by multiple CCM APIs that return this response pattern.

--- a/src/registry/toolsets/pipelines.ts
+++ b/src/registry/toolsets/pipelines.ts
@@ -506,6 +506,13 @@ export const pipelinesToolset: ToolsetDefinition = {
       scope: "project",
       identifierFields: ["execution_id"],
       diagnosticHint: "Use harness_diagnose with execution_id to analyze a failed execution — includes step-level error details, log snippets, delegate info, and chained pipeline traversal.",
+      relatedResources: [
+        {
+          resourceType: "execution_inputs",
+          relationship: "produced-from",
+          description: "The merged input set YAML that produced this execution. Use harness_get(resource_type='execution_inputs', execution_id=...) to see what runtime inputs the run actually used (post-run forensics).",
+        },
+      ],
       listFilterFields: [
         { name: "search_term", description: "Filter executions by name or keyword" },
         { name: "pipeline_id", description: "Pipeline identifier to filter executions" },

--- a/src/registry/toolsets/pipelines.ts
+++ b/src/registry/toolsets/pipelines.ts
@@ -1,5 +1,5 @@
-import type { ToolsetDefinition, BodySchema } from "../types.js";
-import { ngExtract, pageExtract, passthrough, v1ListExtract, runtimeInputExtract } from "../extractors.js";
+import type { ToolsetDefinition, BodySchema, ParamsSchema } from "../types.js";
+import { ngExtract, pageExtract, passthrough, v1ListExtract, runtimeInputExtract, executionInputsExtract } from "../extractors.js";
 import YAML from "yaml";
 
 /**
@@ -557,6 +557,56 @@ export const pipelinesToolset: ToolsetDefinition = {
           bodySchema: { description: "No body required. Interrupt type is specified via the interrupt_type query parameter (IMPORTANT: do not pass this as a body parameter, otherwise the request will fail)", fields: [] },
           responseExtractor: ngExtract,
           actionDescription: "Interrupt a running execution. Pass interrupt_type as a param: AbortAll (abort all stages), Pause, Resume, StageRollback, Abort (abort current retry), ExpireAll, or Retry.",
+        },
+      },
+    },
+    {
+      resourceType: "execution_inputs",
+      displayName: "Pipeline Execution Inputs",
+      description:
+        "Merged input set YAML for a pipeline execution — the inputs that produced a given run. Supports get only. Use to answer 'what inputs triggered this execution?' without leaving the MCP tool chain.",
+      toolset: "pipelines",
+      scope: "project",
+      identifierFields: ["execution_id"],
+      relatedResources: [
+        {
+          resourceType: "execution",
+          relationship: "produced-by",
+          description: "The pipeline execution this input set was used for. Use harness_get(resource_type='execution', execution_id=...) for status/stage details.",
+        },
+        {
+          resourceType: "input_set",
+          relationship: "merged-from",
+          description: "Saved input sets that contributed to this execution's merged YAML. inputSetDetails lists their identifiers/names.",
+        },
+      ],
+      operations: {
+        get: {
+          method: "GET",
+          path: "/pipeline/api/pipelines/execution/{planExecutionId}/inputsetV2",
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          pathParams: { execution_id: "planExecutionId" },
+          queryParams: {
+            resolve_expressions: "resolveExpressions",
+            resolve_expressions_type: "resolveExpressionsType",
+          },
+          responseExtractor: executionInputsExtract,
+          description:
+            "Get the merged input set YAML for a pipeline execution. Returns inputSetYaml (merged inputs used at runtime), inputSetTemplateYaml (template at execution time), resolvedYaml (only when resolve_expressions=true), inputSetDetails (saved input sets that contributed), and inputSetBranchName (source branch for git-backed input sets). Pass execution_id (planExecutionId). Optional params: resolve_expressions (bool), resolve_expressions_type (enum: RESOLVE_ALL_EXPRESSIONS | RESOLVE_TRIGGER_EXPRESSIONS | UNKNOWN — default UNKNOWN means no resolution).",
+          paramsSchema: {
+            fields: [
+              {
+                name: "resolve_expressions",
+                required: false,
+                description: "When true, resolve `<+...>` expressions in the YAML. The resolved output is returned in the resolvedYaml field. Defaults to false.",
+              },
+              {
+                name: "resolve_expressions_type",
+                required: false,
+                description: "Which expressions to resolve. One of: RESOLVE_ALL_EXPRESSIONS, RESOLVE_TRIGGER_EXPRESSIONS, UNKNOWN. Defaults to UNKNOWN (no resolution), matching the upstream API default.",
+              },
+            ],
+          } satisfies ParamsSchema,
         },
       },
     },

--- a/tests/registry/execution-inputs.test.ts
+++ b/tests/registry/execution-inputs.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Config } from "../../src/config.js";
+import type { HarnessClient } from "../../src/client/harness-client.js";
+import { Registry } from "../../src/registry/index.js";
+import { executionInputsExtract } from "../../src/registry/extractors.js";
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    HARNESS_API_KEY: "pat.test",
+    HARNESS_ACCOUNT_ID: "test-account",
+    HARNESS_BASE_URL: "https://app.harness.io",
+    HARNESS_ORG: "default",
+    HARNESS_PROJECT: "test-project",
+    HARNESS_API_TIMEOUT_MS: 30000,
+    HARNESS_MAX_RETRIES: 3,
+    HARNESS_MAX_BODY_SIZE_MB: 10,
+    HARNESS_RATE_LIMIT_RPS: 10,
+    HARNESS_READ_ONLY: false,
+    HARNESS_SKIP_ELICITATION: false,
+    HARNESS_ALLOW_HTTP: false,
+    HARNESS_FME_BASE_URL: "https://api.split.io",
+    LOG_LEVEL: "info",
+    ...overrides,
+  };
+}
+
+function makeClient(requestFn: (...args: unknown[]) => unknown): HarnessClient {
+  return {
+    request: requestFn,
+    account: "test-account",
+  } as unknown as HarnessClient;
+}
+
+describe("executionInputsExtract — response shape", () => {
+  it("projects the NG envelope to the documented public shape", () => {
+    const raw = {
+      status: "SUCCESS",
+      correlationId: "cid-1",
+      data: {
+        inputSetYaml: "pipeline:\n  identifier: p1\n",
+        inputSetTemplateYaml: "pipeline:\n  identifier: p1\n  variables: <+input>\n",
+        resolvedYaml: null,
+        inputSetDetails: [
+          { identifier: "is1", name: "Input Set One" },
+          { identifier: "is2", name: "Input Set Two" },
+        ],
+        inputSetBranchName: "main",
+      },
+    };
+    expect(executionInputsExtract(raw, { execution_id: "exec-42" })).toEqual({
+      executionId: "exec-42",
+      inputSetYaml: "pipeline:\n  identifier: p1\n",
+      inputSetTemplateYaml: "pipeline:\n  identifier: p1\n  variables: <+input>\n",
+      resolvedYaml: null,
+      inputSetDetails: [
+        { identifier: "is1", name: "Input Set One" },
+        { identifier: "is2", name: "Input Set Two" },
+      ],
+      inputSetBranchName: "main",
+    });
+  });
+
+  it("drops backend envelope/debug fields (no raw passthrough)", () => {
+    const raw = {
+      status: "SUCCESS",
+      metaData: { internal: "should-be-stripped" },
+      correlationId: "cid-2",
+      data: {
+        inputSetYaml: "yaml",
+        // Extra unknown key the API might add — must NOT leak through.
+        debugInfo: { trace: "x" },
+      },
+    };
+    const result = executionInputsExtract(raw, { execution_id: "e1" }) as Record<string, unknown>;
+    expect(result).not.toHaveProperty("status");
+    expect(result).not.toHaveProperty("metaData");
+    expect(result).not.toHaveProperty("correlationId");
+    expect(result).not.toHaveProperty("debugInfo");
+    expect(Object.keys(result).sort()).toEqual([
+      "executionId",
+      "inputSetBranchName",
+      "inputSetDetails",
+      "inputSetTemplateYaml",
+      "inputSetYaml",
+      "resolvedYaml",
+    ]);
+  });
+
+  it("returns nulls and empty inputSetDetails when fields are missing", () => {
+    expect(executionInputsExtract({ status: "SUCCESS", data: {} }, { execution_id: "e1" })).toEqual({
+      executionId: "e1",
+      inputSetYaml: null,
+      inputSetTemplateYaml: null,
+      resolvedYaml: null,
+      inputSetDetails: [],
+      inputSetBranchName: null,
+    });
+  });
+
+  it("normalizes inputSetDetails — only identifier/name survive", () => {
+    const raw = {
+      data: {
+        inputSetDetails: [
+          { identifier: "is1", name: "A", extra: "leak", internalRef: { x: 1 } },
+          { identifier: "is2" }, // missing name
+          { name: "C-no-id" },   // missing identifier
+        ],
+      },
+    };
+    const result = executionInputsExtract(raw, {}) as { inputSetDetails: unknown[] };
+    expect(result.inputSetDetails).toEqual([
+      { identifier: "is1", name: "A" },
+      { identifier: "is2", name: null },
+      { identifier: null, name: "C-no-id" },
+    ]);
+  });
+
+  it("falls back to null executionId when input is missing", () => {
+    const result = executionInputsExtract({ data: {} }, undefined) as { executionId: unknown };
+    expect(result.executionId).toBeNull();
+  });
+
+  it("handles a non-array inputSetDetails value defensively", () => {
+    const raw = { data: { inputSetDetails: "oops-not-an-array" } };
+    const result = executionInputsExtract(raw, {}) as { inputSetDetails: unknown[] };
+    expect(result.inputSetDetails).toEqual([]);
+  });
+});
+
+describe("execution_inputs resource — request shape", () => {
+  it("dispatches GET to /inputsetV2 with planExecutionId path param", async () => {
+    const registry = new Registry(makeConfig());
+    const mockRequest = vi.fn().mockResolvedValue({ data: { inputSetYaml: "" } });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "execution_inputs", "get", {
+      execution_id: "exec-abc",
+      org_id: "myorg",
+      project_id: "myproj",
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "GET",
+        path: "/pipeline/api/pipelines/execution/exec-abc/inputsetV2",
+        params: expect.objectContaining({
+          orgIdentifier: "myorg",
+          projectIdentifier: "myproj",
+        }),
+      }),
+    );
+  });
+
+  it("maps resolve_expressions and resolve_expressions_type to the API query params", async () => {
+    const registry = new Registry(makeConfig());
+    const mockRequest = vi.fn().mockResolvedValue({ data: { resolvedYaml: "ok" } });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "execution_inputs", "get", {
+      execution_id: "exec-1",
+      resolve_expressions: true,
+      resolve_expressions_type: "RESOLVE_ALL_EXPRESSIONS",
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "GET",
+        path: "/pipeline/api/pipelines/execution/exec-1/inputsetV2",
+        params: expect.objectContaining({
+          resolveExpressions: true,
+          resolveExpressionsType: "RESOLVE_ALL_EXPRESSIONS",
+        }),
+      }),
+    );
+  });
+
+  it("omits resolveExpressions params when not provided (defaults to upstream UNKNOWN)", async () => {
+    const registry = new Registry(makeConfig());
+    const mockRequest = vi.fn().mockResolvedValue({ data: {} });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "execution_inputs", "get", {
+      execution_id: "exec-1",
+    });
+
+    const call = mockRequest.mock.calls[0]![0] as { params?: Record<string, unknown> };
+    expect(call.params).not.toHaveProperty("resolveExpressions");
+    expect(call.params).not.toHaveProperty("resolveExpressionsType");
+  });
+
+  it("returns the projected response shape after dispatch (extractor wired up)", async () => {
+    const registry = new Registry(makeConfig());
+    const mockRequest = vi.fn().mockResolvedValue({
+      status: "SUCCESS",
+      data: {
+        inputSetYaml: "yaml-1",
+        inputSetTemplateYaml: "yaml-2",
+        resolvedYaml: "yaml-3",
+        inputSetDetails: [{ identifier: "is1", name: "One" }],
+        inputSetBranchName: "feature/x",
+      },
+    });
+    const client = makeClient(mockRequest);
+
+    const result = await registry.dispatch(client, "execution_inputs", "get", {
+      execution_id: "exec-9",
+    });
+
+    expect(result).toEqual({
+      executionId: "exec-9",
+      inputSetYaml: "yaml-1",
+      inputSetTemplateYaml: "yaml-2",
+      resolvedYaml: "yaml-3",
+      inputSetDetails: [{ identifier: "is1", name: "One" }],
+      inputSetBranchName: "feature/x",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a new `execution_inputs` resource type to the pipelines toolset, wrapping `GET /pipeline/api/pipelines/execution/{planExecutionId}/inputsetV2`. Lets agents answer "what inputs triggered this run?" without leaving the MCP tool chain.
- Projects the upstream NG response to a stable, documented public shape — `{ executionId, inputSetYaml, inputSetTemplateYaml, resolvedYaml, inputSetDetails, inputSetBranchName }` — and drops the envelope/debug fields. `inputSetDetails` is normalized to `[{identifier, name}]`.
- Supports optional `resolve_expressions` (boolean) and `resolve_expressions_type` (`RESOLVE_ALL_EXPRESSIONS` | `RESOLVE_TRIGGER_EXPRESSIONS` | `UNKNOWN`); when omitted, no params are sent so the upstream default (`UNKNOWN`, no resolution) applies.

## Why

Today, agents that need pipeline execution inputs have to drop into raw REST, which breaks the MCP abstraction, expands the auth/credential surface for agent tooling, and makes "explain this run" prompts impossible to answer in a single tool-call chain. This closes the gap so execution context (status, logs, **and** inputs) is fully MCP-native.

## Implementation notes

- `risk: "read"`, `retryPolicy: "safe"` — passes through read-only mode and standard retry policy.
- `paramsSchema` documents the optional resolve params on the get op (not as global list filters).
- New `executionInputsExtract` lives in `src/registry/extractors.ts` next to `runtimeInputExtract` for symmetry. Defensive against missing/non-array `inputSetDetails`.
- `relatedResources` links back to `execution` and `input_set` for multi-turn flows.

## Test plan

- [x] New tests: `tests/registry/execution-inputs.test.ts` (10 cases)
  - Response-shape: projection, envelope drop (no `status`/`metaData`/`correlationId`/`debugInfo` leakage), missing-field defaults, `inputSetDetails` normalization (extra fields stripped, missing identifier/name → null), defensive non-array handling
  - Request-shape: GET path with `planExecutionId`, query-param mapping (`resolveExpressions`, `resolveExpressionsType`), optional-param omission, end-to-end dispatch returns the projected shape
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1932/1932 passing
- [x] `pnpm build`
- [x] `pnpm docs:generate` — README resource count 213 → 214
- [x] `pnpm docs:check` — up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)