### PR TITLE
fix: expose return_download_url in harness_get input schema

### DIFF
--- a/src/tools/harness-get.ts
+++ b/src/tools/harness-get.ts
@@ -33,6 +33,7 @@ export function registerGetTool(server: McpServer, registry: Registry, client: H
         org_id: z.string().optional().describe("Organization identifier (overrides default)"),
         project_id: z.string().optional().describe("Project identifier (overrides default)"),
         params: z.record(z.string(), z.unknown()).optional().describe("Additional identifiers for nested resources. Call harness_describe for fields per resource_type."),
+        return_download_url: z.union([z.boolean(), z.enum(["true", "false"])]).optional().describe("For execution_log only: return a directly fetchable log download URL instead of buffering log content."),
       },
       outputSchema: getOutputSchema,
       annotations: {

--- a/tests/tools/zod-input-schema-descriptions.test.ts
+++ b/tests/tools/zod-input-schema-descriptions.test.ts
@@ -147,6 +147,7 @@ describe("Zod 4 input schema descriptions (PR #398 regression)", () => {
       "project_id",
       "resource_scope",
       "params",
+      "return_download_url",
     ]);
   });
 


### PR DESCRIPTION
## Description
The `execution_log` URL-only path in `harness_get` reads `input.return_download_url`, but the flag was **never declared in the tool's `inputSchema`**. Schema-driven MCP clients could not discover the option and could drop or reject it, silently falling back to buffering full log content instead of returning a fetchable download URL.

## Fix
- Declare `return_download_url` on the public `harness_get` input schema, accepting `boolean` or `"true"`/`"false"` to match the existing `isTrue()` coercion.
- Extend the Zod-4 schema-description regression test (`zod-input-schema-descriptions.test.ts`) to require the field be present with a description on the registered schema. Verified red-before / green-after.

This harvests the one still-live gap from the now-superseded #339; that PR's other change (throwing in `rewriteDownloadUrlIfNeeded`) is intentionally omitted because `main` already handles server-auth blob links via CDN host rewrite, which the throw would regress.

## Type of Change
- [x] Bug fix

## Validation
- `pnpm build`
- `pnpm docs:generate` && `pnpm docs:check` (README up to date)
- `pnpm typecheck`
- `pnpm exec vitest run tests/tools/zod-input-schema-descriptions.test.ts tests/tools/tool-handlers.test.ts` (146 passed)
- Confirmed the new assertion fails without the schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)