### PR TITLE
Review pass: align semantic search docs and enable local search in Docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,7 +74,9 @@ HARNESS_PIPELINE_VERSION=0
 # when HOME is set.
 HARNESS_MCP_LOG_FILE=
 
-# Semantic search (harness_search). Provider: none (disabled) or local (default).
+# Semantic search (harness_search). Provider: none (disabled, default) or local (opt-in).
+# Set to local to enable in-process ONNX embeddings (~23MB model). Requires optional
+# @huggingface/transformers. Docker images bake the model and default to local.
 # HARNESS_SEARCH_PROVIDER=local
 # HARNESS_SEARCH_SERVICE_URL=
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ COPY --from=build /app/build build/
 COPY --from=build /app/.cache/hf /app/.cache/hf
 
 ENV HARNESS_HF_CACHE_DIR=/app/.cache/hf
+# Model is pre-baked above — enable local semantic search in hosted HTTP deployments.
+ENV HARNESS_SEARCH_PROVIDER=local
 
 # Non-root user for security
 RUN addgroup -S mcp && adduser -S mcp -G mcp

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ When running in HTTP mode, the server exposes:
 | `/mcp`    | `GET`     | SSE stream for server-initiated messages (progress, elicitation) |
 | `/mcp`    | `DELETE`  | Terminate an active MCP session                                  |
 | `/mcp`    | `OPTIONS` | CORS preflight                                                   |
-| `/health` | `GET`     | Health check — returns `{ "status": "ok", "sessions": <count> }` |
+| `/health` | `GET`     | Health check — returns `{ "status": "ok"|"degraded", "sessions": <count>, "search": { "state": "disabled"|"initializing"|"ready"|"failed", ... } }`. HTTP 503 when `search.state === "failed"` (configured provider failed to initialize). |
 
 
 The HTTP transport runs in **session-based mode**. A new MCP session is created on `initialize`, the server returns an `mcp-session-id` header, and subsequent requests for that session must include the same header.
@@ -550,6 +550,9 @@ The server automatically loads environment variables from a `.env` file in the p
 | `HARNESS_SKIP_ELICITATION`  | No       | `false`                     | **Deprecated** — use `HARNESS_AUTO_APPROVE_RISK=all` instead. Kept for backward compatibility                                                                                                                                                         |
 | `HARNESS_ALLOW_HTTP`        | No       | `false`                     | Allow non-HTTPS `HARNESS_BASE_URL`. By default, the server enforces HTTPS for security. Set to `true` only for local development against a non-TLS Harness instance                                                                                   |
 | `HARNESS_PIPELINE_VERSION`  | No       | `0`                         | **(Alpha)** Pipeline YAML version. `0` loads the `pipeline` resource type and excludes `pipeline_v1`; `1` loads `pipeline_v1` and excludes `pipeline`. HTTP sessions can override this at initialize time with `x-harness-pipeline-version: 0` or `1` |
+| `HARNESS_SEARCH_PROVIDER`   | No       | `none`                      | Semantic search for `harness_search`. `none` disables in-process embeddings (default). `local` enables ONNX-based routing via optional `@huggingface/transformers`. Docker images pre-bake the model and default to `local`. In multi-user HTTP mode, `local` indexes static `mcp_resources` only — live account data requires a future `harness` provider. |
+| `HARNESS_HF_CACHE_DIR`      | No       | `/tmp/hf-cache`             | HuggingFace model cache directory for `HARNESS_SEARCH_PROVIDER=local`. Use a persistent volume in Kubernetes. Docker images bake the model into `/app/.cache/hf`. |
+| `HARNESS_SEARCH_SERVICE_URL`| No       | --                          | Reserved for a future hosted search-service provider (`HARNESS_SEARCH_PROVIDER=harness`). |
 | `HARNESS_MCP_ALLOWED_HOSTS` | No       | --                          | Comma-separated hostnames allowed by HTTP transport Host-header validation. `mcp.harness.io` is allowed by default for localhost binds; add proxy/custom domains here                                                                                 |
 | `HARNESS_MCP_AUTH_TOKEN`    | No       | --                          | Bearer token required on `/mcp` HTTP routes when set. Required by default when HTTP transport binds to a non-loopback host                                                                                                                             |
 | `HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP` | No | `false`         | Explicitly allow unauthenticated HTTP transport on non-loopback binds. Use only behind another authenticated control                                                                                                                                    |

--- a/plans/2026-06-26-semantic-search-provider.md
+++ b/plans/2026-06-26-semantic-search-provider.md
@@ -38,13 +38,13 @@ merge + tier-0 semantic results
 |------|------|
 | `src/search/types.ts` | `SearchProvider` interface, `IndexableItem`, `SearchResult`, `SearchCorpus`, TTL types |
 | `src/search/null-provider.ts` | No-op, `isAvailable()=false` — used when `HARNESS_SEARCH_PROVIDER=none` |
-| `src/search/local-provider.ts` | `@huggingface/transformers` v3, `Xenova/all-MiniLM-L6-v2` (384-dim), in-memory cosine similarity, TTL eviction |
+| `src/search/local-provider.ts` | `@huggingface/transformers` v4 (optional dep), `Xenova/all-MiniLM-L6-v2` (384-dim), in-memory cosine similarity, TTL eviction, cross-key LRU + global item ceiling |
 | `src/search/manager.ts` | Loads provider, runs `indexStaticContent` + `initializeIndex` on startup |
 | `src/search/index.ts` | Re-exports |
 | `src/tools/harness-search.ts` | Semantic routing gate — narrows targetTypes before scatter-gather |
