### PR TITLE
chore: bump version to 3.2.12

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "harness-mcp-server",
   "display_name": "Harness",
-  "version": "3.2.11",
+  "version": "3.2.12",
   "description": "Connect AI agents to Harness for CI/CD, code repositories, pull requests, services, environments, and feature flags.",
   "long_description": "The Harness MCP Server gives MCP-compatible clients access to Harness platform workflows through consolidated tools, resources, and prompts. It supports local stdio usage and can be bundled as a Node-based MCPB extension.",
   "author": {

--- a/mcp-directory/manifest.json
+++ b/mcp-directory/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "harness-mcp-server",
   "display_name": "Harness",
-  "version": "3.2.11",
+  "version": "3.2.12",
   "description": "Connect AI agents to Harness for CI/CD, code repositories, pull requests, services, environments, and feature flags.",
   "long_description": "The Harness MCP Server gives MCP-compatible clients access to Harness platform workflows through consolidated tools, resources, and prompts. It supports local stdio usage and can be bundled as a Node-based MCPB extension.",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-mcp-v2",
-  "version": "3.2.11",
+  "version": "3.2.12",
   "description": "Give AI agents full access to the Harness.io platform — manage pipelines, deployments, cloud costs, chaos engineering, feature flags, SEI, and 125+ resource types through 11 MCP tools",
   "type": "module",
   "main": "build/index.js",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -3,13 +3,18 @@
 ## Version Bump 3.2.12 (2026-07-19)
 - [x] Update package and bundle manifest versions to 3.2.12
 - [x] Update the release metadata version test
-- [ ] Commit and push the metadata update
-- [ ] Run focused verification and update the pull request
+- [x] Commit and push the metadata update
+- [x] Run focused verification and update the pull request
 
 ### Plan
 - Keep this as a metadata-only patch release bump.
 - Update `package.json`, `manifest.json`, `mcp-directory/manifest.json`, and the pinned release metadata expectation.
 - Verify the focused release metadata test and repository diff.
+
+### Review
+- Updated package and bundle metadata from `3.2.11` to `3.2.12`.
+- Updated the release metadata regression expectation to `3.2.12`.
+- Verification passed: `pnpm exec vitest run tests/release-metadata.test.ts` (3 tests), `pnpm typecheck`, and `git diff --check HEAD`.
 
 ## Critical Bug Investigation Automation (2026-07-13)
 - [x] Baseline branch state and identify recent behavioral commits

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,16 @@
 # Harness MCP Server — Task Tracking
 
+## Version Bump 3.2.12 (2026-07-19)
+- [x] Update package and bundle manifest versions to 3.2.12
+- [x] Update the release metadata version test
+- [ ] Commit and push the metadata update
+- [ ] Run focused verification and update the pull request
+
+### Plan
+- Keep this as a metadata-only patch release bump.
+- Update `package.json`, `manifest.json`, `mcp-directory/manifest.json`, and the pinned release metadata expectation.
+- Verify the focused release metadata test and repository diff.
+
 ## Critical Bug Investigation Automation (2026-07-13)
 - [x] Baseline branch state and identify recent behavioral commits
 - [x] Review high-blast-radius diffs and trace concrete trigger scenarios

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -24,7 +24,7 @@ describe("release metadata", () => {
     const rootManifest = readJson("manifest.json");
     const directoryManifest = readJson("mcp-directory/manifest.json");
 
-    expect(packageJson.version).toBe("3.2.11");
+    expect(packageJson.version).toBe("3.2.12");
     expect(rootManifest.version).toBe(packageJson.version);
     expect(directoryManifest.version).toBe(packageJson.version);
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Bump the package and bundled manifest versions to `3.2.12`, and update the pinned release metadata test expectation.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Other

## Checklist
- [x] `pnpm test` passes (focused release metadata test: 3 tests)
- [x] `pnpm typecheck` passes
- [ ] `pnpm build` passes
- [ ] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [ ] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
Not applicable; this metadata-only change does not add or change Harness API coverage.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f77fc-e44c-7741-8242-36c616192626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f77fc-e44c-7741-8242-36c616192626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

