### PR TITLE
fix: bump hono to ^4.12.25 to resolve five Dependabot advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@resvg/resvg-js": "^2.6.2",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
-    "hono": "^4.12.23",
+    "hono": "^4.12.25",
     "jsonwebtoken": "^9.0.3",
     "yaml": "^2.8.3",
     "zod": "^4.0.0"
@@ -93,7 +93,7 @@
   "pnpm": {
     "overrides": {
       "picomatch": ">=4.0.4",
-      "hono": ">=4.12.21",
+      "hono": ">=4.12.25",
       "path-to-regexp": ">=8.4.0",
       "@hono/node-server": ">=1.19.10",
       "express-rate-limit": ">=8.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   picomatch: '>=4.0.4'
-  hono: '>=4.12.21'
+  hono: '>=4.12.25'
   path-to-regexp: '>=8.4.0'
   '@hono/node-server': '>=1.19.10'
   express-rate-limit: '>=8.2.2'
@@ -24,7 +24,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: '>=1.19.10'
-        version: 2.0.0(hono@4.12.23)
+        version: 2.0.0(hono@4.12.25)
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.1
         version: 1.27.1(zod@4.3.6)
@@ -38,8 +38,8 @@ importers:
         specifier: ^5.2.1
         version: 5.2.1
       hono:
-        specifier: '>=4.12.21'
-        version: 4.12.23
+        specifier: '>=4.12.25'
+        version: 4.12.25
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3
@@ -243,7 +243,7 @@ packages:
     resolution: {integrity: sha512-n3GfHwwCvHCkGmOwKfxUPOlbfzuO64Sbc5XC4NGPIXxkuOnJrdgExdRKmHfF924r914WRJPT397GdqLvdYTeyQ==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: '>=4.12.21'
+      hono: '>=4.12.25'
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -822,8 +822,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.23:
-    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+  hono@4.12.25:
+    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -1372,15 +1372,15 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@hono/node-server@2.0.0(hono@4.12.23)':
+  '@hono/node-server@2.0.0(hono@4.12.25)':
     dependencies:
-      hono: 4.12.23
+      hono: 4.12.25
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 2.0.0(hono@4.12.23)
+      '@hono/node-server': 2.0.0(hono@4.12.25)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -1390,7 +1390,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.23
+      hono: 4.12.25
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -1946,7 +1946,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.23: {}
+  hono@4.12.25: {}
 
   http-errors@2.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

Hono <4.12.25 carries five Dependabot advisories, all patched in 4.12.25:

| Severity | GHSA | Issue |
|---|---|---|
| High | [GHSA-88fw-hqm2-52qc](https://github.com/honojs/hono/security/advisories/GHSA-88fw-hqm2-52qc) | CORS Middleware reflects any Origin with credentials when origin defaults to wildcard |
| Moderate | [GHSA-rv63-4mwf-qqc2](https://github.com/honojs/hono/security/advisories/GHSA-rv63-4mwf-qqc2) | Body Limit Middleware bypassable on AWS Lambda by understating Content-Length |
| Moderate | [GHSA-wwfh-h76j-fc44](https://github.com/honojs/hono/security/advisories/GHSA-wwfh-h76j-fc44) | Path traversal in serve-static on Windows via encoded backslash (%5C) |
| Moderate | [GHSA-j6c9-x7qj-28xf](https://github.com/honojs/hono/security/advisories/GHSA-j6c9-x7qj-28xf) | AWS Lambda adapter drops Set-Cookie on ALB / VPC Lattice |
| Moderate | [GHSA-wgpf-jwqj-8h8p](https://github.com/honojs/hono/security/advisories/GHSA-wgpf-jwqj-8h8p) | Lambda@Edge adapter keeps only the last value of repeated request headers |

This repo doesn't directly use the affected surfaces (CORS middleware, body-limit middleware, serve-static, or any Lambda adapter — `grep -rn 'cors\|bodyLimit\|serveStatic\|aws-lambda\|lambda-edge' src/` returned zero hits), but `hono` is a direct dependency via `@hono/node-server` and `@modelcontextprotocol/sdk`'s transport substrate, so the alerts apply and the bump is the right defense-in-depth move.

## Changes

- `package.json` direct dep `hono: ^4.12.23` → `^4.12.25`
- `package.json` pnpm override `hono: >=4.12.21` → `>=4.12.25`
- `pnpm-lock.yaml` regenerated; all hono refs resolve to `4.12.25`

## Test plan

- [x] `pnpm install` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1990/1990 passing
- [x] `pnpm build` — clean
- [x] `pnpm docs:check` — README up to date
- [x] Lockfile spot-check: `grep "hono@" pnpm-lock.yaml` shows only `hono@4.12.25`

🤖 Generated with [Claude Code](https://claude.com/claude-code)