### PR TITLE
fix(http): stop dropping MCP sessions that force re-authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,12 +35,18 @@ LOG_LEVEL=info
 # HTTP transport only — ignored in stdio mode
 PORT=3000
 # Idle HTTP sessions are reaped after this many milliseconds once no request
-# or SSE stream is active.
-MCP_SESSION_TTL_MS=300000
+# or SSE stream is active. Default 30m — kept generous so interactive clients
+# (e.g. the claude.ai connector, which does not hold a persistent SSE stream
+# between prompts) are not evicted mid-conversation.
+MCP_SESSION_TTL_MS=1800000
 # Require Authorization: Bearer <token> on /mcp routes when set.
 HARNESS_MCP_AUTH_TOKEN=
 # Non-loopback HTTP binds require HARNESS_MCP_AUTH_TOKEN unless this is true.
 HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP=false
+# Number of proxy hops to trust for client IP resolution (Express `trust
+# proxy`). Set to the number of reverse proxies / load balancers in front of
+# the server so per-IP rate limiting keys on the real client. Default 0.
+HARNESS_MCP_TRUST_PROXY=0
 # Comma-separated public hostnames allowed by HTTP transport Host-header validation.
 # mcp.harness.io is allowed by default for hosted MCP.
 HARNESS_MCP_ALLOWED_HOSTS=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,7 @@ See `.env.example` for the full list. Non-obvious ones:
 | `HARNESS_FME_API_KEY` | Feature Management Engine (Split.io) key; falls back to `HARNESS_API_KEY` if unset |
 | `HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP` | Set `true` for local HTTP dev without auth token |
 | `HARNESS_MCP_ALLOWED_HOSTS` | Comma-separated allowed hostnames for HTTP Host-header validation |
+| `HARNESS_MCP_TRUST_PROXY` | Number of proxy hops to trust for client IP (`trust proxy`); set behind an LB so rate limiting keys on the real client (default `0`) |
 | `HARNESS_ALLOW_HTTP` | Allow non-HTTPS base URL (default `false`) |
 
 Deprecated aliases (still work, emit deprecation warning to stderr):

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -6,7 +6,15 @@ metadata:
   labels:
     app.kubernetes.io/name: harness-mcp-server
 spec:
-  replicas: 2
+  # MCP sessions are held in an in-memory Map per pod (see src/index.ts). A
+  # session initialized on one pod is unknown to any other, so a request
+  # load-balanced to a different replica returns "Session not found", forcing
+  # the client to re-initialize / re-authenticate. Until the session store is
+  # externalized (e.g. shared store + SDK eventStore for resumability), run a
+  # single replica. If you must scale out, you MUST also add sticky routing
+  # (Service sessionAffinity: ClientIP below is not sufficient through an
+  # L7 ingress — configure sticky sessions at the ingress too).
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: harness-mcp-server

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -7,6 +7,15 @@ metadata:
     app.kubernetes.io/name: harness-mcp-server
 spec:
   type: ClusterIP
+  # Pin a client to the same pod so in-memory MCP sessions resolve on follow-up
+  # requests. This covers direct Service traffic; L7 ingress in front of the
+  # Service must configure its own sticky sessions for this to hold end-to-end.
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      # Match the app's idle session TTL (MCP_SESSION_TTL_MS default 30m = 1800s)
+      # so affinity does not expire before the session does.
+      timeoutSeconds: 1800
   selector:
     app.kubernetes.io/name: harness-mcp-server
   ports:

