### PR TITLE
Add create and update support for IDP entities, scorecards, and checks.

### DIFF
--- a/src/registry/toolsets/idp.ts
+++ b/src/registry/toolsets/idp.ts
@@ -1,4 +1,4 @@
-import type { PathBuilderConfig, ToolsetDefinition } from "../types.js";
+import type { BodySchema, PathBuilderConfig, ToolsetDefinition } from "../types.js";
 import { ngExtract, passthrough, v1ListExtract } from "../extractors.js";
 import { parse as parseYaml } from "yaml";
 
@@ -47,6 +47,163 @@ const scorecardStatsExtract = (raw: unknown): unknown => {
   };
 };
 
+const idpEntityMutateBodySchema: BodySchema = {
+  description: "IDP catalog entity YAML payload",
+  fields: [
+    {
+      name: "yaml",
+      type: "yaml",
+      required: true,
+      description:
+        "Full entity YAML (Harness v1 format: apiVersion: harness.io/v1, kind, metadata, spec). " +
+        "Pass as body.yaml, or as a raw YAML string body.",
+    },
+    {
+      name: "git_details",
+      type: "object",
+      required: false,
+      description:
+        "Optional Git storage for REMOTE entities: branch_name, file_path, connector_ref, repo_name, store_type, commit_message, is_harness_code_repo.",
+    },
+  ],
+};
+
+const buildIdpEntityScopePath = (input: Record<string, unknown>): string => {
+  let scope = "account";
+  const orgId = input.org_id as string | undefined;
+  const projectId = input.project_id as string | undefined;
+  if (orgId) {
+    scope += `.${orgId}`;
+    if (projectId) {
+      scope += `.${projectId}`;
+    }
+  }
+
+  const kind = input.kind as string | undefined;
+  const entityId = input.entity_id as string | undefined;
+  if (!kind) {
+    throw new Error(`Missing required field "kind" for idp_entity. Pass it via params: { kind: "component" }.`);
+  }
+  if (!entityId) {
+    throw new Error(`Missing required field "entity_id" for idp_entity. Pass it via params or as resource_id.`);
+  }
+
+  if (orgId) input.org_id = orgId;
+  if (projectId) input.project_id = projectId;
+
+  return `/v1/entities/${encodeURIComponent(scope)}/${encodeURIComponent(kind)}/${encodeURIComponent(entityId)}`;
+};
+
+const buildIdpEntityMutateBody = (input: Record<string, unknown>): Record<string, unknown> => {
+  const body = input.body;
+  if (typeof body === "string") {
+    return { yaml: body };
+  }
+  const b = (body as Record<string, unknown> | undefined) ?? {};
+  const yaml = typeof b.yaml === "string" ? b.yaml : undefined;
+  if (!yaml) {
+    throw new Error(
+      'yaml is required. Pass body as a raw YAML string, or body: { yaml: "...", git_details?: {...} }.',
+    );
+  }
+  const out: Record<string, unknown> = { yaml };
+  if (b.git_details != null) out.git_details = b.git_details;
+  return out;
+};
+
+const idpEntityScopeQueryParams = {
+  org_id: "orgIdentifier",
+  project_id: "projectIdentifier",
+} as const;
+
+const requireObjectBody = (input: Record<string, unknown>): Record<string, unknown> => {
+  const body = input.body;
+  if (body == null || typeof body !== "object" || Array.isArray(body)) {
+    throw new Error("body must be a JSON object for this resource.");
+  }
+  return body as Record<string, unknown>;
+};
+
+const buildScorecardMutateBody = (input: Record<string, unknown>): Record<string, unknown> => {
+  const body = requireObjectBody(input);
+  if (!body.scorecard || typeof body.scorecard !== "object" || Array.isArray(body.scorecard)) {
+    throw new Error(
+      'scorecard is required. Pass body: { scorecard: {...}, checks?: [...] }. ' +
+        "Use harness_get(scorecard) to round-trip an existing scorecard.",
+    );
+  }
+  return body;
+};
+
+const buildScorecardCheckMutateBody = (input: Record<string, unknown>): Record<string, unknown> => {
+  const body = requireObjectBody(input);
+  if (!body.checkDetails || typeof body.checkDetails !== "object" || Array.isArray(body.checkDetails)) {
+    throw new Error(
+      'checkDetails is required. Pass body: { checkDetails: {...} }. ' +
+        "Use harness_get(scorecard_check) to round-trip an existing check.",
+    );
+  }
+  return body;
+};
+
+const scorecardMutateBodySchema: BodySchema = {
+  description: "ScorecardDetailsRequest — scorecard metadata and associated checks",
+  fields: [
+    {
+      name: "scorecard",
+      type: "object",
+      required: true,
+      description:
+        "Scorecard definition: name, identifier, description, filter, weightageStrategy (EQUAL_WEIGHTS|CUSTOM), published, onDemand",
+      fields: [
+        { name: "name", type: "string", required: true, description: "Display name" },
+        { name: "identifier", type: "string", required: true, description: "Unique scorecard identifier" },
+        { name: "description", type: "string", required: true, description: "Scorecard description" },
+        {
+          name: "filter",
+          type: "object",
+          required: false,
+          description: "Entity filter: kind, type, owners, tags, lifecycle, scopes",
+        },
+        { name: "weightageStrategy", type: "string", required: false, description: "EQUAL_WEIGHTS or CUSTOM" },
+        { name: "published", type: "boolean", required: false, description: "Whether the scorecard is published" },
+        { name: "onDemand", type: "boolean", required: false, description: "Whether scores are computed on demand" },
+      ],
+    },
+    {
+      name: "checks",
+      type: "array",
+      required: false,
+      description: "Checks to include: [{ identifier, weightage, custom? }]",
+      itemType: "{ identifier: string, weightage: number, custom?: boolean }",
+    },
+  ],
+};
+
+const scorecardCheckMutateBodySchema: BodySchema = {
+  description: "CheckDetailsRequest — custom scorecard check definition",
+  fields: [
+    {
+      name: "checkDetails",
+      type: "object",
+      required: true,
+      description: "Check definition",
+      fields: [
+        { name: "identifier", type: "string", required: true, description: "Unique check identifier" },
+        { name: "name", type: "string", required: true, description: "Display name" },
+        { name: "description", type: "string", required: true, description: "Check description" },
+        { name: "expression", type: "string", required: false, description: "Advanced expression (when ruleStrategy=ADVANCED)" },
+        { name: "tags", type: "array", required: false, description: "Tags", itemType: "string" },
+        { name: "custom", type: "boolean", required: false, description: "Whether this is a custom check" },
+        { name: "ruleStrategy", type: "string", required: false, description: "ALL_OF, ANY_OF, or ADVANCED" },
+        { name: "rules", type: "array", required: false, description: "Rules for ALL_OF/ANY_OF strategies", itemType: "object" },
+        { name: "defaultBehaviour", type: "string", required: false, description: "PASS or FAIL when data is missing" },
+        { name: "failMessage", type: "string", required: false, description: "Message shown on check failure" },
+      ],
+    },
+  ],
+};
+
 export const idpToolset: ToolsetDefinition = {
   name: "idp",
   displayName: "Internal Developer Portal",
@@ -55,9 +212,12 @@ export const idpToolset: ToolsetDefinition = {
     {
       resourceType: "idp_entity",
       displayName: "IDP Entity",
-      description: "Internal Developer Portal catalog entity. Supports list and get. Lists Harness IDP catalog metadata (services, APIs, user groups, resources, etc.) including identifier, scope, kind, ref type (INLINE/GIT), YAML, Git details, ownership, tags, lifecycle, scorecards, status, and group.",
+      description:
+        "Internal Developer Portal catalog entity. Supports list, get, create, and update. " +
+        "Lists Harness IDP catalog metadata (services, APIs, user groups, resources, etc.) including identifier, scope, kind, ref type (INLINE/GIT), YAML, Git details, ownership, tags, lifecycle, scorecards, status, and group.",
       toolset: "idp",
       scope: "account",
+      supportedScopes: ["account", "org", "project"],
       identifierFields: ["kind", "entity_id"],
       listFilterFields: [
         { name: "kind", description: "Comma-separated list of entity kinds to fetch. Defaults to 'component,api,resource'.", enum: ["api", "component", "environment", "environmentblueprint", "group", "resource", "user", "workflow"] },
@@ -136,45 +296,55 @@ export const idpToolset: ToolsetDefinition = {
         get: {
           method: "GET",
           path: "/v1/entities/{scope}/{kind}/{entityId}",
-          pathBuilder: (input) => {
-            let scope = "account";
-            const orgId = input.org_id as string | undefined;
-            const projectId = input.project_id as string | undefined;
-            if (orgId) {
-              scope += `.${orgId}`;
-              if (projectId) {
-                scope += `.${projectId}`;
-              }
-            }
-
-            const kind = input.kind as string | undefined;
-            const entityId = input.entity_id as string | undefined;
-            if (!kind) {
-              throw new Error(`Missing required field "kind" for idp_entity. Pass it via params: { kind: "component" }.`);
-            }
-            if (!entityId) {
-              throw new Error(`Missing required field "entity_id" for idp_entity. Pass it via params or as resource_id.`);
-            }
-
-            if (orgId) input.org_id = orgId;
-            if (projectId) input.project_id = projectId;
-
-            return `/v1/entities/${encodeURIComponent(scope)}/${encodeURIComponent(kind)}/${encodeURIComponent(entityId)}`;
-          },
-          queryParams: {
-            org_id: "orgIdentifier",
-            project_id: "projectIdentifier",
-          },
+          pathBuilder: buildIdpEntityScopePath,
+          queryParams: idpEntityScopeQueryParams,
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           responseExtractor: passthrough,
           description: "Get details of a specific IDP catalog entity by kind + entity_id. Returns the entity's identifier, scope, kind, ref type (INLINE/GIT), YAML, Git details, ownership, tags, lifecycle, scorecards, status, and group. Use list_entities first to discover the entity_id. Note: workflow entities may include a 'token' field — IGNORE it.",
+        },
+        create: {
+          method: "POST",
+          path: "/v1/entities",
+          operationPolicy: { risk: "low_write", retryPolicy: "do_not_retry" },
+          skipScopeBodyInjection: true,
+          queryParams: {
+            ...idpEntityScopeQueryParams,
+            convert: "convert",
+            dry_run: "dry_run",
+            operation_mode: "operationMode",
+          },
+          bodyBuilder: buildIdpEntityMutateBody,
+          responseExtractor: passthrough,
+          description:
+            "Create an IDP catalog entity. Scope via org_id/project_id (account scope when both omitted). " +
+            "INLINE entities: pass yaml only. REMOTE/Git-backed: include git_details in body. " +
+            "Optional params: convert (Backstage YAML conversion), dry_run (validate only), operation_mode=UPSERT (create or update).",
+          bodySchema: idpEntityMutateBodySchema,
+        },
+        update: {
+          method: "PUT",
+          path: "/v1/entities/{scope}/{kind}/{entityId}",
+          pathBuilder: buildIdpEntityScopePath,
+          operationPolicy: { risk: "low_write", retryPolicy: "safe" },
+          skipScopeBodyInjection: true,
+          queryParams: {
+            ...idpEntityScopeQueryParams,
+            convert: "convert",
+            dry_run: "dry_run",
+          },
+          bodyBuilder: buildIdpEntityMutateBody,
+          responseExtractor: passthrough,
+          description:
+            "Update an IDP catalog entity (full replacement). Requires kind + entity_id (or resource_id + params.kind). " +
+            "Pass the complete entity yaml in body. For Git-backed entities include git_details when updating remote storage.",
+          bodySchema: idpEntityMutateBodySchema,
         },
       },
     },
     {
       resourceType: "scorecard",
       displayName: "Scorecard",
-      description: "IDP scorecard for tracking developer standards. Supports list and get.",
+      description: "IDP scorecard for tracking developer standards. Supports list, get, create, and update.",
       toolset: "idp",
       scope: "account",
       identifierFields: ["scorecard_id"],
@@ -199,12 +369,39 @@ export const idpToolset: ToolsetDefinition = {
           responseExtractor: passthrough,
           description: "Get details of a specific scorecard in the Harness IDP Catalog. Use this only when the scorecard_id is known (use list_scorecards first to discover it).",
         },
+        create: {
+          method: "POST",
+          path: "/v1/scorecards",
+          operationPolicy: { risk: "low_write", retryPolicy: "do_not_retry" },
+          skipScopeBodyInjection: true,
+          bodyBuilder: buildScorecardMutateBody,
+          responseExtractor: passthrough,
+          description:
+            "Create an IDP scorecard. Pass body: { scorecard: { name, identifier, description, filter?, weightageStrategy?, published? }, checks?: [...] }. " +
+            "Create scorecard_check resources first when referencing custom checks. Set published=true to publish.",
+          bodySchema: scorecardMutateBodySchema,
+        },
+        update: {
+          method: "PUT",
+          path: "/v1/scorecards/{scorecardIdentifier}",
+          operationPolicy: { risk: "low_write", retryPolicy: "safe" },
+          pathParams: { scorecard_id: "scorecardIdentifier" },
+          skipScopeBodyInjection: true,
+          bodyBuilder: buildScorecardMutateBody,
+          responseExtractor: passthrough,
+          description:
+            "Update an IDP scorecard (full replacement). Requires scorecard_id. " +
+            "Pass the complete body from harness_get — { scorecard, checks }.",
+          bodySchema: scorecardMutateBodySchema,
+        },
       },
     },
     {
       resourceType: "scorecard_check",
       displayName: "Scorecard Check",
-      description: "Individual check within an IDP scorecard. A check is a query performed against a data point for a software component which results in either Pass or Fail. Supports list and get.",
+      description:
+        "Individual check within an IDP scorecard. A check is a query performed against a data point for a software component which results in either Pass or Fail. " +
+        "Supports list, get, create, and update.",
       toolset: "idp",
       scope: "account",
       identifierFields: ["check_id"],
@@ -247,6 +444,31 @@ export const idpToolset: ToolsetDefinition = {
           defaultQueryParams: { custom: "false" },
           responseExtractor: passthrough,
           description: "Get details of a specific scorecard check. Pass is_custom=true for custom checks (the scorecard details indicate this).",
+        },
+        create: {
+          method: "POST",
+          path: "/v1/checks",
+          operationPolicy: { risk: "low_write", retryPolicy: "do_not_retry" },
+          skipScopeBodyInjection: true,
+          bodyBuilder: buildScorecardCheckMutateBody,
+          responseExtractor: passthrough,
+          description:
+            "Create a custom scorecard check. Pass body: { checkDetails: { identifier, name, description, ruleStrategy?, rules?, expression?, defaultBehaviour?, failMessage? } }. " +
+            "ruleStrategy: ALL_OF, ANY_OF, or ADVANCED. defaultBehaviour: PASS or FAIL.",
+          bodySchema: scorecardCheckMutateBodySchema,
+        },
+        update: {
+          method: "PUT",
+          path: "/v1/checks/{checkIdentifier}",
+          operationPolicy: { risk: "low_write", retryPolicy: "safe" },
+          pathParams: { check_id: "checkIdentifier" },
+          skipScopeBodyInjection: true,
+          bodyBuilder: buildScorecardCheckMutateBody,
+          responseExtractor: passthrough,
+          description:
+            "Update a scorecard check (full replacement). Requires check_id. " +
+            "Pass the complete body from harness_get — { checkDetails: {...} }.",
+          bodySchema: scorecardCheckMutateBodySchema,
         },
       },
     },

--- a/tests/registry/idp-entity.test.ts
+++ b/tests/registry/idp-entity.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Unit tests for idp_entity create/update operations.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Registry } from "../../src/registry/index.js";
+import type { Config } from "../../src/config.js";
+import type { HarnessClient } from "../../src/client/harness-client.js";
+import { idpToolset } from "../../src/registry/toolsets/idp.js";
+import type { EndpointSpec, ResourceDefinition } from "../../src/registry/types.js";
+
+const SAMPLE_YAML = `apiVersion: harness.io/v1
+kind: component
+type: service
+metadata:
+  name: boutique-service
+  namespace: default
+spec:
+  owner: group:default/platform-team`;
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    HARNESS_MCP_MODE: "single-user",
+    HARNESS_API_KEY: "pat.test",
+    HARNESS_ACCOUNT_ID: "test-account",
+    HARNESS_BASE_URL: "https://app.harness.io",
+    HARNESS_ORG: "default",
+    HARNESS_PROJECT: "test-project",
+    HARNESS_API_TIMEOUT_MS: 30000,
+    HARNESS_MAX_RETRIES: 3,
+    LOG_LEVEL: "info",
+    HARNESS_MAX_BODY_SIZE_MB: 10,
+    HARNESS_RATE_LIMIT_RPS: 10,
+    HARNESS_READ_ONLY: false,
+    HARNESS_SKIP_ELICITATION: false,
+    HARNESS_AUTO_APPROVE_RISK: "none",
+    HARNESS_ALLOW_HTTP: false,
+    HARNESS_MCP_ALLOWED_HOSTS: undefined,
+    HARNESS_MCP_AUTH_TOKEN: undefined,
+    HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP: false,
+    HARNESS_FME_BASE_URL: "https://api.split.io",
+    HARNESS_LOG_UNSAFE_BODIES: false,
+    HARNESS_PIPELINE_VERSION: undefined,
+    HARNESS_AUDIT_FILE: undefined,
+    HARNESS_AUDIT_WEBHOOK_URL: undefined,
+    HARNESS_AUDIT_WEBHOOK_TOKEN: undefined,
+    HARNESS_AUDIT_WEBHOOK_BATCH_SIZE: 10,
+    HARNESS_AUDIT_WEBHOOK_FLUSH_MS: 5000,
+    ...overrides,
+  };
+}
+
+function makeClient(requestFn?: (...args: unknown[]) => unknown): HarnessClient {
+  return {
+    request: requestFn ?? vi.fn().mockResolvedValue({}),
+    account: "test-account",
+  } as unknown as HarnessClient;
+}
+
+function findResource(type: string): ResourceDefinition {
+  const res = idpToolset.resources.find((r) => r.resourceType === type);
+  if (!res) throw new Error(`Resource type "${type}" not found in idpToolset`);
+  return res;
+}
+
+function getOp(type: string, op: string): EndpointSpec {
+  const res = findResource(type);
+  const spec = res.operations[op as keyof typeof res.operations];
+  if (!spec) throw new Error(`Operation "${op}" not found on "${type}"`);
+  return spec;
+}
+
+describe("idp_entity mutate operations", () => {
+  let registry: Registry;
+
+  beforeEach(() => {
+    registry = new Registry(makeConfig());
+  });
+
+  it("exposes create and update but not delete", () => {
+    const def = findResource("idp_entity");
+    expect(def.operations.create).toBeDefined();
+    expect(def.operations.update).toBeDefined();
+    expect(def.operations.delete).toBeUndefined();
+    expect(def.supportedScopes).toEqual(["account", "org", "project"]);
+  });
+
+  it("create: POST /v1/entities with yaml body and scope query params", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ identifier: "boutique-service", kind: "component" });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "idp_entity", "create", {
+      org_id: "my_org",
+      project_id: "my_project",
+      body: { yaml: SAMPLE_YAML },
+    });
+
+    expect(mockRequest).toHaveBeenCalledOnce();
+    const call = mockRequest.mock.calls[0][0] as {
+      method: string;
+      path: string;
+      params: Record<string, string>;
+      body: Record<string, unknown>;
+    };
+    expect(call.method).toBe("POST");
+    expect(call.path).toBe("/v1/entities");
+    expect(call.params.orgIdentifier).toBe("my_org");
+    expect(call.params.projectIdentifier).toBe("my_project");
+    expect(call.body).toEqual({ yaml: SAMPLE_YAML });
+    expect(call.body.orgIdentifier).toBeUndefined();
+    expect(call.body.projectIdentifier).toBeUndefined();
+  });
+
+  it("create: accepts raw YAML string body", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({});
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "idp_entity", "create", {
+      body: SAMPLE_YAML,
+    });
+
+    const call = mockRequest.mock.calls[0][0] as { body: Record<string, unknown> };
+    expect(call.body).toEqual({ yaml: SAMPLE_YAML });
+  });
+
+  it("create: forwards optional query params", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({});
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "idp_entity", "create", {
+      body: { yaml: SAMPLE_YAML },
+      convert: true,
+      dry_run: true,
+      operation_mode: "UPSERT",
+    });
+
+    const call = mockRequest.mock.calls[0][0] as { params: Record<string, unknown> };
+    expect(call.params.convert).toBe(true);
+    expect(call.params.dry_run).toBe(true);
+    expect(call.params.operationMode).toBe("UPSERT");
+  });
+
+  it("create: includes git_details when provided", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({});
+    const client = makeClient(mockRequest);
+    const gitDetails = {
+      branch_name: "main",
+      file_path: ".harness/idp.yaml",
+      connector_ref: "github_conn",
+      repo_name: "catalog-repo",
+      store_type: "REMOTE",
+    };
+
+    await registry.dispatch(client, "idp_entity", "create", {
+      body: { yaml: SAMPLE_YAML, git_details: gitDetails },
+    });
+
+    const call = mockRequest.mock.calls[0][0] as { body: Record<string, unknown> };
+    expect(call.body.git_details).toEqual(gitDetails);
+  });
+
+  it("create: fails when yaml is missing", async () => {
+    const client = makeClient();
+
+    await expect(
+      registry.dispatch(client, "idp_entity", "create", { body: {} }),
+    ).rejects.toThrow(/yaml is required/);
+  });
+
+  it("update: PUT scoped path with kind and entity_id", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ identifier: "boutique-service" });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "idp_entity", "update", {
+      org_id: "my_org",
+      project_id: "my_project",
+      kind: "component",
+      entity_id: "boutique-service",
+      body: { yaml: SAMPLE_YAML },
+    });
+
+    const call = mockRequest.mock.calls[0][0] as {
+      method: string;
+      path: string;
+      params: Record<string, string>;
+      body: Record<string, unknown>;
+    };
+    expect(call.method).toBe("PUT");
+    expect(call.path).toBe("/v1/entities/account.my_org.my_project/component/boutique-service");
+    expect(call.params.orgIdentifier).toBe("my_org");
+    expect(call.params.projectIdentifier).toBe("my_project");
+    expect(call.body).toEqual({ yaml: SAMPLE_YAML });
+  });
+
+  it("update: requires kind and entity_id", async () => {
+    const client = makeClient();
+
+    await expect(
+      registry.dispatch(client, "idp_entity", "update", {
+        entity_id: "boutique-service",
+        body: { yaml: SAMPLE_YAML },
+      }),
+    ).rejects.toThrow(/Missing required field "kind"/);
+
+    await expect(
+      registry.dispatch(client, "idp_entity", "update", {
+        kind: "component",
+        body: { yaml: SAMPLE_YAML },
+      }),
+    ).rejects.toThrow(/Missing required field "entity_id"/);
+  });
+
+  it("bodyBuilder helpers match registry specs", () => {
+    const createSpec = getOp("idp_entity", "create");
+    const updateSpec = getOp("idp_entity", "update");
+
+    expect(createSpec.skipScopeBodyInjection).toBe(true);
+    expect(updateSpec.skipScopeBodyInjection).toBe(true);
+    expect(createSpec.bodySchema?.fields.map((f) => f.name)).toEqual(["yaml", "git_details"]);
+    expect(createSpec.operationPolicy).toEqual({ risk: "low_write", retryPolicy: "do_not_retry" });
+    expect(updateSpec.operationPolicy).toEqual({ risk: "low_write", retryPolicy: "safe" });
+  });
+});

