### PR TITLE
fix: green main — reconcile GitOps delete paramsSchema with tests + IDP update config

### DIFF
--- a/src/registry/toolsets/gitops.ts
+++ b/src/registry/toolsets/gitops.ts
@@ -241,10 +241,11 @@ export const gitopsToolset: ToolsetDefinition = {
           paramsSchema: {
             fields: [
               {
-                name: "resource_id",
+                name: "agent_id",
                 required: true,
                 description:
                   "Raw agent identifier — no scope prefix. E.g. 'myagent', not 'account.myagent'. " +
+                  "Passed as resource_id to harness_delete. " +
                   "Use harness_list(resource_type='gitops_agent') to discover the identifier.",
               },
               {
@@ -494,8 +495,12 @@ export const gitopsToolset: ToolsetDefinition = {
                 description: "Scope-prefixed agent identifier (e.g. 'account.myagent', 'org.myagent', or 'myagent' for project-level).",
               },
               {
+                // Not marked required here: the bodyBuilder owns deletion-mode
+                // validation and emits the detailed "ask the user" guidance
+                // (mode + finalizer choice). A generic required-param error
+                // would pre-empt that richer message.
                 name: "cascade",
-                required: true,
+                required: false,
                 description: "Whether to cascade deletion to K8s resources. 'true' = cascade (foreground or background), 'false' = non-cascading (leaves K8s resources running). Ask the user before setting.",
               },
               {
@@ -504,8 +509,10 @@ export const gitopsToolset: ToolsetDefinition = {
                 description: "Required when cascade='true'. 'foreground' — waits for all K8s child resources to be deleted first. 'background' — deletes immediately, async cleanup. Omit when cascade='false'.",
               },
               {
+                // Optional with a safe default ('false'); do not force callers
+                // to supply it just to reach the deletion-mode validation.
                 name: "remove_existing_finalizers",
-                required: true,
+                required: false,
                 description: "Whether to strip existing finalizers before deletion. 'true' unblocks stuck apps; 'false' is the safe default. Ask the user before setting.",
               },
               {

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -962,7 +962,7 @@ describe("harness_update", () => {
     client = makeClient(mockRequest);
     const idpServer = makeMcpServer("accept");
     const { registerUpdateTool } = await import("../../src/tools/harness-update.js");
-    registerUpdateTool(idpServer, registry, client);
+    registerUpdateTool(idpServer, registry, client, makeConfig());
 
     const result = await idpServer.call("harness_update", {
       resource_type: "idp_entity",


### PR DESCRIPTION
## Description

`main` is red: `build-and-test` fails on 4 tests (both Node 20 and 22). This blocks every downstream PR (including the pending version bump / release). The failures come from three **independently-merged PRs that collided** — none was caused by a single PR in isolation:

- **#614** (GitOps delete endpoint mappings) shipped `paramsSchema` blocks that contradict #614's own tests.
- **#613** (scoped IDP updates) added a test on a parallel branch that missed the `config` arg **#566** made required.

This PR reconciles them. No product behavior is dumbed down — the tests encode the intended UX; the schemas were the bug.

### Fixes

1. **`gitops_agent.delete`** — required `resource_id` in `paramsSchema`, but the resource's native identifier is `agent_id` (`identifierFields: ["agent_id"]`). Registry dispatch validates native params, so valid calls were rejected with `Missing required param(s): resource_id`. Now requires `agent_id`, matching the sibling `gitops_application.delete` and the real `harness_delete` flow (which populates `input.agent_id` from `resource_id`).

2. **`gitops_application.delete`** — marked `cascade` and `remove_existing_finalizers` **required**, so the generic dispatch error pre-empted the `bodyBuilder`'s detailed deletion-mode guidance ("ask the user: foreground/background/non-cascading…"). Both are now optional: the `bodyBuilder` owns that validation, and `remove_existing_finalizers` has a documented safe default (`'false'`).

3. **IDP update test** — one `registerUpdateTool(...)` call site omitted the now-required `config` arg (a parallel-branch merge gap vs. #566), so `config.HARNESS_READ_ONLY` threw and the handler returned `isError`. Now passes `makeConfig()` like every sibling call site.

## Type of Change
- [x] Bug fix

## Checklist
- [x] `pnpm test` — 2528 passed (116 files)
- [x] `pnpm typecheck`
- [x] `pnpm standards:check` — 80 passed
- [x] `pnpm build`
- [x] `pnpm docs:check` — README up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)