### PR TITLE
Add search routing benchmark baseline

### DIFF
--- a/docs/search-guidelines.md
+++ b/docs/search-guidelines.md
@@ -60,13 +60,47 @@ Examples are the second routing signal. Add at least one example for new resourc
 
 ### 3. Test routing locally
 
-After adding your resource, run the smoke test to verify routing fires:
+After adding your resource, run the credential-free routing benchmark:
+
+```bash
+pnpm build
+pnpm search:benchmark
+```
+
+The benchmark uses `tests/fixtures/search-routing-golden.json` and the static
+`knowledge` corpus only. It does not call Harness APIs or require
+`HARNESS_API_KEY`. For machine-readable output:
+
+```bash
+pnpm search:benchmark -- --json
+```
+
+To make the benchmark fail when any golden case misses an expected type:
+
+```bash
+pnpm search:benchmark -- --fail-on-miss
+```
+
+To compare a candidate embedding model without editing source:
+
+```bash
+pnpm build
+pnpm search:benchmark -- --model=Xenova/bge-small-en-v1.5
+pnpm search:benchmark -- --model=Xenova/e5-small-v2
+```
+
+For live end-to-end smoke coverage against a real account, run:
 
 ```bash
 HARNESS_API_KEY=<pat> HARNESS_ACCOUNT_ID=<id> node scripts/smoke-test-search.mjs
 ```
 
-Or test a specific query manually via the MCP inspector — look for `semantic_routed: true` and `types_skipped > 0` in the response.
+The live smoke test verifies MCP wiring, API calls, and account behavior. Use
+the benchmark for model/threshold comparisons; use the smoke test for runtime
+integration confidence.
+
+Or test a specific query manually via the MCP inspector — look for
+`semantic_routed: true` and `types_skipped > 0` in the response.
 
 To test routing in isolation (no live API needed):
 
