### PR TITLE
refactor: type PreflightContext client/registry to drop unsafe casts

### DIFF
--- a/src/registry/toolsets/ansible.ts
+++ b/src/registry/toolsets/ansible.ts
@@ -36,9 +36,8 @@ const ansibleListExtract = (
 // ─── Preflight guards ────────────────────────────────────────────────────────
 
 const requireProjectScope = async (ctx: PreflightContext): Promise<void> => {
-  const cfg = (ctx.registry as unknown as { config: { HARNESS_ORG?: string; HARNESS_PROJECT?: string } }).config ?? {};
-  const orgId = ctx.input["org_id"] ?? cfg.HARNESS_ORG;
-  const projectId = ctx.input["project_id"] ?? cfg.HARNESS_PROJECT;
+  const orgId = ctx.input["org_id"] ?? ctx.registry.orgId;
+  const projectId = ctx.input["project_id"] ?? ctx.registry.projectId;
   const missing: string[] = [];
   if (!orgId) missing.push("org_id");
   if (!projectId) missing.push("project_id");

--- a/src/registry/toolsets/ccm.ts
+++ b/src/registry/toolsets/ccm.ts
@@ -2,16 +2,6 @@ import type { ToolsetDefinition, PreflightContext, ParamsSchema } from "../types
 import type { PathBuilderConfig } from "../types.js";
 import { ngExtract, passthrough, gqlExtract, ccmViewsExtract, anomalyListExtract, ccmBreakdownExtract, ccmTimeseriesExtract, ccmSummaryExtract, ccmRecommendationsExtract } from "../extractors.js";
 
-/** Narrow preflight client for CCM perspective create defaults fetch. */
-interface CcmPreflightClient {
-  readonly account: string;
-  request<T>(opts: {
-    method: string;
-    path: string;
-    params?: Record<string, string>;
-  }): Promise<T>;
-}
-
 // ---------------------------------------------------------------------------
 // GraphQL queries — ported from the official Go MCP server
 // (client/ccmcommons/ccmgraphqlqueries.go)
@@ -454,16 +444,16 @@ function deepMerge(base: Record<string, unknown>, override: Record<string, unkno
  * mcpServerInternal/mcp-server-pkg/common/pkg/tools/ccmperspectives.go
  */
 async function perspectiveCreatePreflight(ctx: PreflightContext): Promise<void> {
-  const harnessClient = ctx.client as unknown as CcmPreflightClient;
+  const { client } = ctx;
   const input = ctx.input as { body?: Record<string, unknown> };
   if (!input.body) input.body = {};
 
-  const accountId = harnessClient.account;
+  const accountId = client.account;
   if (!accountId) return;
 
   // Fetch account preference defaults
   try {
-    const resp = await harnessClient.request<{ resource?: SettingsValue[]; data?: SettingsValue[] } | SettingsValue[]>({
+    const resp = await client.request<{ resource?: SettingsValue[]; data?: SettingsValue[] } | SettingsValue[]>({
       method: "GET",
       path: "/ng/api/settings",
       params: {

--- a/src/registry/toolsets/iacm.ts
+++ b/src/registry/toolsets/iacm.ts
@@ -131,9 +131,8 @@ const activityChangesExtract = (raw: unknown): unknown => {
 const requireProjectScope = async (ctx: PreflightContext): Promise<void> => {
   // Fall back to registry config defaults (HARNESS_ORG / HARNESS_PROJECT) before erroring,
   // mirroring the same defaulting the registry applies to path params after preflight.
-  const cfg = (ctx.registry as unknown as { config: { HARNESS_ORG?: string; HARNESS_PROJECT?: string } }).config ?? {};
-  const orgId = ctx.input["org_id"] ?? cfg.HARNESS_ORG;
-  const projectId = ctx.input["project_id"] ?? cfg.HARNESS_PROJECT;
+  const orgId = ctx.input["org_id"] ?? ctx.registry.orgId;
+  const projectId = ctx.input["project_id"] ?? ctx.registry.projectId;
   const missing: string[] = [];
   if (!orgId) missing.push("org_id");
   if (!projectId) missing.push("project_id");

--- a/src/registry/toolsets/sto.ts
+++ b/src/registry/toolsets/sto.ts
@@ -1,11 +1,6 @@
 import type { ToolsetDefinition } from "../types.js";
 import { passthrough, stoExemptionsExtract } from "../extractors.js";
 
-/** Narrow preflight client for STO exemption create (getCurrentUserId only). */
-interface StoPreflightClient {
-  getCurrentUserId(): Promise<string>;
-}
-
 /**
  * Injects a redirect hint into every security_issue list response.
  * When the LLM lands here while trying to approve/reject an exemption, it sees
@@ -435,8 +430,7 @@ export const stoToolset: ToolsetDefinition = {
                 `Use harness_describe(resource_type="security_exemption") to see the schema.`
               );
             }
-            const harnessClient = client as unknown as StoPreflightClient;
-            body.requester_id = await harnessClient.getCurrentUserId();
+            body.requester_id = await client.getCurrentUserId();
             input.body = body;
           },
           bodyBuilder: (input) => {
@@ -520,9 +514,8 @@ export const stoToolset: ToolsetDefinition = {
               input.project_id = "";
             }
 
-            const harnessClient = client as unknown as StoPreflightClient;
             if (!b.approver_id) {
-              b.approver_id = await harnessClient.getCurrentUserId();
+              b.approver_id = await client.getCurrentUserId();
               input.body = b;
             }
           },
@@ -569,10 +562,9 @@ export const stoToolset: ToolsetDefinition = {
           operationPolicy: { risk: "high_write", retryPolicy: "do_not_retry" },
           pathParams: { exemption_id: "exemptionId" },
           preflight: async ({ client, input }) => {
-            const harnessClient = client as unknown as StoPreflightClient;
             const body = ((input.body as Record<string, unknown> | undefined) ?? {});
             if (!body.approver_id) {
-              body.approver_id = await harnessClient.getCurrentUserId();
+              body.approver_id = await client.getCurrentUserId();
               input.body = body;
             }
           },
@@ -685,8 +677,7 @@ export const stoToolset: ToolsetDefinition = {
 
             // Auto-derive requester from the authenticated PAT, same as the
             // single-create path.
-            const harnessClient = client as unknown as StoPreflightClient;
-            body.requester_id = await harnessClient.getCurrentUserId();
+            body.requester_id = await client.getCurrentUserId();
             input.body = body;
           },
           bodyBuilder: (input) => {

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -2,6 +2,8 @@
  * Core types for the resource registry and dispatch system.
  */
 
+import type { RequestOptions } from "../client/types.js";
+
 export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 
 // ---------------------------------------------------------------------------
@@ -71,13 +73,18 @@ export function requiresConfirmation(risk: RiskLevel): boolean {
 
 // ---------------------------------------------------------------------------
 // Minimal interfaces for PreflightContext (avoids circular imports).
-// The concrete HarnessClient and Registry satisfy these structurally.
-// Preflight hooks that need concrete-only methods (e.g. getCurrentUserId)
-// can narrow via `(client as unknown as HarnessClient)`.
+// The concrete HarnessClient and Registry satisfy these structurally, so
+// preflight hooks can call the methods they need without unsafe casts.
+// `RequestOptions` is imported from client/types (which has no registry
+// imports), so no dependency cycle is introduced.
 // ---------------------------------------------------------------------------
 
 export interface HarnessClientInterface {
   readonly account: string;
+  /** Resolve the current user's id (cached). Used by preflight hooks that stamp requester/approver. */
+  getCurrentUserId(): Promise<string>;
+  /** Issue an authenticated Harness request. Used by preflight hooks that fetch defaults. */
+  request<T>(options: RequestOptions): Promise<T>;
 }
 
 export interface RegistryDispatchInterface {
@@ -89,13 +96,16 @@ export interface RegistryDispatchInterface {
     signal?: AbortSignal,
   ): Promise<unknown>;
   getResource(resourceType: string): ResourceDefinition;
+  /** Default org identifier from config, when set. */
+  readonly orgId: string | undefined;
+  /** Default project identifier from config, when set. */
+  readonly projectId: string | undefined;
 }
 
 /**
  * Context passed to EndpointSpec.preflight hooks. Uses structural interfaces
  * so this module does not import HarnessClient/Registry (which would create a
- * cycle). Hooks that need concrete-only methods can narrow:
- *   `const hc = client as unknown as HarnessClient;`
+ * cycle), while still exposing the concrete methods hooks need.
  */
 export interface PreflightContext {
   client: HarnessClientInterface;


### PR DESCRIPTION
## Description
Preflight hooks in four toolsets needed concrete methods and config the structural `PreflightContext` interfaces didn't expose, so they narrowed via `as unknown as <LocalInterface>` casts — bypassing type checking on the exact call sites that hit the live API.

This widens the structural interfaces to expose precisely what the hooks use, eliminating all 7 casts:
- **`HarnessClientInterface`**: add `getCurrentUserId()` and `request<T>(RequestOptions)`.
- **`RegistryDispatchInterface`**: add `readonly orgId` / `projectId`.

`RequestOptions` is imported from `client/types` (which has no `registry` imports), so **no dependency cycle** is introduced — the reason the casts existed in the first place. Removes two now-redundant local client interfaces (`CcmPreflightClient`, `StoPreflightClient`). The concrete `HarnessClient` and `Registry` already satisfy the widened shapes structurally.

Net −11 lines; touches ccm, sto, iacm, ansible toolsets + `registry/types.ts`.

## Context
Salvaged from the type-safety portion of #375/#377 (both closed — their `scripts/check-standards.js` enforcement approach was superseded by main's vitest `tests/coding-standards/` suite, and their other source fixes already merged). This is the one still-applicable improvement from those PRs.

## Type of Change
- [x] Refactor (no behavior change)

## Validation
- `pnpm build` && `pnpm typecheck`
- `pnpm docs:generate` && `pnpm docs:check` (README up to date)
- `pnpm exec vitest run tests/coding-standards tests/registry/structural-validation.test.ts` (80 passed)
- Affected suites: iacm, sto-exemptions, sto-exemption-actions, scs (390 passed)
- Full suite green except a pre-existing HuggingFace live-download flake in `tests/search/manager.test.ts` (unrelated; passes in isolation, 64/64)
- `grep -rn 'as unknown as' src/registry/toolsets/` → 0 remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)