### PR TITLE
Chaos: Updating LoadTest Locust schema & adding LoadTest K6 support

### DIFF
--- a/src/registry/extractors.ts
+++ b/src/registry/extractors.ts
@@ -618,15 +618,30 @@ export const chaosK8sInfraListExtract = (raw: unknown): { items: unknown[]; tota
   };
 };
 
+type LoadtestInputLike = { name?: unknown; value?: unknown; type?: unknown; required?: unknown };
+
+// Read a well-known input value from the inputs[] slice by name.
+const readLoadtestInput = (inputs: LoadtestInputLike[] | undefined, name: string): unknown =>
+  (inputs ?? []).find((i) => i?.name === name)?.value;
+
 /**
  * Project a single load test (InternalApiLoadTestResponse) to a stable shape.
- * Drops backend user-detail envelopes and the large base64 scriptContent
- * (scriptSource is retained). Mirrors `identity` into `loadtestId` so the
- * deep-link resolver fills {loadtestId} instead of falling back to the name.
+ *
+ * The new wire format carries every recognised tunable inside `inputs[]`
+ * (TemplateInput) and user-defined non-secrets inside `variables[]`
+ * (TemplateVariable). We pass both arrays through as-is for fidelity AND
+ * surface derived convenience scalars (target_url / users / duration_sec / ...)
+ * that mirror the create-side LLM surface so round-trips are intuitive.
+ *
+ * Drops the large base64 scriptContent and backend user-detail envelopes.
+ * Mirrors `identity` into `loadtestId` so the deep-link resolver fills
+ * {loadtestId} instead of falling back to the name.
  */
 export const chaosLoadTestExtract = (raw: unknown): unknown => {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return raw;
   const t = raw as Record<string, unknown>;
+  const inputs = Array.isArray(t.inputs) ? (t.inputs as LoadtestInputLike[]) : undefined;
+  const variables = Array.isArray(t.variables) ? (t.variables as unknown[]) : undefined;
   return {
     loadtestId: t.identity,
     identity: t.identity,
@@ -636,14 +651,21 @@ export const chaosLoadTestExtract = (raw: unknown): unknown => {
     environmentIdentifier: t.environmentIdentifier,
     infraIdentifier: t.infraIdentifier,
     targetType: t.targetType,
-    targetUrl: t.targetUrl,
     toolType: t.toolType,
     scriptSource: t.scriptSource,
-    defaultUsers: t.defaultUsers,
-    defaultDurationSec: t.defaultDurationSec,
-    defaultRampUpTimeSec: t.defaultRampUpTimeSec,
-    defaultWorkerCount: t.defaultWorkerCount,
-    variables: t.variables,
+    // Canonical slices — passed through as-is for fidelity.
+    inputs,
+    variables,
+    yaml: t.yaml,
+    // Derived convenience scalars (read-side mirror of the create-side LLM surface).
+    target_url: readLoadtestInput(inputs, "targetUrl"),
+    users: readLoadtestInput(inputs, "targetUsers"),
+    duration_sec: readLoadtestInput(inputs, "durationSeconds"),
+    ramp_up_sec: readLoadtestInput(inputs, "rampUpTimeSec"),
+    worker_count: readLoadtestInput(inputs, "workerCount"),
+    script_image: readLoadtestInput(inputs, "scriptImage"),
+    script_entrypoint: readLoadtestInput(inputs, "scriptEntrypoint"),
+    load_args: readLoadtestInput(inputs, "loadArgs"),
     lastExecuted: t.lastExecuted,
     createdAt: t.createdAt,
     updatedAt: t.updatedAt,

--- a/src/registry/toolsets/chaos-descriptions.ts
+++ b/src/registry/toolsets/chaos-descriptions.ts
@@ -104,8 +104,35 @@ export const descChaosExperimentVariable = `Variables for a chaos experiment. Li
 export const descChaosInfrastructure = `Linux/machine infrastructure registered for chaos experiments and load testing. For Kubernetes infrastructure, use chaos_k8s_infrastructure. Supports list.`;
 
 export const descChaosLoadtest = `Load test (Resilience Testing) instance. Supports list, get, create, delete; run/stop via execute actions.
-Only the Locust tool type is supported today (JMeter and K6 are coming soon).
-To create one, first pick a load-runner infrastructure: for Linux VM use chaos_infrastructure (loadEnabled infras), for Kubernetes use chaos_enabled_infrastructure. Then pass its environment_id + infra_id with target_url and the Python (locust) script.`;
+Locust is supported on Linux VM and Kubernetes (script + image modes). K6 is supported on Kubernetes only (script + image modes; UI mode deferred) — LinuxVM K6 is not supported. JMeter is coming soon.
+To create one, first pick a load-runner infrastructure: for Linux VM use chaos_infrastructure (loadEnabled infras), for Kubernetes use chaos_enabled_infrastructure. Then pass its environment_id + infra_id with target_url and the Python (locust) script.
+
+Response / read schema (what list/get returns — agents NEVER need to construct these on create; MCP builds them automatically):
+- inputs: array of {name, value, type ("Integer" | "String"), required?: true}. Well-known names the backend recognises:
+    targetUsers (Integer, required), durationSeconds (Integer), rampUpTimeSec (Integer),
+    workerCount (Integer; Kubernetes only), targetUrl (String),
+    scriptImage (String, required in image mode), scriptEntrypoint (String, required in image mode),
+    loadArgs (String; image mode only).
+- variables: array of {name, value, type ("String" | "Number")} — user-defined non-secret env vars (currently always empty; custom variables are a deferred feature).
+- yaml: base64-encoded LoadTest manifest. Decoded shape:
+    kind: LoadTest
+    apiVersion: v1alpha1
+    name: <name>
+    description: <optional>
+    tags: [<optional>]
+    spec:
+      identity: <slug>
+      toolType: Locust
+      infraType: kubernetes | linux           # derived from targetType
+      targetType: kubernetes | machine-chaos-linux | linux-chaos
+      scriptSource: inline | image
+      scriptContent: <PLAIN TEXT inside YAML; inline mode only>
+      infraId: <id>
+      envId: <id>
+      inputs: [<same shape as response.inputs>]
+- scriptContent: base64-encoded Python script (inline mode). Large — dropped from list responses.
+- Derived convenience scalars (read-side projection of inputs[] by MCP, matching the create-side scalars):
+    target_url, users, duration_sec, ramp_up_sec, worker_count, script_image, script_entrypoint, load_args.`;
 
 export const descChaosK8sInfrastructure = `Kubernetes chaos infrastructure available for running experiments.
 Use chaos_environment list first to get an environmentId, then pass it here to filter infrastructures for that environment.
@@ -374,12 +401,16 @@ export const descCreateLoadtest = `Creates a Locust load test (Resilience Testin
 IMPORTANT: You MUST NOT auto-select, assume, or pre-fill any value on behalf of the user.
 At every step below, present the options / ask for the value and wait for explicit user confirmation before proceeding.
 Do NOT assume org/project/infrastructure/script/URL based on previous activity — the user may choose differently each time.
-Only the Locust tool type is supported today (JMeter and K6 are coming soon) — do not offer or assume the others.
+Locust (Python) and K6 (JavaScript) are supported. JMeter is coming soon. K6 requires Kubernetes (LinuxVM K6 is not supported). For K6, "Upload K6 script" and "Custom Image" modes are supported via MCP; "Define test via UI" is deferred.
 
 Required workflow — follow in order, pausing for user input after each step:
 
 Step 1 — Select the execution environment target type:
   Ask whether the load test runs on "Linux VM" (target_type=machine-chaos-linux) or "Kubernetes" (target_type=kubernetes). Wait for the user to choose.
+
+Step 1b — Select the tool type:
+  Linux VM only supports Locust. Kubernetes supports Locust or K6 — ask which. Pass tool_type='Locust' (default) or 'K6'.
+  K6 is JavaScript; Locust is Python. K6 currently supports script-mode only (Custom Image and UI are deferred).
 
 Step 2 — Select a load-runner infrastructure:
   Linux VM: call harness_list resource_type=chaos_infrastructure, show the list, wait for the user to pick one. Only infras with loadEnabled=true and status ACTIVE can run load tests.
@@ -389,42 +420,85 @@ Step 2 — Select a load-runner infrastructure:
 Step 3 — Collect the target (host) URL:
   Ask for the base URL of the application under test (e.g. https://www.google.com) -> target_url. Do NOT assume it.
 
-Step 4 — Choose how to define the test (Test Configuration):
-  Linux VM supports the inline Python script only. Kubernetes supports two modes — ask which:
-  (a) Upload Python script (script_source=inline): ask the user to paste the raw Python locust script (their locustfile.py contents). Pass it verbatim in 'script' — base64-encoded into scriptContent automatically. Do NOT generate, modify, or assume a script.
-  (b) Custom Image (script_source=image, Kubernetes only): ask for the container image -> script_image (e.g. my-registry/my-load-test:latest); optionally an entrypoint -> script_entrypoint (e.g. locustfile.py); and optional arguments -> load_args (key=value pairs, comma-separated per key, separated by ';', e.g. "tags=smoke,fast;headless=true").
+Step 4 — Test configuration (branch on tool_type from Step 1b):
+  Locust (Linux VM or Kubernetes):
+    (a) Upload Python script (script_source=inline): ask for the raw Python locust script -> script (verbatim; do NOT generate or pre-encode). MCP base64-encodes it into top-level scriptContent.
+    (b) Custom Image (script_source=image, Kubernetes only): ask for script_image (+ optional script_entrypoint, load_args).
+  K6 (Kubernetes only):
+    (a) Upload K6 script (script_source=inline): ask the user to paste the raw K6 JavaScript source. Pass it verbatim in 'script'. MANDATORY rule: the script MUST contain 'export default function ...'. If it does not, REJECT before calling MCP — MCP will throw and no load test will be created. MCP base64-encodes the script into toolConfig.scriptContent; do NOT pre-encode.
+    (b) Custom Image (script_source=image): ask for the container image -> script_image (e.g. my-registry/my-load-test:latest); optionally an entrypoint inside the image -> script_entrypoint (e.g. /script.js); optional container args -> load_args. MCP routes script_image and script_entrypoint into BOTH toolConfig.customImage (image, entrypoint) AND inputs[] (scriptImage required:true, scriptEntrypoint required:true); load_args rides ONLY in inputs[name=loadArgs]. No script is needed.
+    (c) Define test via UI: NOT YET SUPPORTED via MCP. Inform the user it is deferred and stop.
+  Optional K6-only knobs to ask the user about (skip if user says no):
+    - host_url: origin of the target system (protocol+host, no path). Defaults to the origin of target_url.
+    - rps_limit: requests-per-second cap (toolConfig.options.rpsLimit). Optional.
+    - iterations: total iteration cap (toolConfig.iterations). Optional.
+    - env_vars: see Step 4c.
 
-Step 5 — Collect the load configuration:
-  Ask for Number of Users (users), Test Duration in seconds (duration_sec), and Ramp Up Duration in seconds (ramp_up_sec).
-  Defaults only if the user explicitly accepts them: users=100, duration_sec=600, ramp_up_sec=120.
-  Kubernetes only: optionally ask for worker_count (distributed worker pods; 0 = standalone, default 0).
+Step 4c — Optional K6 environment variables (env_vars):
+  The env_vars param is a structured array. Each entry sets EITHER a literal value OR a secret reference:
+    - Literal:           {key: "FOO", value: "bar"}
+    - Secret reference:  {key: "TOKEN", secret_id: "<harness-secret-identifier>", secret_scope: "account"|"org"|"project"}
+  To discover available secrets, call harness_list resource_type=secret type=SecretText. Each list item has
+  a nested secret.{identifier, orgIdentifier?, projectIdentifier?}. Derive secret_scope from the response:
+    - no orgIdentifier AND no projectIdentifier  → secret_scope: "account"
+    - orgIdentifier only                          → secret_scope: "org"
+    - both orgIdentifier AND projectIdentifier   → secret_scope: "project"
+  MCP builds the wire string 'secrets.getValue("<prefix><id>")' (account.<id> / org.<id> / <id>) and sets
+  secret: true automatically — do NOT construct the secrets.getValue(...) string yourself.
+  Disallowed keys (reserved, case-insensitive): RUN_ID, LOAD_TEST_ID, TARGET_USERS, SPAWN_RATE,
+  SCRIPT_CONTENT_BASE64, TARGET_URL, ACCOUNT_ID, ORG_ID, PROJECT_ID, ENV_ID, DURATION_SECONDS,
+  CONTROL_PLANE_URL, CONTROL_PLANE_TOKEN, HARNESS_CUSTOM_VAR_NAMES, METRICS_PUSH_INTERVAL, INFRA_ID,
+  ACCESS_KEY, TENANT_ID, PYTHONPATH, PATH, HOME, USER, SHELL, LANG, TERM, HOSTNAME, PWD,
+  LD_LIBRARY_PATH, LD_PRELOAD, TMPDIR, TMP, TEMP.
+  Key pattern: /^[A-Za-z_][A-Za-z0-9_]*$/.
+
+Step 5 — Load configuration:
+  Ask users, duration_sec, ramp_up_sec (defaults 100 / 600 / 120 only if user accepts).
+  K8s: also ask worker_count — do NOT skip (default 0). VM: skip worker_count.
 
 Step 6 — Collect name and optional metadata:
-  Ask for a name. identity is auto-derived from name (alphanumeric) unless the user provides one. description and tags are optional — ask, but do not require them.
+  Ask for a name (any non-empty string). identity is auto-derived from name by stripping non-alphanumerics unless the user provides one (must be letters/numbers/underscores). description and tags are optional — ask, but do not require them.
 
 Only after the user confirms all of the above should you call harness_create resource_type=chaos_loadtest.
 
+HOW THE BODY IS BUILT (you do NOT construct any of this — MCP handles it):
+- Your scalars (users / duration_sec / ramp_up_sec / worker_count / target_url / script_image / script_entrypoint / load_args)
+  are translated into a canonical inputs[] array with backend-wire names
+  (targetUsers / durationSeconds / rampUpTimeSec / workerCount / targetUrl / scriptImage / scriptEntrypoint / loadArgs).
+- Inline mode (Locust): your raw 'script' is base64-encoded into top-level scriptContent.
+- Image mode (Locust): scriptContent is omitted; script_image / script_entrypoint / load_args ride in inputs[].
+- K6 script mode: top-level scriptContent is OMITTED. The base64 script lives in toolConfig.scriptContent only.
+  toolConfig also carries hostUrl, optional options.rpsLimit, optional iterations, and optional envVars.
+- env_vars (K6): structured only. {key, value} for literals; {key, secret_id, secret_scope?} for secrets —
+  MCP builds the wire 'secrets.getValue("<prefix><id>")' string and sets secret: true automatically.
+- A canonical LoadTest YAML manifest is synthesized and base64-encoded into the 'yaml' request field.
+- description defaults to "", tags defaults to []. tool_type is fixed to "Locust" server-side (K6/JMeter coming).
+
 INPUT FIELDS:
-  name (string, required): Display name for the load test.
+  name (string, required): Display name for the load test. Any non-empty string (e.g. "My Load Test", "locust-1").
   environment_id (string, required): environmentID of the chosen infrastructure (Step 2).
   infra_id (string, required): infraID of the chosen infrastructure (Step 2).
-  target_url (string, required): Base URL of the application under test (Step 3).
-  script (string): Inline Python locust script; base64-encoded automatically into scriptContent. Required when script_source=inline.
-  script_source (string): "inline" (default) or "image" (Kubernetes). Inferred as "image" when script_image is set.
-  script_image (string): Custom Image mode — prebuilt container image. Required when script_source=image.
-  script_entrypoint (string): Custom Image mode — entrypoint file inside the image (optional).
-  load_args (string): Custom Image mode — container args as "k=v,v2;k2=v" pairs (optional).
-  target_type (string): machine-chaos-linux (Linux VM, default) or kubernetes.
-  tool_type (string): Only "Locust" is supported. Default: Locust.
-  users (number): Number of simulated users. Default 100.
-  duration_sec (number): Total test duration in seconds. Default 600.
-  ramp_up_sec (number): Ramp-up duration in seconds. Default 120.
-  worker_count (number): Kubernetes only — distributed worker pods (0 = standalone, default 0), sent as variables.workerCount.
-  identity (string): Stable identifier; auto-derived from name when omitted.
-  description (string): Optional description.
-  tags (string[]): Optional tags.
+  target_url (string, required): Base URL of the application under test (Step 3). Goes into inputs[name=targetUrl].
+  script (string): Raw Python locust script. VM always requires this; K8s when inline. MCP base64-encodes it into the top-level scriptContent field — do NOT pre-encode.
+  script_source (string): "inline" (default) or "image". "image" is K8s-only; VM is always "inline". Inferred as "image" when script_image is set.
+  script_image (string): K8s + image mode only — prebuilt container image. Required when script_source=image. Goes into inputs[name=scriptImage, required:true].
+  script_entrypoint (string): Custom Image mode — entrypoint file inside the image. Goes into inputs[name=scriptEntrypoint, required:true] when provided.
+  load_args (string): Custom Image mode — container args as "k=v,v2;k2=v" pairs. Goes into inputs[name=loadArgs] when provided.
+  target_type (string): machine-chaos-linux (Linux VM, default), linux-chaos, or kubernetes.
+  users (number, default 100): Number of simulated users. Goes into inputs[name=targetUsers, required:true].
+  duration_sec (number, default 600): Total test duration in seconds. Goes into inputs[name=durationSeconds].
+  ramp_up_sec (number, default 120): Ramp-up duration in seconds. Goes into inputs[name=rampUpTimeSec].
+  worker_count (number, default 0): K8s — agent must ask; default 0. VM: N/A. Goes into inputs[name=workerCount].
+  tool_type (string, default "Locust"): "Locust" or "K6". K6 requires target_type=kubernetes.
+  host_url (string, K6 only): K6 host origin (protocol://host, no path). Defaults to origin of target_url. Goes into toolConfig.hostUrl.
+  rps_limit (number, K6 only): requests-per-second cap. Goes into toolConfig.options.rpsLimit when > 0.
+  iterations (number, K6 only): total iteration cap. Goes into toolConfig.iterations when > 0.
+  env_vars (array, K6 only): environment variables. Array of {key, value} (literal) or {key, secret_id, secret_scope?} (secret reference). See Step 4c.
+  identity (string): Stable slug-safe identifier (letters / numbers / underscores). Auto-derived from name by stripping non-alphanumerics when omitted.
+  description (string): Optional human-readable description. Defaults to "".
+  tags (string[]): Optional tags. Defaults to [].
 
-Returns the created load test (identity, name, environment/infra, targetType, targetUrl, toolType, load config) plus an openInHarness deep link.`;
+Returns the created load test (identity, name, environment/infra, targetType, toolType, scriptSource, inputs[], plus derived target_url/users/duration_sec/ramp_up_sec/worker_count convenience scalars) and an openInHarness deep link.`;
 export const descDeleteLoadtest = `Delete a load test instance`;
 
 export const descListK8sInfra = `List Kubernetes chaos infrastructures available for running experiments.
@@ -745,7 +819,15 @@ Requires the template identity, hub identity, and two revision numbers.`;
 export const descBodyExperimentRun = `Optional runtime inputs for the chaos experiment. Use chaos_experiment_variable list to discover required variables first.`;
 export const descBodyNoBody = `No body required. Resource identified by path parameter.`;
 export const descBodyCreateFromTemplate = `Chaos experiment from template`;
-export const descBodyLoadtestDefinition = `Locust load test definition. name, environment_id, infra_id and target_url are required. Provide EITHER 'script' (inline Python; script_source=inline, default) OR 'script_image' (Custom Image; script_source=image, Kubernetes). The rest have sensible defaults.`;
+export const descBodyLoadtestDefinition = `Locust load test definition. Required: name, environment_id, infra_id, target_url. Mode: either 'script' (inline Python, script_source=inline, default) or 'script_image' (Custom Image, script_source=image).
+MCP translates your scalars into the wire shape automatically:
+  - users / duration_sec / ramp_up_sec  → inputs[targetUsers / durationSeconds / rampUpTimeSec] (Integer)
+  - target_url                          → inputs[targetUrl] (String)
+  - worker_count                        → inputs[workerCount] (Integer; Kubernetes only)
+  - script_image / script_entrypoint / load_args → inputs[scriptImage / scriptEntrypoint / loadArgs] (String; image mode)
+  - script (raw Python)                 → top-level scriptContent (base64)
+  - A canonical LoadTest YAML manifest is built and base64-encoded into a 'yaml' field.
+You never construct inputs[], scriptContent base64, or the yaml field — pass scalars only.`;
 
 // ── Field Descriptions ───────────────────────────────────────────────
 
@@ -757,24 +839,28 @@ export const descExperimentIdentity = `Experiment identity (auto-generated from 
 export const descInfraRef = `Infrastructure reference in format: environmentId/infraId. Use chaos_environment list to find environments, then chaos_k8s_infrastructure list to find infraIDs.`;
 export const descExperimentId = `Chaos experiment identifier. Accepts either the internal UUID (default, with is_identity=false) or the human-readable identity slug (set is_identity=true). Use harness_list with resource_type=chaos_experiment to find experiment IDs.`;
 export const descInfraStatus = `Filter by infra status: Active (default) or All`;
-export const descLoadtestName = `Display name for the load test. Only lowercase letters, numbers and dashes are allowed (e.g. "kubernete-example-1").`;
-export const descLoadtestType = `Load test tool type. Only "Locust" is supported today (JMeter and K6 are coming soon). Default: Locust.`;
-export const descLoadtestIdentity = `Stable identifier for the load test. Auto-derived from name (alphanumeric) when omitted.`;
-export const descLoadtestDescription = `Optional human-readable description.`;
-export const descLoadtestTags = `Optional tags (array of strings, or comma-separated string).`;
+export const descLoadtestName = `Display name for the load test. Any non-empty string (e.g. "My Load Test", "locust-1"). The slug-safe identifier rule applies to 'identity' (auto-derived from name) — not to name.`;
+export const descLoadtestType = `Load test tool type: "Locust" (default; Python on Linux VM or Kubernetes) or "K6" (JavaScript on Kubernetes only). JMeter is coming soon. K6 supports script mode and Custom Image mode; "Define test via UI" is deferred.`;
+export const descLoadtestIdentity = `Stable identifier (letters, numbers and underscores). Auto-derived from name by stripping non-alphanumerics when omitted.`;
+export const descLoadtestDescription = `Optional human-readable description. Defaults to "".`;
+export const descLoadtestTags = `Optional tags (array of strings, or comma-separated string). Defaults to [].`;
 export const descLoadtestEnvId = `Environment identifier of the load-runner infrastructure. Use the 'environmentID' from chaos_infrastructure (Linux VM) or chaos_enabled_infrastructure (Kubernetes).`;
 export const descLoadtestInfraId = `Load-runner infrastructure identifier. Use the 'infraID' from chaos_infrastructure (Linux VM) or chaos_enabled_infrastructure (Kubernetes).`;
-export const descLoadtestTargetType = `Execution environment target type: "machine-chaos-linux" (Linux VM, default) or "kubernetes".`;
-export const descLoadtestTargetUrl = `Base URL of the application under test (e.g. https://www.google.com).`;
-export const descLoadtestScript = `Raw Python (locust) script contents for inline mode (script_source=inline). Base64-encoded automatically into scriptContent. Required for inline mode; omit for Custom Image mode.`;
-export const descLoadtestScriptSource = `Test definition source: "inline" (default — upload a raw Python locust script via 'script') or "image" (Kubernetes only — use a prebuilt container image via 'script_image'). Inferred as "image" when script_image is set, otherwise "inline".`;
-export const descLoadtestScriptImage = `Custom Image mode (Kubernetes): prebuilt container image used as the load test source, e.g. "my-registry/my-load-test:latest". Required when script_source=image.`;
-export const descLoadtestScriptEntrypoint = `Custom Image mode (optional): entrypoint file inside the image, e.g. "locustfile.py".`;
-export const descLoadtestLoadArgs = `Custom Image mode (optional): arguments passed to the container as key=value pairs — comma-separated for multiple values per key, separated by ';'. Example: "tags=smoke,fast;headless=true".`;
-export const descLoadtestUsers = `Number of simulated users. Default: 100.`;
-export const descLoadtestDurationSec = `Total test duration in seconds. Default: 600.`;
-export const descLoadtestRampUpSec = `Ramp-up duration in seconds. Default: 120.`;
-export const descLoadtestWorkerCount = `Kubernetes only: number of distributed worker pods (0 = standalone, default 0). Sent as variables.workerCount.`;
+export const descLoadtestTargetType = `Execution environment target type: "machine-chaos-linux" (Linux VM, default), "linux-chaos", or "kubernetes". "workerCount" is only emitted into inputs[] for "kubernetes".`;
+export const descLoadtestTargetUrl = `Base URL of the application under test (e.g. https://www.google.com). Sent as an entry in inputs[] with name="targetUrl", type="String".`;
+export const descLoadtestScript = `Raw script contents for inline mode (script_source=inline). Locust expects Python (locustfile.py); K6 expects JavaScript and MUST contain 'export default function ...' (mandatory — MCP rejects scripts without it). MCP base64-encodes onto the wire — do NOT pre-encode. For Locust this lands at top-level scriptContent; for K6 it lands at toolConfig.scriptContent (and top-level scriptContent is omitted). Required for inline mode; omit for Custom Image mode.`;
+export const descLoadtestScriptSource = `Test definition source: "inline" (default — upload a raw Python locust script via 'script') or "image" (use a prebuilt container image via 'script_image'). "image" is K8s-only; VM is always "inline". Inferred as "image" when script_image is set, otherwise "inline".`;
+export const descLoadtestScriptImage = `Custom Image mode (both Locust and K6, Kubernetes only): prebuilt container image used as the load test source, e.g. "my-registry/my-load-test:latest". Required when script_source=image. Sent as inputs[name=scriptImage, type=String, required:true]. For K6 also wired into toolConfig.customImage.image.`;
+export const descLoadtestScriptEntrypoint = `Custom Image mode (optional, both Locust and K6): entrypoint file inside the image, e.g. "locustfile.py" (Locust) or "/script.js" (K6). Sent as inputs[name=scriptEntrypoint, type=String, required:true] when provided. For K6 also wired into toolConfig.customImage.entrypoint.`;
+export const descLoadtestLoadArgs = `Custom Image mode (optional, both Locust and K6): arguments passed to the container as key=value pairs — comma-separated for multiple values per key, separated by ';'. Example: "tags=smoke,random;headless=true". Sent as inputs[name=loadArgs, type=String] only — for K6 this does NOT go into toolConfig.customImage.`;
+export const descLoadtestUsers = `Number of simulated users. Default: 100. Sent as inputs[name=targetUsers, type=Integer, required:true].`;
+export const descLoadtestDurationSec = `Total test duration in seconds. Default: 600. Sent as inputs[name=durationSeconds, type=Integer].`;
+export const descLoadtestRampUpSec = `Ramp-up duration in seconds. Default: 120. Sent as inputs[name=rampUpTimeSec, type=Integer].`;
+export const descLoadtestWorkerCount = `K8s: agent must ask; default 0 (0 = standalone). VM: N/A. Sent as inputs[name=workerCount, type=Integer]. Ignored for Linux target types.`;
+export const descLoadtestHostUrl = `K6 only: host origin (protocol+host with no path, e.g. https://api.example.com). Defaults to the origin parsed from target_url when omitted. Goes into toolConfig.hostUrl.`;
+export const descLoadtestRpsLimit = `K6 only: requests-per-second cap. Goes into toolConfig.options.rpsLimit when > 0. Omitted from the wire when unset or 0.`;
+export const descLoadtestIterations = `K6 only: total iteration cap. Goes into toolConfig.iterations when > 0. Omitted from the wire when unset or 0.`;
+export const descLoadtestEnvVars = `K6 only: environment variables for the K6 runner. Array of entries — each sets EITHER {key, value} for a literal OR {key, secret_id, secret_scope?: "account"|"org"|"project"} for a Harness secret (default secret_scope = "project"). MCP builds the wire 'secrets.getValue("<prefix><id>")' string and sets secret: true automatically — do NOT construct that string yourself. Discover secrets via harness_list resource_type=secret type=SecretText and read each item's secret.{identifier, orgIdentifier?, projectIdentifier?} to derive scope. Key pattern: /^[A-Za-z_][A-Za-z0-9_]*$/. Reserved names (case-insensitive) are rejected: RUN_ID, LOAD_TEST_ID, TARGET_USERS, SPAWN_RATE, SCRIPT_CONTENT_BASE64, TARGET_URL, ACCOUNT_ID, ORG_ID, PROJECT_ID, ENV_ID, DURATION_SECONDS, CONTROL_PLANE_URL, CONTROL_PLANE_TOKEN, HARNESS_CUSTOM_VAR_NAMES, METRICS_PUSH_INTERVAL, INFRA_ID, ACCESS_KEY, TENANT_ID, PYTHONPATH, PATH, HOME, USER, SHELL, LANG, TERM, HOSTNAME, PWD, LD_LIBRARY_PATH, LD_PRELOAD, TMPDIR, TMP, TEMP.`;
 
 export const descHubIdentityExact = `The unique identity of the ChaosHub. Use harness_list with resource_type=chaos_hub to find hub identities.`;
 export const descHubName = `Display name for the ChaosHub.`;

--- a/src/registry/toolsets/chaos.ts
+++ b/src/registry/toolsets/chaos.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import YAML from "yaml";
 import type { ToolsetDefinition, ParamsSchema } from "../types.js";
 import {
   passthrough,
@@ -90,6 +91,7 @@ import {
   descLoadtestDurationSec, descLoadtestRampUpSec, descLoadtestWorkerCount,
   descLoadtestScriptSource, descLoadtestScriptImage,
   descLoadtestScriptEntrypoint, descLoadtestLoadArgs,
+  descLoadtestHostUrl, descLoadtestRpsLimit, descLoadtestIterations, descLoadtestEnvVars,
   descHubIdentityExact, descHubName, descHubNameUpdate,
   descHubDescription, descHubDescriptionUpdate,
   descHubTags, descHubTagsReplace,
@@ -191,6 +193,285 @@ function coerceBody(input: Record<string, unknown>): Record<string, unknown> {
     }
   }
   return raw as Record<string, unknown>;
+}
+
+// ── Load test helpers ────────────────────────────────────────────────
+// The load-test backend now carries every recognised tunable (run params, target
+// URL, image fields, worker count) inside a flat `inputs: TemplateInput[]` array
+// instead of the legacy top-level `defaultUsers/...` fields. The MCP keeps its
+// LLM surface as ergonomic snake_case scalars and translates them into the wire
+// shape here, so agents never construct the array, base64, or YAML themselves.
+
+type LoadtestInput = {
+  name: string;
+  value: number | string;
+  type: "Integer" | "String";
+  required?: true;
+};
+
+/**
+ * Map ergonomic snake_case scalars to the canonical TemplateInput[] array the
+ * load-test backend expects. Only emits entries for values the caller provided
+ * (plus the three always-present run params and the K8s-only workerCount).
+ */
+function buildLoadtestInputs(
+  b: Record<string, unknown>,
+  opts: { targetType: string; scriptSource: string },
+): LoadtestInput[] {
+  const inputs: LoadtestInput[] = [];
+
+  // Run params: always emitted (backend treats targetUsers as required).
+  const users = b.users != null ? (b.users as number) : 100;
+  const duration = b.duration_sec != null ? (b.duration_sec as number) : 600;
+  const rampUp = b.ramp_up_sec != null ? (b.ramp_up_sec as number) : 120;
+  inputs.push({ name: "targetUsers", value: users, type: "Integer", required: true });
+  inputs.push({ name: "durationSeconds", value: duration, type: "Integer" });
+  inputs.push({ name: "rampUpTimeSec", value: rampUp, type: "Integer" });
+
+  // workerCount is Kubernetes-only (0 = standalone, N > 0 = distributed).
+  if (opts.targetType === "kubernetes") {
+    const workerCount = b.worker_count != null ? (b.worker_count as number) : 0;
+    inputs.push({ name: "workerCount", value: workerCount, type: "Integer" });
+  }
+
+  // Target URL: present on every load test (backend treats it as the host under test).
+  const targetUrl = (b.target_url ?? b.targetUrl) as string | undefined;
+  if (targetUrl != null) {
+    inputs.push({ name: "targetUrl", value: targetUrl, type: "String" });
+  }
+
+  // Image-mode tunables (Custom Image): scriptImage/scriptEntrypoint are
+  // mandatory in image mode (marked required), loadArgs is optional.
+  if (opts.scriptSource === "image") {
+    const scriptImage = (b.script_image ?? b.scriptImage) as string | undefined;
+    if (scriptImage != null) {
+      inputs.push({ name: "scriptImage", value: scriptImage, type: "String", required: true });
+    }
+    const entrypoint = (b.script_entrypoint ?? b.scriptEntrypoint) as string | undefined;
+    if (entrypoint != null) {
+      inputs.push({ name: "scriptEntrypoint", value: entrypoint, type: "String", required: true });
+    }
+    const loadArgs = (b.load_args ?? b.loadArgs) as string | undefined;
+    if (loadArgs != null) {
+      inputs.push({ name: "loadArgs", value: loadArgs, type: "String" });
+    }
+  }
+
+  return inputs;
+}
+
+// ── K6-specific helpers ──────────────────────────────────────────────
+// K6 is a Kubernetes-only load test runner. Script mode wraps the K6 JS source
+// in a `toolConfig` object (rather than top-level `scriptContent` like Locust).
+// Env vars and secret references live exclusively in `toolConfig.envVars`.
+
+// Reserved K6 env-var names (case-insensitive). Mirrors
+// loadTestManager/internal/domain/ReservedEnvVarNames; the frontend list is at
+// hce-saas/web/src/services/loadTest/loadTestVariables.ts:337-372.
+const RESERVED_K6_ENV_VAR_NAMES = new Set<string>([
+  "RUN_ID", "LOAD_TEST_ID", "TARGET_USERS", "SPAWN_RATE", "SCRIPT_CONTENT_BASE64",
+  "TARGET_URL", "ACCOUNT_ID", "ORG_ID", "PROJECT_ID", "ENV_ID", "DURATION_SECONDS",
+  "CONTROL_PLANE_URL", "CONTROL_PLANE_TOKEN", "HARNESS_CUSTOM_VAR_NAMES",
+  "METRICS_PUSH_INTERVAL", "INFRA_ID", "ACCESS_KEY", "TENANT_ID",
+  "PYTHONPATH", "PATH", "HOME", "USER", "SHELL", "LANG", "TERM", "HOSTNAME",
+  "PWD", "LD_LIBRARY_PATH", "LD_PRELOAD", "TMPDIR", "TMP", "TEMP",
+]);
+const K6_ENV_VAR_KEY_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+type K6EnvVarWire = { key: string; value: string; secret?: true };
+
+// Build the HSM secret reference: account → "account.<id>", org → "org.<id>", project → "<id>".
+// Matches the Harness UI convention (scope prefix encodes which secret manager the value lives in).
+function buildSecretReference(secretId: string, scope: "account" | "org" | "project"): string {
+  const prefix = scope === "account" ? "account." : scope === "org" ? "org." : "";
+  return `secrets.getValue("${prefix}${secretId}")`;
+}
+
+// Validate + project the structured env_vars input into the wire shape K6 expects.
+// Each entry sets exactly one of:
+//   - { key, value }                              → literal env var
+//   - { key, secret_id, secret_scope?: "..." }    → MCP builds the secrets.getValue(...) string
+function buildK6EnvVars(raw: unknown): K6EnvVarWire[] {
+  if (raw == null) return [];
+  if (!Array.isArray(raw)) {
+    throw new Error("env_vars must be an array of {key, value | secret_id, secret_scope?} entries.");
+  }
+  const seen = new Set<string>();
+  return raw.map((entry, idx) => {
+    const ev = entry as Record<string, unknown>;
+    const key = ev.key as string | undefined;
+    if (!key || typeof key !== "string") {
+      throw new Error(`env_vars[${idx}].key is required.`);
+    }
+    if (!K6_ENV_VAR_KEY_REGEX.test(key)) {
+      throw new Error(
+        `env_vars[${idx}].key '${key}' is invalid: must match /^[A-Za-z_][A-Za-z0-9_]*$/.`,
+      );
+    }
+    if (RESERVED_K6_ENV_VAR_NAMES.has(key.toUpperCase())) {
+      throw new Error(
+        `env_vars[${idx}].key '${key}' is a reserved name and cannot be used as a custom env var.`,
+      );
+    }
+    if (seen.has(key)) {
+      throw new Error(`env_vars[${idx}].key '${key}' is duplicated.`);
+    }
+    seen.add(key);
+
+    const hasValue = ev.value != null;
+    const hasSecretId = ev.secret_id != null;
+    if (hasValue === hasSecretId) {
+      throw new Error(
+        `env_vars[${idx}] must set exactly one of 'value' (literal) or 'secret_id' (with optional secret_scope).`,
+      );
+    }
+    if (hasSecretId) {
+      const scopeRaw = (ev.secret_scope as string | undefined) ?? "project";
+      if (scopeRaw !== "account" && scopeRaw !== "org" && scopeRaw !== "project") {
+        throw new Error(
+          `env_vars[${idx}].secret_scope '${scopeRaw}' must be 'account', 'org', or 'project'.`,
+        );
+      }
+      return { key, value: buildSecretReference(ev.secret_id as string, scopeRaw), secret: true };
+    }
+    return { key, value: String(ev.value) };
+  });
+}
+
+// Strip path/query/fragment, keep <protocol>//<host>. Mirrors K6LoadTestService's
+// resolveBaseHost (web/src/services/loadTest/K6LoadTestService.ts:117-129).
+function parseHostOrigin(rawUrl: string | undefined): string | undefined {
+  if (!rawUrl) return undefined;
+  try {
+    const u = new URL(rawUrl);
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return rawUrl;
+  }
+}
+
+// Build the K6 `toolConfig` object for script or image mode (UI mode is deferred).
+// Script mode: enforces the mandatory `export default function` rule client-side so the
+// agent gets a clear error before the API trip. Image mode: wires the prebuilt container
+// image (+ optional entrypoint) into customImage. hostUrl / options / envVars are shared.
+function buildK6ToolConfig(
+  b: Record<string, unknown>,
+  args: { scriptSource: string; script?: string; targetUrl?: string },
+): Record<string, unknown> {
+  const hostUrl =
+    (b.host_url as string | undefined) ??
+    (b.hostUrl as string | undefined) ??
+    parseHostOrigin(args.targetUrl);
+  const rpsLimit = b.rps_limit != null ? (b.rps_limit as number) : undefined;
+  const envVars = buildK6EnvVars(b.env_vars);
+
+  const options: Record<string, unknown> = {};
+  if (rpsLimit != null && rpsLimit > 0) options.rpsLimit = rpsLimit;
+
+  // Build the mode-specific payload first; shared keys (hostUrl, options, envVars,
+  // iterations) are appended after so we get a stable key order matching the studio.
+  let toolConfig: Record<string, unknown>;
+  if (args.scriptSource === "image") {
+    // Custom Image: image + optional entrypoint live in toolConfig.customImage.
+    // Note: load_args is NOT part of customImage for K6 — it rides only in inputs[]
+    // (matches K6LoadTestService.ts:487-495 where customImage only has image/entrypoint).
+    const scriptImage = (b.script_image ?? b.scriptImage) as string | undefined;
+    if (scriptImage == null) {
+      // Defensive — the early image-mode gate in bodyBuilder already throws this.
+      throw new Error("K6 image mode requires 'script_image'.");
+    }
+    const customImage: Record<string, unknown> = { image: scriptImage };
+    const entrypoint = (b.script_entrypoint ?? b.scriptEntrypoint) as string | undefined;
+    if (entrypoint != null) customImage.entrypoint = entrypoint;
+    toolConfig = { mode: "image", customImage };
+  } else {
+    // Script mode: base64 JS source. Mandatory client-side rule (matches Harness UI:
+    // validateScriptContent at K6LoadTestService.ts:767-774). Substring check (not
+    // full AST) matches the UI exactly.
+    if (args.script == null) {
+      throw new Error("K6 script mode requires 'script' (the raw JavaScript K6 source).");
+    }
+    if (!args.script.includes("export default")) {
+      throw new Error(
+        "K6 script must export a default function (export default function ...).",
+      );
+    }
+    toolConfig = {
+      mode: "script",
+      scriptContent: Buffer.from(args.script, "utf8").toString("base64"),
+    };
+    // iterations is K6 script-mode-only (matches K6LoadTestService.ts:483-484).
+    const iterations = b.iterations != null ? (b.iterations as number) : undefined;
+    if (iterations != null && iterations > 0) toolConfig.iterations = iterations;
+  }
+
+  if (hostUrl) toolConfig.hostUrl = hostUrl;
+  if (Object.keys(options).length > 0) toolConfig.options = options;
+  if (envVars.length > 0) toolConfig.envVars = envVars;
+  return toolConfig;
+}
+
+/**
+ * Build the canonical LoadTest YAML manifest. Mirrors the studio's
+ * formDataToManifest shape (kind: LoadTest, apiVersion: v1alpha1, spec.{...}).
+ *
+ * scriptContent inside the YAML is PLAIN TEXT (so the manifest is human-
+ * readable); only the JSON request body's top-level scriptContent is base64.
+ * Caller base64-encodes the returned string into the `yaml` request field.
+ */
+function buildLoadtestYamlManifest(args: {
+  name: string;
+  description?: string;
+  tags?: string[];
+  identity: string;
+  toolType: "Locust" | "K6";
+  targetType: string;
+  scriptSource: string;
+  script?: string;                         // Locust inline source OR K6 source (plain text)
+  k6ToolConfig?: Record<string, unknown>;  // wire-shape K6 toolConfig (with base64 scriptContent)
+  environmentIdentifier: string;
+  infraIdentifier: string;
+  inputs: LoadtestInput[];
+}): string {
+  const infraType = args.targetType === "kubernetes" ? "kubernetes" : "linux";
+  const manifest: Record<string, unknown> = {
+    kind: "LoadTest",
+    apiVersion: "v1alpha1",
+    name: args.name,
+  };
+  if (args.description) manifest.description = args.description;
+  if (args.tags && args.tags.length) manifest.tags = args.tags;
+
+  const spec: Record<string, unknown> = {
+    identity: args.identity,
+    toolType: args.toolType,
+    infraType,
+    targetType: args.targetType,
+    scriptSource: args.scriptSource,
+  };
+  // Locust inline only: readable scriptContent at the manifest root (plain text).
+  // K6 keeps the script inside spec.toolConfig instead.
+  if (args.toolType === "Locust" && args.scriptSource === "inline" && args.script) {
+    spec.scriptContent = args.script;
+  }
+  spec.infraId = args.infraIdentifier;
+  spec.envId = args.environmentIdentifier;
+  spec.inputs = args.inputs;
+
+  // K6: emit spec.toolConfig with PLAIN TEXT scriptContent (decode the base64 from
+  // the wire-shape toolConfig so the YAML view is human-readable). Other
+  // toolConfig keys (mode, hostUrl, options, envVars, iterations) pass through.
+  if (args.toolType === "K6" && args.k6ToolConfig) {
+    const tc: Record<string, unknown> = { ...args.k6ToolConfig };
+    if (typeof tc.scriptContent === "string" && args.script) {
+      tc.scriptContent = args.script; // plain text for YAML readability
+    }
+    spec.toolConfig = tc;
+  }
+
+  manifest.spec = spec;
+
+  return YAML.stringify(manifest);
 }
 
 export const chaosToolset: ToolsetDefinition = {
@@ -1469,80 +1750,130 @@ export const chaosToolset: ToolsetDefinition = {
           bodyBuilder: (input) => {
             const b = coerceBody(input);
             const name = (b.name as string) ?? "";
-            // Backend constraint: name allows only lowercase letters, numbers and dashes.
-            if (name && !/^[a-z0-9-]+$/.test(name)) {
+            if (!name) {
+              throw new Error("name is required.");
+            }
+
+            // identity is the slug-constrained key; auto-derive from name when omitted.
+            // The display name is permissive (any non-empty string) — only the identity
+            // must be a slug. We strip non-alphanumerics from name as a sensible default;
+            // a fully-blank slug falls back to a UUID so we never write an empty id.
+            const slug = (s: string) => s.replace(/[^a-zA-Z0-9]/g, "");
+            const identity = (b.identity as string) || slug(name) || randomUUID();
+            if (!/^[a-zA-Z0-9_]+$/.test(identity)) {
               throw new Error(
-                `Invalid load test name '${name}': only lowercase letters, numbers and dashes are allowed.`,
+                `Invalid identity '${identity}': only letters, numbers and underscores are allowed (derived from name when omitted).`,
               );
             }
-            const slug = (s: string) => s.replace(/[^a-zA-Z0-9]/g, "");
+
             const targetType = (b.target_type as string) ?? "machine-chaos-linux";
-            const tags = b.tags;
-            const environmentIdentifier = b.environment_id ?? b.environmentIdentifier;
-            const infraIdentifier = b.infra_id ?? b.infraIdentifier;
-            const targetUrl = b.target_url ?? b.targetUrl;
+            const environmentIdentifier = (b.environment_id ?? b.environmentIdentifier) as
+              | string
+              | undefined;
+            const infraIdentifier = (b.infra_id ?? b.infraIdentifier) as string | undefined;
+            const targetUrl = (b.target_url ?? b.targetUrl) as string | undefined;
             const script = b.script as string | undefined;
             const scriptImage = (b.script_image ?? b.scriptImage) as string | undefined;
-            // Resolve test-definition source: explicit script_source wins, else infer
-            // "image" when an image is supplied, otherwise "inline" (Python script).
+            // Explicit script_source wins, else infer "image" when an image is supplied.
             const scriptSource =
               (b.script_source as string) ?? (scriptImage != null ? "image" : "inline");
 
-            const body: Record<string, unknown> = {
-              identity: (b.identity as string) || slug(name) || randomUUID(),
+            // Mode-specific required fields (fail loudly before we touch the wire).
+            // Tool-agnostic message: Locust = Python locust source, K6 = JavaScript with 'export default'.
+            // The K6-specific 'export default' rule is enforced later in buildK6ToolConfig.
+            if (scriptSource === "inline" && script == null) {
+              throw new Error("script is required when script_source='inline'.");
+            }
+            if (scriptSource === "image" && scriptImage == null) {
+              throw new Error("script_image is required when script_source='image'.");
+            }
+
+            // Tool type: Locust (default) or K6. K6 is Kubernetes-only and supports
+            // script and image modes (UI mode is deferred).
+            const toolType = ((b.tool_type as string) ?? "Locust") as "Locust" | "K6";
+            if (toolType !== "Locust" && toolType !== "K6") {
+              throw new Error(`tool_type '${toolType}' must be 'Locust' or 'K6'.`);
+            }
+            if (toolType === "K6" && targetType !== "kubernetes") {
+              throw new Error(
+                "K6 load tests require target_type='kubernetes' (LinuxVM is not supported).",
+              );
+            }
+
+            // Normalise tags (accept array or comma-separated string; default []).
+            const rawTags = b.tags;
+            const tags: string[] = Array.isArray(rawTags)
+              ? (rawTags as string[])
+              : typeof rawTags === "string"
+                ? (rawTags as string).split(",").map((t) => t.trim()).filter(Boolean)
+                : [];
+
+            // Build the canonical inputs[] array (well-known tunables → TemplateInput[]).
+            // inputs[] is identical between Locust and K6 script/image modes.
+            const inputs = buildLoadtestInputs(b, { targetType, scriptSource });
+
+            // K6 wraps the script in a toolConfig object (no top-level scriptContent).
+            // Built up-front so the same value drives both the JSON body and the YAML view.
+            let k6ToolConfig: Record<string, unknown> | undefined;
+            if (toolType === "K6") {
+              k6ToolConfig = buildK6ToolConfig(b, { scriptSource, script, targetUrl });
+            }
+
+            // Build the canonical LoadTest YAML manifest, then base64-encode for the wire.
+            // The manifest carries plain-text scriptContent (Locust inline) OR plain-text
+            // toolConfig.scriptContent (K6), so the YAML view is human-readable; the JSON
+            // body's base64 lives only on the wire.
+            const yamlManifest = buildLoadtestYamlManifest({
               name,
+              description: b.description as string | undefined,
+              tags,
+              identity,
+              toolType,
+              targetType,
+              scriptSource,
+              script,
+              k6ToolConfig,
+              environmentIdentifier: environmentIdentifier as string,
+              infraIdentifier: infraIdentifier as string,
+              inputs,
+            });
+
+            const body: Record<string, unknown> = {
+              identity,
+              name,
+              description: (b.description as string) ?? "",
+              tags,
               environmentIdentifier,
               infraIdentifier,
-              targetType,
-              toolType: (b.tool_type as string) ?? "Locust",
-              targetUrl,
               scriptSource,
-              defaultUsers: b.users != null ? b.users : 100,
-              defaultDurationSec: b.duration_sec != null ? b.duration_sec : 600,
-              defaultRampUpTimeSec: b.ramp_up_sec != null ? b.ramp_up_sec : 120,
+              targetType,
+              toolType,
+              inputs,
+              yaml: Buffer.from(yamlManifest, "utf8").toString("base64"),
             };
-            // Emit snake_case aliases for the required fields whose API key is a
-            // camelCase rename, so the registry's required-field validator (which
-            // checks the built body against the snake_case bodySchema field names)
-            // sees them. The load-test backend reads the camelCase keys and ignores
-            // the extra ones (same pattern as chaos_action create).
+
+            // Top-level scriptContent rules:
+            //   - Locust inline: base64 of the raw Python script.
+            //   - Locust image:  omitted (script_image rides in inputs[]).
+            //   - K6 script:     OMITTED at top level — the K6 script lives in
+            //                    toolConfig.scriptContent only (top-level would be
+            //                    treated as a Locust-style script and double-encoded).
+            //   - K6 image:      not yet supported (rejected earlier).
+            if (toolType === "Locust" && scriptSource === "inline") {
+              body.scriptContent = Buffer.from(script as string, "utf8").toString("base64");
+            }
+            if (toolType === "K6" && k6ToolConfig) {
+              body.toolConfig = k6ToolConfig;
+            }
+
+            // Emit snake_case aliases for the registry's required-field validator (which
+            // checks the built body against the snake_case bodySchema field names). The
+            // load-test backend reads the camelCase / inputs[] keys and ignores extras
+            // (same pattern as chaos_action create).
             if (environmentIdentifier != null) body.environment_id = environmentIdentifier;
             if (infraIdentifier != null) body.infra_id = infraIdentifier;
             if (targetUrl != null) body.target_url = targetUrl;
-            if (b.description != null) body.description = b.description;
-            if (tags != null) {
-              body.tags = Array.isArray(tags)
-                ? tags
-                : (tags as string).split(",").map((t: string) => t.trim()).filter(Boolean);
-            }
 
-            if (scriptSource === "image") {
-              // Custom Image mode (Kubernetes): prebuilt container image as the source.
-              if (scriptImage == null) {
-                throw new Error("script_image is required when script_source='image'.");
-              }
-              body.scriptImage = scriptImage;
-              const entrypoint = b.script_entrypoint ?? b.scriptEntrypoint;
-              if (entrypoint != null) body.scriptEntrypoint = entrypoint;
-              const loadArgs = b.load_args ?? b.loadArgs;
-              if (loadArgs != null) body.loadArgs = loadArgs;
-            } else {
-              // Inline (Python script) mode: base64-encode the raw locust script.
-              if (script == null) {
-                throw new Error(
-                  "script is required when script_source='inline' (the raw Python locust script).",
-                );
-              }
-              body.scriptContent = Buffer.from(script, "utf8").toString("base64");
-            }
-
-            // Kubernetes always carries a worker count (0 = standalone, N = distributed).
-            if (targetType === "kubernetes") {
-              const workerCount = b.worker_count != null ? b.worker_count : 0;
-              body.variables = {
-                workerCount: { type: "fixed", valueType: "int", value: workerCount },
-              };
-            }
             return body;
           },
           responseExtractor: chaosLoadTestExtract,
@@ -1568,6 +1899,10 @@ export const chaosToolset: ToolsetDefinition = {
               { name: "duration_sec", type: "number", required: false, description: descLoadtestDurationSec },
               { name: "ramp_up_sec", type: "number", required: false, description: descLoadtestRampUpSec },
               { name: "worker_count", type: "number", required: false, description: descLoadtestWorkerCount },
+              { name: "host_url", type: "string", required: false, description: descLoadtestHostUrl },
+              { name: "rps_limit", type: "number", required: false, description: descLoadtestRpsLimit },
+              { name: "iterations", type: "number", required: false, description: descLoadtestIterations },
+              { name: "env_vars", type: "array", required: false, description: descLoadtestEnvVars },
             ],
           },
         },
@@ -1586,6 +1921,9 @@ export const chaosToolset: ToolsetDefinition = {
           path: `${CHAOS_LOADTEST}/v1/load-tests/{loadtestId}/runs`,
           operationPolicy: { risk: "high_write", retryPolicy: "do_not_retry" },
           pathParams: { loadtest_id: "loadtestId" },
+          // TODO(runtime-inputs): accept { values: TemplateInputMinimum[] } when runtime
+          // inputs ('<+input>' sentinel) are added (see deferred follow-up plan). The empty
+          // body is correct while runtime inputs are unsupported on the create side.
           bodyBuilder: () => ({}),
           responseExtractor: passthrough,
           actionDescription: descRunLoadtest,

--- a/tests/registry/chaos-loadtest.test.ts
+++ b/tests/registry/chaos-loadtest.test.ts
@@ -1,12 +1,16 @@
 /**
  * Verifies chaos_loadtest create/list/get: request shape and response extraction.
  *
- * The load test API lives under a separate service path (loadTest/manager/api),
- * scopes via organizationIdentifier (CHAOS_SCOPE), and takes a Locust script in
- * "script mode" — the raw Python script is base64-encoded into scriptContent.
- * The create request mirrors the verified Harness UI curl.
+ * The load test API now uses a canonical TemplateInput[] array for every
+ * recognised tunable (run-params, target URL, worker count, image fields) and
+ * carries an optional base64-encoded YAML manifest alongside the JSON body.
+ * The three describe-block tests below mirror real verified Harness UI curls:
+ *   1. Locust + Kubernetes + inline Python script
+ *   2. Locust + Kubernetes + Custom Image
+ *   3. Locust + Linux VM + inline Python script
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import YAML from "yaml";
 import { Registry } from "../../src/registry/index.js";
 import type { Config } from "../../src/config.js";
 import type { HarnessClient } from "../../src/client/harness-client.js";
@@ -38,6 +42,13 @@ function makeClient(requestFn?: (...args: unknown[]) => unknown): HarnessClient 
   } as unknown as HarnessClient;
 }
 
+type LoadtestInput = {
+  name: string;
+  value: number | string;
+  type: "Integer" | "String";
+  required?: true;
+};
+
 const SCRIPT = `from locust import HttpUser, task, between
 
 
@@ -49,28 +60,47 @@ class GoogleUser(HttpUser):
         self.client.get("/")
 `;
 
+const K6_SCRIPT = `/**
+ * main.js - Sample JavaScript file with an entry function
+ */
+
+function greet(name) {
+  return \`Hello, \${name}!\`;
+}
+
+function add(a, b) {
+  return a + b;
+}
+
+// Entry point
+export default function main() {
+  console.log(greet("World"));
+  console.log("2 + 3 =", add(2, 3));
+}
+
+main();
+`;
+
 describe("chaos_loadtest create", () => {
   let registry: Registry;
   beforeEach(() => {
     registry = new Registry(makeConfig());
   });
 
-  it("create (Linux VM): builds the body matching the verified curl, base64 script, organizationIdentifier scope", async () => {
-    const mockRequest = vi.fn().mockResolvedValue({ identity: "ranndom10223", name: "ranndom-10223" });
+  it("create (Linux VM, inline script): mirrors verified curl 3 — inputs[], base64 scriptContent, base64 yaml manifest", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ identity: "locust3", name: "locust-3" });
     const client = makeClient(mockRequest);
 
     await registry.dispatch(client, "chaos_loadtest", "create", {
       org_id: "templatescopetest",
       project_id: "templatescopetest",
-      name: "ranndom-10223",
-      identity: "ranndom10223",
-      environment_id: "env90x",
-      infra_id: "ce7dcb77-b327-4865-92b5-899ee1718e30",
-      target_url: "https://www.google.com",
+      name: "locust-3",
+      identity: "locust3",
+      environment_id: "env91x",
+      infra_id: "79608c02-f1ed-46c0-8551-483509d68111",
+      target_url: "http://www.example.com",
       script: SCRIPT,
-      users: 100,
-      duration_sec: 600,
-      ramp_up_sec: 120,
+      target_type: "machine-chaos-linux",
     });
 
     expect(mockRequest).toHaveBeenCalledOnce();
@@ -83,26 +113,146 @@ describe("chaos_loadtest create", () => {
     expect(call.params.projectIdentifier).toBe("templatescopetest");
     expect(call.params.orgIdentifier).toBeUndefined();
 
-    // Body matches the curl: camelCase API keys, base64 scriptContent, inline source.
+    // Top-level wire shape — NEW canonical form.
     expect(call.body).toMatchObject({
-      identity: "ranndom10223",
-      name: "ranndom-10223",
-      environmentIdentifier: "env90x",
-      infraIdentifier: "ce7dcb77-b327-4865-92b5-899ee1718e30",
-      targetUrl: "https://www.google.com",
+      identity: "locust3",
+      name: "locust-3",
+      description: "",
+      tags: [],
+      environmentIdentifier: "env91x",
+      infraIdentifier: "79608c02-f1ed-46c0-8551-483509d68111",
+      scriptSource: "inline",
       targetType: "machine-chaos-linux",
       toolType: "Locust",
-      scriptSource: "inline",
-      defaultUsers: 100,
-      defaultDurationSec: 600,
-      defaultRampUpTimeSec: 120,
     });
     expect(call.body.scriptContent).toBe(Buffer.from(SCRIPT, "utf8").toString("base64"));
+
+    // Legacy fields are gone.
+    expect(call.body.defaultUsers).toBeUndefined();
+    expect(call.body.defaultDurationSec).toBeUndefined();
+    expect(call.body.defaultRampUpTimeSec).toBeUndefined();
+    expect(call.body.variables).toBeUndefined();
+    expect(call.body.targetUrl).toBeUndefined(); // moved into inputs[]
+
+    // inputs[] in canonical order (no workerCount on Linux), exact shape per curl 3.
+    expect(call.body.inputs).toEqual([
+      { name: "targetUsers", value: 100, type: "Integer", required: true },
+      { name: "durationSeconds", value: 600, type: "Integer" },
+      { name: "rampUpTimeSec", value: 120, type: "Integer" },
+      { name: "targetUrl", value: "http://www.example.com", type: "String" },
+    ]);
+
+    // yaml field is base64; decode and assert canonical manifest shape.
+    const yamlText = Buffer.from(call.body.yaml as string, "base64").toString("utf8");
+    const manifest = YAML.parse(yamlText);
+    expect(manifest.kind).toBe("LoadTest");
+    expect(manifest.apiVersion).toBe("v1alpha1");
+    expect(manifest.name).toBe("locust-3");
+    expect(manifest.spec).toMatchObject({
+      identity: "locust3",
+      toolType: "Locust",
+      infraType: "linux",
+      targetType: "machine-chaos-linux",
+      scriptSource: "inline",
+      infraId: "79608c02-f1ed-46c0-8551-483509d68111",
+      envId: "env91x",
+    });
+    // YAML scriptContent is PLAIN TEXT (not base64).
+    expect(manifest.spec.scriptContent).toBe(SCRIPT);
+    expect(manifest.spec.inputs).toEqual(call.body.inputs);
 
     // skipScopeBodyInjection: scope must NOT be injected into the JSON body.
     expect(call.body.orgIdentifier).toBeUndefined();
     expect(call.body.organizationIdentifier).toBeUndefined();
     expect(call.body.projectIdentifier).toBeUndefined();
+  });
+
+  it("create (Kubernetes inline): mirrors verified curl 1 — inputs[workerCount=1], no variables map", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ identity: "locust1" });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "chaos_loadtest", "create", {
+      org_id: "templatescopetest",
+      project_id: "templatescopetest",
+      name: "locust-1",
+      identity: "locust1",
+      description: "op desc",
+      tags: ["op:1", "op:2"],
+      environment_id: "ashloadtest",
+      infra_id: "deletelater1",
+      target_url: "http://www.example.com",
+      script: SCRIPT,
+      target_type: "kubernetes",
+      worker_count: 1,
+    });
+
+    const body = mockRequest.mock.calls[0][0].body;
+    expect(body.targetType).toBe("kubernetes");
+    expect(body.scriptSource).toBe("inline");
+    expect(body.description).toBe("op desc");
+    expect(body.tags).toEqual(["op:1", "op:2"]);
+    expect(body.variables).toBeUndefined(); // legacy {workerCount: {...}} map is gone
+
+    expect(body.inputs).toEqual([
+      { name: "targetUsers", value: 100, type: "Integer", required: true },
+      { name: "durationSeconds", value: 600, type: "Integer" },
+      { name: "rampUpTimeSec", value: 120, type: "Integer" },
+      { name: "workerCount", value: 1, type: "Integer" },
+      { name: "targetUrl", value: "http://www.example.com", type: "String" },
+    ]);
+
+    const manifest = YAML.parse(Buffer.from(body.yaml as string, "base64").toString("utf8"));
+    expect(manifest.description).toBe("op desc");
+    expect(manifest.tags).toEqual(["op:1", "op:2"]);
+    expect(manifest.spec.infraType).toBe("kubernetes");
+    expect(manifest.spec.targetType).toBe("kubernetes");
+    expect(manifest.spec.inputs).toEqual(body.inputs);
+  });
+
+  it("create (Kubernetes Custom Image): mirrors verified curl 2 — image inputs[] entries, no scriptContent", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ identity: "locust2" });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "chaos_loadtest", "create", {
+      org_id: "templatescopetest",
+      project_id: "templatescopetest",
+      name: "locust-2",
+      identity: "locust2",
+      environment_id: "ashloadtest",
+      infra_id: "expertdatest1",
+      target_url: "http://www.example.com",
+      target_type: "kubernetes",
+      script_source: "image",
+      script_image: "imageregistry",
+      script_entrypoint: "/script/xyz",
+      load_args: "tags=smoke",
+      worker_count: 1,
+    });
+
+    const body = mockRequest.mock.calls[0][0].body;
+    expect(body.scriptSource).toBe("image");
+    expect(body.scriptContent).toBeUndefined();
+    // Legacy top-level image fields gone.
+    expect(body.scriptImage).toBeUndefined();
+    expect(body.scriptEntrypoint).toBeUndefined();
+    expect(body.loadArgs).toBeUndefined();
+
+    expect(body.inputs).toEqual([
+      { name: "targetUsers", value: 100, type: "Integer", required: true },
+      { name: "durationSeconds", value: 600, type: "Integer" },
+      { name: "rampUpTimeSec", value: 120, type: "Integer" },
+      { name: "workerCount", value: 1, type: "Integer" },
+      { name: "targetUrl", value: "http://www.example.com", type: "String" },
+      { name: "scriptImage", value: "imageregistry", type: "String", required: true },
+      { name: "scriptEntrypoint", value: "/script/xyz", type: "String", required: true },
+      { name: "loadArgs", value: "tags=smoke", type: "String" },
+    ]);
+
+    const manifest = YAML.parse(Buffer.from(body.yaml as string, "base64").toString("utf8"));
+    expect(manifest.spec.scriptSource).toBe("image");
+    // Image mode → no scriptContent in YAML (the script lives in the container image).
+    expect(manifest.spec.scriptContent).toBeUndefined();
+    expect(manifest.spec.inputs).toEqual(body.inputs);
   });
 
   it("create: derives identity from name (alphanumeric) when omitted", async () => {
@@ -121,7 +271,7 @@ describe("chaos_loadtest create", () => {
     expect(mockRequest.mock.calls[0][0].body.identity).toBe("testloadone");
   });
 
-  it("create: applies load-config defaults (100/600/120) when omitted", async () => {
+  it("create: applies load-config defaults (100/600/120) in inputs[] when omitted", async () => {
     const mockRequest = vi.fn().mockResolvedValue({});
     const client = makeClient(mockRequest);
 
@@ -132,12 +282,15 @@ describe("chaos_loadtest create", () => {
     });
 
     const body = mockRequest.mock.calls[0][0].body;
-    expect(body.defaultUsers).toBe(100);
-    expect(body.defaultDurationSec).toBe(600);
-    expect(body.defaultRampUpTimeSec).toBe(120);
+    const byName = Object.fromEntries(
+      (body.inputs as LoadtestInput[]).map((i) => [i.name, i.value]),
+    );
+    expect(byName.targetUsers).toBe(100);
+    expect(byName.durationSeconds).toBe(600);
+    expect(byName.rampUpTimeSec).toBe(120);
   });
 
-  it("create: zero-valued load config survives (!= null, not truthiness)", async () => {
+  it("create: zero-valued load config survives in inputs[] (!= null, not truthiness)", async () => {
     const mockRequest = vi.fn().mockResolvedValue({});
     const client = makeClient(mockRequest);
 
@@ -149,12 +302,15 @@ describe("chaos_loadtest create", () => {
     });
 
     const body = mockRequest.mock.calls[0][0].body;
-    expect(body.defaultUsers).toBe(0);
-    expect(body.defaultDurationSec).toBe(0);
-    expect(body.defaultRampUpTimeSec).toBe(0);
+    const byName = Object.fromEntries(
+      (body.inputs as LoadtestInput[]).map((i) => [i.name, i.value]),
+    );
+    expect(byName.targetUsers).toBe(0);
+    expect(byName.durationSeconds).toBe(0);
+    expect(byName.rampUpTimeSec).toBe(0);
   });
 
-  it("create (Kubernetes): worker_count is sent as variables.workerCount", async () => {
+  it("create (Kubernetes): worker_count emitted as inputs[name=workerCount]", async () => {
     const mockRequest = vi.fn().mockResolvedValue({});
     const client = makeClient(mockRequest);
 
@@ -167,12 +323,13 @@ describe("chaos_loadtest create", () => {
 
     const body = mockRequest.mock.calls[0][0].body;
     expect(body.targetType).toBe("kubernetes");
-    expect(body.variables).toEqual({
-      workerCount: { type: "fixed", valueType: "int", value: 3 },
-    });
+    const workerEntry = (body.inputs as LoadtestInput[]).find((i) => i.name === "workerCount");
+    expect(workerEntry).toEqual({ name: "workerCount", value: 3, type: "Integer" });
+    // No legacy variables map.
+    expect(body.variables).toBeUndefined();
   });
 
-  it("create: Linux VM does not emit worker variables", async () => {
+  it("create: Linux VM does NOT emit workerCount in inputs[]", async () => {
     const mockRequest = vi.fn().mockResolvedValue({});
     const client = makeClient(mockRequest);
 
@@ -180,13 +337,31 @@ describe("chaos_loadtest create", () => {
       org_id: "o", project_id: "p",
       name: "lt", environment_id: "e", infra_id: "i",
       target_url: "https://example.com", script: SCRIPT,
-      worker_count: 3,
+      worker_count: 3, // even when explicitly set on Linux, it should NOT show up.
     });
 
-    expect(mockRequest.mock.calls[0][0].body.variables).toBeUndefined();
+    const body = mockRequest.mock.calls[0][0].body;
+    const workerEntry = (body.inputs as LoadtestInput[]).find((i) => i.name === "workerCount");
+    expect(workerEntry).toBeUndefined();
   });
 
-  it("create: rejects when a required field (target_url) is missing", async () => {
+  it("create (Kubernetes): worker_count defaults to 0 in inputs[] when omitted", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({});
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "chaos_loadtest", "create", {
+      org_id: "o", project_id: "p",
+      name: "k8s-lt", environment_id: "e", infra_id: "i",
+      target_url: "https://example.com", script: SCRIPT,
+      target_type: "kubernetes",
+    });
+
+    const body = mockRequest.mock.calls[0][0].body;
+    const workerEntry = (body.inputs as LoadtestInput[]).find((i) => i.name === "workerCount");
+    expect(workerEntry).toEqual({ name: "workerCount", value: 0, type: "Integer" });
+  });
+
+  it("create: rejects when target_url is missing", async () => {
     const mockRequest = vi.fn().mockResolvedValue({});
     const client = makeClient(mockRequest);
 
@@ -199,7 +374,7 @@ describe("chaos_loadtest create", () => {
     expect(mockRequest).not.toHaveBeenCalled();
   });
 
-  it("create: rejects when the script is missing", async () => {
+  it("create: rejects when the inline script is missing", async () => {
     const mockRequest = vi.fn().mockResolvedValue({});
     const client = makeClient(mockRequest);
 
@@ -213,61 +388,7 @@ describe("chaos_loadtest create", () => {
     expect(mockRequest).not.toHaveBeenCalled();
   });
 
-  it("create (Kubernetes inline): mirrors curl 1 — base64 script + workerCount=1", async () => {
-    const mockRequest = vi.fn().mockResolvedValue({ identity: "kuberneteexample1" });
-    const client = makeClient(mockRequest);
-
-    await registry.dispatch(client, "chaos_loadtest", "create", {
-      org_id: "templatescopetest", project_id: "templatescopetest",
-      name: "kubernete-example-1", identity: "kuberneteexample1",
-      environment_id: "ashloadtest", infra_id: "discoverytestallsettingsset",
-      target_url: "https://www.google.com", script: SCRIPT,
-      target_type: "kubernetes", worker_count: 1,
-    });
-
-    const body = mockRequest.mock.calls[0][0].body;
-    expect(body.targetType).toBe("kubernetes");
-    expect(body.scriptSource).toBe("inline");
-    expect(body.scriptContent).toBe(Buffer.from(SCRIPT, "utf8").toString("base64"));
-    expect(body.scriptImage).toBeUndefined();
-    expect(body.variables).toEqual({
-      workerCount: { type: "fixed", valueType: "int", value: 1 },
-    });
-  });
-
-  it("create (Kubernetes Custom Image): mirrors curl 2 — image/entrypoint/loadArgs, no scriptContent, workerCount=0", async () => {
-    const mockRequest = vi.fn().mockResolvedValue({ identity: "kubernetesexample2" });
-    const client = makeClient(mockRequest);
-
-    await registry.dispatch(client, "chaos_loadtest", "create", {
-      org_id: "templatescopetest", project_id: "templatescopetest",
-      name: "kubernetes-example-2", identity: "kubernetesexample2",
-      environment_id: "ashloadtest", infra_id: "discoverytestallsettingsset",
-      target_url: "https://www.google.com",
-      target_type: "kubernetes",
-      script_source: "image",
-      script_image: "my-registry/my-load-test:latest",
-      script_entrypoint: "locustfile.py",
-      load_args: "tags=smoke,fast;headless=true",
-      worker_count: 0,
-    });
-
-    const body = mockRequest.mock.calls[0][0].body;
-    expect(body).toMatchObject({
-      targetType: "kubernetes",
-      toolType: "Locust",
-      scriptSource: "image",
-      scriptImage: "my-registry/my-load-test:latest",
-      scriptEntrypoint: "locustfile.py",
-      loadArgs: "tags=smoke,fast;headless=true",
-    });
-    expect(body.scriptContent).toBeUndefined();
-    expect(body.variables).toEqual({
-      workerCount: { type: "fixed", valueType: "int", value: 0 },
-    });
-  });
-
-  it("create: image mode is inferred from script_image when script_source omitted", async () => {
+  it("create: image mode is inferred from script_image when script_source is omitted", async () => {
     const mockRequest = vi.fn().mockResolvedValue({});
     const client = makeClient(mockRequest);
 
@@ -281,23 +402,13 @@ describe("chaos_loadtest create", () => {
 
     const body = mockRequest.mock.calls[0][0].body;
     expect(body.scriptSource).toBe("image");
-    expect(body.scriptImage).toBe("my-registry/my-load-test:latest");
     expect(body.scriptContent).toBeUndefined();
-  });
-
-  it("create (Kubernetes): worker_count defaults to 0 when omitted", async () => {
-    const mockRequest = vi.fn().mockResolvedValue({});
-    const client = makeClient(mockRequest);
-
-    await registry.dispatch(client, "chaos_loadtest", "create", {
-      org_id: "o", project_id: "p",
-      name: "k8s-lt", environment_id: "e", infra_id: "i",
-      target_url: "https://example.com", script: SCRIPT,
-      target_type: "kubernetes",
-    });
-
-    expect(mockRequest.mock.calls[0][0].body.variables).toEqual({
-      workerCount: { type: "fixed", valueType: "int", value: 0 },
+    const imageEntry = (body.inputs as LoadtestInput[]).find((i) => i.name === "scriptImage");
+    expect(imageEntry).toEqual({
+      name: "scriptImage",
+      value: "my-registry/my-load-test:latest",
+      type: "String",
+      required: true,
     });
   });
 
@@ -316,18 +427,20 @@ describe("chaos_loadtest create", () => {
     expect(mockRequest).not.toHaveBeenCalled();
   });
 
-  it("create: rejects an invalid name (uppercase / spaces)", async () => {
+  it("create: display name is permissive; identity is auto-slugged when omitted", async () => {
     const mockRequest = vi.fn().mockResolvedValue({});
     const client = makeClient(mockRequest);
 
-    await expect(
-      registry.dispatch(client, "chaos_loadtest", "create", {
-        org_id: "o", project_id: "p",
-        name: "Invalid Name", environment_id: "e", infra_id: "i",
-        target_url: "https://example.com", script: SCRIPT,
-      }),
-    ).rejects.toThrow(/name/);
-    expect(mockRequest).not.toHaveBeenCalled();
+    await registry.dispatch(client, "chaos_loadtest", "create", {
+      org_id: "o", project_id: "p",
+      name: "My Load Test",
+      environment_id: "e", infra_id: "i",
+      target_url: "https://example.com", script: SCRIPT,
+    });
+
+    const body = mockRequest.mock.calls[0][0].body;
+    expect(body.name).toBe("My Load Test");
+    expect(body.identity).toBe("MyLoadTest");
   });
 });
 
@@ -350,6 +463,11 @@ describe("chaos_loadtest list/get", () => {
           scriptSource: "inline",
           scriptContent: "BIG_BASE64_BLOB",
           createdByUserDetails: { name: "someone", email: "a@b.com" },
+          inputs: [
+            { name: "targetUsers", value: 100, type: "Integer", required: true },
+            { name: "targetUrl", value: "http://www.example.com", type: "String" },
+          ],
+          variables: [],
         },
       ],
       pagination: { totalItems: 5 },
@@ -372,38 +490,463 @@ describe("chaos_loadtest list/get", () => {
     expect(item.loadtestId).toBe("testloadone");
     expect(item.identity).toBe("testloadone");
     expect(item.name).toBe("test-load-one");
-    // Large/opaque fields are dropped from the projected shape.
+    // Large / opaque fields are dropped from the projected shape.
     expect(item.scriptContent).toBeUndefined();
     expect(item.createdByUserDetails).toBeUndefined();
+    // Canonical inputs[] passes through; derived target_url + users are surfaced.
+    expect(item.inputs).toHaveLength(2);
+    expect(item.users).toBe(100);
+    expect(item.target_url).toBe("http://www.example.com");
   });
 
-  it("get: projects a stable shape and attaches a load-tests deep link", async () => {
+  it("get: extracts canonical inputs[] AND derives convenience scalars from inputs[]", async () => {
     const mockRequest = vi.fn().mockResolvedValue({
-      identity: "testloadone",
-      name: "test-load-one",
-      environmentIdentifier: "env90x",
-      infraIdentifier: "infra-1",
-      targetUrl: "https://www.google.com",
+      identity: "locust1",
+      name: "locust-1",
+      environmentIdentifier: "ashloadtest",
+      infraIdentifier: "deletelater1",
+      targetType: "kubernetes",
       toolType: "Locust",
+      scriptSource: "inline",
+      inputs: [
+        { name: "targetUsers", value: 100, type: "Integer", required: true },
+        { name: "durationSeconds", value: 600, type: "Integer" },
+        { name: "rampUpTimeSec", value: 120, type: "Integer" },
+        { name: "workerCount", value: 1, type: "Integer" },
+        { name: "targetUrl", value: "http://www.example.com", type: "String" },
+      ],
+      variables: [],
+      yaml: "BASE64_YAML_BLOB",
       scriptContent: "BIG_BASE64_BLOB",
       updatedByUserDetails: { name: "someone" },
     });
     const client = makeClient(mockRequest);
 
     const result = (await registry.dispatch(client, "chaos_loadtest", "get", {
-      loadtest_id: "testloadone",
+      loadtest_id: "locust1",
       org_id: "templatescopetest",
       project_id: "templatescopetest",
     })) as Record<string, unknown>;
 
     const call = mockRequest.mock.calls[0][0];
-    expect(call.path).toBe("/loadTest/manager/api/v1/load-tests/testloadone");
+    expect(call.path).toBe("/loadTest/manager/api/v1/load-tests/locust1");
 
-    expect(result.identity).toBe("testloadone");
+    // Canonical arrays preserved.
+    expect(result.inputs).toHaveLength(5);
+    expect(result.variables).toEqual([]);
+    expect(result.yaml).toBe("BASE64_YAML_BLOB");
+
+    // Derived convenience scalars match the create-side LLM surface.
+    expect(result.target_url).toBe("http://www.example.com");
+    expect(result.users).toBe(100);
+    expect(result.duration_sec).toBe(600);
+    expect(result.ramp_up_sec).toBe(120);
+    expect(result.worker_count).toBe(1);
+
+    // Legacy top-level projections are not surfaced anymore.
+    expect((result as Record<string, unknown>).defaultUsers).toBeUndefined();
+    expect((result as Record<string, unknown>).defaultDurationSec).toBeUndefined();
+    expect((result as Record<string, unknown>).defaultRampUpTimeSec).toBeUndefined();
+    expect((result as Record<string, unknown>).defaultWorkerCount).toBeUndefined();
+    expect((result as Record<string, unknown>).targetUrl).toBeUndefined();
+
+    // Large blobs still dropped.
     expect(result.scriptContent).toBeUndefined();
     expect(result.updatedByUserDetails).toBeUndefined();
+
+    // Deep link is attached.
     expect(result.openInHarness).toBe(
-      "https://app.harness.io/ng/account/test-account/module/chaos/orgs/templatescopetest/projects/templatescopetest/load-tests/testloadone",
+      "https://app.harness.io/ng/account/test-account/module/chaos/orgs/templatescopetest/projects/templatescopetest/load-tests/locust1",
     );
+  });
+});
+
+describe("chaos_loadtest create — K6", () => {
+  let registry: Registry;
+  beforeEach(() => {
+    registry = new Registry(makeConfig());
+  });
+
+  it("create (K6 Kubernetes, Upload K6 script): mirrors verified curl — inputs[], toolConfig with base64 script, env-var literal + secret reference, base64 yaml manifest", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ identity: "k61", name: "k6-1" });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "chaos_loadtest", "create", {
+      org_id: "templatescopetest",
+      project_id: "templatescopetest",
+      tool_type: "K6",
+      name: "k6-1",
+      identity: "k61",
+      description: "op desc",
+      tags: ["tag:1"],
+      environment_id: "ashloadtest",
+      infra_id: "deletelater1",
+      target_url: "http://www.google.com",
+      script: K6_SCRIPT,
+      target_type: "kubernetes",
+      worker_count: 3,
+      rps_limit: 98,
+      env_vars: [
+        { key: "var1", value: "staticValue_withoutSecret" },
+        { key: "secretKeyVar2", secret_id: "vcenter-admin-username", secret_scope: "project" },
+      ],
+    });
+
+    const call = mockRequest.mock.calls[0][0];
+    expect(call.method).toBe("POST");
+    expect(call.path).toBe("/loadTest/manager/api/v1/load-tests");
+
+    const body = call.body;
+
+    // Top-level wire shape matches the verified curl exactly.
+    expect(body).toMatchObject({
+      identity: "k61",
+      name: "k6-1",
+      description: "op desc",
+      tags: ["tag:1"],
+      environmentIdentifier: "ashloadtest",
+      infraIdentifier: "deletelater1",
+      scriptSource: "inline",
+      targetType: "kubernetes",
+      toolType: "K6",
+    });
+    // K6 does NOT send top-level scriptContent.
+    expect(body.scriptContent).toBeUndefined();
+
+    // inputs[] in canonical order (mirrors curl exactly).
+    expect(body.inputs).toEqual([
+      { name: "targetUsers", value: 100, type: "Integer", required: true },
+      { name: "durationSeconds", value: 600, type: "Integer" },
+      { name: "rampUpTimeSec", value: 120, type: "Integer" },
+      { name: "workerCount", value: 3, type: "Integer" },
+      { name: "targetUrl", value: "http://www.google.com", type: "String" },
+    ]);
+
+    // toolConfig: K6 wire shape.
+    expect(body.toolConfig).toMatchObject({
+      mode: "script",
+      hostUrl: "http://www.google.com",
+      options: { rpsLimit: 98 },
+      envVars: [
+        { key: "var1", value: "staticValue_withoutSecret" },
+        {
+          key: "secretKeyVar2",
+          value: 'secrets.getValue("vcenter-admin-username")',
+          secret: true,
+        },
+      ],
+    });
+    expect((body.toolConfig as Record<string, unknown>).scriptContent).toBe(
+      Buffer.from(K6_SCRIPT, "utf8").toString("base64"),
+    );
+
+    // Decoded YAML manifest.
+    const manifest = YAML.parse(Buffer.from(body.yaml as string, "base64").toString("utf8"));
+    expect(manifest.spec).toMatchObject({
+      identity: "k61",
+      toolType: "K6",
+      infraType: "kubernetes",
+      targetType: "kubernetes",
+      scriptSource: "inline",
+      infraId: "deletelater1",
+      envId: "ashloadtest",
+    });
+    // YAML must NOT have spec.scriptContent for K6.
+    expect(manifest.spec.scriptContent).toBeUndefined();
+    // YAML toolConfig.scriptContent is PLAIN TEXT (not base64).
+    expect(manifest.spec.toolConfig.scriptContent).toBe(K6_SCRIPT);
+    expect(manifest.spec.toolConfig.mode).toBe("script");
+    expect(manifest.spec.toolConfig.hostUrl).toBe("http://www.google.com");
+    expect(manifest.spec.toolConfig.options).toEqual({ rpsLimit: 98 });
+    expect(manifest.spec.toolConfig.envVars).toEqual(body.toolConfig.envVars);
+    expect(manifest.spec.inputs).toEqual(body.inputs);
+  });
+
+  it("create (K6): rejects target_type='machine-chaos-linux'", async () => {
+    const client = makeClient(vi.fn());
+    await expect(
+      registry.dispatch(client, "chaos_loadtest", "create", {
+        org_id: "o", project_id: "p",
+        tool_type: "K6",
+        name: "k6-lt", environment_id: "e", infra_id: "i",
+        target_url: "https://example.com",
+        script: K6_SCRIPT,
+        target_type: "machine-chaos-linux",
+      }),
+    ).rejects.toThrow(/K6.*kubernetes/);
+  });
+
+  it("create (K6): rejects script missing 'export default'", async () => {
+    const client = makeClient(vi.fn());
+    await expect(
+      registry.dispatch(client, "chaos_loadtest", "create", {
+        org_id: "o", project_id: "p",
+        tool_type: "K6",
+        name: "k6-lt", environment_id: "e", infra_id: "i",
+        target_url: "https://example.com",
+        script: "function main() { /* no default export */ }",
+        target_type: "kubernetes",
+      }),
+    ).rejects.toThrow(/export default function/);
+  });
+
+  it.each([
+    { caseLabel: "reserved name", env: [{ key: "PATH", value: "x" }], match: /reserved/ },
+    { caseLabel: "invalid key pattern", env: [{ key: "2foo", value: "x" }], match: /must match/ },
+    { caseLabel: "duplicate keys", env: [{ key: "A", value: "1" }, { key: "A", value: "2" }], match: /duplicated/ },
+    { caseLabel: "both value and secret_id", env: [{ key: "A", value: "x", secret_id: "y" }], match: /exactly one of/ },
+    { caseLabel: "neither value nor secret_id", env: [{ key: "A" }], match: /exactly one of/ },
+    { caseLabel: "invalid secret_scope", env: [{ key: "A", secret_id: "x", secret_scope: "global" }], match: /account.*org.*project/ },
+  ])("create (K6): env_vars validation rejects $caseLabel", async ({ env, match }) => {
+    const client = makeClient(vi.fn());
+    await expect(
+      registry.dispatch(client, "chaos_loadtest", "create", {
+        org_id: "o", project_id: "p",
+        tool_type: "K6",
+        name: "k6-lt", environment_id: "e", infra_id: "i",
+        target_url: "https://example.com",
+        script: K6_SCRIPT,
+        target_type: "kubernetes",
+        env_vars: env,
+      }),
+    ).rejects.toThrow(match);
+  });
+
+  it.each([
+    { scope: "account", id: "gcp-ca-cert", wire: 'secrets.getValue("account.gcp-ca-cert")' },
+    { scope: "org", id: "org-level-secret", wire: 'secrets.getValue("org.org-level-secret")' },
+    { scope: "project", id: "vcenter-admin-username", wire: 'secrets.getValue("vcenter-admin-username")' },
+  ])("create (K6): secret_scope='$scope' produces $wire", async ({ scope, id, wire }) => {
+    const mockRequest = vi.fn().mockResolvedValue({});
+    const client = makeClient(mockRequest);
+    await registry.dispatch(client, "chaos_loadtest", "create", {
+      org_id: "o", project_id: "p",
+      tool_type: "K6",
+      name: "k6-lt", environment_id: "e", infra_id: "i",
+      target_url: "https://example.com",
+      script: K6_SCRIPT,
+      target_type: "kubernetes",
+      env_vars: [{ key: "SECRET", secret_id: id, secret_scope: scope }],
+    });
+    const envVars = (mockRequest.mock.calls[0][0].body.toolConfig as Record<string, unknown>)
+      .envVars;
+    expect(envVars).toEqual([{ key: "SECRET", value: wire, secret: true }]);
+  });
+
+  it("create (K6): secret_scope defaults to 'project' when omitted", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({});
+    const client = makeClient(mockRequest);
+    await registry.dispatch(client, "chaos_loadtest", "create", {
+      org_id: "o", project_id: "p",
+      tool_type: "K6",
+      name: "k6-lt", environment_id: "e", infra_id: "i",
+      target_url: "https://example.com",
+      script: K6_SCRIPT,
+      target_type: "kubernetes",
+      env_vars: [{ key: "SECRET", secret_id: "my-secret" }],
+    });
+    const envVars = (mockRequest.mock.calls[0][0].body.toolConfig as Record<string, unknown>)
+      .envVars;
+    expect(envVars).toEqual([
+      { key: "SECRET", value: 'secrets.getValue("my-secret")', secret: true },
+    ]);
+  });
+
+  it("create (K6): host_url defaults to the origin of target_url when omitted", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({});
+    const client = makeClient(mockRequest);
+    await registry.dispatch(client, "chaos_loadtest", "create", {
+      org_id: "o", project_id: "p",
+      tool_type: "K6",
+      name: "k6-lt", environment_id: "e", infra_id: "i",
+      target_url: "https://api.example.com/foo/bar?q=1",
+      script: K6_SCRIPT,
+      target_type: "kubernetes",
+    });
+    const toolConfig = mockRequest.mock.calls[0][0].body.toolConfig as Record<string, unknown>;
+    expect(toolConfig.hostUrl).toBe("https://api.example.com");
+  });
+
+  it("create (K6): omits options/envVars/iterations from toolConfig when empty", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({});
+    const client = makeClient(mockRequest);
+    await registry.dispatch(client, "chaos_loadtest", "create", {
+      org_id: "o", project_id: "p",
+      tool_type: "K6",
+      name: "k6-lt", environment_id: "e", infra_id: "i",
+      target_url: "https://example.com",
+      script: K6_SCRIPT,
+      target_type: "kubernetes",
+    });
+    const tc = mockRequest.mock.calls[0][0].body.toolConfig as Record<string, unknown>;
+    expect(Object.keys(tc).sort()).toEqual(["hostUrl", "mode", "scriptContent"]);
+  });
+
+  it("create (Locust): existing behaviour unchanged — no toolConfig emitted, top-level scriptContent still set", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({});
+    const client = makeClient(mockRequest);
+    await registry.dispatch(client, "chaos_loadtest", "create", {
+      org_id: "o", project_id: "p",
+      name: "lt", environment_id: "e", infra_id: "i",
+      target_url: "https://example.com", script: SCRIPT,
+      target_type: "kubernetes",
+    });
+    const body = mockRequest.mock.calls[0][0].body;
+    expect(body.toolType).toBe("Locust"); // default when tool_type omitted
+    expect(body.toolConfig).toBeUndefined();
+    expect(body.scriptContent).toBe(Buffer.from(SCRIPT, "utf8").toString("base64"));
+  });
+
+  it("create (K6 Kubernetes, Using Custom Image): mirrors verified curl k6-2 — toolConfig.customImage, inputs[] with image fields, base64 yaml manifest", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ identity: "k62", name: "k6-2" });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "chaos_loadtest", "create", {
+      org_id: "templatescopetest",
+      project_id: "templatescopetest",
+      tool_type: "K6",
+      name: "k6-2",
+      identity: "k62",
+      description: "optional desc",
+      tags: ["tag:op1"],
+      environment_id: "ashloadtest",
+      infra_id: "discoverytestallsettingsset",
+      target_url: "http://www.example.com",
+      target_type: "kubernetes",
+      script_source: "image",
+      script_image: " my-image", // preserve leading space per the verified curl
+      script_entrypoint: "/script.json",
+      load_args: "tags=smoke,random;headless=true",
+      worker_count: 1,
+      rps_limit: 29,
+      env_vars: [
+        { key: "var1", value: "val1" },
+        { key: "secretKeyVar2", secret_id: "gcp-ca-cert", secret_scope: "account" },
+      ],
+    });
+
+    const body = mockRequest.mock.calls[0][0].body;
+
+    // Top-level wire shape matches the verified curl exactly.
+    expect(body).toMatchObject({
+      identity: "k62",
+      name: "k6-2",
+      description: "optional desc",
+      tags: ["tag:op1"],
+      environmentIdentifier: "ashloadtest",
+      infraIdentifier: "discoverytestallsettingsset",
+      scriptSource: "image",
+      targetType: "kubernetes",
+      toolType: "K6",
+    });
+    // K6 (any mode) does NOT send top-level scriptContent.
+    expect(body.scriptContent).toBeUndefined();
+
+    // inputs[] order matches the curl (5 standard + 3 image entries).
+    expect(body.inputs).toEqual([
+      { name: "targetUsers", value: 100, type: "Integer", required: true },
+      { name: "durationSeconds", value: 600, type: "Integer" },
+      { name: "rampUpTimeSec", value: 120, type: "Integer" },
+      { name: "workerCount", value: 1, type: "Integer" },
+      { name: "targetUrl", value: "http://www.example.com", type: "String" },
+      { name: "scriptImage", value: " my-image", type: "String", required: true },
+      { name: "scriptEntrypoint", value: "/script.json", type: "String", required: true },
+      { name: "loadArgs", value: "tags=smoke,random;headless=true", type: "String" },
+    ]);
+
+    // toolConfig: K6 image-mode wire shape.
+    expect(body.toolConfig).toEqual({
+      mode: "image",
+      customImage: { image: " my-image", entrypoint: "/script.json" },
+      hostUrl: "http://www.example.com",
+      options: { rpsLimit: 29 },
+      envVars: [
+        { key: "var1", value: "val1" },
+        {
+          key: "secretKeyVar2",
+          value: 'secrets.getValue("account.gcp-ca-cert")',
+          secret: true,
+        },
+      ],
+    });
+    // toolConfig.customImage MUST NOT carry loadArgs (load_args rides only in inputs[]).
+    const ci = (body.toolConfig as Record<string, unknown>).customImage as Record<string, unknown>;
+    expect(ci.runArgs).toBeUndefined();
+    expect(ci.loadArgs).toBeUndefined();
+
+    // Decoded YAML manifest.
+    const manifest = YAML.parse(Buffer.from(body.yaml as string, "base64").toString("utf8"));
+    expect(manifest.spec).toMatchObject({
+      identity: "k62",
+      toolType: "K6",
+      infraType: "kubernetes",
+      targetType: "kubernetes",
+      scriptSource: "image",
+      infraId: "discoverytestallsettingsset",
+      envId: "ashloadtest",
+    });
+    expect(manifest.spec.scriptContent).toBeUndefined();
+    expect(manifest.spec.toolConfig.mode).toBe("image");
+    expect(manifest.spec.toolConfig.customImage).toEqual({
+      image: " my-image",
+      entrypoint: "/script.json",
+    });
+    expect(manifest.spec.toolConfig.scriptContent).toBeUndefined();
+    expect(manifest.spec.inputs).toEqual(body.inputs);
+  });
+
+  it("create (K6 image): script_entrypoint is optional — customImage carries only image", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({});
+    const client = makeClient(mockRequest);
+    await registry.dispatch(client, "chaos_loadtest", "create", {
+      org_id: "o", project_id: "p",
+      tool_type: "K6",
+      name: "k6-lt", environment_id: "e", infra_id: "i",
+      target_url: "https://example.com",
+      target_type: "kubernetes",
+      script_source: "image",
+      script_image: "my-registry/k6:latest",
+    });
+    const tc = mockRequest.mock.calls[0][0].body.toolConfig as Record<string, unknown>;
+    expect(tc.mode).toBe("image");
+    expect(tc.customImage).toEqual({ image: "my-registry/k6:latest" });
+  });
+
+  it("create (K6 image): rejects when script_image is missing", async () => {
+    const client = makeClient(vi.fn());
+    await expect(
+      registry.dispatch(client, "chaos_loadtest", "create", {
+        org_id: "o", project_id: "p",
+        tool_type: "K6",
+        name: "k6-lt", environment_id: "e", infra_id: "i",
+        target_url: "https://example.com",
+        target_type: "kubernetes",
+        script_source: "image",
+      }),
+    ).rejects.toThrow(/script_image/);
+  });
+
+  it("create (K6 image): load_args rides only in inputs[], not toolConfig.customImage", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({});
+    const client = makeClient(mockRequest);
+    await registry.dispatch(client, "chaos_loadtest", "create", {
+      org_id: "o", project_id: "p",
+      tool_type: "K6",
+      name: "k6-lt", environment_id: "e", infra_id: "i",
+      target_url: "https://example.com",
+      target_type: "kubernetes",
+      script_source: "image",
+      script_image: "my-image",
+      load_args: "tags=smoke",
+    });
+    const body = mockRequest.mock.calls[0][0].body;
+    // inputs[] has loadArgs.
+    expect(
+      (body.inputs as Array<Record<string, unknown>>).find((i) => i.name === "loadArgs"),
+    ).toEqual({ name: "loadArgs", value: "tags=smoke", type: "String" });
+    // toolConfig.customImage MUST NOT carry it.
+    const ci = (body.toolConfig as Record<string, unknown>).customImage as Record<string, unknown>;
+    expect(ci.loadArgs).toBeUndefined();
+    expect(ci.runArgs).toBeUndefined();
   });
 });


### PR DESCRIPTION
This PR covers updates to Chaos Load Test MCP endpointSpecs

## Description
- Updating schema changes done on Load Test
- Adding support for K6 load test type for creation flow.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [x] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
If this PR adds or changes Harness API coverage:
- [ ] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [ ] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [ ] `operationPolicy` on every new/changed endpoint
- [ ] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [ ] `identifierFields` and `scope` declared on new resources
- [ ] No `console.log()` in `src/` (stdio JSON-RPC safety)
