### PR TITLE
fix: make local search tests independent of HuggingFace model download

### DIFF
--- a/src/search/local-provider.ts
+++ b/src/search/local-provider.ts
@@ -102,6 +102,8 @@ function resolveExpiresAt(item: IndexableItem, now: number): number | undefined 
 export interface LocalSearchProviderOptions {
   cacheDir?: string;
   model?: string;
+  /** Test-only: skip model download and use a deterministic embed function. */
+  embedFn?: EmbedFn;
 }
 
 export class LocalSearchProvider implements SearchProvider {
@@ -118,9 +120,14 @@ export class LocalSearchProvider implements SearchProvider {
   constructor(options: LocalSearchProviderOptions = {}) {
     this.cacheDir = options.cacheDir ?? DEFAULT_HF_CACHE_DIR;
     this.model = options.model ?? DEFAULT_EMBEDDING_MODEL;
+    if (options.embedFn) {
+      this.embed = options.embedFn;
+      this.available = true;
+    }
   }
 
   async initialize(): Promise<void> {
+    if (this.available && this.embed) return;
     try {
       const { pipeline, env } = await import("@huggingface/transformers");
       env.cacheDir = this.cacheDir;

--- a/tests/search/local-provider.test.ts
+++ b/tests/search/local-provider.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { LocalSearchProvider } from "../../src/search/local-provider.js";
+import { testEmbed } from "./test-embed.js";
 
-// These tests download the model on first run (~23MB); subsequent runs use cache
 describe("LocalSearchProvider", () => {
   let provider: LocalSearchProvider;
 
   beforeAll(async () => {
-    provider = new LocalSearchProvider();
+    provider = new LocalSearchProvider({ embedFn: testEmbed });
     await provider.initialize();
-  }, 60_000); // model download can take a moment
+  });
 
   it("is available after initialize", () => {
     expect(provider.isAvailable()).toBe(true);

--- a/tests/search/manager.test.ts
+++ b/tests/search/manager.test.ts
@@ -102,16 +102,15 @@ describe("SearchManager", () => {
     });
 
     it("indexes resources in single-user mode with local provider", async () => {
+      vi.spyOn(LocalSearchProvider.prototype, "initialize").mockResolvedValue();
+      vi.spyOn(LocalSearchProvider.prototype, "isAvailable").mockReturnValue(true);
+      const indexSpy = vi.spyOn(LocalSearchProvider.prototype, "index").mockResolvedValue();
+
       const mgr = new SearchManager(makeConfig({
         HARNESS_SEARCH_PROVIDER: "local",
         HARNESS_MCP_MODE: "single-user",
       }) as never);
       await mgr.initialize();
-      const provider = mgr.getProvider();
-      if (!(provider instanceof LocalSearchProvider) || !provider.isAvailable()) {
-        return;
-      }
-      const indexSpy = vi.spyOn(provider, "index");
 
       await mgr.indexItem({
         id: "pipeline:foo",
@@ -122,6 +121,7 @@ describe("SearchManager", () => {
       });
 
       expect(indexSpy).toHaveBeenCalledOnce();
+      vi.restoreAllMocks();
     });
   });
 });

--- a/tests/search/test-embed.ts
+++ b/tests/search/test-embed.ts
@@ -1,0 +1,17 @@
+const DIM = 384;
+
+/** Deterministic bag-of-words style embedding for unit tests (no network). */
+export async function testEmbed(text: string): Promise<Float32Array> {
+  const vec = new Float32Array(DIM);
+  for (const token of text.toLowerCase().split(/\W+/).filter(Boolean)) {
+    for (let i = 0; i < token.length; i++) {
+      const idx = (token.charCodeAt(i) + i) % DIM;
+      vec[idx]! += 1;
+    }
+  }
+  let norm = 0;
+  for (let i = 0; i < DIM; i++) norm += vec[i]! * vec[i]!;
+  norm = Math.sqrt(norm) || 1;
+  for (let i = 0; i < DIM; i++) vec[i]! /= norm;
+  return vec;
+}


### PR DESCRIPTION
## Description
Fixes flaky CI failures in tests/search/local-provider.test.ts and tests/search/manager.test.ts that caused PR #482 to fail on the Node 20 matrix job.

Root cause: local search unit tests downloaded the Xenova/all-MiniLM-L6-v2 HuggingFace model at runtime. On CI this intermittently failed with TypeError: fetch failed.

Fix:
- Add optional embedFn injection to LocalSearchProvider for deterministic unit testing
- Use a lightweight test embedder in local-provider.test.ts (no network)
- Mock LocalSearchProvider init/index in manager.test.ts

## Checklist
- [x] pnpm test passes
- [x] pnpm typecheck passes
- [x] pnpm build passes
- [x] pnpm standards:check passes
- [x] pnpm docs:check passes