### PR TITLE
chore: bump version to 3.1.9

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "harness-mcp-server",
   "display_name": "Harness",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "description": "Connect AI agents to Harness for CI/CD, code repositories, pull requests, services, environments, and feature flags.",
   "long_description": "The Harness MCP Server gives MCP-compatible clients access to Harness platform workflows through consolidated tools, resources, and prompts. It supports local stdio usage and can be bundled as a Node-based MCPB extension.",
   "author": {

--- a/mcp-directory/manifest.json
+++ b/mcp-directory/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "harness-mcp-server",
   "display_name": "Harness",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "description": "Connect AI agents to Harness for CI/CD, code repositories, pull requests, services, environments, and feature flags.",
   "long_description": "The Harness MCP Server gives MCP-compatible clients access to Harness platform workflows through consolidated tools, resources, and prompts. It supports local stdio usage and can be bundled as a Node-based MCPB extension.",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-mcp-v2",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "description": "Give AI agents full access to the Harness.io platform — manage pipelines, deployments, cloud costs, chaos engineering, feature flags, SEI, and 125+ resource types through 11 MCP tools",
   "type": "module",
   "main": "build/index.js",

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -24,7 +24,7 @@ describe("release metadata", () => {
     const rootManifest = readJson("manifest.json");
     const directoryManifest = readJson("mcp-directory/manifest.json");
 
-    expect(packageJson.version).toBe("3.1.8");
+    expect(packageJson.version).toBe("3.1.9");
     expect(rootManifest.version).toBe(packageJson.version);
     expect(directoryManifest.version).toBe(packageJson.version);
   });


### PR DESCRIPTION
## Summary

Routine release bump to **3.1.9**, matching the prior pattern (#348, #337, #324) — a metadata-only PR per release.

Picks up the user-facing changes shipped on `main` since `3.1.8`:
- #351 — `confirm: true` override on elicited decline (with the full follow-up review chain: scoped override semantics, distinct `caller_confirmed` audit method, `outcome: "blocked"` audit rows, pre-elicit `HARNESS_READ_ONLY` gating, pathBuilder-safe blocked audits)
- #352 — vite bumped to ^7.3.5 (server.fs.deny bypass advisory)
- #353 — hono bumped to ^4.12.25 (5 advisories incl. CORS-with-credentials wildcard)

## Changes

- `package.json` 3.1.8 → 3.1.9
- `manifest.json` 3.1.8 → 3.1.9
- `mcp-directory/manifest.json` 3.1.8 → 3.1.9
- `tests/release-metadata.test.ts` expected version 3.1.8 → 3.1.9

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 1990/1990 passing (release-metadata test now expects 3.1.9)
- [x] `pnpm build` — clean (script header shows `harness-mcp-v2@3.1.9`)
- [x] `pnpm docs:check` — README up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)