### PR TITLE
fix: require kind param for kg_type/kg_related_type get

### DIFF
--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -399,6 +399,19 @@ export class Registry {
       }
     }
 
+    if (spec.paramsSchema) {
+      const missingParams = spec.paramsSchema.fields
+        .filter(f => f.required && input[f.name] === undefined)
+        .map(f => f.name);
+      if (missingParams.length > 0) {
+        throw new Error(
+          `Missing required param(s) for ${resourceType}.${operation}: ${missingParams.join(", ")}. ` +
+          `Pass them via params (e.g. params: { ${missingParams.map(n => `${n}: "..."`).join(", ")} }). ` +
+          `Use harness_describe(resource_type="${resourceType}") to see valid values.`
+        );
+      }
+    }
+
     return this.executeSpecWithAudit(client, def, spec, operation, resourceType, input, auditCtx, abortSignal);
   }
 

--- a/src/registry/toolsets/semantic-layer.ts
+++ b/src/registry/toolsets/semantic-layer.ts
@@ -157,7 +157,7 @@ function requireTypeId(input: Record<string, unknown>): string {
 
 function schemaTypeGetBody(input: Record<string, unknown>) {
   return {
-    kind: (input.kind as string) ?? "OBJECT_KIND_ENTITY",
+    kind: input.kind as string,
     id: requireTypeId(input),
   };
 }
@@ -165,7 +165,7 @@ function schemaTypeGetBody(input: Record<string, unknown>) {
 function relatedTypesBody(input: Record<string, unknown>) {
   return {
     type_reference: {
-      object_kind: (input.kind as string) ?? "OBJECT_KIND_ENTITY",
+      object_kind: input.kind as string,
       id: requireTypeId(input),
     },
     include_transitive: input.include_transitive === true,
@@ -188,8 +188,11 @@ const KG_TYPE_GET_PARAMS: ParamsSchema = {
   fields: [
     {
       name: "kind",
-      required: false,
-      description: "Object kind of the type (default: OBJECT_KIND_ENTITY). One of OBJECT_KIND_*.",
+      required: true,
+      description:
+        "Object kind of the type. One of OBJECT_KIND_*. The same identifier can exist under multiple " +
+        "kinds with different fields — use the exact kind returned by kg_queryable_type_summary (for " +
+        "queryable types) or kg_type list, not a guess.",
     },
   ],
 };
@@ -198,8 +201,11 @@ const KG_RELATED_GET_PARAMS: ParamsSchema = {
   fields: [
     {
       name: "kind",
-      required: false,
-      description: "Object kind of the source type (default: OBJECT_KIND_ENTITY). One of OBJECT_KIND_*.",
+      required: true,
+      description:
+        "Object kind of the source type. One of OBJECT_KIND_*. The same identifier can exist under " +
+        "multiple kinds with different fields — use the exact kind returned by kg_queryable_type_summary " +
+        "(for queryable types) or kg_type list, not a guess.",
     },
     {
       name: "include_transitive",
@@ -249,7 +255,7 @@ export const semanticLayerToolset: ToolsetDefinition = {
           responseExtractor: schemaTypeExtract,
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           description:
-            "Get a single schema type by kind and ID. Pass the type id as resource_id and kind via params (default: OBJECT_KIND_ENTITY).",
+            "Get a single schema type by kind and ID. Pass the type id as resource_id and the required kind via params.",
           paramsSchema: KG_TYPE_GET_PARAMS,
         },
       },
@@ -277,8 +283,8 @@ export const semanticLayerToolset: ToolsetDefinition = {
           responseExtractor: relatedTypesExtract,
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           description:
-            "Get types related to a source type. Pass the type id as resource_id and optionally " +
-            "kind (default: OBJECT_KIND_ENTITY) and include_transitive (default: false) via params.",
+            "Get types related to a source type. Pass the type id as resource_id, the required kind, " +
+            "and optionally include_transitive (default: false) via params.",
           paramsSchema: KG_RELATED_GET_PARAMS,
         },
       },

--- a/tests/registry/chaos-probe.test.ts
+++ b/tests/registry/chaos-probe.test.ts
@@ -841,7 +841,7 @@ describe("chaos_component_variable.get required field validation (preflight)", (
         org_id: "org1",
         identifier: "some-component",
       }),
-    ).rejects.toThrow(/Missing required field.*type/);
+    ).rejects.toThrow(/Missing required (field|param\(s\)).*type/);
     expect(mockRequest).not.toHaveBeenCalled();
   });
 
@@ -854,7 +854,7 @@ describe("chaos_component_variable.get required field validation (preflight)", (
         org_id: "org1",
         type: "Probe",
       }),
-    ).rejects.toThrow(/Missing required field.*identifier/);
+    ).rejects.toThrow(/Missing required (field|param\(s\)).*identifier/);
     expect(mockRequest).not.toHaveBeenCalled();
   });
 

