### PR TITLE
feat: update execute llm pipeline endpoint with right setting key

### DIFF
--- a/src/registry/toolsets/dbops.ts
+++ b/src/registry/toolsets/dbops.ts
@@ -789,7 +789,7 @@ export const dbopsToolset: ToolsetDefinition = {
         "Both branches require the same common inputs: conversation_id, schema_id, instance_id, changeset. " +
         "Two branches (exactly one must be set): " +
         "(a) custom-pipeline — pass pipeline_identifier (resolved by the skill from the " +
-        "project-level NG setting `dbops_llm_authoring_pipeline_id`) plus optional runtime_inputs; " +
+        "project-level NG setting `dbops_llm_authoring_pipeline`) plus optional runtime_inputs; " +
         "(b) default-pipeline — pass use_default_pipeline=true and the server performs " +
         "get-or-create of the canonical default pipeline. " +
         "Reserved runtime-input keys (schemaId, instanceId, changeset) are rejected by the server. " +
@@ -889,7 +889,7 @@ export const dbopsToolset: ToolsetDefinition = {
                 type: "string",
                 required: false,
                 description:
-                  "Custom-pipeline branch — value of NG setting `dbops_llm_authoring_pipeline_id` " +
+                  "Custom-pipeline branch — value of NG setting `dbops_llm_authoring_pipeline` " +
                   "(alias: pipeline_identifier). Mutually exclusive with useDefaultPipeline.",
               },
               {


### PR DESCRIPTION
## Description
update mcp tool `database_execute_llm_authoring_pipeline` description with right keyword for dbops ng settings

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [ ] `pnpm test` passes
- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes
- [ ] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [ ] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
If this PR adds or changes Harness API coverage:
- [ ] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [ ] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [ ] `operationPolicy` on every new/changed endpoint
- [ ] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [ ] `identifierFields` and `scope` declared on new resources
- [ ] No `console.log()` in `src/` (stdio JSON-RPC safety)
