### PR TITLE
chore: bump version to 3.1.7

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "harness-mcp-server",
   "display_name": "Harness",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "Connect AI agents to Harness for CI/CD, code repositories, pull requests, services, environments, and feature flags.",
   "long_description": "The Harness MCP Server gives MCP-compatible clients access to Harness platform workflows through consolidated tools, resources, and prompts. It supports local stdio usage and can be bundled as a Node-based MCPB extension.",
   "author": {

--- a/mcp-directory/manifest.json
+++ b/mcp-directory/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "harness-mcp-server",
   "display_name": "Harness",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "Connect AI agents to Harness for CI/CD, code repositories, pull requests, services, environments, and feature flags.",
   "long_description": "The Harness MCP Server gives MCP-compatible clients access to Harness platform workflows through consolidated tools, resources, and prompts. It supports local stdio usage and can be bundled as a Node-based MCPB extension.",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-mcp-v2",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "Give AI agents full access to the Harness.io platform — manage pipelines, deployments, cloud costs, chaos engineering, feature flags, SEI, and 125+ resource types through 11 MCP tools",
   "type": "module",
   "main": "build/index.js",

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -24,7 +24,7 @@ describe("release metadata", () => {
     const rootManifest = readJson("manifest.json");
     const directoryManifest = readJson("mcp-directory/manifest.json");
 
-    expect(packageJson.version).toBe("3.1.6");
+    expect(packageJson.version).toBe("3.1.7");
     expect(rootManifest.version).toBe(packageJson.version);
     expect(directoryManifest.version).toBe(packageJson.version);
   });


### PR DESCRIPTION
## Summary

Bumps the package version from 3.1.6 → 3.1.7 across all release-metadata files. Cuts a release after the recent feature merges:

- `feat: add execution_inputs resource` (#334)
- `fix: align execution_inputs guidance with public tool schema` (#335)
- `feat: add pipeline_dynamic_execution resource` (#336)

## Changes

- `package.json` — `3.1.6` → `3.1.7`
- `manifest.json` — `3.1.6` → `3.1.7`
- `mcp-directory/manifest.json` — `3.1.6` → `3.1.7`
- `tests/release-metadata.test.ts` — assertion updated to `3.1.7` (the test pins the next-release version, so it tracks alongside the bump)

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1946/1946 passing (release-metadata sync test passes against the new version)
- [x] `pnpm build`
- [x] `pnpm docs:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)