### PR TITLE
fix: add dbops prefix as qa and prod expect it

### DIFF
--- a/src/registry/toolsets/dbops.ts
+++ b/src/registry/toolsets/dbops.ts
@@ -803,9 +803,7 @@ export const dbopsToolset: ToolsetDefinition = {
       executeActions: {
         run: {
           method: "POST",
-          // /v1/ prefix is intentional — this endpoint is on the new db-devops-service
-          // routing, not the legacy /dbops/v1/ prefix used by older resources in this toolset.
-          path: "/v1/orgs/{org}/projects/{project}/llm-authoring/execute-pipeline",
+          path: "/dbops/v1/orgs/{org}/projects/{project}/llm-authoring/execute-pipeline",
           pathParams: { org_id: "org", project_id: "project" },
           operationPolicy: { risk: "low_write", retryPolicy: "do_not_retry" },
           skipScopeBodyInjection: true,

--- a/tests/registry/dbops.test.ts
+++ b/tests/registry/dbops.test.ts
@@ -723,7 +723,7 @@ describe("database_execute_llm_authoring_pipeline run", () => {
     const call = mockRequest.mock.calls[0][0];
     expect(call.method).toBe("POST");
     expect(call.path).toBe(
-      "/v1/orgs/default/projects/test-project/llm-authoring/execute-pipeline",
+      "/dbops/v1/orgs/default/projects/test-project/llm-authoring/execute-pipeline",
     );
     expect(call.body).toEqual({
       conversationId: "conversation-1",
@@ -762,7 +762,7 @@ describe("database_execute_llm_authoring_pipeline run", () => {
     const call = mockRequest.mock.calls[0][0];
     expect(call.method).toBe("POST");
     expect(call.path).toBe(
-      "/v1/orgs/default/projects/test-project/llm-authoring/execute-pipeline",
+      "/dbops/v1/orgs/default/projects/test-project/llm-authoring/execute-pipeline",
     );
     expect(call.body).toEqual({
       conversationId: "conversation-1",

--- a/tests/registry/toolsets/dbops.test.ts
+++ b/tests/registry/toolsets/dbops.test.ts
@@ -18,7 +18,7 @@ describe("database_execute_llm_authoring_pipeline endpoint spec", () => {
   it("hits the v1 llm-authoring/execute-pipeline path", () => {
     expect(runAction.method).toBe("POST");
     expect(runAction.path).toBe(
-      "/v1/orgs/{org}/projects/{project}/llm-authoring/execute-pipeline",
+      "/dbops/v1/orgs/{org}/projects/{project}/llm-authoring/execute-pipeline",
     );
   });
 


### PR DESCRIPTION
## Description
Adding dbops prefix to this resource as it's expected to use dbops prefix for correct routing else it's throwing 404

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [x] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
If this PR adds or changes Harness API coverage:
- [ ] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [ ] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [ ] `operationPolicy` on every new/changed endpoint
- [ ] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [ ] `identifierFields` and `scope` declared on new resources
- [ ] No `console.log()` in `src/` (stdio JSON-RPC safety)
