### PR TITLE
Fix semantic search cache bounds

### DIFF
--- a/src/search/local-provider.ts
+++ b/src/search/local-provider.ts
@@ -7,19 +7,19 @@ const DEFAULT_HF_CACHE_DIR = "/tmp/hf-cache";
 const EMBEDDING_MODEL = "Xenova/all-MiniLM-L6-v2";
 const EMBEDDING_DIM = 384;
 const CORPORA: SearchCorpus[] = ["entities", "docs", "knowledge"];
-/** Per-key cap for TTL-backed or resources corpus items. */
+/** Per-key cap for TTL-backed or live entity corpus items. */
 const MAX_ITEMS_PER_KEY = 5000;
-/** Max distinct resources:<account> buckets — cross-key LRU evicts the stalest account. */
+/** Max distinct entities:<account> buckets — cross-key LRU evicts the stalest account. */
 const MAX_RESOURCE_ACCOUNT_KEYS = 32;
 /** Global item ceiling across all store keys (safety net for long-lived multi-user processes). */
 const MAX_TOTAL_ITEMS = 20_000;
 
-/** True for per-account resources buckets (not the static global corpora keys). */
+/** True for per-account live entity buckets (not the static global corpora keys). */
 export function isResourceAccountKey(key: string): boolean {
-  return key.startsWith("resources:") && !key.endsWith(":global");
+  return key.startsWith("entities:") && !key.endsWith(":global");
 }
 
-/** resources corpus is always capped; other corpora only cap TTL-backed items. */
+/** entities corpus is always capped; other corpora only cap TTL-backed items. */
 export function needsPerKeyCap(corpus: SearchCorpus, expiresAt: number | undefined): boolean {
   return corpus === "entities" || expiresAt !== undefined;
 }

