### PR TITLE
fix: align execution_inputs guidance with public tool schema

### DIFF
--- a/src/prompts/debug-pipeline.ts
+++ b/src/prompts/debug-pipeline.ts
@@ -37,9 +37,9 @@ Then analyze the diagnostic payload:
 - **child_pipeline section**: if present, the failure is in a chained pipeline — focus on the child's failure details
 - **failed_step_logs**: actual log output from the failed steps — look for error patterns, stack traces, and exit codes
 - **runtime input issues**: if the error mentions unresolved \`<+input>\` expressions or missing variables, check:
-  - For **post-run forensics** (what values *actually* ran?): call harness_get with resource_type="execution_inputs" and execution_id=<execution_id> to see the merged input set YAML used at runtime — this is the source of truth for what the failed run received
+  - For **post-run forensics** (what values *actually* ran?): call harness_get with resource_type="execution_inputs" and resource_id=<execution_id> to see the merged input set YAML used at runtime — this is the source of truth for what the failed run received
   - For **pre-run expectations** (what does the pipeline expect?): call harness_get with resource_type="runtime_input_template" and resource_id=<pipeline_id> to see which inputs the pipeline declares
-  - Call harness_list with resource_type="input_set", pipeline_id=<pipeline_id> to see available input sets that could provide the missing values
+  - Call harness_list with resource_type="input_set" and filters={ pipeline_id: <pipeline_id> } to see available input sets that could provide the missing values
   - Suggest the user either pass the missing values as \`inputs\` or use \`input_set_ids\` referencing a saved input set
 
 Provide actionable recommendations based on the combined evidence.`,

--- a/src/registry/toolsets/pipelines.ts
+++ b/src/registry/toolsets/pipelines.ts
@@ -510,7 +510,7 @@ export const pipelinesToolset: ToolsetDefinition = {
         {
           resourceType: "execution_inputs",
           relationship: "produced-from",
-          description: "The merged input set YAML that produced this execution. Use harness_get(resource_type='execution_inputs', execution_id=...) to see what runtime inputs the run actually used (post-run forensics).",
+          description: "The merged input set YAML that produced this execution. Use harness_get(resource_type='execution_inputs', resource_id=<planExecutionId>) to see what runtime inputs the run actually used (post-run forensics).",
         },
       ],
       listFilterFields: [
@@ -579,7 +579,7 @@ export const pipelinesToolset: ToolsetDefinition = {
         {
           resourceType: "execution",
           relationship: "produced-by",
-          description: "The pipeline execution this input set was used for. Use harness_get(resource_type='execution', execution_id=...) for status/stage details.",
+          description: "The pipeline execution this input set was used for. Use harness_get(resource_type='execution', resource_id=<planExecutionId>) for status/stage details.",
         },
         {
           resourceType: "input_set",
@@ -599,7 +599,7 @@ export const pipelinesToolset: ToolsetDefinition = {
           },
           responseExtractor: executionInputsExtract,
           description:
-            "Get the merged input set YAML for a pipeline execution. Returns inputSetYaml (merged inputs used at runtime), inputSetTemplateYaml (template at execution time), resolvedYaml (only when resolve_expressions=true), inputSetDetails (saved input sets that contributed), and inputSetBranchName (source branch for git-backed input sets). Pass execution_id (planExecutionId). Optional params: resolve_expressions (bool), resolve_expressions_type (enum: RESOLVE_ALL_EXPRESSIONS | RESOLVE_TRIGGER_EXPRESSIONS | UNKNOWN — default UNKNOWN means no resolution).",
+            "Get the merged input set YAML for a pipeline execution. Returns inputSetYaml (merged inputs used at runtime), inputSetTemplateYaml (template at execution time), resolvedYaml (only when resolve_expressions=true), inputSetDetails (saved input sets that contributed), and inputSetBranchName (source branch for git-backed input sets). Call as harness_get(resource_type='execution_inputs', resource_id=<planExecutionId>) — resource_id is mapped to the execution_id path identifier. Optional params (pass via the params argument): resolve_expressions (bool), resolve_expressions_type (enum: RESOLVE_ALL_EXPRESSIONS | RESOLVE_TRIGGER_EXPRESSIONS | UNKNOWN — default UNKNOWN means no resolution).",
           paramsSchema: {
             fields: [
               {


### PR DESCRIPTION
## Summary

Two agent-facing strings — the `execution_inputs.get` registry description and the `debug-pipeline` prompt — described call shapes that don't match what `harness_get` and `harness_list` actually advertise:

- `harness_get` exposes `resource_id` (or `params`), **not** a top-level `execution_id`.
- `harness_list` takes resource-specific keys via the `filters` argument, **not** as top-level fields.

Both descriptions are surfaced verbatim by `harness_describe` and read by strict MCP clients, so the mismatch could push agents to construct invalid top-level arguments.

## Changes

- **`execution_inputs.get` description** — rewrite from "Pass execution_id (planExecutionId)" to "Call as `harness_get(resource_type='execution_inputs', resource_id=<planExecutionId>)` — `resource_id` is mapped to the execution_id path identifier. Optional params (pass via the `params` argument): …"
- **Related-resource hints** — mirror the corrected shape on both sides:
  - `execution_inputs → execution`: `harness_get(resource_type='execution', resource_id=<planExecutionId>)`
  - `execution → execution_inputs`: `harness_get(resource_type='execution_inputs', resource_id=<planExecutionId>)`
- **`debug-pipeline` prompt** — change `execution_id=<execution_id>` to `resource_id=<execution_id>` for `execution_inputs`; change `pipeline_id="…"` top-level on `input_set` to `filters={ pipeline_id: … }`.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1932/1932 passing
- [x] `pnpm build`
- [x] `pnpm docs:check` — README up to date
- [x] Verified `harness_get.inputSchema` exposes only `resource_id` + `params` (no top-level `execution_id`); `harness_list.inputSchema` documents `filters` for resource-specific keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)