### PR TITLE
fix: register pipeline_error_analysis as alias for debug-pipeline-failure prompt

### DIFF
--- a/src/prompts/debug-pipeline.ts
+++ b/src/prompts/debug-pipeline.ts
@@ -55,7 +55,11 @@ export function registerDebugPipelinePrompt(server: McpServer): void {
   // Alias: ml-infra requests this name via get_prompt("pipeline_error_analysis")
   server.registerPrompt(
     "pipeline_error_analysis",
-    promptConfig,
+    {
+      ...promptConfig,
+      description:
+        "Alias of debug-pipeline-failure — analyze a failed pipeline execution and suggest fixes. Accepts an execution ID, pipeline ID, or Harness URL.",
+    },
     async (args) => handleDebugPipeline(args),
   );
 }

--- a/src/prompts/debug-pipeline.ts
+++ b/src/prompts/debug-pipeline.ts
@@ -1,29 +1,26 @@
 import * as z from "zod/v4";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
-export function registerDebugPipelinePrompt(server: McpServer): void {
-  server.registerPrompt(
-    "debug-pipeline-failure",
-    {
-      description: "Analyze a failed pipeline execution and suggest fixes. Accepts an execution ID, pipeline ID, or Harness URL.",
-      argsSchema: {
-        executionId: z.string().describe("The failed execution ID, pipeline ID, or a Harness URL").optional(),
-        projectId: z.string().describe("Project identifier").optional(),
-      },
-    },
-    async ({ executionId, projectId }) => {
-      // Detect if the input looks like a URL
-      const isUrl = executionId?.startsWith("http");
-      const idParam = isUrl
-        ? `url="${executionId}"`
-        : `execution_id="${executionId}"`;
+const promptConfig = {
+  description: "Analyze a failed pipeline execution and suggest fixes. Accepts an execution ID, pipeline ID, or Harness URL.",
+  argsSchema: {
+    executionId: z.string().describe("The failed execution ID, pipeline ID, or a Harness URL").optional(),
+    projectId: z.string().describe("Project identifier").optional(),
+  },
+};
 
-      return {
-        messages: [{
-          role: "user" as const,
-          content: {
-            type: "text" as const,
-            text: `Analyze this failed Harness pipeline execution and provide:
+function handleDebugPipeline({ executionId, projectId }: { executionId?: string; projectId?: string }) {
+  const isUrl = executionId?.startsWith("http");
+  const idParam = isUrl
+    ? `url="${executionId}"`
+    : `execution_id="${executionId}"`;
+
+  return {
+    messages: [{
+      role: "user" as const,
+      content: {
+        type: "text" as const,
+        text: `Analyze this failed Harness pipeline execution and provide:
 
 1. **Root cause** of the failure
 2. **Which step failed** and why
@@ -43,9 +40,22 @@ Then analyze the diagnostic payload:
   - Suggest the user either pass the missing values as \`inputs\` or use \`input_set_ids\` referencing a saved input set
 
 Provide actionable recommendations based on the combined evidence.`,
-          },
-        }],
-      };
-    },
+      },
+    }],
+  };
+}
+
+export function registerDebugPipelinePrompt(server: McpServer): void {
+  server.registerPrompt(
+    "debug-pipeline-failure",
+    promptConfig,
+    async (args) => handleDebugPipeline(args),
+  );
+
+  // Alias: ml-infra requests this name via get_prompt("pipeline_error_analysis")
+  server.registerPrompt(
+    "pipeline_error_analysis",
+    promptConfig,
+    async (args) => handleDebugPipeline(args),
   );
 }

--- a/src/prompts/debug-pipeline.ts
+++ b/src/prompts/debug-pipeline.ts
@@ -52,7 +52,9 @@ export function registerDebugPipelinePrompt(server: McpServer): void {
     async (args) => handleDebugPipeline(args),
   );
 
