### PR TITLE
fix: inject x-tenant-id for gRPC proxy services and fix kg_grammar response shape

### DIFF
--- a/src/client/harness-client.ts
+++ b/src/client/harness-client.ts
@@ -154,6 +154,26 @@ export class HarnessClient {
     return this.baseUrl;
   }
 
+  private buildHeaders(options: RequestOptions): Record<string, string> {
+    const isFme = options.product === "fme";
+    const accountId = this.resolveAccountId();
+    const headers: Record<string, string> = {
+      ...(isFme ? {} : { "Harness-Account": accountId }),
+      ...options.headers,
+    };
+    // gRPC-proxy services (query-service, schema-service, config-service) require x-tenant-id,
+    // consistent with how /log-service/ gets accountID in buildUrl.
+    if (
+      options.path.includes("/query-service/") ||
+      options.path.includes("/schema-service/") ||
+      options.path.includes("/config-service/")
+    ) {
+      headers["x-tenant-id"] = accountId;
+    }
+    this.applyDefaultAuth(headers, isFme);
+    return headers;
+  }
+
   private applyDefaultAuth(headers: Record<string, string>, isFme: boolean): void {
     if (isFme) {
       // FME/Split Admin APIs expect Bearer auth. Drop x-api-key here so
@@ -238,18 +258,7 @@ export class HarnessClient {
 
     const method = options.method ?? "GET";
     const url = this.buildUrl(options);
-    const isFme = options.product === "fme";
-    const accountId = this.resolveAccountId();
-    const headers: Record<string, string> = {
-      ...(isFme ? {} : { "Harness-Account": accountId }),
-      ...options.headers,
-    };
-
-    // Only inject default auth when the caller hasn't already set auth.
-    // When service-routing handles auth (bearer-jwt, remote-mcp), it sets
-    // Authorization directly — sending x-api-key alongside would cause
-    // downstream services to attempt API-key validation on the dummy token.
-    this.applyDefaultAuth(headers, isFme);
+    const headers = this.buildHeaders(options);
 
     if (hasExplicitBody(options.body)) {
       if (isFormDataBody(options.body)) {
@@ -412,15 +421,7 @@ export class HarnessClient {
 
     const method = options.method ?? "POST";
     const url = this.buildUrl(options);
-    const isFme = options.product === "fme";
-    const accountId = this.resolveAccountId();
-    const headers: Record<string, string> = {
-      ...(isFme ? {} : { "Harness-Account": accountId }),
-      ...options.headers,
-    };
-
-    // Same auth-header guard as request() — see comment there.
-    this.applyDefaultAuth(headers, isFme);
+    const headers = this.buildHeaders(options);
 
     if (hasExplicitBody(options.body)) {
       if (isFormDataBody(options.body)) {

--- a/src/registry/toolsets/knowledge-graph.ts
+++ b/src/registry/toolsets/knowledge-graph.ts
@@ -82,7 +82,8 @@ const queryableTypeSummaryExtract = (raw: unknown): { items: unknown[]; total: n
 
 const grammarExtract = (raw: unknown): unknown => {
   const r = raw as { grammar?: string };
-  return r.grammar ?? raw;
+  const grammar = r.grammar;
+  return grammar !== undefined ? { grammar } : raw;
 };
 
 /**

--- a/src/registry/toolsets/knowledge-graph.ts
+++ b/src/registry/toolsets/knowledge-graph.ts
@@ -221,7 +221,7 @@ export const knowledgeGraphToolset: ToolsetDefinition = {
         "Fetch this ONCE when you need to write HQL queries to learn the full " +
         "syntax: find/filter/select/group_by/order_by/join/having/with (CTEs), " +
         "window functions, array functions, case/when, cast, interval, unnest, etc. " +
-        "Returns the grammar as a plain text string.",
+        "Returns { grammar: \"<ANTLR4 .g4 text>\" }.",
       toolset: "knowledge-graph",
       scope: "account",
       identifierFields: [],
@@ -234,7 +234,7 @@ export const knowledgeGraphToolset: ToolsetDefinition = {
           responseExtractor: grammarExtract,
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           description:
-            "Fetch the HQL grammar definition. Returns the full ANTLR4 .g4 grammar as text.",
+            "Fetch the HQL grammar definition. Returns { grammar: \"<ANTLR4 .g4 text>\" }.",
         },
       },
     },

--- a/tests/client/harness-client.test.ts
+++ b/tests/client/harness-client.test.ts
@@ -373,6 +373,44 @@ describe("HarnessClient", () => {
       expect(headers["Harness-Account"]).toBe("resolved-account");
     });
 
+    it.each([
+      "/query-service/grpc/io.harness.platform.query.service.api.v1.QueryServiceGrpc/getGrammar",
+      "/schema-service/grpc/io.harness.platform.schema.service.api.v1.SchemaServiceGrpc/getType",
+    ])("sets x-tenant-id for gRPC proxy paths via request(): %s", async (path) => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      const client = new HarnessClient(makeConfig());
+
+      await client.request({ method: "POST", path });
+
+      const headers = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
+      expect(headers["x-tenant-id"]).toBe("test-account");
+      expect(headers["Harness-Account"]).toBe("test-account");
+    });
+
+    it("sets x-tenant-id for gRPC proxy paths via requestStream()", async () => {
+      fetchSpy.mockResolvedValue(new Response("ok", { status: 200 }));
+      const client = new HarnessClient(makeConfig());
+      client.setAccountIdResolver(() => "resolved-tenant");
+
+      await client.requestStream({
+        method: "POST",
+        path: "/query-service/grpc/io.harness.platform.query.service.api.v1.QueryServiceGrpc/executeQuery",
+      });
+
+      const headers = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
+      expect(headers["x-tenant-id"]).toBe("resolved-tenant");
+    });
+
+    it("omits x-tenant-id for non-gRPC-proxy paths", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      const client = new HarnessClient(makeConfig());
+
+      await client.request({ path: "/ng/api/projects" });
+
+      const headers = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
+      expect(headers["x-tenant-id"]).toBeUndefined();
+    });
+
     it("sets Content-Type to application/json for object body", async () => {
       fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
       const client = new HarnessClient(makeConfig());

--- a/tests/registry/knowledge-graph.test.ts
+++ b/tests/registry/knowledge-graph.test.ts
@@ -388,6 +388,37 @@ describe("kg_type get body validation", () => {
 });
 
 // ---------------------------------------------------------------------------
+// kg_grammar — get response shape
+// ---------------------------------------------------------------------------
+
+describe("kg_grammar get extractor", () => {
+  let registry: Registry;
+
+  beforeEach(() => {
+    registry = new Registry(makeConfig());
+  });
+
+  it("wraps grammar text in an object for MCP output validation", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ grammar: "grammar Hql; /* ... */" });
+    const client = makeClient(mockRequest);
+
+    const result = await registry.dispatch(client, "kg_grammar", "get", {});
+
+    expect(result).toEqual({ grammar: "grammar Hql; /* ... */" });
+    expect(typeof result).toBe("object");
+  });
+
+  it("preserves an empty grammar string", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ grammar: "" });
+    const client = makeClient(mockRequest);
+
+    const result = await registry.dispatch(client, "kg_grammar", "get", {});
+
+    expect(result).toEqual({ grammar: "" });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // hql_query run — read-only mode policy
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **`x-tenant-id` header injection** — gRPC proxy services (`/query-service/`, `/schema-service/`, `/config-service/`) require `x-tenant-id: <accountId>`. Without it every Knowledge Graph and semantic-layer call returned `"Required header 'x-tenant-id' is not present"`.
- **`buildHeaders()` refactor** — extracted shared header construction into a private `buildHeaders()` method called from both `request()` and `requestStream()`. Previously the injection was only in `request()`, leaving `requestStream()` inconsistent.
- **`grammarExtract` fix** — `kg_grammar` get was returning a raw string from the extractor. The MCP output schema requires a plain object; returning a primitive caused an output validation error. Now returns `{ grammar: "..." }`.

## How it was found

Tested all six KG tools live against harness0 after the internal MCP removed its own KG/semantic-layer toolsets in favour of the OSS versions. The `x-tenant-id` gap and the grammar response shape bug were both caught during that live validation — unit tests alone wouldn't catch either since they mock the HTTP layer.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (2057 tests)
- [x] Live verified against harness0 — all six KG tools work end-to-end:
  - `kg_queryable_type_summary` list ✓
  - `kg_type` get ✓
  - `kg_related_type` get ✓
  - `kg_grammar` get ✓
  - `hql_query` validate ✓
  - `hql_query` run ✓ (976,117 CD instances returned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)