--- a/tests/registry/knowledge-graph.test.ts
+++ b/tests/registry/knowledge-graph.test.ts
@@ -338,6 +338,7 @@ describe("kg_related_type get extractor", () => {
 
     const result = (await registry.dispatch(client, "kg_related_type", "get", {
       type_id: "service",
+      kind: "OBJECT_KIND_ENTITY",
     })) as Record<string, unknown>;
 
     expect(result.dcs_enrichments).toEqual([
@@ -383,6 +384,34 @@ describe("kg_type get body validation", () => {
     await expect(
       registry.dispatch(client, "kg_type", "get", { kind: "OBJECT_KIND_ENTITY" }),
     ).rejects.toThrow(/Missing required identifier/);
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it("fails locally with a clear error when kind is missing", async () => {
+    const mockRequest = vi.fn();
+    const client = makeClient(mockRequest);
+
+    await expect(
+      registry.dispatch(client, "kg_type", "get", { type_id: "service" }),
+    ).rejects.toThrow(/Missing required param\(s\) for kg_type\.get: kind/);
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe("kg_related_type get params validation", () => {
+  let registry: Registry;
+
+  beforeEach(() => {
+    registry = new Registry(makeConfig());
+  });
+
+  it("fails locally with a clear error when kind is missing", async () => {
+    const mockRequest = vi.fn();
+    const client = makeClient(mockRequest);
+
+    await expect(
+      registry.dispatch(client, "kg_related_type", "get", { type_id: "service" }),
+    ).rejects.toThrow(/Missing required param\(s\) for kg_related_type\.get: kind/);
     expect(mockRequest).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- `kg_type get` / `kg_related_type get` silently defaulted `kind` to `OBJECT_KIND_ENTITY` when omitted, even though the same type identifier can exist under multiple object kinds (entity/event/view) with entirely different fields.
- This let callers fetch a plausible-looking but non-queryable schema without any error — the mismatch only surfaced later as a bare HQL validation failure ("No data plugin found... no mapping found"), forcing a costly fallback to re-list `kg_queryable_type_summary` to find the correct type.
- Adds generic enforcement of `paramsSchema.fields[].required` in `Registry.dispatch()`, mirroring the existing `bodySchema`/`listFilterFields` required-field checks (previously `paramsSchema.required` was documentation-only, never validated).
- Marks `kind` as `required: true` for `kg_type get` and `kg_related_type get`, and removes the silent `?? "OBJECT_KIND_ENTITY"` fallback in `schemaTypeGetBody`/`relatedTypesBody`.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Verified against live `harness0` MCP: `harness_get(resource_type='kg_type', resource_id='pipeline:stage_execution')` (no kind) now errors with `"Missing required param(s) for kg_type.get: kind..."`
- [x] Verified same call with `params={kind: 'OBJECT_KIND_EVENT'}` still returns the correct schema