-| `src/tools/harness-list.ts` | Fire-and-forget `provider.index()` after successful list |
-| `src/tools/harness-get.ts` | Fire-and-forget `provider.index()` after successful get |
-| `src/config.ts` | `HARNESS_SEARCH_PROVIDER` (default `"local"`), `HARNESS_SEARCH_SERVICE_URL` |
+| `src/tools/harness-list.ts` | Fire-and-forget `searchManager.indexItem()` after successful list (guarded by `canIndexCorpus`) |
+| `src/tools/harness-get.ts` | Fire-and-forget `searchManager.indexItem()` after successful get (guarded by `canIndexCorpus`) |
+| `src/config.ts` | `HARNESS_SEARCH_PROVIDER` (default `"none"`, opt-in `"local"`), `HARNESS_HF_CACHE_DIR`, `HARNESS_SEARCH_SERVICE_URL` |
 
 ### Static Content Indexed at Startup (`mcp_resources` corpus, permanent)
 
@@ -59,12 +59,14 @@ merge + tier-0 semantic results
 // extractRoutingTypes: only fires if semantic score ≥ 0.5
 // Uses resource_type from metadata — works for resource_definition and example entries
 // Schema entries intentionally excluded (comma-separated types won't match any single type)
+// applyRoutingSafetyFloor: always union tier-1 types (pipeline/service/environment/connector)
 // Falls back to full scatter-gather if no high-confidence predictions
+// canIndexCorpus: blocks resources corpus indexing in multi-user + local mode
 ```
 
 ### Key Design Decisions
 
-- **`@huggingface/transformers` v3** (not faiss-node / @xenova/transformers): pure JS, no native bindings, works on darwin arm64/Node 20 without cmake
+- **`@huggingface/transformers` v4** (optional dependency, not faiss-node / @xenova/transformers): pure JS, no native bindings, works on darwin arm64/Node 20 without cmake. Default provider is `none`; opt in to `local`.
 - **Semantic gates scatter-gather** (not concurrent): the whole point is avoiding API calls, not just appending results
 - **TTL system**: `resources` corpus = 30min, `mcp_resources`/`docs` = permanent (`ttlMs: 0`)
 - **Corpus isolation**: store key `${corpus}:${accountId ?? "global"}` — account data never crosses account boundary
@@ -291,7 +293,8 @@ Current routing threshold is 0.5 (conservative). Opportunities:
 
 | Env Var | Values | Default | Notes |
 |---------|--------|---------|-------|
-| `HARNESS_SEARCH_PROVIDER` | `"none"`, `"local"`, `"harness"` | `"local"` | `"none"` skips all semantic search |
-| `HARNESS_SEARCH_SERVICE_URL` | URL | — | Required when provider=`"harness"` |
+| `HARNESS_SEARCH_PROVIDER` | `"none"`, `"local"`, `"harness"` | `"none"` | Opt in to `"local"` for in-process embeddings. Docker image sets `"local"` (model pre-baked). |
+| `HARNESS_HF_CACHE_DIR` | path | `/tmp/hf-cache` | HuggingFace model cache. Use a persistent volume in Kubernetes. Docker image uses `/app/.cache/hf`. |
+| `HARNESS_SEARCH_SERVICE_URL` | URL | — | Required when provider=`"harness"` (future) |
 
-Model cache: `/tmp/hf-cache/Xenova/all-MiniLM-L6-v2/` (~23MB, downloaded once)
+Model: `Xenova/all-MiniLM-L6-v2` (~23MB). Downloaded on first use when not pre-baked; Docker build runs `scripts/preload-hf-model.mjs`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Architecture review pass on #451 addressing remaining documentation gaps and hosted-deployment defaults from @skjindal93's review thread.

## Changes

- **`.env.example`**: Fix contradictory comment — default is `none`, `local` is opt-in
- **`README.md`**: Document `HARNESS_SEARCH_PROVIDER`, `HARNESS_HF_CACHE_DIR`, `HARNESS_SEARCH_SERVICE_URL`; update `/health` response shape (search readiness + 503 on init failure)
- **`plans/2026-06-26-semantic-search-provider.md`**: Correct stale defaults (`none` not `local`), transformers v4, safety floor / `canIndexCorpus`, cache dir config
- **`Dockerfile`**: Set `HARNESS_SEARCH_PROVIDER=local` in production image where the ONNX model is pre-baked (hosted mode per Slack discussion)

## Review checklist (Suni / @skjindal93 blocking items)

| Item | Status in #451 base | This PR |
|------|---------------------|---------|
| Default provider `none` (opt-in local) | ✅ | Docs aligned |
| Configurable `HARNESS_HF_CACHE_DIR` + Docker bake | ✅ | Docker now enables local |
| Search init failure via `/health` 503 | ✅ | README documented |
| `canIndexCorpus()` multi-user guard | ✅ | — |
| Cross-key LRU + global item ceiling | ✅ | — |
| Skip re-embed on unchanged content | ✅ | — |
| Routing safety floor (tier-1 types) | ✅ | — |
| `extractRoutingTypes` / routing unit tests | ✅ | — |
| Tags flattening for embeddings | ✅ | — |

## Verification

- `pnpm build` ✅
- `pnpm test` ✅ (2365 tests)
- `pnpm docs:check` ✅

Stack on #451 — merge into `mcp_search` before landing #451 to `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://harness.slack.com/archives/C08SYT1FWJD/p1782500008908659?thread_ts=1782500008.908659&cid=C08SYT1FWJD)

<div><a href="https://cursor.com/agents/bc-ef1dbe25-7da7-5ca0-bb72-f754b65ada04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef1dbe25-7da7-5ca0-bb72-f754b65ada04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