--- a/src/tools/harness-get.ts
+++ b/src/tools/harness-get.ts
@@ -114,18 +114,21 @@ export function registerGetTool(server: McpServer, registry: Registry, client: H
         // Fire-and-forget: index item for semantic search (skipped in multi-user + local)
         if (searchManager && result && typeof result === "object") {
           const item = result as Record<string, unknown>;
+          const identifier = asString(item["identifier"]) ?? asString(item["id"]);
           const accountId = client.account;
-          void searchManager.indexItem({
-            id: `${resourceType}:${String(item["identifier"] ?? item["id"] ?? "")}`,
-            content: buildResourceIndexContent(resourceType, item),
-            corpus: "entities",
-            accountId,
-            metadata: {
-              resource_type: resourceType,
-              identifier: String(item["identifier"] ?? item["id"] ?? ""),
-              name: String(item["name"] ?? ""),
-            },
-          }).catch(() => { /* never surface indexing errors */ });
+          if (identifier) {
+            void searchManager.indexItem({
+              id: `${resourceType}:${identifier}`,
+              content: buildResourceIndexContent(resourceType, item),
+              corpus: "entities",
+              accountId,
+              metadata: {
+                resource_type: resourceType,
+                identifier,
+                name: String(item["name"] ?? ""),
+              },
+            }).catch(() => { /* never surface indexing errors */ });
+          }
         }
 
         return jsonResult(result);

--- a/src/tools/harness-list.ts
+++ b/src/tools/harness-list.ts
@@ -107,19 +107,21 @@ export function registerListTool(server: McpServer, registry: Registry, client: 
         if (searchManager && isRecord(result) && Array.isArray(result.items)) {
           const accountId = client.account;
           void Promise.all(
-            (result.items as Array<Record<string, unknown>>).map(item =>
-              searchManager.indexItem({
-                id: `${resourceType}:${String(item["identifier"] ?? item["id"] ?? "")}`,
+            (result.items as Array<Record<string, unknown>>).map(item => {
+              const identifier = asString(item["identifier"]) ?? asString(item["id"]);
+              if (!identifier) return Promise.resolve();
+              return searchManager.indexItem({
+                id: `${resourceType}:${identifier}`,
                 content: buildResourceIndexContent(resourceType, item),
                 corpus: "entities",
                 accountId,
                 metadata: {
                   resource_type: resourceType,
-                  identifier: String(item["identifier"] ?? item["id"] ?? ""),
+                  identifier,
                   name: String(item["name"] ?? ""),
                 },
-              })
-            )
+              });
+            })
           ).catch(() => { /* never surface indexing errors to caller */ });
         }
 

--- a/src/tools/harness-search.ts
+++ b/src/tools/harness-search.ts
@@ -246,12 +246,14 @@ export function registerSearchTool(server: McpServer, registry: Registry, client
           entries.flatMap(e => (e.items as Array<Record<string, unknown>>).map(i => String(i["identifier"] ?? i["id"] ?? "")))
         );
         const seenSemanticIds = new Set<string>();
+        let semanticMatchCount = 0;
         for (const sr of semanticResults) {
           if (sr.score < SEMANTIC_DISPLAY_THRESHOLD) continue;
           const dedupeId = sr.metadata["identifier"] || sr.id;
           if (seenSemanticIds.has(dedupeId)) continue;
           seenSemanticIds.add(dedupeId);
           if (sr.metadata["identifier"] && keywordIds.has(sr.metadata["identifier"])) continue;
+          semanticMatchCount++;
           entries.push({
             resource_type: sr.metadata["resource_type"] ?? sr.corpus,
             tier: 0,
@@ -271,7 +273,7 @@ export function registerSearchTool(server: McpServer, registry: Registry, client
           : [];
         return jsonResult({
           query: args.query,
-          total_matches: totalMatches,
+          total_matches: totalMatches + semanticMatchCount,
           searched_types: targetTypes.length,
           ...(semanticRouted ? { semantic_routed: true, types_skipped: skippedTypes } : {}),
           results: entries,

--- a/tests/search/local-provider-memory.test.ts
+++ b/tests/search/local-provider-memory.test.ts
@@ -9,13 +9,14 @@ import {
 } from "../../src/search/local-provider.js";
 
 describe("local-provider memory bounds", () => {
-  it("identifies per-account resources keys", () => {
-    expect(isResourceAccountKey("resources:acc1")).toBe(true);
-    expect(isResourceAccountKey("resources:global")).toBe(false);
-    expect(isResourceAccountKey("mcp_resources:global")).toBe(false);
+  it("identifies per-account entity keys", () => {
+    expect(isResourceAccountKey("entities:acc1")).toBe(true);
+    expect(isResourceAccountKey("entities:global")).toBe(false);
+    expect(isResourceAccountKey("knowledge:global")).toBe(false);
+    expect(isResourceAccountKey("resources:acc1")).toBe(false);
   });
 
-  it("caps resources corpus items even when permanent", () => {
+  it("caps entities corpus items even when permanent", () => {
     expect(needsPerKeyCap("entities", undefined)).toBe(true);
     expect(needsPerKeyCap("knowledge", undefined)).toBe(false);
     expect(needsPerKeyCap("docs", Date.now() + 60_000)).toBe(true);
@@ -23,10 +24,10 @@ describe("local-provider memory bounds", () => {
 
   it("counts resource account keys excluding global", () => {
     const store = new Map<string, unknown[]>([
-      ["resources:acc1", []],
-      ["resources:acc2", []],
-      ["resources:global", []],
-      ["mcp_resources:global", [{}]],
+      ["entities:acc1", []],
+      ["entities:acc2", []],
+      ["entities:global", []],
+      ["knowledge:global", [{}]],
     ]);
     expect(countResourceAccountKeys(store)).toBe(2);
   });
@@ -41,15 +42,15 @@ describe("local-provider memory bounds", () => {
 
   it("finds LRU key among resource account buckets", () => {
     const store = new Map<string, unknown[]>([
-      ["resources:old", []],
-      ["resources:new", []],
-      ["mcp_resources:global", []],
+      ["entities:old", []],
+      ["entities:new", []],
+      ["knowledge:global", []],
     ]);
     const accessed = new Map([
-      ["resources:old", 100],
-      ["resources:new", 500],
+      ["entities:old", 100],
+      ["entities:new", 500],
     ]);
-    expect(findLruKey(store, accessed, isResourceAccountKey)).toBe("resources:old");
+    expect(findLruKey(store, accessed, isResourceAccountKey)).toBe("entities:old");
   });
 
   it("finds soonest-to-expire item index", () => {

--- a/tests/tools/harness-search-routing.test.ts
+++ b/tests/tools/harness-search-routing.test.ts
@@ -87,6 +87,14 @@ function makeSearchManager(results: SearchResult[]): SearchManager {
   return { getProvider: () => provider } as SearchManager;
 }
 
+function makeIndexingSearchManager() {
+  const indexItem = vi.fn().mockResolvedValue(undefined);
+  return {
+    searchManager: { indexItem } as unknown as SearchManager,
+    indexItem,
+  };
+}
+
 function parseResult(result: ToolResult): unknown {
   return JSON.parse(result.content[0]!.text);
 }
@@ -261,12 +269,14 @@ describe("harness_search tier-0 semantic merge/dedup", () => {
 
     const result = await server.call("harness_search", { query: "pipeline yaml" });
     const data = parseResult(result) as {
+      total_matches: number;
       results: Array<{ tier: number; resource_type: string; items: unknown[] }>;
     };
 
     const tier0 = data.results.filter((entry) => entry.tier === 0);
     expect(tier0).toHaveLength(1);
     expect(tier0[0]!.resource_type).toBe("pipeline");
+    expect(data.total_matches).toBe(1);
   });
 
   it("deduplicates semantic hits by identifier", async () => {
@@ -321,5 +331,52 @@ describe("harness_search tier-0 semantic merge/dedup", () => {
       .filter((entry) => entry.tier !== 0)
       .flatMap((entry) => entry.items) as Array<Record<string, unknown>>;
     expect(keywordItems.some((item) => item.identifier === "existing-pipe")).toBe(true);
+  });
+});
+
+describe("live resource indexing guards", () => {
+  it("skips harness_list semantic indexing for items without a stable identifier", async () => {
+    const server = makeMcpServer();
+    const dispatch = vi.fn().mockResolvedValue({
+      items: [
+        { name: "No Id" },
+        { identifier: "stable-id", name: "Stable" },
+      ],
+      total: 2,
+    });
+    const registry = {
+      getAllFilterFields: () => [],
+      getTypesForOperation: () => ["pipeline"],
+      getResource: () => ({}),
+      dispatch,
+    } as unknown as Registry;
+    const { searchManager, indexItem } = makeIndexingSearchManager();
+    const { registerListTool } = await import("../../src/tools/harness-list.js");
+    registerListTool(server, registry, makeClient(), searchManager);
+
+    await server.call("harness_list", { resource_type: "pipeline" });
+
+    expect(indexItem).toHaveBeenCalledOnce();
+    expect(indexItem).toHaveBeenCalledWith(expect.objectContaining({
+      id: "pipeline:stable-id",
+      metadata: expect.objectContaining({ identifier: "stable-id" }),
+    }));
+  });
+
+  it("skips harness_get semantic indexing when the response has no stable identifier", async () => {
+    const server = makeMcpServer();
+    const dispatch = vi.fn().mockResolvedValue({ name: "No Id" });
+    const registry = {
+      getTypesForOperation: () => ["pipeline"],
+      getResource: () => ({ identifierFields: ["identifier"] }),
+      dispatch,
+    } as unknown as Registry;
+    const { searchManager, indexItem } = makeIndexingSearchManager();
+    const { registerGetTool } = await import("../../src/tools/harness-get.js");
+    registerGetTool(server, registry, makeClient(), searchManager);
+
+    await server.call("harness_get", { resource_type: "pipeline", resource_id: "requested-id" });
+
+    expect(indexItem).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Fix live entity cache bucket detection so local semantic search eviction tracks the actual `entities:<account>` keys.
- Keep `harness_search.total_matches` consistent when tier-0 semantic hits are returned.
- Skip semantic indexing for list/get responses that do not expose a stable identifier.

## Test plan
- `pnpm vitest run tests/search/local-provider-memory.test.ts tests/tools/harness-search-routing.test.ts`
- `pnpm typecheck`
- `pnpm build && pnpm docs:generate && pnpm test`

Made with [Cursor](https://cursor.com)