### PR TITLE
fix: warn on invalid auto-approve-risk header; require config in write tools

### DIFF
--- a/src/tools/harness-create.ts
+++ b/src/tools/harness-create.ts
@@ -12,7 +12,7 @@ import { formatBodyPreview } from "../utils/body-preview.js";
 import { resourceScopeSchema, resourceTypeSchema } from "./input-schemas.js";
 import { createOutputSchema } from "./output-schemas.js";
 
-export function registerCreateTool(server: McpServer, registry: Registry, client: HarnessClient, config?: Config): void {
+export function registerCreateTool(server: McpServer, registry: Registry, client: HarnessClient, config: Config): void {
   const creatableTypes = registry.getTypesForOperation("create");
 
   server.registerTool(
@@ -62,7 +62,7 @@ export function registerCreateTool(server: McpServer, registry: Registry, client
         // that can never run, AND so the rejection is captured as a
         // pre-dispatch "blocked" audit row. `create` is never in
         // READ_OPERATIONS, so any read-only deployment blocks.
-        if (config?.HARNESS_READ_ONLY) {
+        if (config.HARNESS_READ_ONLY) {
           const reason = `Read-only mode is enabled (HARNESS_READ_ONLY=true). "create" operations are not allowed.`;
           registry.auditBlockedAttempt(
             args.resource_type,
@@ -79,7 +79,7 @@ export function registerCreateTool(server: McpServer, registry: Registry, client
           toolName: "harness_create",
           message: `Create ${args.resource_type}?\n\n${bodyPreview}`,
           risk,
-          autoApproveRisk: config?.HARNESS_AUTO_APPROVE_RISK,
+          autoApproveRisk: config.HARNESS_AUTO_APPROVE_RISK,
           callerConfirmed: args.confirm === true,
         });
         if (!elicit.proceed) {

--- a/src/tools/harness-delete.ts
+++ b/src/tools/harness-delete.ts
@@ -11,7 +11,7 @@ import { coerceRecord, asString } from "../utils/type-guards.js";
 import { resourceScopeSchema, resourceTypeSchema } from "./input-schemas.js";
 import { deleteOutputSchema } from "./output-schemas.js";
 
-export function registerDeleteTool(server: McpServer, registry: Registry, client: HarnessClient, config?: Config): void {
+export function registerDeleteTool(server: McpServer, registry: Registry, client: HarnessClient, config: Config): void {
   const deletableTypes = registry.getTypesForOperation("delete");
 
   server.registerTool(
@@ -75,7 +75,7 @@ export function registerDeleteTool(server: McpServer, registry: Registry, client
 
         // Fail fast on HARNESS_READ_ONLY before elicitation — see
         // harness_create.ts for the rationale. Mirrors registry.dispatch().
-        if (config?.HARNESS_READ_ONLY) {
+        if (config.HARNESS_READ_ONLY) {
           const reason = `Read-only mode is enabled (HARNESS_READ_ONLY=true). "delete" operations are not allowed.`;
           registry.auditBlockedAttempt(
             args.resource_type,
@@ -91,7 +91,7 @@ export function registerDeleteTool(server: McpServer, registry: Registry, client
           toolName: "harness_delete",
           message: `Delete ${args.resource_type} "${resolvedResourceId}"?\n\nThis is destructive and cannot be undone.`,
           risk: "destructive",
-          autoApproveRisk: config?.HARNESS_AUTO_APPROVE_RISK,
+          autoApproveRisk: config.HARNESS_AUTO_APPROVE_RISK,
           callerConfirmed: args.confirm === true,
         });
         if (!elicit.proceed) {

--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -98,7 +98,7 @@ function extractExecutionId(result: unknown, resourceType: string): string | und
     ?? asString(rec.executionId);
 }
 
-export function registerExecuteTool(server: McpServer, registry: Registry, client: HarnessClient, config?: Config): void {
+export function registerExecuteTool(server: McpServer, registry: Registry, client: HarnessClient, config: Config): void {
   const executableTypes = registry.getTypesWithExecuteActions();
 
   server.registerTool(
@@ -180,7 +180,7 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
         // mode. For everything else we don't ask the user to approve a
         // write that can never run, AND we capture the rejection as a
         // pre-dispatch "blocked" audit row.
-        if (config?.HARNESS_READ_ONLY && risk !== "read") {
+        if (config.HARNESS_READ_ONLY && risk !== "read") {
           const reason = `Read-only mode is enabled (HARNESS_READ_ONLY=true). Execute action "${args.action}" is not allowed.`;
           registry.auditBlockedAttempt(
             resourceType,
@@ -197,7 +197,7 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
           toolName: "harness_execute",
           message: `Execute "${args.action}" on ${resourceType}${resourceId ? ` "${resourceId}"` : ""}?`,
           risk,
-          autoApproveRisk: config?.HARNESS_AUTO_APPROVE_RISK,
+          autoApproveRisk: config.HARNESS_AUTO_APPROVE_RISK,
           callerConfirmed: args.confirm === true,
         });
         if (!elicit.proceed) {
@@ -220,7 +220,7 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
           // Fail fast on policy errors before fan-out — mirrors registry.dispatchExecute()
           // risk-based enforcement: read-safe actions (e.g. hql validate/run) are allowed in
           // read-only mode; write actions are blocked before any query is dispatched.
-          if (config?.HARNESS_READ_ONLY && risk !== "read") {
+          if (config.HARNESS_READ_ONLY && risk !== "read") {
             return errorResult(`Read-only mode is enabled (HARNESS_READ_ONLY=true). Execute action "${args.action}" is not allowed.`);
           }
 

--- a/src/tools/harness-update.ts
+++ b/src/tools/harness-update.ts
@@ -12,7 +12,7 @@ import { formatBodyPreview } from "../utils/body-preview.js";
 import { resourceScopeSchema, resourceTypeSchema } from "./input-schemas.js";
 import { updateOutputSchema } from "./output-schemas.js";
 
-export function registerUpdateTool(server: McpServer, registry: Registry, client: HarnessClient, config?: Config): void {
+export function registerUpdateTool(server: McpServer, registry: Registry, client: HarnessClient, config: Config): void {
   const updatableTypes = registry.getTypesForOperation("update");
 
   server.registerTool(
@@ -80,7 +80,7 @@ export function registerUpdateTool(server: McpServer, registry: Registry, client
         const risk = def.operations.update!.operationPolicy.risk;
         // Fail fast on HARNESS_READ_ONLY before elicitation — see
         // harness_create.ts for the rationale. Mirrors registry.dispatch().
-        if (config?.HARNESS_READ_ONLY) {
+        if (config.HARNESS_READ_ONLY) {
           const reason = `Read-only mode is enabled (HARNESS_READ_ONLY=true). "update" operations are not allowed.`;
           registry.auditBlockedAttempt(
             args.resource_type,
@@ -97,7 +97,7 @@ export function registerUpdateTool(server: McpServer, registry: Registry, client
           toolName: "harness_update",
           message: `Update ${args.resource_type} "${resolvedResourceId}"?\n\n${bodyPreview}`,
           risk,
-          autoApproveRisk: config?.HARNESS_AUTO_APPROVE_RISK,
+          autoApproveRisk: config.HARNESS_AUTO_APPROVE_RISK,
           callerConfirmed: args.confirm === true,
         });
         if (!elicit.proceed) {

--- a/src/utils/session-headers.ts
+++ b/src/utils/session-headers.ts
@@ -2,6 +2,9 @@ import type { IncomingHttpHeaders } from "node:http";
 import type { Config } from "../config.js";
 import { extractAccountIdFromToken } from "../config.js";
 import { RISK_SEVERITY, type RiskLevel } from "../registry/types.js";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("session-headers");
 
 export const PIPELINE_VERSION_HEADER = "x-harness-pipeline-version";
 export const AUTO_APPROVE_RISK_HEADER = "x-harness-auto-approve-risk";
@@ -39,6 +42,13 @@ export function parseAutoApproveRiskHeader(
   ) {
     return normalized as Config["HARNESS_AUTO_APPROVE_RISK"];
   }
+  // Unrecognized value (e.g. "read", a typo) — warn rather than silently fall
+  // back to the deployment default, which would give the client a different
+  // security posture than it intended without any signal.
+  log.warn("Ignoring unrecognized X-Harness-Auto-Approve-Risk header value; using deployment default", {
+    value,
+    allowed: "none | low_write | medium_write | high_write | all",
+  });
   return undefined;
 }
 

--- a/tests/integration/elicitation-flow.test.ts
+++ b/tests/integration/elicitation-flow.test.ts
@@ -89,7 +89,7 @@ describe("Elicitation flow: harness_create", () => {
   it("proceeds without elicitation when client does not support it (non-destructive)", async () => {
     const server = makeMcpServer({ supportsElicitation: false });
     const { registerCreateTool } = await import("../../src/tools/harness-create.js");
-    registerCreateTool(server, registry, client);
+    registerCreateTool(server, registry, client, makeConfig());
 
     const result = await server.call("harness_create", {
       resource_type: "pipeline",
@@ -106,7 +106,7 @@ describe("Elicitation flow: harness_create", () => {
     // requiresConfirmation(risk), which kicks in at medium_write.
     const server = makeMcpServer({ supportsElicitation: true, elicitAction: "accept" });
     const { registerCreateTool } = await import("../../src/tools/harness-create.js");
-    registerCreateTool(server, registry, client);
+    registerCreateTool(server, registry, client, makeConfig());
 
     const result = await server.call("harness_create", {
       resource_type: "pipeline",
@@ -120,7 +120,7 @@ describe("Elicitation flow: harness_create", () => {
   it("proceeds when elicitInput throws (low-risk create silently bypasses)", async () => {
     const server = makeMcpServer({ supportsElicitation: true, elicitThrows: true });
     const { registerCreateTool } = await import("../../src/tools/harness-create.js");
-    registerCreateTool(server, registry, client);
+    registerCreateTool(server, registry, client, makeConfig());
 
     const result = await server.call("harness_create", {
       resource_type: "pipeline",
@@ -145,7 +145,7 @@ describe("Elicitation flow: harness_delete (destructive)", () => {
   it("blocks when client does not support elicitation", async () => {
     const server = makeMcpServer({ supportsElicitation: false });
     const { registerDeleteTool } = await import("../../src/tools/harness-delete.js");
-    registerDeleteTool(server, registry, client);
+    registerDeleteTool(server, registry, client, makeConfig());
 
     const result = await server.call("harness_delete", {
       resource_type: "pipeline",
@@ -161,7 +161,7 @@ describe("Elicitation flow: harness_delete (destructive)", () => {
   it("blocks when elicitInput throws (destructive)", async () => {
     const server = makeMcpServer({ supportsElicitation: true, elicitThrows: true });
     const { registerDeleteTool } = await import("../../src/tools/harness-delete.js");
-    registerDeleteTool(server, registry, client);
+    registerDeleteTool(server, registry, client, makeConfig());
 
     const result = await server.call("harness_delete", {
       resource_type: "pipeline",
@@ -176,7 +176,7 @@ describe("Elicitation flow: harness_delete (destructive)", () => {
   it("proceeds when user accepts", async () => {
     const server = makeMcpServer({ supportsElicitation: true, elicitAction: "accept" });
     const { registerDeleteTool } = await import("../../src/tools/harness-delete.js");
-    registerDeleteTool(server, registry, client);
+    registerDeleteTool(server, registry, client, makeConfig());
 
     const result = await server.call("harness_delete", {
       resource_type: "pipeline",
@@ -191,7 +191,7 @@ describe("Elicitation flow: harness_delete (destructive)", () => {
   it("stops when user declines", async () => {
     const server = makeMcpServer({ supportsElicitation: true, elicitAction: "decline" });
     const { registerDeleteTool } = await import("../../src/tools/harness-delete.js");
-    registerDeleteTool(server, registry, client);
+    registerDeleteTool(server, registry, client, makeConfig());
 
     const result = await server.call("harness_delete", {
       resource_type: "pipeline",
@@ -218,7 +218,7 @@ describe("Elicitation flow: harness_execute", () => {
   it("blocks high_write action when client does not support elicitation", async () => {
     const server = makeMcpServer({ supportsElicitation: false });
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(server, registry, client);
+    registerExecuteTool(server, registry, client, makeConfig());
 
     const result = await server.call("harness_execute", {
       resource_type: "pipeline",
@@ -235,7 +235,7 @@ describe("Elicitation flow: harness_execute", () => {
   it("confirms and proceeds on accept for high_write action", async () => {
     const server = makeMcpServer({ supportsElicitation: true, elicitAction: "accept" });
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(server, registry, client);
+    registerExecuteTool(server, registry, client, makeConfig());
 
     const result = await server.call("harness_execute", {
       resource_type: "pipeline",
@@ -250,7 +250,7 @@ describe("Elicitation flow: harness_execute", () => {
   it("stops on decline", async () => {
     const server = makeMcpServer({ supportsElicitation: true, elicitAction: "decline" });
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(server, registry, client);
+    registerExecuteTool(server, registry, client, makeConfig());
 
     const result = await server.call("harness_execute", {
       resource_type: "pipeline",
@@ -265,7 +265,7 @@ describe("Elicitation flow: harness_execute", () => {
   it("proceeds without elicitation for low_write action on non-elicitation client", async () => {
     const server = makeMcpServer({ supportsElicitation: false });
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(server, registry, client);
+    registerExecuteTool(server, registry, client, makeConfig());
 
     // pipeline import is low_write — should proceed without elicitation
     const result = await server.call("harness_execute", {
@@ -292,7 +292,7 @@ describe("Elicitation flow: harness_update", () => {
   it("proceeds without elicitation (non-destructive)", async () => {
     const server = makeMcpServer({ supportsElicitation: false });
     const { registerUpdateTool } = await import("../../src/tools/harness-update.js");
-    registerUpdateTool(server, registry, client);
+    registerUpdateTool(server, registry, client, makeConfig());
 
     const result = await server.call("harness_update", {
       resource_type: "pipeline",
@@ -310,7 +310,7 @@ describe("Elicitation flow: harness_update", () => {
     // would only matter for medium_write+ updates.
     const server = makeMcpServer({ supportsElicitation: true, elicitAction: "decline" });
     const { registerUpdateTool } = await import("../../src/tools/harness-update.js");
-    registerUpdateTool(server, registry, client);
+    registerUpdateTool(server, registry, client, makeConfig());
 
     const result = await server.call("harness_update", {
       resource_type: "pipeline",
@@ -335,7 +335,7 @@ describe("Elicitation ordering: validate before elicit", () => {
   it("harness_create validates resource_type before asking user to confirm", async () => {
     const server = makeMcpServer({ supportsElicitation: true, elicitAction: "accept" });
     const { registerCreateTool } = await import("../../src/tools/harness-create.js");
-    registerCreateTool(server, registry, client);
+    registerCreateTool(server, registry, client, makeConfig());
 
     // execution has no create operation — should error without eliciting
     const result = await server.call("harness_create", {
@@ -351,7 +351,7 @@ describe("Elicitation ordering: validate before elicit", () => {
   it("harness_delete validates resource_type before asking user to confirm", async () => {
     const server = makeMcpServer({ supportsElicitation: true, elicitAction: "accept" });
     const { registerDeleteTool } = await import("../../src/tools/harness-delete.js");
-    registerDeleteTool(server, registry, client);
+    registerDeleteTool(server, registry, client, makeConfig());
 
     const result = await server.call("harness_delete", {
       resource_type: "execution",
@@ -365,7 +365,7 @@ describe("Elicitation ordering: validate before elicit", () => {
   it("harness_execute validates action before asking user to confirm", async () => {
     const server = makeMcpServer({ supportsElicitation: true, elicitAction: "accept" });
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(server, registry, client);
+    registerExecuteTool(server, registry, client, makeConfig());
 
     const result = await server.call("harness_execute", {
       resource_type: "pipeline",
@@ -392,7 +392,7 @@ describe("Elicitation flow: confirm: true override (end-to-end through tool entr
   it("harness_delete proceeds with confirm:true when client lacks elicitation", async () => {
     const server = makeMcpServer({ supportsElicitation: false });
     const { registerDeleteTool } = await import("../../src/tools/harness-delete.js");
-    registerDeleteTool(server, registry, client);
+    registerDeleteTool(server, registry, client, makeConfig());
 
     const result = await server.call("harness_delete", {
       resource_type: "pipeline",
@@ -407,7 +407,7 @@ describe("Elicitation flow: confirm: true override (end-to-end through tool entr
   it("harness_delete proceeds with confirm:true when elicitInput throws", async () => {
     const server = makeMcpServer({ supportsElicitation: true, elicitThrows: true });
     const { registerDeleteTool } = await import("../../src/tools/harness-delete.js");
-    registerDeleteTool(server, registry, client);
+    registerDeleteTool(server, registry, client, makeConfig());
 
     const result = await server.call("harness_delete", {
       resource_type: "pipeline",
@@ -421,7 +421,7 @@ describe("Elicitation flow: confirm: true override (end-to-end through tool entr
   it("harness_execute proceeds with confirm:true when client lacks elicitation (high_write)", async () => {
     const server = makeMcpServer({ supportsElicitation: false });
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(server, registry, client);
+    registerExecuteTool(server, registry, client, makeConfig());
 
     const result = await server.call("harness_execute", {
       resource_type: "pipeline",
@@ -442,7 +442,7 @@ describe("Elicitation flow: confirm: true override (end-to-end through tool entr
     const server = makeMcpServer({ supportsElicitation: true });
     server._elicitInput.mockResolvedValue({ action: "accept", content: {} });
     const { registerDeleteTool } = await import("../../src/tools/harness-delete.js");
-    registerDeleteTool(server, registry, client);
+    registerDeleteTool(server, registry, client, makeConfig());
 
     const result = await server.call("harness_delete", {
       resource_type: "pipeline",
@@ -457,7 +457,7 @@ describe("Elicitation flow: confirm: true override (end-to-end through tool entr
   it("harness_delete still blocks on explicit decline EVEN with confirm:true (authoritative human decline)", async () => {
     const server = makeMcpServer({ supportsElicitation: true, elicitAction: "decline" });
     const { registerDeleteTool } = await import("../../src/tools/harness-delete.js");
-    registerDeleteTool(server, registry, client);
+    registerDeleteTool(server, registry, client, makeConfig());
 
     const result = await server.call("harness_delete", {
       resource_type: "pipeline",
@@ -475,7 +475,7 @@ describe("Elicitation flow: confirm: true override (end-to-end through tool entr
   it("harness_execute still blocks on explicit cancel EVEN with confirm:true", async () => {
     const server = makeMcpServer({ supportsElicitation: true, elicitAction: "cancel" });
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(server, registry, client);
+    registerExecuteTool(server, registry, client, makeConfig());
 
     const result = await server.call("harness_execute", {
       resource_type: "pipeline",
@@ -491,7 +491,7 @@ describe("Elicitation flow: confirm: true override (end-to-end through tool entr
   it("error hint when client lacks elicitation tells caller to retry with confirm:true (and does NOT misattribute to user)", async () => {
     const server = makeMcpServer({ supportsElicitation: false });
     const { registerDeleteTool } = await import("../../src/tools/harness-delete.js");
-    registerDeleteTool(server, registry, client);
+    registerDeleteTool(server, registry, client, makeConfig());
 
     const result = await server.call("harness_delete", {
       resource_type: "pipeline",
@@ -516,7 +516,7 @@ describe("Elicitation flow: confirm: true override (end-to-end through tool entr
     const server = makeMcpServer({ supportsElicitation: true });
     server._elicitInput.mockResolvedValue({ action: "accept", content: {} });
     const { registerDeleteTool } = await import("../../src/tools/harness-delete.js");
-    registerDeleteTool(server, registry, client);
+    registerDeleteTool(server, registry, client, makeConfig());
 
     const result = await server.call("harness_delete", {
       resource_type: "pipeline",
@@ -545,7 +545,7 @@ describe("Elicitation flow: confirm: true override (end-to-end through tool entr
 
     const server = makeMcpServer({ supportsElicitation: true, elicitAction: "decline" });
     const { registerDeleteTool } = await import("../../src/tools/harness-delete.js");
-    registerDeleteTool(server, auditedRegistry, client);
+    registerDeleteTool(server, auditedRegistry, client, makeConfig());
 
     const result = await server.call("harness_delete", {
       resource_type: "pipeline",
@@ -582,7 +582,7 @@ describe("Elicitation flow: confirm: true override (end-to-end through tool entr
 
     const server = makeMcpServer({ supportsElicitation: false });
     const { registerDeleteTool } = await import("../../src/tools/harness-delete.js");
-    registerDeleteTool(server, auditedRegistry, client);
+    registerDeleteTool(server, auditedRegistry, client, makeConfig());
 
     const result = await server.call("harness_delete", {
       resource_type: "pipeline",
@@ -620,7 +620,7 @@ describe("Elicitation flow: confirm: true override (end-to-end through tool entr
     // Decline elicitation so we hit the blocked audit path.
     const server = makeMcpServer({ supportsElicitation: true, elicitAction: "decline" });
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(server, stoRegistry, client);
+    registerExecuteTool(server, stoRegistry, client, makeConfig());
 
     const result = await server.call("harness_execute", {
       resource_type: "security_exemption",
@@ -695,7 +695,7 @@ describe("Elicitation flow: confirm: true override (end-to-end through tool entr
 
     const server = makeMcpServer({ supportsElicitation: false });
     const { registerDeleteTool } = await import("../../src/tools/harness-delete.js");
-    registerDeleteTool(server, auditedRegistry, client);
+    registerDeleteTool(server, auditedRegistry, client, makeConfig());
 
     const result = await server.call("harness_delete", {
       resource_type: "pipeline",

--- a/tests/tools/incidents.test.ts
+++ b/tests/tools/incidents.test.ts
@@ -196,7 +196,7 @@ describe("incident — harness_create", () => {
     mockRequest = vi.fn().mockResolvedValue({ prettyId: "INC-99" });
     client = makeClient(mockRequest);
     const { registerCreateTool } = await import("../../src/tools/harness-create.js");
-    registerCreateTool(server, registry, client);
+    registerCreateTool(server, registry, client, makeConfig());
   });
 
   it("errors when required fields (templateShortId/title) are missing", async () => {
@@ -235,7 +235,7 @@ describe("incident — harness_update", () => {
     mockRequest = vi.fn().mockResolvedValue({ prettyId: "INC-42" });
     client = makeClient(mockRequest);
     const { registerUpdateTool } = await import("../../src/tools/harness-update.js");
-    registerUpdateTool(server, registry, client);
+    registerUpdateTool(server, registry, client, makeConfig());
   });
 
   it("issues a PATCH to the incident path with the merge-patch body", async () => {
@@ -264,7 +264,7 @@ describe("incident — harness_execute (close)", () => {
     mockRequest = vi.fn().mockResolvedValue({ prettyId: "INC-42", status: "CLOSED" });
     client = makeClient(mockRequest);
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(server, registry, client);
+    registerExecuteTool(server, registry, client, makeConfig());
   });
 
   it("posts to the /close path with no body", async () => {

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -602,7 +602,7 @@ describe("harness_create", () => {
     mockRequest = vi.fn().mockResolvedValue({ data: { identifier: "new-pipe" } });
     client = makeClient(mockRequest);
     const { registerCreateTool } = await import("../../src/tools/harness-create.js");
-    registerCreateTool(server, registry, client);
+    registerCreateTool(server, registry, client, makeConfig());
   });
 
   it("keeps optional input descriptions visible in the registered schema", () => {
@@ -628,7 +628,7 @@ describe("harness_create", () => {
     const fullRegistry = new Registry(makeConfig());
     const fullServer = makeMcpServer("accept");
     const { registerCreateTool } = await import("../../src/tools/harness-create.js");
-    registerCreateTool(fullServer, fullRegistry, client);
+    registerCreateTool(fullServer, fullRegistry, client, makeConfig());
 
     const result = await fullServer.call("harness_create", {
       resource_type: "execution",
@@ -645,7 +645,7 @@ describe("harness_create", () => {
     // is never called).
     const declineServer = makeMcpServer("decline");
     const { registerCreateTool } = await import("../../src/tools/harness-create.js");
-    registerCreateTool(declineServer, registry, client);
+    registerCreateTool(declineServer, registry, client, makeConfig());
 
     const result = await declineServer.call("harness_create", {
       resource_type: "pipeline",
@@ -760,7 +760,7 @@ describe("harness_create", () => {
     client = makeClient(mockRequest);
     const ccmServer = makeMcpServer("accept");
     const { registerCreateTool } = await import("../../src/tools/harness-create.js");
-    registerCreateTool(ccmServer, registry, client);
+    registerCreateTool(ccmServer, registry, client, makeConfig());
 
     const result = await ccmServer.call("harness_create", {
       resource_type: "cost_category",
@@ -784,7 +784,7 @@ describe("harness_create", () => {
     client = makeClient(mockRequest);
     const connectorServer = makeMcpServer("accept");
     const { registerCreateTool } = await import("../../src/tools/harness-create.js");
-    registerCreateTool(connectorServer, registry, client);
+    registerCreateTool(connectorServer, registry, client, makeConfig());
 
     const result = await connectorServer.call("harness_create", {
       resource_type: "connector",
@@ -809,7 +809,7 @@ describe("harness_create", () => {
     client = makeClient(mockRequest);
     const fileStoreServer = makeMcpServer("accept");
     const { registerCreateTool } = await import("../../src/tools/harness-create.js");
-    registerCreateTool(fileStoreServer, registry, client);
+    registerCreateTool(fileStoreServer, registry, client, makeConfig());
 
     const result = await fileStoreServer.call("harness_create", {
       resource_type: "file_store",
@@ -834,7 +834,7 @@ describe("harness_create", () => {
     client = makeClient(mockRequest);
     const fileStoreServer = makeMcpServer("accept");
     const { registerCreateTool } = await import("../../src/tools/harness-create.js");
-    registerCreateTool(fileStoreServer, registry, client);
+    registerCreateTool(fileStoreServer, registry, client, makeConfig());
     const contentBase64 = Buffer.from("sensitive file payload").toString("base64");
 
     const result = await fileStoreServer.call("harness_create", {
@@ -859,7 +859,7 @@ describe("harness_create", () => {
     client = makeClient(mockRequest);
     const fileStoreServer = makeMcpServer("accept");
     const { registerCreateTool } = await import("../../src/tools/harness-create.js");
-    registerCreateTool(fileStoreServer, registry, client);
+    registerCreateTool(fileStoreServer, registry, client, makeConfig());
     const contentBase64 = Buffer.from("sensitive json body payload").toString("base64");
 
     const result = await fileStoreServer.call("harness_create", {
@@ -891,14 +891,14 @@ describe("harness_update", () => {
     mockRequest = vi.fn().mockResolvedValue({ data: { identifier: "my-pipe" } });
     client = makeClient(mockRequest);
     const { registerUpdateTool } = await import("../../src/tools/harness-update.js");
-    registerUpdateTool(server, registry, client);
+    registerUpdateTool(server, registry, client, makeConfig());
   });
 
   it("returns error for resource with no update operation", async () => {
     const fullRegistry = new Registry(makeConfig());
     const fullServer = makeMcpServer("accept");
     const { registerUpdateTool } = await import("../../src/tools/harness-update.js");
-    registerUpdateTool(fullServer, fullRegistry, client);
+    registerUpdateTool(fullServer, fullRegistry, client, makeConfig());
 
     const result = await fullServer.call("harness_update", {
       resource_type: "execution",
@@ -914,7 +914,7 @@ describe("harness_update", () => {
     // requiresConfirmation(risk) which kicks in at medium_write.
     const declineServer = makeMcpServer("decline");
     const { registerUpdateTool } = await import("../../src/tools/harness-update.js");
-    registerUpdateTool(declineServer, registry, client);
+    registerUpdateTool(declineServer, registry, client, makeConfig());
 
     const result = await declineServer.call("harness_update", {
       resource_type: "pipeline",
@@ -940,7 +940,7 @@ describe("harness_update", () => {
     client = makeClient(mockRequest);
     const platformServer = makeMcpServer("accept");
     const { registerUpdateTool } = await import("../../src/tools/harness-update.js");
-    registerUpdateTool(platformServer, registry, client);
+    registerUpdateTool(platformServer, registry, client, makeConfig());
 
     const result = await platformServer.call("harness_update", {
       resource_type: "project",
@@ -962,7 +962,7 @@ describe("harness_update", () => {
     client = makeClient(mockRequest);
     const connectorServer = makeMcpServer("accept");
     const { registerUpdateTool } = await import("../../src/tools/harness-update.js");
-    registerUpdateTool(connectorServer, registry, client);
+    registerUpdateTool(connectorServer, registry, client, makeConfig());
 
     const result = await connectorServer.call("harness_update", {
       resource_type: "connector",
@@ -990,7 +990,7 @@ connector:
     client = makeClient(mockRequest);
     const connectorServer = makeMcpServer("accept");
     const { registerUpdateTool } = await import("../../src/tools/harness-update.js");
-    registerUpdateTool(connectorServer, registry, client);
+    registerUpdateTool(connectorServer, registry, client, makeConfig());
 
     const result = await connectorServer.call("harness_update", {
       resource_type: "connector",
@@ -1020,7 +1020,7 @@ connector:
     client = makeClient(mockRequest);
     const environmentServer = makeMcpServer("accept");
     const { registerUpdateTool } = await import("../../src/tools/harness-update.js");
-    registerUpdateTool(environmentServer, registry, client);
+    registerUpdateTool(environmentServer, registry, client, makeConfig());
 
     const result = await environmentServer.call("harness_update", {
       resource_type: "environment",
@@ -1051,7 +1051,7 @@ environment:
     client = makeClient(mockRequest);
     const fileStoreServer = makeMcpServer("accept");
     const { registerUpdateTool } = await import("../../src/tools/harness-update.js");
-    registerUpdateTool(fileStoreServer, registry, client);
+    registerUpdateTool(fileStoreServer, registry, client, makeConfig());
 
     const result = await fileStoreServer.call("harness_update", {
       resource_type: "file_store",
@@ -1078,7 +1078,7 @@ environment:
     client = makeClient(mockRequest);
     const fileStoreServer = makeMcpServer("accept");
     const { registerUpdateTool } = await import("../../src/tools/harness-update.js");
-    registerUpdateTool(fileStoreServer, registry, client);
+    registerUpdateTool(fileStoreServer, registry, client, makeConfig());
 
     const result = await fileStoreServer.call("harness_update", {
       resource_type: "file_store",
@@ -1104,7 +1104,7 @@ environment:
     client = makeClient(mockRequest);
     const fileStoreServer = makeMcpServer("accept");
     const { registerUpdateTool } = await import("../../src/tools/harness-update.js");
-    registerUpdateTool(fileStoreServer, registry, client);
+    registerUpdateTool(fileStoreServer, registry, client, makeConfig());
     const content = "sensitive replacement file payload";
 
     const result = await fileStoreServer.call("harness_update", {
@@ -1130,7 +1130,7 @@ environment:
     client = makeClient(mockRequest);
     const fileStoreServer = makeMcpServer("accept");
     const { registerUpdateTool } = await import("../../src/tools/harness-update.js");
-    registerUpdateTool(fileStoreServer, registry, client);
+    registerUpdateTool(fileStoreServer, registry, client, makeConfig());
     const content = "sensitive json replacement file payload";
 
     const result = await fileStoreServer.call("harness_update", {
@@ -1202,7 +1202,7 @@ describe("harness_update — pull request", () => {
     const prRequest = vi.fn().mockResolvedValue({ number: 42, title: "New Title" });
     const prClient = makeClient(prRequest);
     const { registerUpdateTool } = await import("../../src/tools/harness-update.js");
-    registerUpdateTool(prServer, prRegistry, prClient);
+    registerUpdateTool(prServer, prRegistry, prClient, makeConfig());
 
     const result = await prServer.call("harness_update", {
       resource_type: "pull_request",
@@ -1225,7 +1225,7 @@ describe("harness_update — pull request", () => {
     const prRequest = vi.fn().mockResolvedValue({ number: 42, state: "closed" });
     const prClient = makeClient(prRequest);
     const { registerUpdateTool } = await import("../../src/tools/harness-update.js");
-    registerUpdateTool(prServer, prRegistry, prClient);
+    registerUpdateTool(prServer, prRegistry, prClient, makeConfig());
 
     const result = await prServer.call("harness_update", {
       resource_type: "pull_request",
@@ -1247,7 +1247,7 @@ describe("harness_update — pull request", () => {
     const prRequest = vi.fn().mockResolvedValue({});
     const prClient = makeClient(prRequest);
     const { registerUpdateTool } = await import("../../src/tools/harness-update.js");
-    registerUpdateTool(prServer, prRegistry, prClient);
+    registerUpdateTool(prServer, prRegistry, prClient, makeConfig());
 
     const result = await prServer.call("harness_update", {
       resource_type: "pull_request",
@@ -1276,14 +1276,14 @@ describe("harness_delete", () => {
     mockRequest = vi.fn().mockResolvedValue({ data: true });
     client = makeClient(mockRequest);
     const { registerDeleteTool } = await import("../../src/tools/harness-delete.js");
-    registerDeleteTool(server, registry, client);
+    registerDeleteTool(server, registry, client, makeConfig());
   });
 
   it("returns error for resource with no delete operation", async () => {
     const fullRegistry = new Registry(makeConfig());
     const fullServer = makeMcpServer("accept");
     const { registerDeleteTool } = await import("../../src/tools/harness-delete.js");
-    registerDeleteTool(fullServer, fullRegistry, client);
+    registerDeleteTool(fullServer, fullRegistry, client, makeConfig());
 
     const result = await fullServer.call("harness_delete", {
       resource_type: "execution",
@@ -1296,7 +1296,7 @@ describe("harness_delete", () => {
   it("returns error when user declines destructive operation", async () => {
     const declineServer = makeMcpServer("decline");
     const { registerDeleteTool } = await import("../../src/tools/harness-delete.js");
-    registerDeleteTool(declineServer, registry, client);
+    registerDeleteTool(declineServer, registry, client, makeConfig());
 
     const result = await declineServer.call("harness_delete", {
       resource_type: "pipeline",
@@ -1326,7 +1326,7 @@ describe("harness_delete", () => {
       version_label: "1.0.0",
     });
     const { registerDeleteTool } = await import("../../src/tools/harness-delete.js");
-    registerDeleteTool(templateServer, templateRegistry, client);
+    registerDeleteTool(templateServer, templateRegistry, client, makeConfig());
 
     const result = await templateServer.call("harness_delete", {
       resource_type: "template_v1",
@@ -1358,7 +1358,7 @@ describe("harness_delete", () => {
     client = makeClient(mockRequest);
     const fileStoreServer = makeMcpServer("accept");
     const { registerDeleteTool } = await import("../../src/tools/harness-delete.js");
-    registerDeleteTool(fileStoreServer, registry, client);
+    registerDeleteTool(fileStoreServer, registry, client, makeConfig());
 
     const result = await fileStoreServer.call("harness_delete", {
       resource_type: "file_store",
@@ -1379,7 +1379,7 @@ describe("harness_delete", () => {
     client = makeClient(mockRequest);
     const fileStoreServer = makeMcpServer("accept");
     const { registerDeleteTool } = await import("../../src/tools/harness-delete.js");
-    registerDeleteTool(fileStoreServer, registry, client);
+    registerDeleteTool(fileStoreServer, registry, client, makeConfig());
 
     const result = await fileStoreServer.call("harness_delete", {
       resource_type: "file_store",
@@ -1427,7 +1427,7 @@ describe("harness_delete", () => {
     registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines" }));
     const conflictServer = makeMcpServer("accept");
     const { registerDeleteTool } = await import("../../src/tools/harness-delete.js");
-    registerDeleteTool(conflictServer, registry, client);
+    registerDeleteTool(conflictServer, registry, client, makeConfig());
 
     const result = await conflictServer.call("harness_delete", {
       resource_type: "pipeline",
@@ -1454,7 +1454,7 @@ describe("harness_execute", () => {
     mockRequest = vi.fn().mockResolvedValue({ data: { planExecutionId: "exec-123" } });
     client = makeClient(mockRequest);
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(server, registry, client);
+    registerExecuteTool(server, registry, client, makeConfig());
   });
 
   it("returns error when resource_type is missing", async () => {
@@ -1505,7 +1505,7 @@ describe("harness_execute", () => {
   it("returns error when user declines", async () => {
     const declineServer = makeMcpServer("decline");
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(declineServer, registry, client);
+    registerExecuteTool(declineServer, registry, client, makeConfig());
 
     const result = await declineServer.call("harness_execute", {
       resource_type: "pipeline",
@@ -1631,7 +1631,7 @@ pipeline:
     const prRequest = vi.fn().mockResolvedValue({ number: 42, state: "closed" });
     const prClient = makeClient(prRequest);
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(prServer, prRegistry, prClient);
+    registerExecuteTool(prServer, prRegistry, prClient, makeConfig());
 
     const result = await prServer.call("harness_execute", {
       url: "https://app.harness.io/ng/account/test-account/module/code/orgs/default/projects/test-project/repos/my-repo/pull-requests/42",
@@ -1652,7 +1652,7 @@ pipeline:
     const prRequest = vi.fn().mockResolvedValue({ number: 42, state: "closed" });
     const prClient = makeClient(prRequest);
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(prServer, prRegistry, prClient);
+    registerExecuteTool(prServer, prRegistry, prClient, makeConfig());
 
     const result = await prServer.call("harness_execute", {
       resource_type: "pull_request",
@@ -1672,7 +1672,7 @@ pipeline:
     const prRequest = vi.fn().mockResolvedValue({ number: 43, state: "closed" });
     const prClient = makeClient(prRequest);
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(prServer, prRegistry, prClient);
+    registerExecuteTool(prServer, prRegistry, prClient, makeConfig());
 
     const result = await prServer.call("harness_execute", {
       url: "https://app.harness.io/ng/account/test-account/module/code/orgs/default/projects/test-project/repos/my-repo/pull-requests/42",
@@ -1691,7 +1691,7 @@ pipeline:
     const prRequest = vi.fn().mockResolvedValue({ branch_deleted: false });
     const prClient = makeClient(prRequest);
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(prServer, prRegistry, prClient);
+    registerExecuteTool(prServer, prRegistry, prClient, makeConfig());
 
     const result = await prServer.call("harness_execute", {
       resource_type: "pull_request",
@@ -1724,7 +1724,7 @@ pipeline:
     const gitopsRequest = vi.fn().mockResolvedValue({});
     const gitopsClient = makeClient(gitopsRequest);
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(gitopsServer, gitopsRegistry, gitopsClient);
+    registerExecuteTool(gitopsServer, gitopsRegistry, gitopsClient, makeConfig());
 
     const result = await gitopsServer.call("harness_execute", {
       resource_type: "gitops_application",
@@ -1744,7 +1744,7 @@ pipeline:
     const fileStoreRequest = vi.fn().mockResolvedValue({ data: { nodes: [] } });
     const fileStoreClient = makeClient(fileStoreRequest);
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(fileStoreServer, fileStoreRegistry, fileStoreClient);
+    registerExecuteTool(fileStoreServer, fileStoreRegistry, fileStoreClient, makeConfig());
 
     const result = await fileStoreServer.call("harness_execute", {
       resource_type: "file_store",
@@ -1767,7 +1767,7 @@ pipeline:
     const fileStoreRequest = vi.fn().mockResolvedValue({ data: { nodes: [] } });
     const fileStoreClient = makeClient(fileStoreRequest);
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(fileStoreServer, fileStoreRegistry, fileStoreClient);
+    registerExecuteTool(fileStoreServer, fileStoreRegistry, fileStoreClient, makeConfig());
 
     const result = await fileStoreServer.call("harness_execute", {
       resource_type: "file_store",
@@ -1789,7 +1789,7 @@ pipeline:
     const fileStoreRequest = vi.fn().mockResolvedValue({ data: { nodes: [] } });
     const fileStoreClient = makeClient(fileStoreRequest);
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(fileStoreServer, fileStoreRegistry, fileStoreClient);
+    registerExecuteTool(fileStoreServer, fileStoreRegistry, fileStoreClient, makeConfig());
 
     const result = await fileStoreServer.call("harness_execute", {
       url: "https://app.harness.io/ng/account/test-account/all/settings/file-store/folder123",
@@ -1810,7 +1810,7 @@ pipeline:
     const fileStoreRequest = vi.fn().mockResolvedValue({ data: { nodes: [] } });
     const fileStoreClient = makeClient(fileStoreRequest);
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(fileStoreServer, fileStoreRegistry, fileStoreClient);
+    registerExecuteTool(fileStoreServer, fileStoreRegistry, fileStoreClient, makeConfig());
 
     const result = await fileStoreServer.call("harness_execute", {
       resource_type: "file_store",
@@ -1832,7 +1832,7 @@ pipeline:
     const fmeRequest = vi.fn().mockResolvedValue({});
     const fmeClient = makeClient(fmeRequest);
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(fmeServer, fmeRegistry, fmeClient);
+    registerExecuteTool(fmeServer, fmeRegistry, fmeClient, makeConfig());
 
     const result = await fmeServer.call("harness_execute", {
       resource_type: "fme_rule_based_segment_definition",
@@ -1859,7 +1859,7 @@ pipeline:
       getCurrentUserId: vi.fn().mockResolvedValue("user-uuid-1"),
     } as unknown as HarnessClient;
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(stoServer, stoRegistry, stoClient);
+    registerExecuteTool(stoServer, stoRegistry, stoClient, makeConfig());
 
     const result = await stoServer.call("harness_execute", {
       resource_type: "security_exemption",
@@ -1883,7 +1883,7 @@ pipeline:
     const fmeRequest = vi.fn().mockResolvedValue(true);
     const fmeClient = makeClient(fmeRequest);
     const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
-    registerExecuteTool(fmeServer, fmeRegistry, fmeClient);
+    registerExecuteTool(fmeServer, fmeRegistry, fmeClient, makeConfig());
 
     const result = await fmeServer.call("harness_execute", {
       resource_type: "fme_feature_flag",

--- a/tests/utils/session-headers.test.ts
+++ b/tests/utils/session-headers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi, afterEach } from "vitest";
 import type { Config } from "../../src/config.js";
 import { resolveFmeApiKey } from "../../src/config.js";
 import {
@@ -53,6 +53,31 @@ describe("session header parsing", () => {
     expect(parseAutoApproveRiskHeader({ "x-harness-auto-approve-risk": "ALL" })).toBe("all");
     expect(parseAutoApproveRiskHeader({ "x-harness-auto-approve-risk": " medium_write " })).toBe("medium_write");
     expect(parseAutoApproveRiskHeader({ "x-harness-auto-approve-risk": "read" })).toBeUndefined();
+  });
+
+  describe("auto-approve risk header warnings", () => {
+    // The logger writes through console.error (see src/utils/logger.ts).
+    afterEach(() => vi.restoreAllMocks());
+
+    it("warns on an unrecognized value instead of silently defaulting", () => {
+      const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+      expect(parseAutoApproveRiskHeader({ "x-harness-auto-approve-risk": "read" })).toBeUndefined();
+      expect(spy).toHaveBeenCalledTimes(1);
+      // The offending value is surfaced so a misconfigured client can debug it.
+      expect(spy.mock.calls[0]?.[0]).toContain("read");
+    });
+
+    it("does not warn on a recognized value", () => {
+      const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+      expect(parseAutoApproveRiskHeader({ "x-harness-auto-approve-risk": "high_write" })).toBe("high_write");
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("does not warn when the header is absent", () => {
+      const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+      expect(parseAutoApproveRiskHeader({})).toBeUndefined();
+      expect(spy).not.toHaveBeenCalled();
+    });
   });
 
   it("merges valid session headers without mutating the base config", () => {


### PR DESCRIPTION
## Summary
Two hardening fixes for the write-tool security path (harvested from the still-valid #207, re-done cleanly on current `main`):

- **`session-headers.ts`** — log a `warn` when `X-Harness-Auto-Approve-Risk` holds an unrecognized value (e.g. `read`, a typo) instead of silently falling back to the deployment default. A misconfigured client otherwise ends up with a different security posture than it intended, with zero signal. The offending value is surfaced in the log to aid debugging.
- **Write-tool registrars** (`harness_create`, `harness_update`, `harness_delete`, `harness_execute`) — change `config?: Config` → `config: Config`. `registerAllTools` always passes it (`src/tools/index.ts`), so optional was a type lie: a future caller could omit it and silently bypass `HARNESS_READ_ONLY` enforcement and the session auto-approve setting. The now-needless `?.` guards at the read-only / auto-approve sites are simplified.

## Context
The changes were originally proposed in #207 (a follow-up to #204 whose two review nits never merged). That PR is conflicting, CI-failing, and CLA-unblocked, so this re-implements the same intent on a fresh branch off `main` and fixes the stale test it flagged. #207 can be closed as superseded.

## Test plan
- `pnpm build`, `pnpm typecheck`
- `pnpm docs:generate` && `pnpm docs:check` (README up to date)
- Added `session-headers.test.ts` coverage: warns on an unrecognized value (surfacing it), does NOT warn on a valid value or when the header is absent
- Updated all write-tool registrar call sites across the test suite to pass `config` (the previously-optional param)
- Full suite green: **118 files, 2513 tests, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)