### PR TITLE
fix: isolate resvg rendering in a child process to prevent native crashes killing the MCP server

### DIFF
--- a/src/utils/svg/render-png-child.ts
+++ b/src/utils/svg/render-png-child.ts
@@ -1,0 +1,39 @@
+/**
+ * Child-process entry point for SVG → PNG conversion.
+ *
+ * Runs in a separate Node process so a native resvg panic (SIGSEGV) cannot
+ * kill the MCP server. Reads JSON from stdin, writes JSON to stdout.
+ */
+import { text } from "node:stream/consumers";
+import { stdin } from "node:process";
+
+interface ChildInput {
+  svg: string;
+  scale?: number;
+}
+
+async function main(): Promise<void> {
+  const raw = await text(stdin);
+  const { svg, scale } = JSON.parse(raw) as ChildInput;
+
+  if (typeof svg !== "string" || !svg) {
+    process.stderr.write("Missing svg input");
+    process.exit(1);
+  }
+
+  const { Resvg } = await import("@resvg/resvg-js");
+  const resvg = new Resvg(svg, {
+    fitTo: { mode: "zoom", value: scale ?? 2 },
+    font: {
+      loadSystemFonts: false,
+    },
+  });
+
+  const pngBuffer = resvg.render().asPng();
+  process.stdout.write(JSON.stringify({ base64: Buffer.from(pngBuffer).toString("base64") }));
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/src/utils/svg/render-png.ts
+++ b/src/utils/svg/render-png.ts
@@ -4,30 +4,130 @@
  * MCP clients (Cursor, Claude Desktop) reject image/svg+xml — only raster
  * formats are supported. This converts our SVG strings to PNG buffers.
  *
- * The import is dynamic because @resvg/resvg-js ships a native .node binary
- * that can fail to load when the host Node ABI doesn't match (e.g. Claude
- * Desktop's embedded Node). A top-level import would crash the entire server
- * at startup; dynamic import confines the failure to PNG rendering only.
+ * Rendering runs in a child process so a native resvg panic (SIGSEGV) cannot
+ * kill the MCP server. JS-level failures are surfaced as catchable errors.
  */
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 
 export interface RenderPngOptions {
   /** Scale factor for higher DPI output. Default 2 (retina). */
   scale?: number;
 }
 
-export async function svgToPngBase64(svgString: string, options?: RenderPngOptions): Promise<string> {
-  const scale = options?.scale ?? 2;
+const RENDER_TIMEOUT_MS = 30_000;
 
-  const { Resvg } = await import("@resvg/resvg-js");
+// Resolved once per module load — the path never changes at runtime.
+let _childScriptPath: string | undefined;
 
-  const resvg = new Resvg(svgString, {
-    fitTo: { mode: "zoom", value: scale },
-    font: {
-      loadSystemFonts: false,
-    },
+function resolveChildScript(): string {
+  if (_childScriptPath) return _childScriptPath;
+
+  const dir = path.dirname(fileURLToPath(import.meta.url));
+  const adjacent = path.join(dir, "render-png-child.js");
+  if (existsSync(adjacent)) {
+    _childScriptPath = adjacent;
+    return _childScriptPath;
+  }
+
+  // Vitest loads parent from src/ but the child entry is compiled under build/.
+  const packageRoot = path.resolve(dir, "../../..");
+  const buildScript = path.join(packageRoot, "build/utils/svg/render-png-child.js");
+  if (existsSync(buildScript)) {
+    _childScriptPath = buildScript;
+    return _childScriptPath;
+  }
+
+  throw new Error("render-png-child.js not found. Run pnpm build before rendering SVG.");
+}
+
+const SVG_WIDTH_RE = /\bwidth="([^"]+)"/i;
+const SVG_HEIGHT_RE = /\bheight="([^"]+)"/i;
+
+/** Reject obviously invalid SVG before spawning the native renderer. */
+export function validateSvgInput(svgString: string): void {
+  const trimmed = svgString.trim();
+  if (!trimmed) {
+    throw new Error("SVG input is empty");
+  }
+  if (!/<svg[\s>]/i.test(trimmed)) {
+    throw new Error("SVG input missing <svg> root element");
+  }
+
+  for (const [attr, re] of [["width", SVG_WIDTH_RE], ["height", SVG_HEIGHT_RE]] as const) {
+    const match = trimmed.match(re);
+    if (!match?.[1]) continue;
+    const value = Number.parseFloat(match[1]);
+    if (Number.isNaN(value) || value <= 0) {
+      throw new Error(`SVG has invalid ${attr}: ${match[1]}`);
+    }
+  }
+}
+
+function renderInChildProcess(svgString: string, scale: number): Promise<string> {
+  const payload = JSON.stringify({ svg: svgString, scale });
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [resolveChildScript()], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`SVG render timed out after ${RENDER_TIMEOUT_MS}ms`));
+    }, RENDER_TIMEOUT_MS);
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+
+    child.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(new Error(`Failed to spawn SVG render child: ${err.message}`));
+    });
+
+    child.on("close", (code, signal) => {
+      clearTimeout(timeout);
+      if (code === 0) {
+        try {
+          const parsed = JSON.parse(stdout) as { base64?: unknown };
+          if (typeof parsed.base64 !== "string") {
+            throw new Error("missing base64 field");
+          }
+          resolve(parsed.base64);
+        } catch {
+          reject(new Error(`SVG render produced invalid output${stderr ? `: ${stderr}` : ""}`));
+        }
+        return;
+      }
+      const detail = stderr.trim() || (signal ? `signal ${signal}` : `exit ${code}`);
+      reject(new Error(`SVG render failed (${detail})`));
+    });
+
+    // Suppress EPIPE: if the child crashes before reading stdin, the broken
+    // pipe emits an error on child.stdin. Without this handler it would be an
+    // uncaught EventEmitter error that kills the parent — the close handler
+    // below will still fire and surface the child's non-zero exit code.
+    child.stdin.on("error", () => {});
+
+    child.stdin.write(payload);
+    child.stdin.end();
   });
