### PR TITLE
feat: unify pipeline_summarizer into failure+success analyzer with RCA

### DIFF
--- a/src/prompts/summarize-pipeline.ts
+++ b/src/prompts/summarize-pipeline.ts
@@ -4,7 +4,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 // snake_case id required by ml-infra (prompt_ref: "pipeline_summarizer")
 const PIPELINE_SUMMARIZER_PROMPT = {
   description:
-    "Fetch and summarize ALL step logs from a pipeline execution. Returns a table with every step's name, status, duration, and a log-based summary of what happened.",
+    "Analyze a pipeline execution — provides root cause analysis for failures and output summaries for successful steps. Supports whole-pipeline and single-step analysis.",
   argsSchema: {
     executionId: z
       .string()
@@ -33,9 +33,9 @@ export function registerSummarizePipelinePrompt(server: McpServer): void {
             role: "user" as const,
             content: {
               type: "text" as const,
-              text: `You are a pipeline execution summarizer for Harness CI/CD pipelines (IACM, CCM, CD, CI, STO).
+              text: `You are a pipeline execution analyzer for Harness CI/CD pipelines (IACM, CCM, CD, CI, STO).
 
-Your job is to summarize EVERY step in the execution by extracting concrete outputs from the logs. Do NOT skip any steps.
+Your job is to analyze every step in the execution: diagnose failures with root cause analysis and summarize outputs for successful steps.
 
 ## Steps
 
@@ -43,25 +43,38 @@ Your job is to summarize EVERY step in the execution by extracting concrete outp
    - Note: harness_diagnose rejects non-terminal executions (Running, Queued). For in-progress runs, use harness_get with resource_type="execution" and resource_id=<execution_id> instead.
    - The response contains \`all_step_logs\` (keyed by node ID) with logs for every step. Steps without available logs will have a \`note\` field instead — use their name/status/duration from the execution tree.
    - If any steps also appear in \`failed_step_logs\`, their log content is already merged into \`all_step_logs\` — use \`all_step_logs\` as the single source of truth.
-2. For each step in the all_step_logs response, extract the specific outputs based on step type (see "What to Extract" below).
-3. If there are more than 10 steps, present results in batches of 3 rows at a time so the user sees partial progress instead of waiting for the full table. After each batch, continue immediately with the next batch until all steps are covered.
-4. Present results as the table below. DO NOT skip any steps — summarize every single one, even if the step has no log (use status and duration).
 
-## What to Extract (by step type)
+2. Detect analysis mode from the response:
+   - If the response contains \`requested_step_log\` → **single-step mode**: analyze only that step in depth.
+   - If the response contains \`all_step_logs\` → **whole-pipeline mode**: analyze every step.
 
-For each step, look for these concrete outputs in the logs:
+3. For each step, branch analysis by status:
 
-- **IACM / Terraform**: Resources created/changed/destroyed (e.g. "3 added, 1 changed, 0 destroyed"), resource names/IDs provisioned, state file changes, plan drift detected
-- **CD / Deploy**: Service deployed, environment/namespace, image tag or artifact version, replicas, rollback info, health check results
-- **CI / Build**: Image built and pushed (repo:tag), build duration, cache hit/miss, test results (passed/failed/skipped counts), artifacts produced
-- **STO / Security**: Vulnerabilities found (critical/high/medium/low counts), policy violations, exemptions applied, scan tool used
-- **CCM / Cost**: Budget alerts, anomalies detected, recommendations applied, savings realized
-- **Approval**: Who approved/rejected, how long it waited
-- **Plugin / Run steps**: Command executed, exit code, key output lines (errors, warnings, final status messages)
+   **Failed / Errored:**
+   - Extract the error message and stack trace from logs
+   - Identify the root cause (misconfiguration, timeout, dependency failure, permission issue, resource limit, etc.)
+   - Provide a suggested fix with specific actions
+   - Note if this is a child pipeline failure — follow the chain to the actual failing step
 
-If a step's log has no meaningful output (e.g. initialization), note what it did briefly (e.g. "Initialized workspace", "Pulled image X").
+   **Success:**
+   - Extract concrete outputs based on step type:
+     - **IACM / Terraform**: Resources created/changed/destroyed, resource names/IDs, state drift
+     - **CD / Deploy**: Service, environment/namespace, image tag, replicas, health check result
+     - **CI / Build**: Image built (repo:tag), test results (passed/failed/skipped), artifacts produced
+     - **STO / Security**: Vulnerability counts (critical/high/medium/low), policy violations, scan tool
+     - **CCM / Cost**: Budget alerts, anomalies, recommendations, savings
+     - **Approval**: Who approved/rejected, wait duration
+     - **Plugin / Run steps**: Command executed, exit code, key output lines
 
-## Required Output
+   **Skipped:**
+   - Note as skipped with the reason (conditional skip, previous stage failure, manual intervention required)
+
+## Required Output (whole-pipeline mode)
+
+### Summary
+A 1–2 sentence executive summary of the entire execution outcome. Examples:
+- Failed: "Pipeline failed at stage Deploy / step rollout-prod because the Kubernetes namespace 'prod-us' hit its resource quota. Fix: increase CPU limits on the namespace or scale down existing pods."
+- Success: "Pipeline deployed service cart-api v2.4.1 to prod-us (3 replicas healthy), built and pushed image in 2m14s, passed 847 tests with 0 vulnerabilities."
 
 ### Execution Overview
 - **Pipeline**: [name]
@@ -70,18 +83,19 @@ If a step's log has no meaningful output (e.g. initialization), note what it did
 - **Duration**: [total wall-clock time]
 - **Trigger**: [manual / webhook / cron / API]
 
-### Step Summary
+### Step Analysis
 
-| Step Name | Status | Duration | What Happened (outputs from logs) |
-|-----------|--------|----------|-----------------------------------|
-| ...       | ...    | ...      | Concrete outputs: what was provisioned/deployed/built/scanned |
+| Step Name | Status | Duration | Analysis |
+|-----------|--------|----------|----------|
+| ...       | Failed | ...      | **Root cause**: ... **Fix**: ... |
+| ...       | Success | ...     | Concrete outputs from logs |
+| ...       | Skipped | ...     | Reason skipped |
 
-### Key Observations
-- Resources provisioned or modified (total count across all steps)
-- Deployments: services, environments, artifact versions
-- Security: vulnerability counts, policy pass/fail
-- Performance bottlenecks or unusually slow steps
-- Errors or warnings worth investigating`,
+### Key Findings
+- **Failures**: Root cause summary, affected steps, suggested fixes
+- **Outputs**: Resources provisioned/deployed/built/scanned (aggregated)
+- **Performance**: Bottlenecks or unusually slow steps
+- **Warnings**: Issues worth investigating even in successful steps`,
             },
           },
         ],

--- a/src/tools/diagnose/pipeline.ts
+++ b/src/tools/diagnose/pipeline.ts
@@ -483,13 +483,17 @@ export const pipelineHandler: DiagnoseHandler = {
 
     const includeYaml = args.include_yaml ?? !isSummary;
     const includeLogs = args.include_logs ?? !isSummary;
-    const includeAllStepLogs = args.include_all_step_logs === true;
     const returnDownloadUrl = args.return_download_url === true;
     const logSnippetLines = asNumber(args.log_snippet_lines) ?? 120;
     const maxFailedSteps = asNumber(args.max_failed_steps) ?? 5;
     const maxAllStepLogs = asNumber(args.max_all_step_logs) ?? 25;
 
     const hasRequestedStep = !!asString(input.step_id);
+    // Suppress all_step_logs when a specific step is requested — the caller
+    // wants single-step analysis; returning all logs would be wasteful and
+    // could confuse downstream consumers into whole-pipeline mode.
+    const includeAllStepLogs = args.include_all_step_logs === true && !hasRequestedStep;
+
     let totalSteps = 1;
     if (includeYaml) totalSteps++;
     if (includeLogs) totalSteps++;

--- a/tests/prompts/summarize-pipeline.test.ts
+++ b/tests/prompts/summarize-pipeline.test.ts
@@ -29,7 +29,7 @@ describe("pipeline_summarizer prompt", () => {
 
     const prompt = prompts.find((p) => p.name === "pipeline_summarizer");
     expect(prompt).toBeDefined();
-    expect(prompt!.description).toContain("Fetch and summarize ALL step logs");
+    expect(prompt!.description).toContain("Analyze a pipeline execution");
   });
 
   it("registers summarize-pipeline as a backward-compatible alias", async () => {
@@ -111,7 +111,7 @@ describe("pipeline_summarizer prompt", () => {
     expect(text).toContain("all_step_logs");
   });
 
-  it("instructs to summarize every step without skipping", async () => {
+  it("includes root cause analysis for failures", async () => {
     const client = await createTestClient();
     const result = await client.getPrompt({
       name: "pipeline_summarizer",
@@ -120,8 +120,37 @@ describe("pipeline_summarizer prompt", () => {
 
     const text = (result.messages[0].content as { type: string; text: string }).text;
 
-    expect(text).toContain("DO NOT skip any steps");
-    expect(text).toContain("summarize every single one");
+    expect(text).toContain("root cause");
+    expect(text).toContain("suggested fix");
+    expect(text).toContain("Failed / Errored");
+  });
+
+  it("branches analysis by step status", async () => {
+    const client = await createTestClient();
+    const result = await client.getPrompt({
+      name: "pipeline_summarizer",
+      arguments: { executionId: "exec123" },
+    });
+
+    const text = (result.messages[0].content as { type: string; text: string }).text;
+
+    expect(text).toContain("Failed / Errored");
+    expect(text).toContain("Success:");
+    expect(text).toContain("Skipped:");
+  });
+
+  it("supports single-step and whole-pipeline modes", async () => {
+    const client = await createTestClient();
+    const result = await client.getPrompt({
+      name: "pipeline_summarizer",
+      arguments: { executionId: "exec123" },
+    });
+
+    const text = (result.messages[0].content as { type: string; text: string }).text;
+
+    expect(text).toContain("requested_step_log");
+    expect(text).toContain("single-step mode");
+    expect(text).toContain("whole-pipeline mode");
   });
 
   it("includes running execution guidance", async () => {
@@ -147,6 +176,18 @@ describe("pipeline_summarizer prompt", () => {
     expect(text).toContain("Step Name");
     expect(text).toContain("Status");
     expect(text).toContain("Duration");
-    expect(text).toContain("What Happened");
+    expect(text).toContain("Analysis");
+  });
+
+  it("includes a TL;DR executive summary section", async () => {
+    const client = await createTestClient();
+    const result = await client.getPrompt({
+      name: "pipeline_summarizer",
+      arguments: { executionId: "exec123" },
+    });
+
+    const text = (result.messages[0].content as { type: string; text: string }).text;
+    expect(text).toContain("### Summary");
+    expect(text).toContain("executive summary");
   });
 });


### PR DESCRIPTION
## Summary

The `pipeline_summarizer` prompt was a flat step-by-step log dumper — it treated every step the same regardless of outcome. This rewrites it into a unified execution analyzer that adapts its behavior based on what actually happened:

- **Failed steps** → root cause analysis, error extraction, suggested fix
- **Successful steps** → concrete outputs (images built, resources provisioned, tests passed)
- **Skipped steps** → reason noted (conditional, upstream failure, manual gate)
- **Executive Summary** → 1-2 sentence outcome at the top so you don't have to read the full table to know what happened

Additionally:

- **Single-step mode**: When the URL contains a `?step=` param, only that step is analyzed in depth — no other step logs are fetched
- **Server-level guard**: `include_all_step_logs` is suppressed at the `harness_diagnose` level when `step_id` is present, making it impossible for the LLM to accidentally enter whole-pipeline mode on a single-step request

### Before
> "Summarize EVERY step... DO NOT skip any steps... present a table with What Happened"

### After
> Detect mode → branch by status → root cause failures → extract outputs from successes → lead with a Summary sentence

## Test plan
- [x] `pnpm typecheck` passes
- [x] All 2617 tests pass (`pnpm test`)
- [x] `pnpm standards:check` passes
- [x] New tests: RCA assertions, status branching, single-step/whole-pipeline mode, executive summary section
- [x] Structural tests preserved: args, URL detection, alias, `harness_diagnose`, `include_all_step_logs`
- [ ] E2E: verify a failed pipeline URL produces root cause + fix in the summary
- [ ] E2E: verify a URL with `?step=` only returns that step's log

🤖 Generated with [Claude Code](https://claude.com/claude-code)