### PR TITLE
fix(execute): apply input_set_ids when inputs is full pipeline YAML

### DIFF
--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -1,5 +1,5 @@
 import * as z from "zod/v4";
-import { parse as parseYaml } from "yaml";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
@@ -12,7 +12,7 @@ import { applyUrlDefaults } from "../utils/url-parser.js";
 import { asRecord, asString, coerceRecord } from "../utils/type-guards.js";
 import { isFlatKeyValueInputs, isResolvableInputs, flattenInputs, resolveRuntimeInputs, resolveRuntimeInputsWithBaseYaml, type ResolutionResult } from "../utils/runtime-input-resolver.js";
 import { applyInputExpansions } from "../utils/input-expander.js";
-import { materializeInputSetsToRuntimeYaml } from "../utils/materialize-input-sets.js";
+import { materializeInputSetsToRuntimeYaml, mergeRuntimePipelineFragments } from "../utils/materialize-input-sets.js";
 import { resourceScopeSchema, resourceTypeSchema } from "./input-schemas.js";
 import { pollExecutionToTerminal, FAILURE_STATUSES, AbortError } from "../utils/poll-execution.js";
 import { sendProgress } from "../utils/progress.js";
@@ -28,6 +28,31 @@ function hasNoInlineRuntimeInputs(inputs: unknown): boolean {
   if (inputs === undefined) return true;
   const record = asRecord(inputs);
   return !!record && Object.keys(record).length === 0;
+}
+
+/**
+ * True when `inputs` is a full pipeline document (`{ pipeline: ... }`) rather
+ * than a flat key/value override map. These are merged fragment-wise with a
+ * materialized input set (see the pipeline run path) instead of being resolved
+ * against the runtime input template.
+ */
+function isFullPipelineInputs(inputs: unknown): inputs is Record<string, unknown> {
+  const record = asRecord(inputs);
+  return !!record && "pipeline" in record;
+}
+
+/**
+ * Extract the inner `pipeline` fragment from a pipeline-execute runtime
+ * document, accepting either a YAML string or an already-parsed object. The
+ * top-level `pipeline` key is unwrapped when present; otherwise the whole
+ * document is treated as the fragment. Used to merge a caller-supplied full
+ * pipeline YAML with a materialized input set.
+ */
+function extractPipelineFragment(yamlOrObj: unknown): Record<string, unknown> {
+  const doc = typeof yamlOrObj === "string" ? parseYaml(yamlOrObj) : yamlOrObj;
+  const root = asRecord(doc);
+  if (!root) return {};
+  return asRecord(root.pipeline) ?? root;
 }
 
 /**
@@ -276,7 +301,10 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
           resourceType === "pipeline" &&
           args.action === "run" &&
           hasInputSets &&
-          (hasNoInlineRuntimeInputs(args.inputs) || isResolvableInputs(args.inputs))
+          (hasNoInlineRuntimeInputs(args.inputs) ||
+            isResolvableInputs(args.inputs) ||
+            isFullPipelineInputs(args.inputs) ||
+            typeof args.inputs === "string")
         ) {
           const pipelineId = asString(input.pipeline_id) ?? resourceId;
           const orgId = asString(input.org_id) || registry.orgId;
@@ -305,6 +333,21 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
             });
             if (materializedInputSetYaml && hasNoInlineRuntimeInputs(args.inputs)) {
               input.inputs = materializedInputSetYaml;
+              delete input.input_set_ids;
+              materializedInputSets = true;
+            } else if (
+              materializedInputSetYaml &&
+              (isFullPipelineInputs(args.inputs) || typeof args.inputs === "string")
+            ) {
+              // Caller supplied a full pipeline document (YAML string or object)
+              // alongside input_set_ids. Merge the input set as the base and the
+              // caller's document as the override (caller wins per variable /
+              // stage). Without this the input set would be dropped to the
+              // `inputSetIdentifiers` query param, which pipeline execute ignores.
+              const base = extractPipelineFragment(materializedInputSetYaml);
+              const override = extractPipelineFragment(args.inputs);
+              const merged = mergeRuntimePipelineFragments(base, override);
+              input.inputs = stringifyYaml({ pipeline: merged });
               delete input.input_set_ids;
               materializedInputSets = true;
             }

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -2232,6 +2232,102 @@ pipeline:
     expect(runCall.params?.inputSetIdentifiers).toBeUndefined();
   });
 
+  it("merges input_set_ids into a full pipeline YAML STRING passed as inputs", async () => {
+    const inputSetYaml = `inputSet:
+  pipeline:
+    identifier: "str_pipe"
+    variables:
+      - name: "environment"
+        type: "String"
+        value: "prod"
+      - name: "branch"
+        type: "String"
+        value: "main"
+`;
+    // Caller passes a full pipeline document as a YAML string alongside an
+    // input set. Previously this skipped materialization and dropped the set.
+    const inlineYaml = `pipeline:
+  identifier: "str_pipe"
+  variables:
+    - name: "branch"
+      type: "String"
+      value: "feature"
+`;
+    mockRequest
+      .mockResolvedValueOnce({ status: "SUCCESS", data: { inputSetYaml } }) // input set GET
+      .mockResolvedValueOnce({ data: { planExecutionId: "exec-str" } }); // execute
+
+    const result = await server.call("harness_execute", {
+      resource_type: "pipeline",
+      action: "run",
+      resource_id: "str_pipe",
+      inputs: inlineYaml,
+      input_set_ids: ["my-input-set"],
+    });
+
+    expect(result.isError).toBeUndefined();
+    // Only the input set GET + the execute POST — no template fetch needed.
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+
+    const getCall = mockRequest.mock.calls[0]![0] as { method?: string; path?: string };
+    expect(getCall.method).toBe("GET");
+    expect(getCall.path).toContain("/pipeline/api/inputSets/");
+    expect(getCall.path).toContain("my-input-set");
+
+    const runCall = mockRequest.mock.calls[1]![0] as {
+      method?: string;
+      body?: string;
+      params?: Record<string, string | string[] | undefined>;
+    };
+    expect(runCall.method).toBe("POST");
+    // Input set base value present...
+    expect(runCall.body).toContain("environment");
+    expect(runCall.body).toContain("prod");
+    // ...and the caller's inline override wins for branch.
+    expect(runCall.body).toContain("feature");
+    expect(runCall.body).not.toContain("main");
+    // Input set applied via body, not the ignored query param.
+    expect(runCall.params?.inputSetIdentifiers).toBeUndefined();
+  });
+
+  it("merges input_set_ids into a full pipeline OBJECT passed as inputs", async () => {
+    const inputSetYaml = `inputSet:
+  pipeline:
+    identifier: "obj_pipe"
+    variables:
+      - name: "environment"
+        type: "String"
+        value: "prod"
+`;
+    mockRequest
+      .mockResolvedValueOnce({ status: "SUCCESS", data: { inputSetYaml } }) // input set GET
+      .mockResolvedValueOnce({ data: { planExecutionId: "exec-obj" } }); // execute
+
+    const result = await server.call("harness_execute", {
+      resource_type: "pipeline",
+      action: "run",
+      resource_id: "obj_pipe",
+      inputs: {
+        pipeline: {
+          identifier: "obj_pipe",
+          variables: [{ name: "branch", type: "String", value: "feature" }],
+        },
+      },
+      input_set_ids: ["my-input-set"],
+    });
+
+    expect(result.isError).toBeUndefined();
+    const runCall = mockRequest.mock.calls[mockRequest.mock.calls.length - 1]![0] as {
+      body?: string;
+      params?: Record<string, string | string[] | undefined>;
+    };
+    // Input set base + caller override both present in the merged body.
+    expect(runCall.body).toContain("environment");
+    expect(runCall.body).toContain("prod");
+    expect(runCall.body).toContain("feature");
+    expect(runCall.params?.inputSetIdentifiers).toBeUndefined();
+  });
+
   it("includes _inputResolution metadata on successful auto-resolved execution", async () => {
     const simpleTemplate = `pipeline:
   identifier: "meta_pipe"


### PR DESCRIPTION
## Problem

A customer's Claude-in-VSCode demo ran an end-to-end pipeline via `harness_execute` and the run **succeeded but without the input set applied** — a silent drop, not an error.

Investigating the current code, the *standard* path — `harness_execute(resource_type="pipeline", action="run", input_set_ids=[...])` with no/flat `inputs` — works correctly: input sets are materialized into the YAML execute body (PR #532). So the broad claim that "`harness_execute` drops `input_set_ids` on the floor" is **not** true for normal usage.

But there is a real gap that produces exactly this silent-drop symptom:

**When `inputs` is a full pipeline document** — a YAML string, or an object with a top-level `pipeline` key — passed alongside `input_set_ids`, the materialization guard (`harness-execute.ts`) only admitted empty or flat key/value inputs (`hasNoInlineRuntimeInputs || isResolvableInputs`). A full-pipeline value failed both, so materialization was skipped and the input set fell through to the `inputSetIdentifiers` query param — which pipeline execute ignores. The pipeline ran without the input set.

## Fix

- Broaden the guard to also admit full-pipeline `inputs` (object with `pipeline` key, or a YAML string).
- Merge the materialized input set as the **base** and the caller's document as the **override** (caller wins per variable / stage) via the existing `mergeRuntimePipelineFragments`, then send the merged YAML as the execute body — the same mechanism the working UI path uses.

## Not in scope

`pipeline_v1` accepts `input_set_ids` in the shared tool schema but never forwards them (its run endpoint has no mapping and its body only emits `inputs_yaml`). Left as-is pending confirmation of the v1 execute API's input-set contract — flagged so it's tracked rather than silently shipped.

## Likely cause of the customer report

Since current `main` handles the standard path correctly, the most probable explanation for "broke today" is a **stale hosted MCP version** predating v3.2.5/#532, or the customer hitting this full-YAML gap. Confirming needs their MCP version + tool-call args + a failed execution ID.

## Testing

- `pnpm typecheck` — clean
- `pnpm test` — 118 files, 2514 tests passing (adds 2 tests: YAML-string and object input forms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)