### PR TITLE
[feat]: [DBOPS-2684]: DBOPS changeset existence check API addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Harness MCP Server 2.0
 
-An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 214 resource types.
+An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 215 resource types.
 
 ## Why Use This MCP Server
 
@@ -8,7 +8,7 @@ Most MCP servers map one tool per API endpoint. For a platform as broad as Harne
 
 This server is built differently:
 
-- **11 tools, 214 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
+- **11 tools, 215 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
 - **Full platform coverage.** 37 default toolsets spanning CI/CD, GitOps, Feature Flags, Cloud Cost Management, Security Testing, Chaos Engineering, Database DevOps, Internal Developer Portal, Software Supply Chain, Infrastructure as Code Management, Governance, Service Overrides, Knowledge Graph, and more. Opt-in Ansible coverage is available when you need inventory and playbook data.
 - **Multi-project workflows out of the box.** Agents discover organizations and projects dynamically — no hardcoded env vars needed. Ask "show failed executions across all projects" and the agent can navigate the full account hierarchy.
 - **34 prompt templates.** Pre-built prompts for common workflows: build & deploy apps end-to-end, debug failed pipelines, review DORA metrics, triage vulnerabilities, optimize cloud costs, audit access control, plan feature flag rollouts, review pull requests, approve pending pipelines, and more.
@@ -1197,7 +1197,7 @@ Harness pipelines can be stored in three ways:
 
 ## Resource Types
 
-214 resource types organized across 37 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
+215 resource types organized across 37 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
 
 ### Platform
 
@@ -1837,7 +1837,7 @@ Available toolset names:
                  +--------v---------+
                 |    Registry       |  <-- Declarative resource definitions
                 |  37 Toolsets      |      (data files, not code)
-                |  214 Resource Types|
+                |  215 Resource Types|
                  +--------+---------+
                           |
                  +--------v---------+

--- a/src/registry/toolsets/dbops.ts
+++ b/src/registry/toolsets/dbops.ts
@@ -696,6 +696,56 @@ export const dbopsToolset: ToolsetDefinition = {
       },
     },
 
+    // ── ChangeSet Existence ─────────────────────────────────────────────
+    {
+      resourceType: "database_changeset_existence",
+      displayName: "Database ChangeSet Existence",
+      description:
+        "Check whether Liquibase changeSet ids already exist in a schema's catalog. " +
+        "Use before presenting new changesets for review to ensure ids are unique. " +
+        "Only the id field is evaluated; author and fileName are ignored by the API.",
+      toolset: "dbops",
+      scope: "project",
+      identifierFields: ["dbschema_id"],
+      operations: {
+        get: {
+          method: "POST",
+          path: "/dbops/v1/orgs/{org}/projects/{project}/dbschema/{dbschema}/changesets/existence",
+          pathParams: {
+            org_id: "org",
+            project_id: "project",
+            dbschema_id: "dbschema",
+          },
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          skipScopeBodyInjection: true,
+          bodyBuilder: (input) => {
+            const rawIds = input.changeset_ids ?? input.changeSetIds ?? input.change_set_ids;
+            if (!Array.isArray(rawIds) || rawIds.length === 0) {
+              throw new Error(
+                "changeset_ids is required — provide a non-empty array of Liquibase changeSet id strings to check",
+              );
+            }
+            if (rawIds.length > 100) {
+              throw new Error("changeset_ids supports at most 100 ids per request");
+            }
+            const ids: string[] = [];
+            for (const entry of rawIds) {
+              if (typeof entry !== "string" || entry.trim().length === 0) {
+                throw new Error("each changeset_ids entry must be a non-empty string");
+              }
+              ids.push(entry.trim());
+            }
+            return { changeSets: ids.map((id) => ({ id })) };
+          },
+          responseExtractor: passthrough,
+          description:
+            "Batch-check changeSet id uniqueness for a schema. " +
+            "Pass changeset_ids (array of id strings) via params or top-level input. " +
+            "Returns { existence: { '<id>': true|false } } — true means the id is already in use.",
+        },
+      },
+    },
+
     // ── Default Authoring Instance ──────────────────────────────────────
     {
       resourceType: "database_default_authoring_instance",

--- a/tests/registry/dbops.test.ts
+++ b/tests/registry/dbops.test.ts
@@ -806,3 +806,31 @@ describe("database_snapshot_object get", () => {
     expect(call.body).not.toHaveProperty("projectIdentifier");
   });
 });
+
+describe("database_changeset_existence get", () => {
+  it("passes changeset id body without scope injection", async () => {
+    const registry = new Registry(makeConfig());
+    const mockRequest = vi.fn().mockResolvedValue({
+      existence: { "add-users-email-column": false, "create-orders-index": true },
+    });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "database_changeset_existence", "get", {
+      org_id: "default",
+      project_id: "test-project",
+      dbschema_id: "my_schema",
+      changeset_ids: ["add-users-email-column", "create-orders-index"],
+    });
+
+    const call = mockRequest.mock.calls[0][0];
+    expect(call.method).toBe("POST");
+    expect(call.path).toBe(
+      "/dbops/v1/orgs/default/projects/test-project/dbschema/my_schema/changesets/existence",
+    );
+    expect(call.body).toEqual({
+      changeSets: [{ id: "add-users-email-column" }, { id: "create-orders-index" }],
+    });
+    expect(call.body).not.toHaveProperty("orgIdentifier");
+    expect(call.body).not.toHaveProperty("projectIdentifier");
+  });
+});


### PR DESCRIPTION
## Description
## Description

Adds `database_changeset_existence` to the DBOPS toolset so agents can check whether Liquibase `changeSet.id` values already exist in a schema catalog before presenting a changeset for review.

**Changes:**
- New resource type `database_changeset_existence` (`harness_get`) — POST `/dbops/v1/orgs/{org}/projects/{project}/dbschema/{dbschema}/changesets/existence`
- Accepts `changeset_ids` (array, max 100) via `params`; maps to `{ changeSets: [{ id }] }` request body
- `skipScopeBodyInjection: true` — org/project stay in path only, not duplicated in body
- `retryPolicy: "safe"` for transient read failures
- Registry unit test for path, body shape, and no scope injection in body
- Regenerated `README.md` resource counts via `pnpm docs:generate`

**Usage (agent / MCP):**
harness_get( resource_type="database_changeset_existence", params={ dbschema_id: "<schema_id>", changeset_ids: ["create-table-users", ...] } )

**Related:** ml-infra PR #1413 — DBOPS changeset skill Step 4 calls this API for id uniqueness validation.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [x] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
If this PR adds or changes Harness API coverage:
- [ ] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [ ] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [ ] `operationPolicy` on every new/changed endpoint
- [ ] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [ ] `identifierFields` and `scope` declared on new resources
- [ ] No `console.log()` in `src/` (stdio JSON-RPC safety)