--- a/src/config.ts
+++ b/src/config.ts
@@ -78,7 +78,12 @@ const RawConfigSchema = z.object({
   HARNESS_DEFAULT_PROJECT_ID: optionalStringFromEnv,
   HARNESS_API_TIMEOUT_MS: z.coerce.number().default(30000),
   HARNESS_MAX_RETRIES: z.coerce.number().default(3),
-  MCP_SESSION_TTL_MS: z.coerce.number().min(1).default(5 * 60_000),
+  // Idle HTTP sessions are reaped after this many ms once no request or SSE
+  // stream is active. Kept generous (30 min) so interactive clients (e.g. the
+  // claude.ai connector, which does not hold a persistent SSE stream between
+  // prompts) are not evicted mid-conversation, which surfaces to users as
+  // repeated "Session not found" → re-authenticate prompts.
+  MCP_SESSION_TTL_MS: z.coerce.number().min(1).default(30 * 60_000),
   LOG_LEVEL: z.preprocess(
     (val) => (val === "" ? undefined : val),
     z.enum(["debug", "info", "warn", "error"]).default("info"),
@@ -96,6 +101,12 @@ const RawConfigSchema = z.object({
   HARNESS_MCP_ALLOWED_HOSTS: optionalStringFromEnv.transform(validateAllowedHosts),
   HARNESS_MCP_AUTH_TOKEN: optionalStringFromEnv,
   HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP: booleanFromEnv.default(false),
+  // Number of proxy hops to trust for client IP resolution (Express `trust
+  // proxy`). Set to the count of reverse proxies / load balancers in front of
+  // the server so per-IP rate limiting keys on the real client rather than the
+  // proxy socket peer (which would bucket every user together). Default 0
+  // (trust nothing) preserves prior behaviour for direct binds.
+  HARNESS_MCP_TRUST_PROXY: z.coerce.number().int().min(0).default(0),
   HARNESS_FME_API_KEY: optionalStringFromEnv,
   HARNESS_FME_BASE_URL: urlFromEnv("https://api.split.io"),
   HARNESS_LOG_UNSAFE_BODIES: booleanFromEnv.default(false),

--- a/src/index.ts
+++ b/src/index.ts
@@ -251,6 +251,14 @@ async function startHttp(config: Config, port: number): Promise<void> {
 
   const app = createHarnessHttpExpressApp(resolveHttpHostValidationOptions(host, config));
 
+  // Trust reverse proxies / load balancers in front of the server so req.ip
+  // resolves to the real client (from X-Forwarded-For) instead of the proxy
+  // socket peer. Without this, per-IP rate limiting buckets every client
+  // behind the LB into a single counter. Default 0 = trust nothing.
+  if (config.HARNESS_MCP_TRUST_PROXY > 0) {
+    app.set("trust proxy", config.HARNESS_MCP_TRUST_PROXY);
+  }
+
   // CORS — allow GET, POST, DELETE for session-based MCP
   app.use((_req, res, next) => {
     res.setHeader("Access-Control-Allow-Origin", `http://${host}:${port}`);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -196,11 +196,11 @@ describe("ConfigSchema", () => {
     }
   });
 
-  it("defaults MCP_SESSION_TTL_MS to five minutes", () => {
+  it("defaults MCP_SESSION_TTL_MS to thirty minutes", () => {
     const result = ConfigSchema.safeParse(validConfig);
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.MCP_SESSION_TTL_MS).toBe(5 * 60_000);
+      expect(result.data.MCP_SESSION_TTL_MS).toBe(30 * 60_000);
     }
   });
 
@@ -219,6 +219,31 @@ describe("ConfigSchema", () => {
     const result = ConfigSchema.safeParse({
       ...validConfig,
       MCP_SESSION_TTL_MS: "0",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("defaults HARNESS_MCP_TRUST_PROXY to 0 and coerces from env", () => {
+    const withDefault = ConfigSchema.safeParse(validConfig);
+    expect(withDefault.success).toBe(true);
+    if (withDefault.success) {
+      expect(withDefault.data.HARNESS_MCP_TRUST_PROXY).toBe(0);
+    }
+
+    const coerced = ConfigSchema.safeParse({
+      ...validConfig,
+      HARNESS_MCP_TRUST_PROXY: "2",
+    });
+    expect(coerced.success).toBe(true);
+    if (coerced.success) {
+      expect(coerced.data.HARNESS_MCP_TRUST_PROXY).toBe(2);
+    }
+  });
+
+  it("rejects negative HARNESS_MCP_TRUST_PROXY", () => {
+    const result = ConfigSchema.safeParse({
+      ...validConfig,
+      HARNESS_MCP_TRUST_PROXY: "-1",
     });
     expect(result.success).toBe(false);
   });


### PR DESCRIPTION
## Problem

Remote clients (e.g. the claude.ai Harness connector in Claude Code) are being prompted to re-authenticate very frequently — reported as escalating from "every 5 minutes" to "every prompt."

The connection isn't actually expiring. The server is **losing the session** and returning `404 Session not found` (`src/index.ts:354`), which the MCP client surfaces as a re-authentication prompt. There are two independent, compounding causes.

## Root causes

**1. Multi-replica + per-pod in-memory session store + no session affinity → "every prompt"**

MCP sessions live in a process-local `Map` (`src/index.ts:295`); the SDK transport for a session physically lives in one pod. `k8s/deployment.yaml` ran `replicas: 2` and `k8s/service.yaml` was a plain `ClusterIP` with no `sessionAffinity`. A session initialized on pod A is unknown to pod B, so any follow-up request the LB round-robins to the wrong pod 404s. With 2 replicas this hits roughly half of requests — matching the regression from occasional to near-constant.

**2. Aggressive 5-minute idle TTL → the original "every 5 minutes"**

`MCP_SESSION_TTL_MS` defaulted to `5 * 60_000` and the reaper (`src/index.ts:318`) destroys any session idle beyond it. The connector holds no persistent SSE stream between prompts, so a short pause reaps the session.

## Changes

- **`k8s/deployment.yaml`**: `replicas: 2 → 1`, with a comment explaining the in-memory store constraint and what scaling out requires.
- **`k8s/service.yaml`**: add `sessionAffinity: ClientIP` (timeout matched to the session TTL) as defense-in-depth; note that an L7 ingress must configure its own sticky sessions.
- **`src/config.ts` / `.env.example`**: raise default `MCP_SESSION_TTL_MS` to 30 min (`1800000`).
- **`src/config.ts` + `src/index.ts`**: add `HARNESS_MCP_TRUST_PROXY` and wire `app.set("trust proxy", …)` so per-IP rate limiting keys on the real client behind a load balancer instead of bucketing every user into one counter (`src/index.ts:271`).
- **`AGENTS.md`**: document `HARNESS_MCP_TRUST_PROXY`.
- **`tests/config.test.ts`**: update TTL default assertion; add coverage for `HARNESS_MCP_TRUST_PROXY`.

## Follow-up (not in this PR)

The correct long-term fix for horizontal scaling is externalizing the session/event store (the MCP SDK supports an `eventStore` for resumability). Until then, `replicas: 1` + affinity is the safe configuration.

## Testing

- `pnpm typecheck` — clean
- `pnpm test` — 118 files, 2515 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)