### PR TITLE
feat: default KG queryable-type discovery to a configurable annotation cohort

### DIFF
--- a/src/registry/toolsets/knowledge-graph.ts
+++ b/src/registry/toolsets/knowledge-graph.ts
@@ -3,6 +3,15 @@ import type { ToolsetDefinition, FilterFieldSpec } from "../types.js";
 const QUERY_SVC =
   "/query-service/grpc/io.harness.platform.query.service.api.v1.QueryServiceGrpc";
 
+// Default annotation cohort applied to queryable-type discovery when the caller
+// supplies none. Empty (unset) preserves the prior behaviour of returning the
+// full unfiltered catalog; set KG_DEFAULT_ANNOTATIONS (comma-separated) per
+// deployment to scope discovery to a cohort.
+const DEFAULT_KG_ANNOTATIONS = (process.env.KG_DEFAULT_ANNOTATIONS ?? "")
+  .split(",")
+  .map((a) => a.trim())
+  .filter(Boolean);
+
 // ─── Response extractors ─────────────────────────────────────────────────────
 
 const MAX_DESC_LEN = 80;
@@ -122,7 +131,9 @@ function queryableTypesBody(input: Record<string, unknown>): Record<string, unkn
     filter.kinds = Array.isArray(kinds) ? kinds : [kinds];
   }
 
-  const annotations = input.annotations;
+  const annotations =
+    input.annotations ??
+    (DEFAULT_KG_ANNOTATIONS.length > 0 ? DEFAULT_KG_ANNOTATIONS : undefined);
   if (annotations) {
     filter.annotations = Array.isArray(annotations) ? annotations : [annotations];
   }

--- a/tests/registry/knowledge-graph.test.ts
+++ b/tests/registry/knowledge-graph.test.ts
@@ -220,6 +220,78 @@ describe("kg_queryable_type_summary list extractor", () => {
 });
 
 // ---------------------------------------------------------------------------
+// kg_queryable_type_summary — request-body filter construction
+// ---------------------------------------------------------------------------
+
+describe("kg_queryable_type_summary list body filter", () => {
+  // KG_DEFAULT_ANNOTATIONS is read at module load, so each env permutation
+  // re-imports the registry with a fresh module graph.
+  async function freshRegistry(): Promise<Registry> {
+    vi.resetModules();
+    const { Registry: FreshRegistry } = await import("../../src/registry/index.js");
+    return new FreshRegistry(makeConfig());
+  }
+
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("forwards caller-supplied annotations and kinds verbatim", async () => {
+    const registry = await freshRegistry();
+    const mockRequest = vi.fn().mockResolvedValue({ queryable_types: [] });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "kg_queryable_type_summary", "list", {
+      kinds: "OBJECT_KIND_VIEW",
+      annotations: ["custom_cohort"],
+    });
+
+    expect(mockRequest.mock.calls[0]![0].body).toEqual({
+      filter: { kinds: ["OBJECT_KIND_VIEW"], annotations: ["custom_cohort"] },
+    });
+  });
+
+  it("sends no filter when the caller supplies none and no default is set", async () => {
+    vi.stubEnv("KG_DEFAULT_ANNOTATIONS", "");
+    const registry = await freshRegistry();
+    const mockRequest = vi.fn().mockResolvedValue({ queryable_types: [] });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "kg_queryable_type_summary", "list", {});
+
+    expect(mockRequest.mock.calls[0]![0].body).toEqual({});
+  });
+
+  it("applies KG_DEFAULT_ANNOTATIONS when the caller supplies no annotations", async () => {
+    vi.stubEnv("KG_DEFAULT_ANNOTATIONS", "cohort_a");
+    const registry = await freshRegistry();
+    const mockRequest = vi.fn().mockResolvedValue({ queryable_types: [] });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "kg_queryable_type_summary", "list", {});
+
+    expect(mockRequest.mock.calls[0]![0].body).toEqual({
+      filter: { annotations: ["cohort_a"] },
+    });
+  });
+
+  it("lets caller-supplied annotations override the configured default", async () => {
+    vi.stubEnv("KG_DEFAULT_ANNOTATIONS", "cohort_a");
+    const registry = await freshRegistry();
+    const mockRequest = vi.fn().mockResolvedValue({ queryable_types: [] });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "kg_queryable_type_summary", "list", {
+      annotations: ["other"],
+    });
+
+    expect(mockRequest.mock.calls[0]![0].body).toEqual({
+      filter: { annotations: ["other"] },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // kg_type / kg_related_type — extractor behavior
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`kg_queryable_type_summary` discovery (`getQueryableTypes`) only filters by annotation when the caller passes `annotations` on the request. With no way to set a server-side default, scoping discovery to a curated cohort depends on every caller remembering to pass the right annotation — and agents often don't, so they discover the full unfiltered catalog.

This adds a `KG_DEFAULT_ANNOTATIONS` env var (comma-separated) that `queryableTypesBody` falls back to **only when the caller supplies no annotations**.

## Scope

- `src/registry/toolsets/knowledge-graph.ts` — `DEFAULT_KG_ANNOTATIONS` parsed from `process.env.KG_DEFAULT_ANNOTATIONS`; `queryableTypesBody` uses it as the fallback.
- `tests/registry/knowledge-graph.test.ts` — 4 cases covering the filter-body construction.

## Behavior

| caller `annotations` | `KG_DEFAULT_ANNOTATIONS` | filter sent |
|---|---|---|
| supplied | (any) | caller's values (unchanged) |
| none | unset / empty | no annotations filter (unchanged) |
| none | set | the configured default |

Backward-compatible: unset/empty preserves today's unfiltered behavior, and an explicit caller value always takes precedence over the default.

## Why this is safe

- Pure-data toolset change: logic stays inside `queryableTypesBody`; no new client/HTTP/stdout. Default is empty, so existing deployments behave identically until they opt in.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm exec vitest run tests/registry/knowledge-graph.test.ts` — 21/21 pass (4 new)

## Rollback

Revert the commit; with `KG_DEFAULT_ANNOTATIONS` unset there is no behavioral change to undo.