### PR TITLE
fix: resolve nested schema definition lookups in harness_schema

### DIFF
--- a/src/tools/harness-schema.ts
+++ b/src/tools/harness-schema.ts
@@ -65,29 +65,90 @@ function inlineRefs(schema: Record<string, unknown>, node: unknown, depth = 0): 
   return result;
 }
 
+function isSchemaNode(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    "title" in v ||
+    "type" in v ||
+    "$ref" in v ||
+    "properties" in v ||
+    "oneOf" in v ||
+    "anyOf" in v ||
+    "allOf" in v ||
+    "enum" in v
+  );
+}
+
+/**
+ * Recursively search for a definition by key name within a resource's
+ * definitions tree. Harness schemas nest reusable definitions under group
+ * keys (e.g. EnvironmentV1 lives at stages.unified.EnvironmentV1), so a bare
+ * name lookup must walk the tree. Returns the node plus its dotted path.
+ */
+function findDefinitionByName(
+  root: Record<string, unknown>,
+  name: string,
+  maxDepth = 8,
+): { node: unknown; path: string } | undefined {
+  const stack: Array<{ node: unknown; path: string[] }> = [{ node: root, path: [] }];
+  while (stack.length > 0) {
+    const entry = stack.pop();
+    if (!entry) continue;
+    const { node, path } = entry;
+    if (path.length > maxDepth) continue;
+    if (!node || typeof node !== "object" || Array.isArray(node)) continue;
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      if (key === name && isSchemaNode(value)) {
+        return { node: value, path: [...path, key].join(".") };
+      }
+      if (value && typeof value === "object") {
+        stack.push({ node: value, path: [...path, key] });
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Resolution order: direct key -> literal dot-path -> recursive name search.
+ * Returns the matched node and the dotted path it resolved to (which may
+ * differ from the requested path when a bare nested name was supplied,
+ * e.g. "EnvironmentV1" -> "stages.unified.EnvironmentV1").
+ */
 function navigateStaticPath(
   schema: Record<string, unknown>,
   resourceType: string,
   path: string,
-): unknown {
+): { node: unknown; path: string } | undefined {
   const definitions = schema.definitions as Record<string, unknown> | undefined;
   if (!definitions) return undefined;
 
   const resourceDefs = definitions[resourceType] as Record<string, unknown> | undefined;
   if (!resourceDefs) return undefined;
 
-  if (resourceDefs[path]) return resourceDefs[path];
+  if (resourceDefs[path]) return { node: resourceDefs[path], path };
 
   const parts = path.split(".");
   let current: unknown = resourceDefs;
+  let dotPathValid = true;
   for (const part of parts) {
     if (current && typeof current === "object" && !Array.isArray(current)) {
       current = (current as Record<string, unknown>)[part];
     } else {
-      return undefined;
+      dotPathValid = false;
+      break;
     }
   }
-  return current;
+  if (dotPathValid && current !== undefined) return { node: current, path };
+
+  // Fall back to a recursive search by the final path segment. Handles bare
+  // definition names that are nested (e.g. "EnvironmentV1").
+  const finalSegment = parts[parts.length - 1] ?? path;
+  const found = findDefinitionByName(resourceDefs, finalSegment);
+  if (found) return { node: found.node, path: found.path };
+
+  return undefined;
 }
 
 function getStaticSummary(schema: Record<string, unknown>, resourceType: string): Record<string, unknown> {
@@ -318,8 +379,8 @@ export function registerSchemaTool(
           return jsonResult(summary);
         }
 
-        const node = navigateStaticPath(schema, args.resource_type, args.path);
-        if (!node) {
+        const match = navigateStaticPath(schema, args.resource_type, args.path);
+        if (!match) {
           const definitions = schema.definitions as Record<string, Record<string, unknown>> | undefined;
           const available = definitions ? Object.keys(definitions[args.resource_type] ?? {}) : [];
           return errorResult(
@@ -328,10 +389,13 @@ export function registerSchemaTool(
           );
         }
 
-        const resolved = inlineRefs(schema, node);
+        const resolved = inlineRefs(schema, match.node);
         return jsonResult({
           resource_type: args.resource_type,
-          path: args.path,
+          // Resolved path may be a nested dotted path when a bare definition
+          // name was supplied (e.g. "EnvironmentV1").
+          path: match.path,
+          ...(match.path !== args.path ? { requested_path: args.path } : {}),
           source: "harness-schema",
           schema: resolved,
         });

--- a/src/tools/harness-schema.ts
+++ b/src/tools/harness-schema.ts
@@ -6,6 +6,7 @@ import { jsonResult, errorResult } from "../utils/response-formatter.js";
 import { SCHEMAS } from "../data/schemas/index.js";
 import type { SchemaEntry } from "../data/schemas/types.js";
 import { getExample, searchExamples, getExamplesForResource } from "../data/examples/index.js";
+import { createLogger } from "../utils/logger.js";
 import { schemaOutputSchema } from "./output-schemas.js";
 import {
   createLiveSchemaFetcher,
@@ -16,6 +17,8 @@ import {
   type HarnessYamlScope,
 } from "./entity-schema/live.js";
 import type { JsonObject } from "./entity-schema/normalize.js";
+
+const log = createLogger("schema");
 
 const scopeSchema = z
   .enum(["account", "org", "project"])
@@ -85,6 +88,10 @@ function isSchemaNode(value: unknown): boolean {
  * definitions tree. Harness schemas nest reusable definitions under group
  * keys (e.g. EnvironmentV1 lives at stages.unified.EnvironmentV1), so a bare
  * name lookup must walk the tree. Returns the node plus its dotted path.
+ *
+ * A schema-node match (the value looks like a definition, per isSchemaNode)
+ * wins. Failing that, the first key-name match of any shape is returned so a
+ * bare wrapper definition still resolves rather than reporting "not found".
  */
 function findDefinitionByName(
   root: Record<string, unknown>,
@@ -92,22 +99,36 @@ function findDefinitionByName(
   maxDepth = 8,
 ): { node: unknown; path: string } | undefined {
   const stack: Array<{ node: unknown; path: string[] }> = [{ node: root, path: [] }];
+  let fallback: { node: unknown; path: string } | undefined;
+  let truncated = false;
   while (stack.length > 0) {
     const entry = stack.pop();
     if (!entry) continue;
     const { node, path } = entry;
-    if (path.length > maxDepth) continue;
+    // Cap traversal depth as a guard against pathological/cyclic structures.
+    // Record truncation so a too-deep definition surfaces a signal rather
+    // than a silent miss — current bundled schemas nest only ~3 levels.
+    if (path.length > maxDepth) {
+      truncated = true;
+      continue;
+    }
     if (!node || typeof node !== "object" || Array.isArray(node)) continue;
     for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
-      if (key === name && isSchemaNode(value)) {
-        return { node: value, path: [...path, key].join(".") };
+      if (key === name) {
+        if (isSchemaNode(value)) {
+          return { node: value, path: [...path, key].join(".") };
+        }
+        if (!fallback) fallback = { node: value, path: [...path, key].join(".") };
       }
       if (value && typeof value === "object") {
         stack.push({ node: value, path: [...path, key] });
       }
     }
   }
-  return undefined;
+  if (!fallback && truncated) {
+    log.warn(`Schema search for '${name}' hit max depth ${maxDepth} without a match; a deeper definition may exist`);
+  }
+  return fallback;
 }
 
 /**

--- a/tests/tools/harness-schema-tool.test.ts
+++ b/tests/tools/harness-schema-tool.test.ts
@@ -150,6 +150,111 @@ describe("harness_schema static enum", () => {
   });
 });
 
+// A static schema whose reusable definition (EnvironmentV1) is nested under
+// group keys, mirroring how harness-schema nests pipeline_v1 definitions
+// (e.g. stages.unified.EnvironmentV1). Registered via additionalSchemas so the
+// nested-lookup contract is tested without coupling to bundled schema content.
+const NESTED_STATIC_SCHEMA = {
+  definitions: {
+    nested_demo: {
+      nested_demo: {
+        type: "object",
+        properties: { stages: { $ref: "#/definitions/nested_demo/stages" } },
+      },
+      stages: {
+        unified: {
+          EnvironmentV1: {
+            type: "object",
+            title: "EnvironmentV1",
+            properties: { ref: { type: "string" } },
+          },
+        },
+      },
+    },
+  },
+};
+
+describe("harness_schema nested static definition lookup", () => {
+  function makeServerWithNestedSchema() {
+    const server = makeMcpServer();
+    registerSchemaTool(server, undefined, undefined, {
+      nested_demo: {
+        schema: NESTED_STATIC_SCHEMA,
+        description: "Nested lookup test schema",
+        group: "test",
+      },
+    });
+    return server;
+  }
+
+  it("resolves a bare nested definition name and reports requested_path", async () => {
+    const server = makeServerWithNestedSchema();
+    const result = await server.call("harness_schema", {
+      resource_type: "nested_demo",
+      path: "EnvironmentV1",
+    });
+    const parsed = parseResult(result) as Record<string, unknown>;
+
+    expect(result.isError).toBeFalsy();
+    expect(parsed.path).toBe("stages.unified.EnvironmentV1");
+    expect(parsed.requested_path).toBe("EnvironmentV1");
+    expect((parsed.schema as Record<string, unknown>).title).toBe("EnvironmentV1");
+  });
+
+  it("resolves an explicit dot-path without setting requested_path", async () => {
+    const server = makeServerWithNestedSchema();
+    const result = await server.call("harness_schema", {
+      resource_type: "nested_demo",
+      path: "stages.unified.EnvironmentV1",
+    });
+    const parsed = parseResult(result) as Record<string, unknown>;
+
+    expect(result.isError).toBeFalsy();
+    expect(parsed.path).toBe("stages.unified.EnvironmentV1");
+    expect(parsed.requested_path).toBeUndefined();
+  });
+
+  it("resolves a direct top-level key without setting requested_path", async () => {
+    const server = makeServerWithNestedSchema();
+    const result = await server.call("harness_schema", {
+      resource_type: "nested_demo",
+      path: "stages",
+    });
+    const parsed = parseResult(result) as Record<string, unknown>;
+
+    expect(result.isError).toBeFalsy();
+    expect(parsed.path).toBe("stages");
+    expect(parsed.requested_path).toBeUndefined();
+  });
+
+  it("errors with available sections when no definition matches", async () => {
+    const server = makeServerWithNestedSchema();
+    const result = await server.call("harness_schema", {
+      resource_type: "nested_demo",
+      path: "DoesNotExist",
+    });
+    const parsed = parseResult(result) as { error: string };
+
+    expect(result.isError).toBe(true);
+    expect(parsed.error).toMatch(/not found/);
+    expect(parsed.error).toContain("nested_demo");
+  });
+
+  it("resolves a bundled pipeline_v1 nested definition by bare name", async () => {
+    const server = makeMcpServer();
+    registerSchemaTool(server, undefined, undefined);
+    const result = await server.call("harness_schema", {
+      resource_type: "pipeline_v1",
+      path: "EnvironmentV1",
+    });
+    const parsed = parseResult(result) as Record<string, unknown>;
+
+    expect(result.isError).toBeFalsy();
+    expect(parsed.path).toBe("stages.unified.EnvironmentV1");
+    expect(parsed.requested_path).toBe("EnvironmentV1");
+  });
+});
+
 describe("extractLiveSchema", () => {
   it("extracts schema from Harness data envelope", () => {
     const schema = { type: "object", properties: { x: { type: "string" } } };


### PR DESCRIPTION
harness_schema(resource_type, path) only resolved a definition by direct key or literal dot-path under definitions[resourceType]. Reusable definitions that are nested under group keys (e.g. EnvironmentV1 lives at stages.unified.EnvironmentV1 in pipeline_v1) could not be found by their bare name, returning a misleading "not found" error that listed only the top-level sections.

Add a recursive fallback that searches the resource's definitions tree by the final path segment when direct and dot-path lookups fail, and surface the resolved dotted path (plus requested_path when it differs) so agents learn the correct nested location. Resolution order is now: direct key -> literal dot-path -> recursive name search.

## Description
<!-- What does this PR do? -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] Tests pass
- [x] Typecheck passes
