### PR TITLE
add supportedScopes to GitOps resources for account/org scope validation

### DIFF
--- a/src/registry/toolsets/gitops.ts
+++ b/src/registry/toolsets/gitops.ts
@@ -191,6 +191,7 @@ export const gitopsToolset: ToolsetDefinition = {
       toolset: "gitops",
       scope: "project",
       scopeOptional: true,
+      supportedScopes: ["account", "org", "project"],
       identifierFields: ["agent_id"],
       listFilterFields: [
         { name: "search_term", description: "Filter GitOps agents by name or keyword" },
@@ -569,6 +570,7 @@ export const gitopsToolset: ToolsetDefinition = {
       toolset: "gitops",
       scope: "project",
       scopeOptional: true,
+      supportedScopes: ["account", "org", "project"],
       identifierFields: ["agent_id", "cluster_id"],
       listFilterFields: [
         { name: "search_term", description: "Filter clusters by name or keyword" },
@@ -614,6 +616,7 @@ export const gitopsToolset: ToolsetDefinition = {
       toolset: "gitops",
       scope: "project",
       scopeOptional: true,
+      supportedScopes: ["account", "org", "project"],
       identifierFields: ["agent_id", "repo_id"],
       listFilterFields: [
         { name: "search_term", description: "Filter repositories by name or URL" },
@@ -863,6 +866,7 @@ export const gitopsToolset: ToolsetDefinition = {
       toolset: "gitops",
       scope: "project",
       scopeOptional: true,
+      supportedScopes: ["account", "org", "project"],
       identifierFields: ["agent_id", "credential_id"],
       listFilterFields: [
         { name: "search_term", description: "Filter repository credentials by name or keyword" },


### PR DESCRIPTION
## Summary

Fixes resource_scope validation failures for GitOps resources when `resource_scope: "account"` is passed.

**Root cause:** `gitops_agent`, `gitops_cluster`, `gitops_repository`, and `gitops_repo_credential` all have `scopeOptional: true` (which allows account-level queries) but were missing `supportedScopes`, causing the scope validator introduced in PR #185 to reject account-scope requests with:
> `gitops_agent does not support account scope. Supported scopes: project`

**Fix:** Add `supportedScopes: ["account", "org", "project"]` to all four affected resources — identical to the fix applied to `template_v1` in PR #263.

## Affected resources
- `gitops_agent`
- `gitops_cluster`
- `gitops_repository`
- `gitops_repo_credential`

## Test plan
- [ ] Pass `resource_scope: "account"` to `harness_list` / `harness_get` for each of the 4 affected resource types — should succeed without scope validation error
- [ ] Pass `resource_scope: "org"` — should succeed
- [ ] Pass `resource_scope: "project"` — should succeed (unchanged behavior)
- [ ] Verify `gitops_application` and `gitops_applicationset` (no `scopeOptional`) are unaffected
