### PR TITLE
fix(execute): forward git context so remote input sets resolve correctly

### DIFF
--- a/src/registry/toolsets/pipelines.ts
+++ b/src/registry/toolsets/pipelines.ts
@@ -828,9 +828,17 @@ export const pipelinesToolset: ToolsetDefinition = {
           path: "/pipeline/api/inputSets/{inputSetIdentifier}",
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           pathParams: { input_set_id: "inputSetIdentifier" },
-          queryParams: { pipeline_id: "pipelineIdentifier" },
+          queryParams: {
+            pipeline_id: "pipelineIdentifier",
+            // Git context for remote/Git-stored input sets — without a branch
+            // the API silently resolves from the repo's default branch.
+            branch: "branch",
+            repo_name: "repoName",
+            connector_ref: "connectorRef",
+            store_type: "storeType",
+          },
           responseExtractor: ngExtract,
-          description: "Get input set details",
+          description: "Get input set details. For remote/git-backed input sets, pass branch (and repo_name for multi-repo) to read from a specific branch; otherwise the default branch is used.",
         },
         create: {
           method: "POST",

--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -325,11 +325,22 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
             );
           }
           try {
+            // Forward git context so remote / Git-stored input sets resolve
+            // from the correct branch/repo instead of silently defaulting to
+            // the repo's default branch. `normalizeRemotePipelineRunParams`
+            // (called above) has already populated these on `input`.
+            const gitContext = {
+              branch: asString(input.pipeline_branch) ?? asString(input.branch),
+              repoName: asString(input.repo_name),
+              connectorRef: asString(input.connector_ref),
+              storeType: asString(input.store_type),
+            };
             materializedInputSetYaml = await materializeInputSetsToRuntimeYaml(client, {
               pipelineId,
               orgId,
               projectId,
               inputSetIds,
+              gitContext,
             });
             if (materializedInputSetYaml && hasNoInlineRuntimeInputs(args.inputs)) {
               input.inputs = materializedInputSetYaml;

--- a/src/utils/materialize-input-sets.ts
+++ b/src/utils/materialize-input-sets.ts
@@ -13,6 +13,19 @@ export interface MaterializeParams {
   orgId: string;
   projectId: string;
   inputSetIds: string[];
+  /**
+   * Git context for remote / Git-stored input sets. When omitted, the Harness
+   * API resolves the input set from the repo's default branch — which silently
+   * returns the wrong values (or 404s) when the set lives on another branch.
+   */
+  gitContext?: InputSetGitContext;
+}
+
+export interface InputSetGitContext {
+  branch?: string;
+  repoName?: string;
+  connectorRef?: string;
+  storeType?: string;
 }
 
 function mergeVariableLists(
@@ -104,6 +117,7 @@ async function fetchInputSetPipelineFragment(
   orgId: string,
   projectId: string,
   inputSetId: string,
+  gitContext?: InputSetGitContext,
 ): Promise<Record<string, unknown> | undefined> {
   const raw = await client.request<unknown>({
     method: "GET",
@@ -112,6 +126,12 @@ async function fetchInputSetPipelineFragment(
       orgIdentifier: orgId,
       projectIdentifier: projectId,
       pipelineIdentifier: pipelineId,
+      // Git context for remote input sets. Empty/undefined values are dropped
+      // by the client's query serializer, so inline sets are unaffected.
+      branch: gitContext?.branch,
+      repoName: gitContext?.repoName,
+      connectorRef: gitContext?.connectorRef,
+      storeType: gitContext?.storeType,
     },
   });
   const r = asRecord(raw);
@@ -149,6 +169,7 @@ export async function materializeInputSetsToRuntimeYaml(
       params.orgId,
       params.projectId,
       id,
+      params.gitContext,
     );
     if (!fragment) {
       throw new HarnessApiError(

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -2171,6 +2171,48 @@ pipeline:
     expect(runCall.body).not.toContain("<+input>");
   });
 
+  it("forwards git branch/repo to the input set GET for a remote pipeline run", async () => {
+    const inputSetYaml = `inputSet:
+  pipeline:
+    identifier: "remote_pipe"
+    variables:
+      - name: "env"
+        type: "String"
+        value: "prod"
+`;
+    mockRequest
+      .mockResolvedValueOnce({ status: "SUCCESS", data: { inputSetYaml } }) // input set GET
+      .mockResolvedValueOnce({ data: { planExecutionId: "exec-remote" } }); // execute
+
+    const result = await server.call("harness_execute", {
+      resource_type: "pipeline",
+      action: "run",
+      resource_id: "remote_pipe",
+      input_set_ids: ["remote-set"],
+      params: {
+        store_type: "REMOTE",
+        connector_ref: "gh_conn",
+        repo_name: "my-repo",
+        branch: "feature/x",
+      },
+    });
+
+    expect(result.isError).toBeUndefined();
+    const getCall = mockRequest.mock.calls[0]![0] as {
+      method?: string;
+      path?: string;
+      params?: Record<string, string | undefined>;
+    };
+    expect(getCall.method).toBe("GET");
+    expect(getCall.path).toContain("/pipeline/api/inputSets/remote-set");
+    // Git context must reach the input-set GET, else a remote set silently
+    // resolves from the repo's default branch (wrong values, no error).
+    expect(getCall.params?.branch).toBe("feature/x");
+    expect(getCall.params?.repoName).toBe("my-repo");
+    expect(getCall.params?.connectorRef).toBe("gh_conn");
+    expect(getCall.params?.storeType).toBe("REMOTE");
+  });
+
   it("materializes input_set_ids before applying inline input overrides", async () => {
     const inputSetYaml = `inputSet:
   pipeline:

--- a/tests/utils/materialize-input-sets.test.ts
+++ b/tests/utils/materialize-input-sets.test.ts
@@ -220,6 +220,54 @@ describe("materializeInputSetsToRuntimeYaml", () => {
         orgIdentifier: "my-org",
         projectIdentifier: "my-project",
         pipelineIdentifier: "my-pipe",
+        // Git params are present but undefined for inline sets; the client's
+        // query serializer drops undefined/empty values.
+        branch: undefined,
+        repoName: undefined,
+        connectorRef: undefined,
+        storeType: undefined,
+      },
+    });
+  });
+
+  it("forwards git context so remote input sets resolve from the right branch", async () => {
+    const request = vi.fn().mockResolvedValueOnce({
+      status: "SUCCESS",
+      data: {
+        inputSetYaml: `inputSet:
+  pipeline:
+    identifier: my-pipe
+    variables:
+      - name: env
+        type: String
+        value: staging
+`,
+      },
+    });
+    const client = makeClient(request);
+
+    await materializeInputSetsToRuntimeYaml(client, {
+      ...baseParams,
+      inputSetIds: ["remote-set"],
+      gitContext: {
+        branch: "feature/x",
+        repoName: "my-repo",
+        connectorRef: "gh_conn",
+        storeType: "REMOTE",
+      },
+    });
+
+    expect(request).toHaveBeenCalledWith({
+      method: "GET",
+      path: "/pipeline/api/inputSets/remote-set",
+      params: {
+        orgIdentifier: "my-org",
+        projectIdentifier: "my-project",
+        pipelineIdentifier: "my-pipe",
+        branch: "feature/x",
+        repoName: "my-repo",
+        connectorRef: "gh_conn",
+        storeType: "REMOTE",
       },
     });
   });


### PR DESCRIPTION
## Problem

A customer on the latest release ran a **v0 pipeline** via `harness_execute` with `input_set_ids`. The pipeline ran but the input set was **not applied** — a silent drop, no error. They were confirmed on 3.2.8, which already contains the input-set materialization fix (#532) and predates the full-YAML fix (#575), so neither explained it.

Root cause (verified against the **live Harness API**, not just mocks): for a **remote / Git-stored** input set, `materializeInputSetsToRuntimeYaml` issued `GET /pipeline/api/inputSets/{id}` with only `orgIdentifier`/`projectIdentifier`/`pipelineIdentifier` — **no git context**. The API then resolves the input set from the repo's **default branch**. When the set lives on another branch (or the pipeline runs from a feature branch), the GET silently returns default-branch content and materialization proceeds with the wrong values. No error surfaces.

This was systemic: the registry's own `input_set` **get** action forwarded only `pipelineIdentifier`, while `create`/`update` forwarded full git context. The entire input-set **read** path was missing branch/repo.

## Live-API verification

Against a real remote input set on `app.harness.io`:
- `GET /pipeline/api/inputSets/{id}` **honors** `branch`, `repoName`, `connectorRef`, `storeType` query params (all returned HTTP 200).
- Omitting `branch` returns `SUCCESS` with **default-branch** YAML (the silent-default).
- A non-existent branch returns a loud `ERROR`.
- Response field names (`inputSetYaml` → `inputSet.pipeline`) are **correct** as the code already reads them — not a parsing bug.

## Fix

- `materializeInputSetsToRuntimeYaml` accepts an optional `gitContext` (`branch`/`repoName`/`connectorRef`/`storeType`) and forwards it on each input-set GET.
- `harness_execute` builds `gitContext` from the run's already-normalized remote params (`pipeline_branch` ?? `branch`, `repo_name`, `connector_ref`, `store_type`) and passes it through.
- The standalone `input_set` **get** action gains the same git query params, fixing the parallel silent-default on `harness_get(resource_type="input_set")`.
- **Inline input sets are unaffected** — empty/undefined values are dropped by the client's query serializer, so no `branch=undefined` is ever sent.

## Not addressed (flagged for follow-up)

The audit surfaced two further latent gaps, left out to keep this focused: **overlay input sets** (contain `inputSetReferences`, not a `pipeline` fragment → currently error) and **nested multi-set shallow merge** (`stage.spec` sub-objects can be overwritten). Worth separate issues.

## Testing

- `pnpm typecheck` — clean
- `pnpm test` — 112 files, 2461 tests passing (adds git-context forwarding tests in `materialize-input-sets` and an end-to-end remote-run → input-set-GET test). One unrelated test (`zod-input-schema-descriptions`) is flaky under parallel load (5s timeout); passes in isolation and on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)