### PR TITLE
fix: block harness_diagnose for running executions

### DIFF
--- a/src/tools/diagnose/pipeline.ts
+++ b/src/tools/diagnose/pipeline.ts
@@ -524,6 +524,27 @@ export const pipelineHandler: DiagnoseHandler = {
       const pes = asRecord(exec.pipelineExecutionSummary);
       resolvedPipelineId = asString(pes?.pipelineIdentifier);
 
+      // Block diagnosis of running executions — only allow terminal statuses.
+      // Terminal statuses are: Success, Failed, Errored, IgnoreFailed, Expired, Aborted,
+      // Skipped, ApprovalRejected, Suspended, AbortedByFreeze.
+      // All other statuses (Running, Queued, Paused, etc.) are in-progress and rejected.
+      const executionStatus = asString(pes?.status);
+      const terminalStatuses = [
+        "Success",
+        "Failed",
+        "Errored",
+        "IgnoreFailed",
+        "Expired",
+        "Aborted",
+        "Skipped",
+        "ApprovalRejected",
+        "Suspended",
+        "AbortedByFreeze",
+      ];
+      if (executionStatus && !terminalStatuses.includes(executionStatus)) {
+        throw new Error(`Cannot diagnose execution with status '${executionStatus}'. Diagnosis is only available for completed executions (Success, Failed, Aborted, Expired, etc.). Please wait for the execution to complete.`);
+      }
+
       // Always extract the full graph node map — needed for both failed-step
       // log fetching and the explicit step log lookup below.
       const execGraph = asRecord(exec.executionGraph);
@@ -583,6 +604,11 @@ export const pipelineHandler: DiagnoseHandler = {
         currentStep++;
       }
     } catch (err) {
+      // Re-throw errors about running executions — these are user errors that
+      // should be surfaced immediately, not logged as execution_error
+      if (err instanceof Error && err.message.includes("Cannot diagnose execution with status")) {
+        throw err;
+      }
       diagnostic.execution_error = String(err);
     }
 

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -2946,4 +2946,88 @@ describe("harness_diagnose", () => {
       expect(data.error).not.toContain("not supported");
     }
   });
+
+  it("rejects running executions", async () => {
+    // Test a representative subset of non-terminal statuses
+    const runningStatuses = [
+      "Running",
+      "AsyncWaiting",
+      "TaskWaiting",
+      "TimedWaiting",
+      "NotStarted",
+      "Queued",
+      "Paused",
+      "ResourceWaiting",
+      "InterventionWaiting",
+      "ApprovalWaiting",
+      "WaitStepRunning",
+      "QueuedLicenseLimitReached",
+      "QueuedExecutionConcurrencyReached",
+      "Pausing",
+      "InputWaiting",
+      "UploadWaiting",
+      "QueuedGlobalInfraCapacityReached",
+      "Discontinuing",
+    ];
+
+    for (const status of runningStatuses) {
+      mockRequest.mockResolvedValue({
+        data: {
+          pipelineExecutionSummary: {
+            status,
+            pipelineIdentifier: "test",
+            planExecutionId: "e1",
+            layoutNodeMap: {},
+          },
+        },
+      });
+
+      const result = await server.call("harness_diagnose", {
+        options: { execution_id: "e1" },
+      });
+
+      expect(result.isError).toBe(true);
+      const data = parseResult(result) as { error: string };
+      expect(data.error).toContain(`Cannot diagnose execution with status '${status}'`);
+      expect(data.error).toContain("Diagnosis is only available for completed executions");
+    }
+  });
+
+  it("allows completed executions", async () => {
+    const completedStatuses = [
+      "Success",
+      "Failed",
+      "Errored",
+      "IgnoreFailed",
+      "Expired",
+      "Aborted",
+      "Skipped",
+      "ApprovalRejected",
+      "Suspended",
+      "AbortedByFreeze",
+    ];
+
+    for (const status of completedStatuses) {
+      mockRequest.mockResolvedValue({
+        data: {
+          pipelineExecutionSummary: {
+            status,
+            pipelineIdentifier: "test",
+            planExecutionId: "e1",
+            layoutNodeMap: {},
+          },
+        },
+      });
+
+      const result = await server.call("harness_diagnose", {
+        options: { execution_id: "e1" },
+      });
+
+      // Should not return an error about running execution
+      if (result.isError) {
+        const data = parseResult(result) as { error: string };
+        expect(data.error).not.toContain("Cannot diagnose execution with status");
+      }
+    }
+  });
 });


### PR DESCRIPTION
## Description

Add validation to reject diagnosis requests for in-progress executions. Running executions (Running, Queued, Waiting, etc.) now return a clear error message directing users to wait for completion.

- Add status check in pipeline diagnose handler
- Re-throw running execution errors from catch block
- Add tests for both rejection and acceptance cases


<img width="764" height="765" alt="Screenshot 2026-07-07 at 7 35 25 PM" src="https://github.com/user-attachments/assets/b6048737-b3a0-4193-8302-a47289c7d78b" />



## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [x] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
If this PR adds or changes Harness API coverage:
- [] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [ ] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [ ] `operationPolicy` on every new/changed endpoint
- [ ] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [ ] `identifierFields` and `scope` declared on new resources
- [ ] No `console.log()` in `src/` (stdio JSON-RPC safety)