-  // Alias: ml-infra requests this name via get_prompt("pipeline_error_analysis")
+  // Alias: ml-infra requests this name via get_prompt("pipeline_error_analysis").
+  // Intentionally omitted from README prompt table — internal lookup alias, not a distinct template.
+  // Tracking: #677 for aligning canonical names across ml-infra and mcp-server.
   server.registerPrompt(
     "pipeline_error_analysis",
     {

--- a/tests/prompts/debug-pipeline.test.ts
+++ b/tests/prompts/debug-pipeline.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerDebugPipelinePrompt } from "../../src/prompts/debug-pipeline.js";
+
+async function createTestClient(): Promise<Client> {
+  const server = new McpServer(
+    { name: "test-server", version: "0.0.1" },
+    { capabilities: { prompts: {} } },
+  );
+  registerDebugPipelinePrompt(server);
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test-client", version: "0.0.1" });
+
+  await Promise.all([
+    client.connect(clientTransport),
+    server.connect(serverTransport),
+  ]);
+
+  return client;
+}
+
+describe("debug-pipeline-failure prompt", () => {
+  it("appears in the prompt list", async () => {
+    const client = await createTestClient();
+    const { prompts } = await client.listPrompts();
+
+    const prompt = prompts.find((p) => p.name === "debug-pipeline-failure");
+    expect(prompt).toBeDefined();
+    expect(prompt!.description).toContain("Analyze a failed pipeline execution");
+  });
+
+  it("registers pipeline_error_analysis as an alias", async () => {
+    const client = await createTestClient();
+    const { prompts } = await client.listPrompts();
+
+    const alias = prompts.find((p) => p.name === "pipeline_error_analysis");
+    expect(alias).toBeDefined();
+    expect(alias!.description).toBe(
+      prompts.find((p) => p.name === "debug-pipeline-failure")!.description,
+    );
+  });
+
+  it("pipeline_error_analysis returns the same prompt content", async () => {
+    const client = await createTestClient();
+
+    const original = await client.getPrompt({
+      name: "debug-pipeline-failure",
+      arguments: { executionId: "exec-123" },
+    });
+    const alias = await client.getPrompt({
+      name: "pipeline_error_analysis",
+      arguments: { executionId: "exec-123" },
+    });
+
+    const originalText = (original.messages[0].content as { type: string; text: string }).text;
+    const aliasText = (alias.messages[0].content as { type: string; text: string }).text;
+    expect(aliasText).toBe(originalText);
+  });
+
+  it("interpolates executionId and projectId", async () => {
+    const client = await createTestClient();
+    const result = await client.getPrompt({
+      name: "pipeline_error_analysis",
+      arguments: {
+        executionId: "exec-abc-123",
+        projectId: "my-project",
+      },
+    });
+
+    expect(result.messages).toHaveLength(1);
+    const text = (result.messages[0].content as { type: string; text: string }).text;
+    expect(text).toContain('execution_id="exec-abc-123"');
+    expect(text).toContain('project_id="my-project"');
+  });
+
+  it("detects URL input and uses url param", async () => {
+    const client = await createTestClient();
+    const result = await client.getPrompt({
+      name: "pipeline_error_analysis",
+      arguments: {
+        executionId: "https://app.harness.io/ng/#/account/abc/pipelines/exec123",
+      },
+    });
+
+    const text = (result.messages[0].content as { type: string; text: string }).text;
+    expect(text).toContain('url="https://app.harness.io/ng/#/account/abc/pipelines/exec123"');
+    expect(text).not.toContain("execution_id=");
+  });
+
+  it("references harness_diagnose with include_logs", async () => {
+    const client = await createTestClient();
+    const result = await client.getPrompt({
+      name: "pipeline_error_analysis",
+      arguments: { executionId: "exec123" },
+    });
+
+    const text = (result.messages[0].content as { type: string; text: string }).text;
+    expect(text).toContain("harness_diagnose");
+    expect(text).toContain("include_logs=true");
+  });
+});

--- a/tests/prompts/debug-pipeline.test.ts
+++ b/tests/prompts/debug-pipeline.test.ts
@@ -32,15 +32,14 @@ describe("debug-pipeline-failure prompt", () => {
     expect(prompt!.description).toContain("Analyze a failed pipeline execution");
   });
 
-  it("registers pipeline_error_analysis as an alias", async () => {
+  it("registers pipeline_error_analysis as an alias with a distinguishing description", async () => {
     const client = await createTestClient();
     const { prompts } = await client.listPrompts();
 
     const alias = prompts.find((p) => p.name === "pipeline_error_analysis");
     expect(alias).toBeDefined();
-    expect(alias!.description).toBe(
-      prompts.find((p) => p.name === "debug-pipeline-failure")!.description,
-    );
+    expect(alias!.description).toContain("Alias of debug-pipeline-failure");
+    expect(alias!.description).toContain("analyze a failed pipeline execution");
   });
 
   it("pipeline_error_analysis returns the same prompt content", async () => {


### PR DESCRIPTION
## Summary
- Registers `pipeline_error_analysis` as an alias for the existing `debug-pipeline-failure` MCP prompt
- Fixes a naming mismatch where ml-infra calls `get_prompt("pipeline_error_analysis")` but the server only registered `debug-pipeline-failure`, causing the prompt lookup to fail silently
- Extracts shared handler/config so both names use identical logic with zero duplication

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm build` succeeds
- [x] All 2607 tests pass (`pnpm test`)
- [x] `pnpm standards:check` passes (80 checks)
- [x] `pnpm docs:check` passes (README up to date)
- [ ] Verify ml-infra can now successfully fetch the prompt via `get_prompt("pipeline_error_analysis")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)