--- a/tests/registry/scorecard-mutate.test.ts
+++ b/tests/registry/scorecard-mutate.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Unit tests for scorecard and scorecard_check create/update operations.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Registry } from "../../src/registry/index.js";
+import type { Config } from "../../src/config.js";
+import type { HarnessClient } from "../../src/client/harness-client.js";
+import { idpToolset } from "../../src/registry/toolsets/idp.js";
+import type { EndpointSpec, ResourceDefinition } from "../../src/registry/types.js";
+
+const SAMPLE_SCORECARD_BODY = {
+  scorecard: {
+    name: "Production Readiness",
+    identifier: "production_readiness",
+    description: "Checks required before production deployment",
+    filter: { kind: "component" },
+    weightageStrategy: "EQUAL_WEIGHTS",
+    published: false,
+  },
+  checks: [{ identifier: "has_owner", weightage: 10, custom: false }],
+};
+
+const SAMPLE_CHECK_BODY = {
+  checkDetails: {
+    identifier: "has_readme",
+    name: "Has README",
+    description: "Component must have a README file",
+    custom: true,
+    ruleStrategy: "ALL_OF",
+    rules: [
+      {
+        identifier: "readme_exists",
+        dataSourceIdentifier: "catalog",
+        dataPointIdentifier: "readme",
+        operator: "EXISTS",
+        value: "",
+      },
+    ],
+    defaultBehaviour: "FAIL",
+    failMessage: "README is missing",
+  },
+};
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    HARNESS_MCP_MODE: "single-user",
+    HARNESS_API_KEY: "pat.test",
+    HARNESS_ACCOUNT_ID: "test-account",
+    HARNESS_BASE_URL: "https://app.harness.io",
+    HARNESS_ORG: "default",
+    HARNESS_PROJECT: "test-project",
+    HARNESS_API_TIMEOUT_MS: 30000,
+    HARNESS_MAX_RETRIES: 3,
+    LOG_LEVEL: "info",
+    HARNESS_MAX_BODY_SIZE_MB: 10,
+    HARNESS_RATE_LIMIT_RPS: 10,
+    HARNESS_READ_ONLY: false,
+    HARNESS_SKIP_ELICITATION: false,
+    HARNESS_AUTO_APPROVE_RISK: "none",
+    HARNESS_ALLOW_HTTP: false,
+    HARNESS_MCP_ALLOWED_HOSTS: undefined,
+    HARNESS_MCP_AUTH_TOKEN: undefined,
+    HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP: false,
+    HARNESS_FME_BASE_URL: "https://api.split.io",
+    HARNESS_LOG_UNSAFE_BODIES: false,
+    HARNESS_PIPELINE_VERSION: undefined,
+    HARNESS_AUDIT_FILE: undefined,
+    HARNESS_AUDIT_WEBHOOK_URL: undefined,
+    HARNESS_AUDIT_WEBHOOK_TOKEN: undefined,
+    HARNESS_AUDIT_WEBHOOK_BATCH_SIZE: 10,
+    HARNESS_AUDIT_WEBHOOK_FLUSH_MS: 5000,
+    ...overrides,
+  };
+}
+
+function makeClient(requestFn?: (...args: unknown[]) => unknown): HarnessClient {
+  return {
+    request: requestFn ?? vi.fn().mockResolvedValue({}),
+    account: "test-account",
+  } as unknown as HarnessClient;
+}
+
+function findResource(type: string): ResourceDefinition {
+  const res = idpToolset.resources.find((r) => r.resourceType === type);
+  if (!res) throw new Error(`Resource type "${type}" not found in idpToolset`);
+  return res;
+}
+
+function getOp(type: string, op: string): EndpointSpec {
+  const res = findResource(type);
+  const spec = res.operations[op as keyof typeof res.operations];
+  if (!spec) throw new Error(`Operation "${op}" not found on "${type}"`);
+  return spec;
+}
+
+describe("scorecard mutate operations", () => {
+  let registry: Registry;
+
+  beforeEach(() => {
+    registry = new Registry(makeConfig());
+  });
+
+  it("exposes create and update but not delete", () => {
+    const def = findResource("scorecard");
+    expect(def.operations.create).toBeDefined();
+    expect(def.operations.update).toBeDefined();
+    expect(def.operations.delete).toBeUndefined();
+  });
+
+  it("create: POST /v1/scorecards with scorecard body", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ identifier: "production_readiness" });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "scorecard", "create", { body: SAMPLE_SCORECARD_BODY });
+
+    const call = mockRequest.mock.calls[0][0] as {
+      method: string;
+      path: string;
+      body: Record<string, unknown>;
+    };
+    expect(call.method).toBe("POST");
+    expect(call.path).toBe("/v1/scorecards");
+    expect(call.body).toEqual(SAMPLE_SCORECARD_BODY);
+    expect(call.body.orgIdentifier).toBeUndefined();
+    expect(call.body.projectIdentifier).toBeUndefined();
+  });
+
+  it("create: fails when scorecard is missing", async () => {
+    const client = makeClient();
+
+    await expect(registry.dispatch(client, "scorecard", "create", { body: {} })).rejects.toThrow(
+      /scorecard is required/,
+    );
+  });
+
+  it("update: PUT /v1/scorecards/{scorecardIdentifier}", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({});
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "scorecard", "update", {
+      scorecard_id: "production_readiness",
+      body: SAMPLE_SCORECARD_BODY,
+    });
+
+    const call = mockRequest.mock.calls[0][0] as { method: string; path: string; body: Record<string, unknown> };
+    expect(call.method).toBe("PUT");
+    expect(call.path).toBe("/v1/scorecards/production_readiness");
+    expect(call.body).toEqual(SAMPLE_SCORECARD_BODY);
+  });
+
+  it("bodyBuilder helpers match registry specs", () => {
+    const createSpec = getOp("scorecard", "create");
+    const updateSpec = getOp("scorecard", "update");
+
+    expect(createSpec.skipScopeBodyInjection).toBe(true);
+    expect(updateSpec.skipScopeBodyInjection).toBe(true);
+    expect(createSpec.bodySchema?.fields.map((f) => f.name)).toEqual(["scorecard", "checks"]);
+    expect(createSpec.operationPolicy).toEqual({ risk: "low_write", retryPolicy: "do_not_retry" });
+    expect(updateSpec.operationPolicy).toEqual({ risk: "low_write", retryPolicy: "safe" });
+  });
+});
+
+describe("scorecard_check mutate operations", () => {
+  let registry: Registry;
+
+  beforeEach(() => {
+    registry = new Registry(makeConfig());
+  });
+
+  it("exposes create and update but not delete", () => {
+    const def = findResource("scorecard_check");
+    expect(def.operations.create).toBeDefined();
+    expect(def.operations.update).toBeDefined();
+    expect(def.operations.delete).toBeUndefined();
+  });
+
+  it("create: POST /v1/checks with checkDetails body", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ identifier: "has_readme" });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "scorecard_check", "create", { body: SAMPLE_CHECK_BODY });
+
+    const call = mockRequest.mock.calls[0][0] as {
+      method: string;
+      path: string;
+      body: Record<string, unknown>;
+    };
+    expect(call.method).toBe("POST");
+    expect(call.path).toBe("/v1/checks");
+    expect(call.body).toEqual(SAMPLE_CHECK_BODY);
+  });
+
+  it("create: fails when checkDetails is missing", async () => {
+    const client = makeClient();
+
+    await expect(registry.dispatch(client, "scorecard_check", "create", { body: {} })).rejects.toThrow(
+      /checkDetails is required/,
+    );
+  });
+
+  it("update: PUT /v1/checks/{checkIdentifier}", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({});
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "scorecard_check", "update", {
+      check_id: "has_readme",
+      body: SAMPLE_CHECK_BODY,
+    });
+
+    const call = mockRequest.mock.calls[0][0] as { method: string; path: string; body: Record<string, unknown> };
+    expect(call.method).toBe("PUT");
+    expect(call.path).toBe("/v1/checks/has_readme");
+    expect(call.body).toEqual(SAMPLE_CHECK_BODY);
+  });
+
+  it("bodyBuilder helpers match registry specs", () => {
+    const createSpec = getOp("scorecard_check", "create");
+    const updateSpec = getOp("scorecard_check", "update");
+
+    expect(createSpec.skipScopeBodyInjection).toBe(true);
+    expect(updateSpec.skipScopeBodyInjection).toBe(true);
+    expect(createSpec.bodySchema?.fields.map((f) => f.name)).toEqual(["checkDetails"]);
+    expect(createSpec.operationPolicy).toEqual({ risk: "low_write", retryPolicy: "do_not_retry" });
+    expect(updateSpec.operationPolicy).toEqual({ risk: "low_write", retryPolicy: "safe" });
+  });
+});


### PR DESCRIPTION
Expose write operations in the idp toolset so agents can manage catalog entities via YAML and scorecards/checks via JSON bodies round-tripped from harness_get.

## Description
<!-- What does this PR do? -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [ ] `pnpm test` passes
- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes
- [ ] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [ ] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
If this PR adds or changes Harness API coverage:
- [ ] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [ ] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [ ] `operationPolicy` on every new/changed endpoint
- [ ] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [ ] `identifierFields` and `scope` declared on new resources
- [ ] No `console.log()` in `src/` (stdio JSON-RPC safety)
