### PR TITLE
Fix GitOps org scope listing

### DIFF
--- a/src/registry/toolsets/gitops.ts
+++ b/src/registry/toolsets/gitops.ts
@@ -233,6 +233,8 @@ export const gitopsToolset: ToolsetDefinition = {
         "- Project-scoped agent: 'myagent' (no prefix)",
       toolset: "gitops",
       scope: "project",
+      scopeOptional: true,
+      supportedScopes: ["account", "org", "project"],
       diagnosticHint: "Use harness_diagnose with resource_type='gitops_application', agent_id, and resource_id (app name) to analyze sync failures, health issues, and unhealthy K8s resources. Combines app status, resource tree, and recent events.",
       executeHint:
         "SYNC: action='sync' for single app, action='bulk_sync' for multiple. " +
@@ -659,6 +661,8 @@ export const gitopsToolset: ToolsetDefinition = {
         "    Then use: harness_get(resource_type='gitops_applicationset', resource_id='<uuid>', params={agent_id:'...'})",
       toolset: "gitops",
       scope: "project",
+      scopeOptional: true,
+      supportedScopes: ["account", "org", "project"],
       identifierFields: ["agent_id", "appset_id"],
       executeHint:
         "GET/UPDATE requires the ApplicationSet UUID, NOT its name. The API uses UUID as the identifier.\n" +

--- a/tests/registry/registry.test.ts
+++ b/tests/registry/registry.test.ts
@@ -669,6 +669,25 @@ describe("Registry", () => {
       expect(projectCall.params.projectIdentifier).toBe("proj-level");
     });
 
+    it.each([
+      ["gitops_application", { applications: [] }],
+      ["gitops_applicationset", { applicationsets: [] }],
+    ])("supports org-scope listing for %s", async (resourceType, response) => {
+      const scopedRegistry = new Registry(makeConfig({ HARNESS_TOOLSETS: "gitops" }));
+      const mockRequest = vi.fn().mockResolvedValue(response);
+      const client = makeClient(mockRequest);
+
+      await scopedRegistry.dispatch(client, resourceType, "list", {
+        resource_scope: "org",
+        org_id: "AI_Devops",
+      });
+
+      const call = mockRequest.mock.calls[0][0];
+      expect(call.params.orgIdentifier).toBe("AI_Devops");
+      expect(call.params.projectIdentifier).toBeUndefined();
+      expect(call.body.accountIdentifier).toBe("test-account");
+    });
+
     it("omits default org/project query params for explicit account-scope secret get", async () => {
       const accountRegistry = new Registry(makeConfig({ HARNESS_TOOLSETS: "secrets" }));
       const mockRequest = vi.fn().mockResolvedValue({ data: { identifier: "acctSecret" } });


### PR DESCRIPTION
## Summary
- Allow GitOps applications and ApplicationSets to be listed at account, org, or project scope.
- Add regression coverage for org-level list dispatch so requests with `resource_scope: "org"` pass `orgIdentifier` without `projectIdentifier`.

## Test plan
- `pnpm exec vitest run tests/registry/registry.test.ts`
- `pnpm typecheck`


Made with [Cursor](https://cursor.com)