+}
 
-  const rendered = resvg.render();
-  const pngBuffer = rendered.asPng();
-  return Buffer.from(pngBuffer).toString("base64");
+export async function svgToPngBase64(svgString: string, options?: RenderPngOptions): Promise<string> {
+  validateSvgInput(svgString);
+  const scale = options?.scale ?? 2;
+  return renderInChildProcess(svgString, scale);
 }

--- a/tests/utils/svg/render-png.test.ts
+++ b/tests/utils/svg/render-png.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { svgToPngBase64, validateSvgInput } from "../../../src/utils/svg/render-png.js";
+
+const VALID_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect width="100" height="100" fill="red"/></svg>';
+
+describe("validateSvgInput", () => {
+  it("rejects empty input", () => {
+    expect(() => validateSvgInput("")).toThrow(/empty/i);
+  });
+
+  it("rejects non-SVG input", () => {
+    expect(() => validateSvgInput("<div>not svg</div>")).toThrow(/missing <svg>/i);
+  });
+
+  it("rejects zero or negative dimensions", () => {
+    expect(() => validateSvgInput('<svg width="0" height="10"></svg>')).toThrow(/invalid width/i);
+    expect(() => validateSvgInput('<svg width="10" height="-1"></svg>')).toThrow(/invalid height/i);
+  });
+
+  it("allows SVG without explicit width/height", () => {
+    expect(() => validateSvgInput('<svg viewBox="0 0 10 10"></svg>')).not.toThrow();
+  });
+});
+
+describe("svgToPngBase64", () => {
+  it("renders valid SVG to base64 PNG via child process", { timeout: 15_000 }, async () => {
+    const base64 = await svgToPngBase64(VALID_SVG);
+    const buf = Buffer.from(base64, "base64");
+    expect(buf[0]).toBe(0x89);
+    expect(buf[1]).toBe(0x50);
+  });
+
+  it("rejects with a catchable error for invalid SVG without crashing the caller", async () => {
+    await expect(svgToPngBase64("")).rejects.toThrow(/empty/i);
+  });
+});


### PR DESCRIPTION
## Problem

A native panic in `@resvg/resvg-js` (SIGSEGV/SIGABRT from the Rust renderer) previously crashed the entire MCP server process. Because the native module ran inline in the server, there was no isolation boundary — one bad SVG input could take down the whole server.

The previous dynamic-import approach only guarded against ABI-mismatch load failures at startup; it did not protect against runtime panics during rendering.

## Solution

SVG→PNG rendering now runs in a dedicated child process (`src/utils/svg/render-png-child.ts`). The parent spawns it per render call, sends the SVG over stdin as JSON, and reads back the base64 PNG over stdout. A native crash in the child stays isolated — the parent receives a non-zero exit code and surfaces a catchable error instead of dying.

## Changes

- **`src/utils/svg/render-png.ts`** — replaces the inline `Resvg` call with `renderInChildProcess()`: spawns a Node child, handles stdout/stderr collection, timeout (30s), and error surfacing. Adds `validateSvgInput()` to reject obviously bad SVG before spawning (empty input, missing `<svg>` root, zero/negative dimensions).
- **`src/utils/svg/render-png-child.ts`** (new) — the child entry point: reads JSON from stdin, runs `Resvg.render()`, writes `{ base64: "..." }` JSON to stdout.
- **`tests/utils/svg/render-png.test.ts`** (new) — unit tests for both the validator and the full child-process render path.

## Hardening fixes included

| Issue | Fix |
|---|---|
| `child.stdin` had no `error` handler — an EPIPE from the child crashing before reading stdin would kill the parent (defeating the whole isolation) | Added `child.stdin.on("error", () => {})` |
| Child output shape not validated at runtime | Added `typeof parsed.base64 !== "string"` check before resolving |
| `resolveChildScript()` probed the filesystem on every render call | Memoized in a module-level variable |
| `validateSvgInput` constructed `new RegExp(...)` inside a loop on every call | Extracted as module-level `SVG_WIDTH_RE` / `SVG_HEIGHT_RE` constants |
| `readStdin` re-implemented a Node stdlib primitive | Replaced with `text(stdin)` from `node:stream/consumers` |

## Test plan

- [x] `pnpm typecheck` — no errors
- [x] `pnpm test` — 2510/2510 pass (118 test files)
- [x] `validateSvgInput` rejects: empty input, non-SVG markup, zero/negative `width`/`height`
- [x] `svgToPngBase64` renders a valid SVG through the child process and returns a valid PNG buffer (PNG magic bytes `0x89 0x50` verified)
- [x] `svgToPngBase64("")` rejects with a catchable error (does not crash the caller)

**Manual verification against a running server:**
```sh
curl -s -X POST http://localhost:3000/mcp \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"harness_list","arguments":{"resource_type":"execution","visualize":true}}}' \
  | jq '.result.content[] | select(.type == "image") | .mimeType'
# → "image/png"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)