@@ -95,6 +129,108 @@ const routed = extractRoutingTypes(mockResults, ["secret", "connector", "pipelin
 | `SEMANTIC_DISPLAY_THRESHOLD` | 0.35 | Minimum score to show a hit as a tier-0 result (display only) |
 
 If your resource type isn't routing but you think it should, check the actual score by calling `provider.search()` directly and logging scores. Usually the fix is richer content, not a lower threshold.
+
+## Golden Routing Benchmark
+
+The golden set in `tests/fixtures/search-routing-golden.json` is the baseline
+for search-model and threshold decisions. Each case contains:
+
+| Field | Meaning |
+|-------|---------|
+| `query` | User-like search phrase |
+| `mode` | `specific`, `cross_domain`, or `ambiguous` |
+| `expectedTypes` | Resource types that must be searched when routing narrows |
+| `acceptableTypes` | Extra routed types that are reasonable but not required |
+| `description` | Why the label exists |
+
+The benchmark reports:
+
+| Metric | Use |
+|--------|-----|
+| Expected-type recall | Whether expected resource types remain in the target set |
+| False negatives | Count of expected types missed by semantic routing |
+| Average searched types | Scatter-gather reduction versus the full candidate set |
+| Average latency | Per-query embedding search latency |
+| Init + static index time | Startup cost for the local model and static corpus |
+| RSS delta | Approximate memory added by model loading and indexing |
+
+### Model Comparison Workflow
+
+When evaluating a new local embedding model:
+
+1. Run the baseline model first:
+
+   ```bash
+   pnpm build
+   pnpm search:benchmark -- --json --model=Xenova/all-MiniLM-L6-v2
+   ```
+
+2. Run candidate models with the same fixture and threshold:
+
+   ```bash
+   pnpm search:benchmark -- --json --model=Xenova/bge-small-en-v1.5
+   pnpm search:benchmark -- --json --model=Xenova/e5-small-v2
+   pnpm search:benchmark -- --json --model=Xenova/all-MiniLM-L12-v2
+   ```
+
+3. Compare `summary.expectedTypeRecall`, `summary.falseNegativeCount`,
+   `summary.averageSearchedTypes`, `summary.averageLatencyMs`, `initMs`, and
+   `rssDeltaMb`.
+
+4. Inspect failed cases before choosing a model. A lower
+   `averageSearchedTypes` is only useful if the model does not skip important
+   resource types.
+
+5. If changing the default model, update both `DEFAULT_EMBEDDING_MODEL` in
+   `src/search/local-provider.ts` and the Docker preload model in
+   `scripts/preload-hf-model.mjs`, then rerun the benchmark and Docker build.
+
+Initial comparison captured on 2026-06-26 with the 40-case golden set:
+
+| Model | Pass | Recall | False negatives | Avg searched | Avg latency |
+|-------|------|--------|-----------------|--------------|-------------|
+| `Xenova/all-MiniLM-L6-v2` | 36/40 | 91.1% | 4 | 66.83/168 | 3.07 ms |
+| `Xenova/bge-small-en-v1.5` | 38/40 | 95.6% | 2 | 18.57/168 | 21.87 ms |
+| `Xenova/e5-small-v2` | 37/40 | 93.3% | 3 | 16.70/168 | 15.54 ms |
+| `Xenova/all-MiniLM-L12-v2` | 37/40 | 93.3% | 3 | 58.60/168 | 4.77 ms |
+
+On that run, `Xenova/bge-small-en-v1.5` was the strongest candidate by recall
+and scatter-gather reduction, but it still had long-tail misses. Treat this as
+directional, not a permanent benchmark result; rerun after changing the golden
+set, indexed content, thresholds, model package, Node version, or runtime host.
+
+When updating the golden set:
+
+1. Use only resource types that support `list`; `harness_search` cannot
+   scatter-gather get-only resources.
+2. Prefer user phrases over internal API names.
+3. Include obvious, cross-domain, and ambiguous queries.
+4. Add synonyms to registry descriptions or examples before lowering
+   thresholds.
+
+## Model / Threshold Upgrade Criteria
+
+Run `pnpm build && pnpm search:benchmark` before changing:
+
+- `EMBEDDING_MODEL` in `src/search/local-provider.ts`
+- `SEMANTIC_ROUTING_THRESHOLD` or `SEMANTIC_DISPLAY_THRESHOLD` in
+  `src/tools/harness-search.ts`
+- Static corpus construction in `src/search/manager.ts`
+- Resource descriptions or examples that affect routing
+
+Upgrade only when the candidate model or threshold:
+
+1. Has zero critical false negatives for `specific` and `cross_domain` cases.
+2. Improves or preserves expected-type recall versus the current MiniLM
+   baseline.
+3. Preserves useful scatter-gather reduction (`averageSearchedTypes` should not
+   jump without a recall gain).
+4. Keeps startup time, query latency, and RSS delta acceptable for local MCP
+   usage.
+5. Still works with Docker model preloading via `scripts/preload-hf-model.mjs`.
+
+Do not compare raw cosine scores across models. Re-run the benchmark and retune
+thresholds because each embedding model has its own score distribution.
 
 ## Safety Floor
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "sync-schemas": "node scripts/sync-schemas.js",
     "sync-entity-schemas": "node scripts/sync-entity-schemas.js",
     "check-schema-coverage": "node scripts/check-schema-coverage.js",
+    "search:benchmark": "node scripts/benchmark-search-routing.mjs",
     "docs:generate": "node scripts/generate-docs.js",
     "docs:check": "node scripts/generate-docs.js --check",
     "standards:check": "vitest run tests/coding-standards tests/registry/structural-validation.test.ts",

--- a/scripts/benchmark-search-routing.mjs
+++ b/scripts/benchmark-search-routing.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+
+/**
+ * Credential-free semantic routing benchmark.
+ *
+ * Usage:
+ *   pnpm build
+ *   node scripts/benchmark-search-routing.mjs
+ *   node scripts/benchmark-search-routing.mjs --json
+ *   node scripts/benchmark-search-routing.mjs --fail-on-miss
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { performance } from "node:perf_hooks";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..");
+const BUILD = join(ROOT, "build");
+const GOLDEN_PATH = join(ROOT, "tests", "fixtures", "search-routing-golden.json");
+
+function parseArgs(argv) {
+  const options = {
+    json: false,
+    failOnMiss: false,
+    k: 30,
+    model: process.env.HARNESS_SEARCH_MODEL ?? "Xenova/all-MiniLM-L6-v2",
+  };
+  for (const arg of argv) {
+    if (arg === "--") {
+      continue;
+    } else if (arg === "--json") {
+      options.json = true;
+    } else if (arg === "--fail-on-miss") {
+      options.failOnMiss = true;
+    } else if (arg.startsWith("--k=")) {
+      const value = Number(arg.slice("--k=".length));
+      if (!Number.isInteger(value) || value <= 0) {
+        throw new Error(`Invalid --k value: ${arg}`);
+      }
+      options.k = value;
+    } else if (arg.startsWith("--model=")) {
+      const value = arg.slice("--model=".length).trim();
+      if (!value) {
+        throw new Error(`Invalid --model value: ${arg}`);
+      }
+      options.model = value;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return options;
+}
+
+function printHelp() {
+  console.log(`Search routing benchmark
+
+Usage:
+  pnpm build
+  node scripts/benchmark-search-routing.mjs [--json] [--fail-on-miss] [--k=30] [--model=Xenova/all-MiniLM-L6-v2]
+
+Options:
+  --json          Print machine-readable JSON instead of a text report
+  --fail-on-miss  Exit non-zero when any golden case misses an expected type
+  --k=N           Number of semantic hits to inspect per query (default 30)
+  --model=MODEL   HuggingFace/Transformers.js feature-extraction model to test
+`);
+}
+
+function makeBenchmarkConfig() {
+  return {
+    HARNESS_MCP_MODE: "single-user",
+    HARNESS_API_KEY: "pat.search.benchmark.secret",
+    HARNESS_ACCOUNT_ID: "search",
+    HARNESS_BASE_URL: "https://app.harness.io",
+    HARNESS_ORG: "default",
+    HARNESS_PROJECT: "benchmark",
+    HARNESS_API_TIMEOUT_MS: 30000,
+    HARNESS_MAX_RETRIES: 3,
+    LOG_LEVEL: process.env.LOG_LEVEL ?? "error",
+    HARNESS_SEARCH_PROVIDER: "local",
+    HARNESS_HF_CACHE_DIR: process.env.HARNESS_HF_CACHE_DIR ?? "/tmp/hf-cache",
+  };
+}
+
+function formatPercent(value) {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatNumber(value) {
+  return Number.isInteger(value) ? String(value) : value.toFixed(2);
+}
+
+function summarizeCase(result) {
+  const status = result.passed ? "PASS" : "MISS";
+  const routed = result.semanticRouted ? result.routedTypes.join(",") : "fallback";
+  const missing = result.missingExpectedTypes.length > 0
+    ? ` missing=${result.missingExpectedTypes.join(",")}`
+    : "";
+  return `${status} ${result.id}: searched=${result.searchedTypes}/${result.candidateTypes} top=${result.topScore.toFixed(3)} routed=${routed}${missing}`;
+}
+
+async function loadBuildModules() {
+  try {
+    const [
+      { Registry, ALL_TOOLSET_NAMES },
+      { SearchManager },
+      { extractRoutingTypes, applyRoutingSafetyFloor },
+      { evaluateRouting, validateGoldenCases },
+      { setLogLevel },
+    ] = await Promise.all([
+      import(join(BUILD, "registry", "index.js")),
+      import(join(BUILD, "search", "manager.js")),
+      import(join(BUILD, "tools", "harness-search.js")),
+      import(join(BUILD, "search", "routing-eval.js")),
+      import(join(BUILD, "utils", "logger.js")),
+    ]);
+    setLogLevel(process.env.LOG_LEVEL ?? "error");
+    return {
+      Registry,
+      ALL_TOOLSET_NAMES,
+      SearchManager,
+      extractRoutingTypes,
+      applyRoutingSafetyFloor,
+      evaluateRouting,
+      validateGoldenCases,
+    };
+  } catch (err) {
+    throw new Error(`Failed to load build artifacts. Run "pnpm build" first. ${err.message}`);
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  process.env.HARNESS_SEARCH_MODEL = options.model;
+  const {
+    Registry,
+    ALL_TOOLSET_NAMES,
+    SearchManager,
+    extractRoutingTypes,
+    applyRoutingSafetyFloor,
+    evaluateRouting,
+    validateGoldenCases,
+  } = await loadBuildModules();
+
+  const config = makeBenchmarkConfig();
+  const defaultRegistry = new Registry(config);
+  const defaultToolsets = new Set(defaultRegistry.getAllToolsets().map((toolset) => toolset.name));
+  const additiveToolsets = ALL_TOOLSET_NAMES
+    .filter((name) => !defaultToolsets.has(name))
+    .map((name) => `+${name}`)
+    .join(",");
+  const registry = additiveToolsets
+    ? new Registry({ ...config, HARNESS_TOOLSETS: additiveToolsets })
+    : defaultRegistry;
+  const candidateTypes = registry.getTypesForOperation("list");
+  const cases = JSON.parse(readFileSync(GOLDEN_PATH, "utf8"));
+  const validationErrors = validateGoldenCases(cases, candidateTypes);
+  if (validationErrors.length > 0) {
+    console.error("Invalid search routing golden set:");
+    for (const error of validationErrors) console.error(`- ${error}`);
+    process.exit(1);
+  }
+
+  const manager = new SearchManager(config);
+  const rssBefore = process.memoryUsage().rss;
+  const initStart = performance.now();
+  await manager.initialize();
+  if (!manager.getProvider().isAvailable()) {
+    console.error("Local search provider is unavailable. Check @huggingface/transformers and model cache access.");
+    process.exit(1);
+  }
+  await manager.indexStaticContent(registry);
+  const initMs = performance.now() - initStart;
+  const rssAfterIndex = process.memoryUsage().rss;
+  const provider = manager.getProvider();
+
+  const observations = [];
+  for (const testCase of cases) {
+    const started = performance.now();
+    const semanticResults = await provider.search(testCase.query, {
+      corpus: "knowledge",
+      k: options.k,
+    });
+    const latencyMs = performance.now() - started;
+    const predictedTypes = extractRoutingTypes(semanticResults, candidateTypes);
+    const semanticRouted = predictedTypes !== null;
+    const routedTypes = semanticRouted
+      ? applyRoutingSafetyFloor(predictedTypes, candidateTypes)
+      : candidateTypes;
+
+    observations.push({
+      id: testCase.id,
+      query: testCase.query,
+      mode: testCase.mode,
+      expectedTypes: testCase.expectedTypes,
+      acceptableTypes: testCase.acceptableTypes ?? [],
+      routedTypes,
+      semanticRouted,
+      searchedTypes: routedTypes.length,
+      candidateTypes: candidateTypes.length,
+      topScore: semanticResults[0]?.score ?? 0,
+      latencyMs,
+    });
+  }
+
+  const evaluation = evaluateRouting(observations);
+  const output = {
+    model: options.model,
+    provider: manager.getProvider().constructor.name,
+    fixture: "tests/fixtures/search-routing-golden.json",
+    candidateTypes: candidateTypes.length,
+    initMs,
+    rssDeltaMb: (rssAfterIndex - rssBefore) / 1024 / 1024,
+    ...evaluation,
+  };
+
+  if (options.json) {
+    console.log(JSON.stringify(output, null, 2));
+  } else {
+    console.log("Search routing benchmark");
+    console.log(`Model: ${output.model}`);
+    console.log(`Cases: ${evaluation.summary.totalCases}`);
+    console.log(`Pass: ${evaluation.summary.passedCases}, Miss: ${evaluation.summary.failedCases}`);
+    console.log(`Expected-type recall: ${formatPercent(evaluation.summary.expectedTypeRecall)}`);
+    console.log(`False negatives: ${evaluation.summary.falseNegativeCount}`);
+    console.log(`Avg searched types: ${formatNumber(evaluation.summary.averageSearchedTypes)} / ${candidateTypes.length}`);
+    console.log(`Avg latency: ${formatNumber(evaluation.summary.averageLatencyMs)} ms`);
+    console.log(`Init + static index: ${formatNumber(initMs)} ms`);
+    console.log(`RSS delta: ${formatNumber(output.rssDeltaMb)} MB`);
+    console.log("");
+    for (const result of evaluation.cases) {
+      console.log(summarizeCase(result));
+    }
+  }
+
+  if (options.failOnMiss && evaluation.summary.failedCases > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -7,6 +7,19 @@ export type {
   IndexableItem,
   SearchCorpus,
 } from "./types.js";
+export type {
+  SearchRoutingGoldenCase,
+  SearchRoutingObservation,
+  SearchRoutingCaseResult,
+  SearchRoutingSummary,
+  SearchRoutingEvaluation,
+} from "./routing-eval.js";
 export { NullSearchProvider } from "./null-provider.js";
 export { LocalSearchProvider } from "./local-provider.js";
 export { SearchManager } from "./manager.js";
+export {
+  validateGoldenCases,
+  evaluateRoutingCase,
+  summarizeRoutingEvaluation,
+  evaluateRouting,
+} from "./routing-eval.js";

--- a/src/search/local-provider.ts
+++ b/src/search/local-provider.ts
@@ -4,7 +4,7 @@ import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("local-provider");
 const DEFAULT_HF_CACHE_DIR = "/tmp/hf-cache";
-const EMBEDDING_MODEL = "Xenova/all-MiniLM-L6-v2";
+export const DEFAULT_EMBEDDING_MODEL = "Xenova/all-MiniLM-L6-v2";
 const EMBEDDING_DIM = 384;
 const CORPORA: SearchCorpus[] = ["entities", "docs", "knowledge"];
 /** Per-key cap for TTL-backed or live entity corpus items. */
@@ -101,6 +101,7 @@ function resolveExpiresAt(item: IndexableItem, now: number): number | undefined 
 
 export interface LocalSearchProviderOptions {
   cacheDir?: string;
+  model?: string;
 }
 
 export class LocalSearchProvider implements SearchProvider {
@@ -108,6 +109,7 @@ export class LocalSearchProvider implements SearchProvider {
   private initError: string | undefined;
   private embed: EmbedFn | null = null;
   private readonly cacheDir: string;
+  private readonly model: string;
   // key: `${corpus}:${accountId ?? "global"}`
   private store = new Map<string, StoredItem[]>();
   private keyLastAccessed = new Map<string, number>();
@@ -115,13 +117,14 @@ export class LocalSearchProvider implements SearchProvider {
 
   constructor(options: LocalSearchProviderOptions = {}) {
     this.cacheDir = options.cacheDir ?? DEFAULT_HF_CACHE_DIR;
+    this.model = options.model ?? DEFAULT_EMBEDDING_MODEL;
   }
 
   async initialize(): Promise<void> {
     try {
       const { pipeline, env } = await import("@huggingface/transformers");
       env.cacheDir = this.cacheDir;
-      const extractor = await pipeline("feature-extraction", EMBEDDING_MODEL, { dtype: "fp32" });
+      const extractor = await pipeline("feature-extraction", this.model, { dtype: "fp32" });
       this.embed = async (text: string): Promise<Float32Array> => {
         const out = await extractor(text, { pooling: "mean", normalize: true });
         const raw = out.data;
@@ -130,7 +133,8 @@ export class LocalSearchProvider implements SearchProvider {
       this.available = true;
       // Run eviction every 10 minutes
       this.evictionTimer = setInterval(() => this.evictExpired(), 10 * 60 * 1000);
-      log.info("LocalSearchProvider initialized", { model: EMBEDDING_MODEL, dim: EMBEDDING_DIM, cacheDir: this.cacheDir });
+      this.evictionTimer.unref?.();
+      log.info("LocalSearchProvider initialized", { model: this.model, dim: EMBEDDING_DIM, cacheDir: this.cacheDir });
     } catch (err) {
       this.initError = String(err);
       log.error("LocalSearchProvider initialization failed", { error: this.initError });

--- a/src/search/manager.ts
+++ b/src/search/manager.ts
@@ -258,7 +258,10 @@ export class SearchManager {
 
   private loadProvider(config: Config): SearchProvider {
     if (this.configuredProvider === "local") {
-      return new LocalSearchProvider({ cacheDir: config.HARNESS_HF_CACHE_DIR });
+      return new LocalSearchProvider({
+        cacheDir: config.HARNESS_HF_CACHE_DIR,
+        model: process.env.HARNESS_SEARCH_MODEL,
+      });
     }
     return new NullSearchProvider();
   }

--- a/src/search/routing-eval.ts
+++ b/src/search/routing-eval.ts
@@ -1,0 +1,142 @@
+export type SearchRoutingMode = "specific" | "cross_domain" | "ambiguous";
+
+export interface SearchRoutingGoldenCase {
+  id: string;
+  query: string;
+  mode: SearchRoutingMode;
+  expectedTypes: string[];
+  acceptableTypes?: string[];
+  description?: string;
+}
+
+export interface SearchRoutingObservation {
+  id: string;
+  query: string;
+  mode: SearchRoutingMode;
+  expectedTypes: string[];
+  acceptableTypes: string[];
+  routedTypes: string[];
+  semanticRouted: boolean;
+  searchedTypes: number;
+  candidateTypes: number;
+  topScore: number;
+  latencyMs: number;
+}
+
+export interface SearchRoutingCaseResult extends SearchRoutingObservation {
+  matchedExpectedTypes: string[];
+  missingExpectedTypes: string[];
+  extraRoutedTypes: string[];
+  expectedRecall: number;
+  passed: boolean;
+}
+
+export interface SearchRoutingSummary {
+  totalCases: number;
+  passedCases: number;
+  failedCases: number;
+  expectedTypeRecall: number;
+  falseNegativeCount: number;
+  averageRoutedTypes: number;
+  averageSearchedTypes: number;
+  averageLatencyMs: number;
+  averageTopScore: number;
+}
+
+export interface SearchRoutingEvaluation {
+  cases: SearchRoutingCaseResult[];
+  summary: SearchRoutingSummary;
+}
+
+function unique(values: readonly string[]): string[] {
+  return Array.from(new Set(values));
+}
+
+export function validateGoldenCases(
+  cases: readonly SearchRoutingGoldenCase[],
+  knownResourceTypes: readonly string[],
+): string[] {
+  const known = new Set(knownResourceTypes);
+  const errors: string[] = [];
+  const ids = new Set<string>();
+  for (const testCase of cases) {
+    if (!testCase.id) errors.push("Golden case is missing id");
+    if (ids.has(testCase.id)) errors.push(`Duplicate golden case id: ${testCase.id}`);
+    ids.add(testCase.id);
+    if (!testCase.query) errors.push(`${testCase.id}: query is required`);
+    if (!["specific", "cross_domain", "ambiguous"].includes(testCase.mode)) {
+      errors.push(`${testCase.id}: invalid mode ${String(testCase.mode)}`);
+    }
+    if (!Array.isArray(testCase.expectedTypes) || testCase.expectedTypes.length === 0) {
+      errors.push(`${testCase.id}: expectedTypes must contain at least one resource type`);
+    }
+    for (const resourceType of [...testCase.expectedTypes, ...(testCase.acceptableTypes ?? [])]) {
+      if (!known.has(resourceType)) {
+        errors.push(`${testCase.id}: unknown resource type "${resourceType}"`);
+      }
+    }
+  }
+  return errors;
+}
+
+export function evaluateRoutingCase(observation: SearchRoutingObservation): SearchRoutingCaseResult {
+  const expectedTypes = unique(observation.expectedTypes);
+  const acceptableTypes = unique(observation.acceptableTypes);
+  const expectedSet = new Set(expectedTypes);
+  const acceptableSet = new Set(acceptableTypes);
+  const routedSet = new Set(observation.routedTypes);
+  const matchedExpectedTypes = expectedTypes.filter((resourceType) => routedSet.has(resourceType));
+  const missingExpectedTypes = expectedTypes.filter((resourceType) => !routedSet.has(resourceType));
+  const extraRoutedTypes = observation.routedTypes.filter(
+    (resourceType) => !expectedSet.has(resourceType) && !acceptableSet.has(resourceType),
+  );
+  const expectedRecall = expectedTypes.length === 0
+    ? 1
+    : matchedExpectedTypes.length / expectedTypes.length;
+  const passed = observation.mode === "ambiguous"
+    ? missingExpectedTypes.length === 0 || !observation.semanticRouted
+    : missingExpectedTypes.length === 0;
+
+  return {
+    ...observation,
+    expectedTypes,
+    acceptableTypes,
+    matchedExpectedTypes,
+    missingExpectedTypes,
+    extraRoutedTypes,
+    expectedRecall,
+    passed,
+  };
+}
+
+export function summarizeRoutingEvaluation(
+  cases: readonly SearchRoutingCaseResult[],
+): SearchRoutingSummary {
+  const totalCases = cases.length;
+  const expectedTypeCount = cases.reduce((sum, result) => sum + result.expectedTypes.length, 0);
+  const matchedExpectedTypeCount = cases.reduce((sum, result) => sum + result.matchedExpectedTypes.length, 0);
+  const average = (values: readonly number[]): number =>
+    values.length === 0 ? 0 : values.reduce((sum, value) => sum + value, 0) / values.length;
+
+  return {
+    totalCases,
+    passedCases: cases.filter((result) => result.passed).length,
+    failedCases: cases.filter((result) => !result.passed).length,
+    expectedTypeRecall: expectedTypeCount === 0 ? 1 : matchedExpectedTypeCount / expectedTypeCount,
+    falseNegativeCount: cases.reduce((sum, result) => sum + result.missingExpectedTypes.length, 0),
+    averageRoutedTypes: average(cases.map((result) => result.routedTypes.length)),
+    averageSearchedTypes: average(cases.map((result) => result.searchedTypes)),
+    averageLatencyMs: average(cases.map((result) => result.latencyMs)),
+    averageTopScore: average(cases.map((result) => result.topScore)),
+  };
+}
+
+export function evaluateRouting(
+  observations: readonly SearchRoutingObservation[],
+): SearchRoutingEvaluation {
+  const cases = observations.map(evaluateRoutingCase);
+  return {
+    cases,
+    summary: summarizeRoutingEvaluation(cases),
+  };
+}

--- a/tests/fixtures/search-routing-golden.json
+++ b/tests/fixtures/search-routing-golden.json
@@ -1,0 +1,322 @@
+[
+  {
+    "id": "connector-kubernetes",
+    "query": "kubernetes connector",
+    "mode": "specific",
+    "expectedTypes": ["connector"],
+    "acceptableTypes": ["infrastructure"],
+    "description": "Kubernetes integration should route to connectors, with infrastructure acceptable because cluster infra references connectors."
+  },
+  {
+    "id": "connector-github",
+    "query": "github connector",
+    "mode": "specific",
+    "expectedTypes": ["connector"],
+    "acceptableTypes": ["repository", "pipeline"],
+    "description": "GitHub auth and SCM connection setup should route to connectors."
+  },
+  {
+    "id": "connector-docker-registry",
+    "query": "docker registry connector",
+    "mode": "specific",
+    "expectedTypes": ["connector"],
+    "acceptableTypes": ["registry", "artifact"],
+    "description": "Container registry connection setup should route to connectors."
+  },
+  {
+    "id": "connector-test-connection",
+    "query": "test connector connection",
+    "mode": "specific",
+    "expectedTypes": ["connector"],
+    "acceptableTypes": [],
+    "description": "Connector connectivity language should identify connector resources."
+  },
+  {
+    "id": "pipeline-cd",
+    "query": "create a CD pipeline",
+    "mode": "specific",
+    "expectedTypes": ["pipeline"],
+    "acceptableTypes": ["pipeline_v1", "template"],
+    "description": "Pipeline creation should route to pipeline resources."
+  },
+  {
+    "id": "pipeline-agent",
+    "query": "agent pipeline yaml",
+    "mode": "specific",
+    "expectedTypes": ["pipeline_v1"],
+    "acceptableTypes": ["pipeline", "template"],
+    "description": "Agent pipeline language should include v1 pipelines."
+  },
+  {
+    "id": "pipeline-execute",
+    "query": "run pipeline on main branch",
+    "mode": "specific",
+    "expectedTypes": ["pipeline"],
+    "acceptableTypes": ["pipeline_v1", "execution"],
+    "description": "Execution requests should keep pipeline routing available."
+  },
+  {
+    "id": "pipeline-execution-history",
+    "query": "pipeline execution history status",
+    "mode": "cross_domain",
+    "expectedTypes": ["execution", "pipeline"],
+    "acceptableTypes": [],
+    "description": "Historical run/status language spans pipeline and execution resources."
+  },
+  {
+    "id": "execution-logs",
+    "query": "download failed execution logs",
+    "mode": "specific",
+    "expectedTypes": ["execution"],
+    "acceptableTypes": ["pipeline"],
+    "description": "Log retrieval language should route to execution logs."
+  },
+  {
+    "id": "service-create",
+    "query": "create a service for payments api",
+    "mode": "specific",
+    "expectedTypes": ["service"],
+    "acceptableTypes": ["pipeline"],
+    "description": "Service setup should route to services."
+  },
+  {
+    "id": "environment-prod",
+    "query": "production environment",
+    "mode": "specific",
+    "expectedTypes": ["environment"],
+    "acceptableTypes": ["infrastructure"],
+    "description": "Environment language should route to environments."
+  },
+  {
+    "id": "infrastructure-k8s",
+    "query": "kubernetes infrastructure definition",
+    "mode": "specific",
+    "expectedTypes": ["infrastructure"],
+    "acceptableTypes": ["connector", "environment"],
+    "description": "Infrastructure definition should route to infrastructure resources."
+  },
+  {
+    "id": "template-pipeline",
+    "query": "pipeline template with stage template",
+    "mode": "specific",
+    "expectedTypes": ["template"],
+    "acceptableTypes": ["template_v1", "pipeline"],
+    "description": "Template authoring should route to templates."
+  },
+  {
+    "id": "template-step-group",
+    "query": "step group template",
+    "mode": "specific",
+    "expectedTypes": ["template"],
+    "acceptableTypes": ["template_v1", "pipeline"],
+    "description": "Step group template language should route to templates."
+  },
+  {
+    "id": "trigger-webhook",
+    "query": "github webhook trigger",
+    "mode": "specific",
+    "expectedTypes": ["trigger"],
+    "acceptableTypes": ["pipeline", "repository"],
+    "description": "Webhook automation should route to triggers."
+  },
+  {
+    "id": "input-set",
+    "query": "pipeline input set values",
+    "mode": "specific",
+    "expectedTypes": ["input_set"],
+    "acceptableTypes": ["pipeline"],
+    "description": "Input-set language should route to input set resources."
+  },
+  {
+    "id": "secret-github-pat",
+    "query": "github personal access token secret",
+    "mode": "specific",
+    "expectedTypes": ["secret"],
+    "acceptableTypes": ["connector"],
+    "description": "Credential storage language should route to secrets."
+  },
+  {
+    "id": "secret-ssh",
+    "query": "ssh key secret",
+    "mode": "specific",
+    "expectedTypes": ["secret"],
+    "acceptableTypes": ["connector"],
+    "description": "SSH key credential language should route to secrets."
+  },
+  {
+    "id": "repository-pr",
+    "query": "pull request comments",
+    "mode": "specific",
+    "expectedTypes": ["pull_request"],
+    "acceptableTypes": ["repository"],
+    "description": "PR collaboration language should route to pull request resources."
+  },
+  {
+    "id": "repository-code",
+    "query": "code repository branches",
+    "mode": "specific",
+    "expectedTypes": ["repository"],
+    "acceptableTypes": ["branch", "pull_request"],
+    "description": "Code repository language should route to repository resources."
+  },
+  {
+    "id": "feature-flag",
+    "query": "feature flag rollout",
+    "mode": "specific",
+    "expectedTypes": ["fme_feature_flag"],
+    "acceptableTypes": ["fme_environment", "fme_rule_based_segment", "fme_standard_segment"],
+    "description": "Feature flag rollout language should route to FME flag resources."
+  },
+  {
+    "id": "feature-flag-targeting",
+    "query": "target users with a feature flag",
+    "mode": "cross_domain",
+    "expectedTypes": ["fme_feature_flag", "fme_rule_based_segment"],
+    "acceptableTypes": ["fme_standard_segment", "fme_environment"],
+    "description": "Targeting language spans flags and segments."
+  },
+  {
+    "id": "delegate-health",
+    "query": "delegate health status",
+    "mode": "specific",
+    "expectedTypes": ["delegate"],
+    "acceptableTypes": ["delegate_token"],
+    "description": "Delegate health should route to delegate resources."
+  },
+  {
+    "id": "rbac-user",
+    "query": "invite user to account",
+    "mode": "specific",
+    "expectedTypes": ["user"],
+    "acceptableTypes": ["user_group"],
+    "description": "User management language should route to users."
+  },
+  {
+    "id": "rbac-role",
+    "query": "assign role permissions",
+    "mode": "specific",
+    "expectedTypes": ["role"],
+    "acceptableTypes": ["role_assignment", "user_group"],
+    "description": "Permission assignment language should route to RBAC resources."
+  },
+  {
+    "id": "policy-governance",
+    "query": "opa policy governance",
+    "mode": "specific",
+    "expectedTypes": ["policy"],
+    "acceptableTypes": ["policy_set"],
+    "description": "OPA governance language should route to policy resources."
+  },
+  {
+    "id": "freeze-window",
+    "query": "deployment freeze window",
+    "mode": "specific",
+    "expectedTypes": ["freeze_window"],
+    "acceptableTypes": ["pipeline", "environment"],
+    "description": "Deployment freeze language should route to freeze windows."
+  },
+  {
+    "id": "gitops-app",
+    "query": "gitops application sync status",
+    "mode": "specific",
+    "expectedTypes": ["gitops_application"],
+    "acceptableTypes": ["gitops_cluster"],
+    "description": "GitOps sync status language should route to GitOps applications."
+  },
+  {
+    "id": "chaos-experiment",
+    "query": "chaos experiment",
+    "mode": "specific",
+    "expectedTypes": ["chaos_experiment"],
+    "acceptableTypes": ["chaos_infrastructure"],
+    "description": "Chaos experiment language should route to chaos resources."
+  },
+  {
+    "id": "cost-perspective",
+    "query": "software engineering insight metrics",
+    "mode": "specific",
+    "expectedTypes": ["sei_metric"],
+    "acceptableTypes": ["sei_business_alignment"],
+    "description": "Engineering insights language should route to SEI metrics."
+  },
+  {
+    "id": "slo",
+    "query": "service level objective error budget",
+    "mode": "specific",
+    "expectedTypes": ["sei_metric"],
+    "acceptableTypes": ["sei_business_alignment"],
+    "description": "SLO and error budget language should route to SLO resources."
+  },
+  {
+    "id": "security-scan",
+    "query": "security scan vulnerabilities",
+    "mode": "specific",
+    "expectedTypes": ["artifact_security"],
+    "acceptableTypes": ["code_repo_security", "scs_compliance_result"],
+    "description": "Security scan language should route to security resources."
+  },
+  {
+    "id": "artifact-component",
+    "query": "artifact component sbom",
+    "mode": "specific",
+    "expectedTypes": ["scs_artifact_component"],
+    "acceptableTypes": ["scs_artifact_source", "artifact_security"],
+    "description": "SBOM component language should route to artifact component resources."
+  },
+  {
+    "id": "dashboard",
+    "query": "project dashboard widgets",
+    "mode": "specific",
+    "expectedTypes": ["dashboard"],
+    "acceptableTypes": [],
+    "description": "Dashboard language should route to dashboard resources."
+  },
+  {
+    "id": "audit",
+    "query": "audit trail events",
+    "mode": "specific",
+    "expectedTypes": ["audit_event"],
+    "acceptableTypes": [],
+    "description": "Audit trail language should route to audit resources."
+  },
+  {
+    "id": "file-store",
+    "query": "file store folder",
+    "mode": "specific",
+    "expectedTypes": ["file_store"],
+    "acceptableTypes": [],
+    "description": "File store language should route to file store resources."
+  },
+  {
+    "id": "dbops-instance",
+    "query": "database schema migration instance",
+    "mode": "specific",
+    "expectedTypes": ["database_instance"],
+    "acceptableTypes": ["database_schema"],
+    "description": "Database migration language should route to DBOps resources."
+  },
+  {
+    "id": "iac-workspace",
+    "query": "terraform workspace plan",
+    "mode": "specific",
+    "expectedTypes": ["iacm_workspace"],
+    "acceptableTypes": ["iacm_module"],
+    "description": "Terraform workspace language should route to IaCM resources."
+  },
+  {
+    "id": "ambiguous-github-secret",
+    "query": "github secret",
+    "mode": "ambiguous",
+    "expectedTypes": ["secret", "connector"],
+    "acceptableTypes": ["pipeline", "repository"],
+    "description": "GitHub secret can mean stored credential, connector auth, or pipeline secret reference."
+  },
+  {
+    "id": "ambiguous-prod",
+    "query": "prod deployment",
+    "mode": "ambiguous",
+    "expectedTypes": ["pipeline", "environment", "service"],
+    "acceptableTypes": ["execution", "deploy"],
+    "description": "Production deployment spans several core CD resources."
+  }
+]

--- a/tests/search/routing-eval.test.ts
+++ b/tests/search/routing-eval.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import goldenCases from "../fixtures/search-routing-golden.json" with { type: "json" };
+import { ALL_TOOLSET_NAMES, Registry } from "../../src/registry/index.js";
+import {
+  evaluateRouting,
+  evaluateRoutingCase,
+  validateGoldenCases,
+  type SearchRoutingGoldenCase,
+} from "../../src/search/routing-eval.js";
+
+function makeConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    HARNESS_API_KEY: "pat.test.token.secret",
+    HARNESS_ACCOUNT_ID: "test",
+    HARNESS_BASE_URL: "https://app.harness.io",
+    HARNESS_ORG: "default",
+    HARNESS_PROJECT: "project",
+    HARNESS_API_TIMEOUT_MS: 30000,
+    HARNESS_MAX_RETRIES: 3,
+    LOG_LEVEL: "error",
+    ...overrides,
+  };
+}
+
+describe("search routing golden fixture", () => {
+  it("contains only known resource types from the all-toolsets registry", () => {
+    const defaultRegistry = new Registry(makeConfig() as never);
+    const defaultNames = new Set(defaultRegistry.getAllToolsets().map((toolset) => toolset.name));
+    const additiveToolsets = ALL_TOOLSET_NAMES
+      .filter((name) => !defaultNames.has(name))
+      .map((name) => `+${name}`)
+      .join(",");
+    const registry = new Registry(makeConfig({
+      ...(additiveToolsets ? { HARNESS_TOOLSETS: additiveToolsets } : {}),
+    }) as never);
+
+    const errors = validateGoldenCases(
+      goldenCases as SearchRoutingGoldenCase[],
+      registry.getAllResourceTypes(),
+    );
+
+    expect(errors).toEqual([]);
+  });
+});
+
+describe("validateGoldenCases", () => {
+  it("reports duplicate ids and unknown resource types", () => {
+    const errors = validateGoldenCases([
+      {
+        id: "duplicate",
+        query: "known query",
+        mode: "specific",
+        expectedTypes: ["pipeline"],
+      },
+      {
+        id: "duplicate",
+        query: "unknown query",
+        mode: "specific",
+        expectedTypes: ["missing_type"],
+      },
+    ], ["pipeline"]);
+
+    expect(errors).toContain("Duplicate golden case id: duplicate");
+    expect(errors).toContain('duplicate: unknown resource type "missing_type"');
+  });
+});
+
+describe("evaluateRoutingCase", () => {
+  it("passes a specific case when every expected type is routed", () => {
+    const result = evaluateRoutingCase({
+      id: "pipeline",
+      query: "create pipeline",
+      mode: "specific",
+      expectedTypes: ["pipeline"],
+      acceptableTypes: ["template"],
+      routedTypes: ["pipeline", "template"],
+      semanticRouted: true,
+      searchedTypes: 2,
+      candidateTypes: 10,
+      topScore: 0.8,
+      latencyMs: 12,
+    });
+
+    expect(result.passed).toBe(true);
+    expect(result.expectedRecall).toBe(1);
+    expect(result.extraRoutedTypes).toEqual([]);
+  });
+
+  it("fails a specific case when an expected type is missing", () => {
+    const result = evaluateRoutingCase({
+      id: "secret",
+      query: "github secret",
+      mode: "specific",
+      expectedTypes: ["secret"],
+      acceptableTypes: ["connector"],
+      routedTypes: ["connector"],
+      semanticRouted: true,
+      searchedTypes: 1,
+      candidateTypes: 10,
+      topScore: 0.8,
+      latencyMs: 12,
+    });
+
+    expect(result.passed).toBe(false);
+    expect(result.missingExpectedTypes).toEqual(["secret"]);
+    expect(result.expectedRecall).toBe(0);
+  });
+
+  it("passes an ambiguous case when semantic routing falls back", () => {
+    const result = evaluateRoutingCase({
+      id: "ambiguous",
+      query: "prod deployment",
+      mode: "ambiguous",
+      expectedTypes: ["pipeline", "environment"],
+      acceptableTypes: ["service"],
+      routedTypes: [],
+      semanticRouted: false,
+      searchedTypes: 10,
+      candidateTypes: 10,
+      topScore: 0.2,
+      latencyMs: 12,
+    });
+
+    expect(result.passed).toBe(true);
+    expect(result.missingExpectedTypes).toEqual(["pipeline", "environment"]);
+  });
+});
+
+describe("evaluateRouting", () => {
+  it("aggregates recall, false negatives, routed count, and latency", () => {
+    const evaluation = evaluateRouting([
+      {
+        id: "one",
+        query: "pipeline",
+        mode: "specific",
+        expectedTypes: ["pipeline"],
+        acceptableTypes: [],
+        routedTypes: ["pipeline"],
+        semanticRouted: true,
+        searchedTypes: 1,
+        candidateTypes: 4,
+        topScore: 0.8,
+        latencyMs: 10,
+      },
+      {
+        id: "two",
+        query: "secret",
+        mode: "specific",
+        expectedTypes: ["secret"],
+        acceptableTypes: [],
+        routedTypes: ["connector"],
+        semanticRouted: true,
+        searchedTypes: 1,
+        candidateTypes: 4,
+        topScore: 0.6,
+        latencyMs: 30,
+      },
+    ]);
+
+    expect(evaluation.summary.totalCases).toBe(2);
+    expect(evaluation.summary.passedCases).toBe(1);
+    expect(evaluation.summary.failedCases).toBe(1);
+    expect(evaluation.summary.expectedTypeRecall).toBe(0.5);
+    expect(evaluation.summary.falseNegativeCount).toBe(1);
+    expect(evaluation.summary.averageRoutedTypes).toBe(1);
+    expect(evaluation.summary.averageSearchedTypes).toBe(1);
+    expect(evaluation.summary.averageLatencyMs).toBe(20);
+    expect(evaluation.summary.averageTopScore).toBe(0.7);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a credential-free golden benchmark for semantic search routing so model and threshold changes can be compared without Harness credentials.
- Add reusable routing evaluation helpers plus a 40-case golden query fixture covering core and long-tail resource families.
- Document the benchmark workflow, model comparison commands, and initial MiniLM/BGE/E5 comparison results.

## OSS safety
- The benchmark data is synthetic user-like queries, public resource type names, public model names, and aggregate local benchmark metrics.
- No customer data, credentials, private account identifiers, or internal ticket IDs are included.

## Test plan
- `pnpm build`
- `pnpm vitest run tests/search/routing-eval.test.ts`
- `pnpm typecheck`
- `pnpm search:benchmark`
- `pnpm search:benchmark -- --json`
- `pnpm test`
- `pnpm docs:generate`


Made with [Cursor](https://cursor.com)