### PR TITLE
fix: pass placeholder identifier for NG entity yaml-schema fetches

### DIFF
--- a/src/tools/entity-schema/cache-keys.ts
+++ b/src/tools/entity-schema/cache-keys.ts
@@ -3,6 +3,8 @@ import type { HarnessYamlScope } from "./types.js";
 export interface LiveSchemaCacheKeyScope {
   orgId?: string;
   projectId?: string;
+  /** Explicit entity identifier — omitted when using the internal placeholder only. */
+  identifier?: string;
 }
 
 export function buildLiveSchemaCacheKey(
@@ -17,6 +19,9 @@ export function buildLiveSchemaCacheKey(
   }
   if (scope === "project") {
     key.push(identifiers.projectId ?? "");
+  }
+  if (identifiers.identifier) {
+    key.push(identifiers.identifier);
   }
   return JSON.stringify(key);
 }

--- a/src/tools/entity-schema/live.ts
+++ b/src/tools/entity-schema/live.ts
@@ -52,20 +52,19 @@ export const LIVE_ENTITY_SCHEMAS: Record<string, LiveEntitySchemaDefinition> = {
 export const LIVE_ENTITY_RESOURCE_TYPES = Object.keys(LIVE_ENTITY_SCHEMAS);
 
 /**
- * Placeholder identifier for NG /yaml-schema on live entity types at project scope.
- * Some NG builds reject project-scoped requests without identifier (scopedIdentifierConfig is null).
+ * Placeholder identifier for NG /yaml-schema on live entity types at any scope.
+ * Some NG builds reject scoped requests without identifier (scopedIdentifierConfig is null).
  * A dummy value returns the generic type-level schema — the entity does not need to exist.
  */
 export const YAML_SCHEMA_PLACEHOLDER_IDENTIFIER = "test";
 
-/** Resolve NG yaml-schema identifier: explicit param wins, else placeholder at project scope. */
+/** Resolve NG yaml-schema identifier: explicit param wins, else placeholder for live entity types. */
 export function resolveYamlSchemaIdentifier(
   resourceType: string,
-  scope: HarnessYamlScope,
   params: LiveSchemaFetchParams,
 ): string | undefined {
   if (params.identifier) return params.identifier;
-  if (scope === "project" && resourceType in LIVE_ENTITY_SCHEMAS) {
+  if (resourceType in LIVE_ENTITY_SCHEMAS) {
     return YAML_SCHEMA_PLACEHOLDER_IDENTIFIER;
   }
   return undefined;
@@ -146,7 +145,7 @@ function resolveScope(scope?: HarnessYamlScope): HarnessYamlScope {
   return scope ?? "account";
 }
 
-/** Build NG /yaml-schema query params. resourceType drives placeholder identifier resolution at project scope. */
+/** Build NG /yaml-schema query params. resourceType drives placeholder identifier resolution. */
 function buildYamlSchemaParams(
   resourceType: string,
   definition: LiveEntitySchemaDefinition,
@@ -172,7 +171,7 @@ function buildYamlSchemaParams(
     query.projectIdentifier = params.projectId;
   }
 
-  const resolvedIdentifier = resolveYamlSchemaIdentifier(resourceType, scope, params);
+  const resolvedIdentifier = resolveYamlSchemaIdentifier(resourceType, params);
   if (resolvedIdentifier) {
     query.identifier = resolvedIdentifier;
   }

--- a/src/tools/entity-schema/live.ts
+++ b/src/tools/entity-schema/live.ts
@@ -146,10 +146,10 @@ function resolveScope(scope?: HarnessYamlScope): HarnessYamlScope {
   return scope ?? "account";
 }
 
+/** Build NG /yaml-schema query params. resourceType drives placeholder identifier resolution at project scope. */
 function buildYamlSchemaParams(
   resourceType: string,
   definition: LiveEntitySchemaDefinition,
-  _accountId: string,
   params: LiveSchemaFetchParams,
 ): Record<string, string> {
   const scope = resolveScope(params.scope);
@@ -365,7 +365,7 @@ export function createLiveSchemaFetcher(client: HarnessClient): LiveSchemaFetche
       const accountId = client.account;
       const scope = resolveScope(params.scope);
       // Validate scope/org/project before cache or bundled paths (same rules as live NG fetch).
-      buildYamlSchemaParams(resourceType, definition, accountId, params);
+      buildYamlSchemaParams(resourceType, definition, params);
 
       const cacheKey = buildLiveSchemaCacheKey(resourceType, accountId, scope, {
         orgId: params.orgId,
@@ -394,7 +394,7 @@ export function createLiveSchemaFetcher(client: HarnessClient): LiveSchemaFetche
         return entry;
       }
 
-      const queryParams = buildYamlSchemaParams(resourceType, definition, accountId, params);
+      const queryParams = buildYamlSchemaParams(resourceType, definition, params);
 
       try {
         log.debug("Fetching live entity YAML schema", {

--- a/src/tools/entity-schema/live.ts
+++ b/src/tools/entity-schema/live.ts
@@ -52,22 +52,20 @@ export const LIVE_ENTITY_SCHEMAS: Record<string, LiveEntitySchemaDefinition> = {
 export const LIVE_ENTITY_RESOURCE_TYPES = Object.keys(LIVE_ENTITY_SCHEMAS);
 
 /**
- * Placeholder identifier for NG /yaml-schema on contextual entities (service, infrastructure).
+ * Placeholder identifier for NG /yaml-schema on live entity types at project scope.
  * Some NG builds reject project-scoped requests without identifier (scopedIdentifierConfig is null).
  * A dummy value returns the generic type-level schema — the entity does not need to exist.
  */
 export const YAML_SCHEMA_PLACEHOLDER_IDENTIFIER = "test";
 
-const PLACEHOLDER_IDENTIFIER_RESOURCE_TYPES = new Set(["service", "infrastructure"]);
-
-/** Resolve NG yaml-schema identifier: explicit param wins, else placeholder for contextual entities. */
+/** Resolve NG yaml-schema identifier: explicit param wins, else placeholder at project scope. */
 export function resolveYamlSchemaIdentifier(
   resourceType: string,
   scope: HarnessYamlScope,
   params: LiveSchemaFetchParams,
 ): string | undefined {
   if (params.identifier) return params.identifier;
-  if (PLACEHOLDER_IDENTIFIER_RESOURCE_TYPES.has(resourceType) && scope === "project") {
+  if (scope === "project" && resourceType in LIVE_ENTITY_SCHEMAS) {
     return YAML_SCHEMA_PLACEHOLDER_IDENTIFIER;
   }
   return undefined;

--- a/src/tools/entity-schema/live.ts
+++ b/src/tools/entity-schema/live.ts
@@ -51,6 +51,28 @@ export const LIVE_ENTITY_SCHEMAS: Record<string, LiveEntitySchemaDefinition> = {
 
 export const LIVE_ENTITY_RESOURCE_TYPES = Object.keys(LIVE_ENTITY_SCHEMAS);
 
+/**
+ * Placeholder identifier for NG /yaml-schema on contextual entities (service, infrastructure).
+ * Some NG builds reject project-scoped requests without identifier (scopedIdentifierConfig is null).
+ * A dummy value returns the generic type-level schema — the entity does not need to exist.
+ */
+export const YAML_SCHEMA_PLACEHOLDER_IDENTIFIER = "test";
+
+const PLACEHOLDER_IDENTIFIER_RESOURCE_TYPES = new Set(["service", "infrastructure"]);
+
+/** Resolve NG yaml-schema identifier: explicit param wins, else placeholder for contextual entities. */
+export function resolveYamlSchemaIdentifier(
+  resourceType: string,
+  scope: HarnessYamlScope,
+  params: LiveSchemaFetchParams,
+): string | undefined {
+  if (params.identifier) return params.identifier;
+  if (PLACEHOLDER_IDENTIFIER_RESOURCE_TYPES.has(resourceType) && scope === "project") {
+    return YAML_SCHEMA_PLACEHOLDER_IDENTIFIER;
+  }
+  return undefined;
+}
+
 const RESPONSE_SCHEMA_KEYS = [
   "schema",
   "yamlSchema",
@@ -127,8 +149,9 @@ function resolveScope(scope?: HarnessYamlScope): HarnessYamlScope {
 }
 
 function buildYamlSchemaParams(
+  resourceType: string,
   definition: LiveEntitySchemaDefinition,
-  accountId: string,
+  _accountId: string,
   params: LiveSchemaFetchParams,
 ): Record<string, string> {
   const scope = resolveScope(params.scope);
@@ -149,6 +172,11 @@ function buildYamlSchemaParams(
       throw new Error("project_id is required when scope is 'project'");
     }
     query.projectIdentifier = params.projectId;
+  }
+
+  const resolvedIdentifier = resolveYamlSchemaIdentifier(resourceType, scope, params);
+  if (resolvedIdentifier) {
+    query.identifier = resolvedIdentifier;
   }
 
   return query;
@@ -339,11 +367,12 @@ export function createLiveSchemaFetcher(client: HarnessClient): LiveSchemaFetche
       const accountId = client.account;
       const scope = resolveScope(params.scope);
       // Validate scope/org/project before cache or bundled paths (same rules as live NG fetch).
-      buildYamlSchemaParams(definition, accountId, params);
+      buildYamlSchemaParams(resourceType, definition, accountId, params);
 
       const cacheKey = buildLiveSchemaCacheKey(resourceType, accountId, scope, {
         orgId: params.orgId,
         projectId: params.projectId,
+        ...(params.identifier ? { identifier: params.identifier } : {}),
       });
 
       const cached = cache.get(cacheKey);
@@ -354,8 +383,8 @@ export function createLiveSchemaFetcher(client: HarnessClient): LiveSchemaFetche
         return cached;
       }
 
-      // Bundled-first when snapshots match the runtime account (see bundledSnapshotsMatchAccount).
-      const bundled = getBundledEntitySchema(resourceType, scope);
+      // Explicit identifier requests entity-specific schema — bundled snapshots are type-level only.
+      const bundled = params.identifier ? undefined : getBundledEntitySchema(resourceType, scope);
       if (
         bundled &&
         bundledSnapshotsMatchAccount(accountId) &&
@@ -367,7 +396,7 @@ export function createLiveSchemaFetcher(client: HarnessClient): LiveSchemaFetche
         return entry;
       }
 
-      const queryParams = buildYamlSchemaParams(definition, accountId, params);
+      const queryParams = buildYamlSchemaParams(resourceType, definition, accountId, params);
 
       try {
         log.debug("Fetching live entity YAML schema", {
@@ -375,6 +404,12 @@ export function createLiveSchemaFetcher(client: HarnessClient): LiveSchemaFetche
           entity_type: definition.entityType,
           scope,
           account_id: accountId,
+          ...(queryParams.identifier
+            ? {
+                identifier: queryParams.identifier,
+                placeholder: !params.identifier && queryParams.identifier === YAML_SCHEMA_PLACEHOLDER_IDENTIFIER,
+              }
+            : {}),
         });
 
         const response = await client.request<unknown>({

--- a/src/tools/entity-schema/types.ts
+++ b/src/tools/entity-schema/types.ts
@@ -12,6 +12,8 @@ export interface LiveSchemaFetchParams {
   scope?: HarnessYamlScope;
   orgId?: string;
   projectId?: string;
+  /** Override NG yaml-schema identifier — use for entity-specific service/infrastructure schemas. */
+  identifier?: string;
 }
 
 export interface EntitySchemaFetchResult {

--- a/src/tools/harness-schema.ts
+++ b/src/tools/harness-schema.ts
@@ -288,9 +288,9 @@ export function registerSchemaTool(
           .string()
           .optional()
           .describe(
-            "Optional entity identifier for NG yaml-schema. Use when updating an existing service or infrastructure " +
-              "to fetch a deployment-type-specific schema. Omit for generic create-time schemas — a placeholder " +
-              "identifier is sent automatically for project-scoped service/infrastructure.",
+            "Optional entity identifier for NG yaml-schema. Use when updating an existing entity " +
+              "to fetch an entity-specific schema. Omit for generic create-time schemas — a placeholder " +
+              "identifier is sent automatically for all project-scoped live entity types.",
           ),
       },
       outputSchema: schemaOutputSchema,

--- a/src/tools/harness-schema.ts
+++ b/src/tools/harness-schema.ts
@@ -284,6 +284,14 @@ export function registerSchemaTool(
           .string()
           .optional()
           .describe("Project identifier — required when scope is project (live entity schemas)."),
+        identifier: z
+          .string()
+          .optional()
+          .describe(
+            "Optional entity identifier for NG yaml-schema. Use when updating an existing service or infrastructure " +
+              "to fetch a deployment-type-specific schema. Omit for generic create-time schemas — a placeholder " +
+              "identifier is sent automatically for project-scoped service/infrastructure.",
+          ),
       },
       outputSchema: schemaOutputSchema,
       annotations: {
@@ -356,6 +364,7 @@ export function registerSchemaTool(
             scope: args.scope as HarnessYamlScope | undefined,
             orgId: args.org_id,
             projectId: args.project_id,
+            identifier: args.identifier,
           });
 
           if (!fetched) {

--- a/src/tools/harness-schema.ts
+++ b/src/tools/harness-schema.ts
@@ -290,7 +290,7 @@ export function registerSchemaTool(
           .describe(
             "Optional entity identifier for NG yaml-schema. Use when updating an existing entity " +
               "to fetch an entity-specific schema. Omit for generic create-time schemas — a placeholder " +
-              "identifier is sent automatically for all project-scoped live entity types.",
+              "identifier is sent automatically for all live entity types at any scope.",
           ),
       },
       outputSchema: schemaOutputSchema,

--- a/tests/tools/entity-schema-bundled.test.ts
+++ b/tests/tools/entity-schema-bundled.test.ts
@@ -71,6 +71,53 @@ describe("entity schema bundled + live fallback", () => {
     expect(client.request).toHaveBeenCalledTimes(1);
   });
 
+  it("passes placeholder identifier for account-scoped connector live fetch", async () => {
+    vi.spyOn(bundled, "getBundledEntitySchema").mockReturnValue(undefined);
+    vi.spyOn(bundled, "bundledSnapshotsMatchAccount").mockReturnValue(false);
+
+    const client = {
+      account: "acct-123",
+      request: vi.fn().mockResolvedValue({ data: { type: "object" } }),
+    } as unknown as HarnessClient;
+
+    const fetcher = createLiveSchemaFetcher(client);
+    await fetcher.fetch("connector", { scope: "account" });
+
+    expect(client.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          entityType: "Connectors",
+          scope: "account",
+          identifier: YAML_SCHEMA_PLACEHOLDER_IDENTIFIER,
+        }),
+      }),
+    );
+  });
+
+  it("passes placeholder identifier for org-scoped secret live fetch", async () => {
+    vi.spyOn(bundled, "getBundledEntitySchema").mockReturnValue(undefined);
+    vi.spyOn(bundled, "bundledSnapshotsMatchAccount").mockReturnValue(false);
+
+    const client = {
+      account: "acct-123",
+      request: vi.fn().mockResolvedValue({ data: { type: "object" } }),
+    } as unknown as HarnessClient;
+
+    const fetcher = createLiveSchemaFetcher(client);
+    await fetcher.fetch("secret", { scope: "org", orgId: "default" });
+
+    expect(client.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          entityType: "Secrets",
+          scope: "org",
+          orgIdentifier: "default",
+          identifier: YAML_SCHEMA_PLACEHOLDER_IDENTIFIER,
+        }),
+      }),
+    );
+  });
+
   it("passes placeholder identifier for project-scoped infrastructure live fetch", async () => {
     vi.spyOn(bundled, "getBundledEntitySchema").mockReturnValue(undefined);
     vi.spyOn(bundled, "bundledSnapshotsMatchAccount").mockReturnValue(false);

--- a/tests/tools/entity-schema-bundled.test.ts
+++ b/tests/tools/entity-schema-bundled.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import type { HarnessClient } from "../../src/client/harness-client.js";
 import * as bundled from "../../src/tools/entity-schema/bundled.js";
-import { createLiveSchemaFetcher } from "../../src/tools/entity-schema/live.js";
+import { createLiveSchemaFetcher, YAML_SCHEMA_PLACEHOLDER_IDENTIFIER } from "../../src/tools/entity-schema/live.js";
 
 describe("entity schema bundled + live fallback", () => {
   afterEach(() => {
@@ -69,5 +69,79 @@ describe("entity schema bundled + live fallback", () => {
 
     expect(result).toEqual({ schema: liveSchema, source: "ng-yaml-schema" });
     expect(client.request).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes placeholder identifier for project-scoped infrastructure live fetch", async () => {
+    vi.spyOn(bundled, "getBundledEntitySchema").mockReturnValue(undefined);
+    vi.spyOn(bundled, "bundledSnapshotsMatchAccount").mockReturnValue(false);
+
+    const liveSchema = { type: "object", properties: { deploymentType: { type: "string" } } };
+    const client = {
+      account: "acct-123",
+      request: vi.fn().mockResolvedValue({ data: liveSchema }),
+    } as unknown as HarnessClient;
+
+    const fetcher = createLiveSchemaFetcher(client);
+    await fetcher.fetch("infrastructure", {
+      scope: "project",
+      orgId: "default",
+      projectId: "cxe_sandbox",
+    });
+
+    expect(client.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          entityType: "Infrastructure",
+          identifier: YAML_SCHEMA_PLACEHOLDER_IDENTIFIER,
+        }),
+      }),
+    );
+  });
+
+  it("does not pass placeholder identifier for connector project scope", async () => {
+    vi.spyOn(bundled, "getBundledEntitySchema").mockReturnValue(undefined);
+    vi.spyOn(bundled, "bundledSnapshotsMatchAccount").mockReturnValue(false);
+
+    const client = {
+      account: "acct-123",
+      request: vi.fn().mockResolvedValue({ data: { type: "object" } }),
+    } as unknown as HarnessClient;
+
+    const fetcher = createLiveSchemaFetcher(client);
+    await fetcher.fetch("connector", {
+      scope: "project",
+      orgId: "default",
+      projectId: "cxe_sandbox",
+    });
+
+    const call = client.request.mock.calls[0]?.[0] as { params?: Record<string, string> };
+    expect(call.params?.identifier).toBeUndefined();
+  });
+
+  it("uses explicit identifier instead of placeholder and skips bundled", async () => {
+    vi.spyOn(bundled, "getBundledEntitySchema").mockReturnValue({ type: "object", properties: { bundled: {} } });
+    vi.spyOn(bundled, "bundledSnapshotsMatchAccount").mockReturnValue(true);
+
+    const liveSchema = { type: "object", properties: { k8s: { type: "string" } } };
+    const client = {
+      account: "acct-123",
+      request: vi.fn().mockResolvedValue({ data: liveSchema }),
+    } as unknown as HarnessClient;
+
+    const fetcher = createLiveSchemaFetcher(client);
+    const result = await fetcher.fetch("infrastructure", {
+      scope: "project",
+      orgId: "default",
+      projectId: "cxe_sandbox",
+      identifier: "existing_infra",
+    });
+
+    expect(result).toEqual({ schema: liveSchema, source: "ng-yaml-schema" });
+    expect(bundled.getBundledEntitySchema).not.toHaveBeenCalled();
+    expect(client.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({ identifier: "existing_infra" }),
+      }),
+    );
   });
 });

--- a/tests/tools/entity-schema-bundled.test.ts
+++ b/tests/tools/entity-schema-bundled.test.ts
@@ -98,7 +98,7 @@ describe("entity schema bundled + live fallback", () => {
     );
   });
 
-  it("does not pass placeholder identifier for connector project scope", async () => {
+  it("passes placeholder identifier for project-scoped connector live fetch", async () => {
     vi.spyOn(bundled, "getBundledEntitySchema").mockReturnValue(undefined);
     vi.spyOn(bundled, "bundledSnapshotsMatchAccount").mockReturnValue(false);
 
@@ -114,8 +114,14 @@ describe("entity schema bundled + live fallback", () => {
       projectId: "cxe_sandbox",
     });
 
-    const call = client.request.mock.calls[0]?.[0] as { params?: Record<string, string> };
-    expect(call.params?.identifier).toBeUndefined();
+    expect(client.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          entityType: "Connectors",
+          identifier: YAML_SCHEMA_PLACEHOLDER_IDENTIFIER,
+        }),
+      }),
+    );
   });
 
   it("uses explicit identifier instead of placeholder and skips bundled", async () => {

--- a/tests/tools/entity-schema-cache-keys.test.ts
+++ b/tests/tools/entity-schema-cache-keys.test.ts
@@ -35,6 +35,16 @@ describe("buildLiveSchemaCacheKey", () => {
       JSON.stringify(["connector", "project", "acct-1", "", ""]),
     );
   });
+
+  it("includes explicit identifier in cache key", () => {
+    expect(
+      buildLiveSchemaCacheKey("infrastructure", "acct-1", "project", {
+        orgId: "default",
+        projectId: "cxe_sandbox",
+        identifier: "my_infra",
+      }),
+    ).toBe(JSON.stringify(["infrastructure", "project", "acct-1", "default", "cxe_sandbox", "my_infra"]));
+  });
 });
 
 describe("bundledSnapshotMatchesScope", () => {

--- a/tests/tools/harness-schema-tool.test.ts
+++ b/tests/tools/harness-schema-tool.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ToolResult } from "../../src/utils/response-formatter.js";
 import type { HarnessClient } from "../../src/client/harness-client.js";
 import { registerSchemaTool } from "../../src/tools/harness-schema.js";
-import { extractLiveSchema } from "../../src/tools/entity-schema/live.js";
+import { extractLiveSchema, YAML_SCHEMA_PLACEHOLDER_IDENTIFIER } from "../../src/tools/entity-schema/live.js";
 import { VALID_SCHEMAS } from "../../src/data/schemas/index.js";
 
 function makeMcpServer() {
@@ -144,6 +144,47 @@ describe("harness_schema live entities", () => {
           scope: "project",
           orgIdentifier: "my-org",
           projectIdentifier: "my-proj",
+        }),
+      }),
+    );
+  });
+
+  it("passes placeholder identifier for project-scoped service live fetch", async () => {
+    requestMock.mockClear();
+    await server.call("harness_schema", {
+      resource_type: "service",
+      scope: "project",
+      org_id: "default",
+      project_id: "cxe_sandbox",
+    });
+
+    expect(requestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          entityType: "Service",
+          scope: "project",
+          orgIdentifier: "default",
+          projectIdentifier: "cxe_sandbox",
+          identifier: YAML_SCHEMA_PLACEHOLDER_IDENTIFIER,
+        }),
+      }),
+    );
+  });
+
+  it("passes explicit identifier when provided", async () => {
+    requestMock.mockClear();
+    await server.call("harness_schema", {
+      resource_type: "infrastructure",
+      scope: "project",
+      org_id: "default",
+      project_id: "cxe_sandbox",
+      identifier: "my_k8s_infra",
+    });
+
+    expect(requestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          identifier: "my_k8s_infra",
         }),
       }),
     );

--- a/tests/tools/harness-schema-tool.test.ts
+++ b/tests/tools/harness-schema-tool.test.ts
@@ -90,7 +90,11 @@ describe("harness_schema live entities", () => {
       expect.objectContaining({
         method: "GET",
         path: "/ng/api/yaml-schema",
-        params: expect.objectContaining({ entityType: "Connectors", scope: "account" }),
+        params: expect.objectContaining({
+          entityType: "Connectors",
+          scope: "account",
+          identifier: YAML_SCHEMA_PLACEHOLDER_IDENTIFIER,
+        }),
       }),
     );
     expect(parsed.source).toBe("ng-yaml-schema");
@@ -144,6 +148,26 @@ describe("harness_schema live entities", () => {
           scope: "project",
           orgIdentifier: "my-org",
           projectIdentifier: "my-proj",
+        }),
+      }),
+    );
+  });
+
+  it("passes placeholder identifier for org-scoped environment live fetch", async () => {
+    requestMock.mockClear();
+    await server.call("harness_schema", {
+      resource_type: "environment",
+      scope: "org",
+      org_id: "my-org",
+    });
+
+    expect(requestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          entityType: "Environment",
+          scope: "org",
+          orgIdentifier: "my-org",
+          identifier: YAML_SCHEMA_PLACEHOLDER_IDENTIFIER,
         }),
       }),
     );

--- a/tests/tools/zod-input-schema-descriptions.test.ts
+++ b/tests/tools/zod-input-schema-descriptions.test.ts
@@ -157,6 +157,7 @@ describe("Zod 4 input schema descriptions (PR #398 regression)", () => {
       "scope",
       "org_id",
       "project_id",
+      "identifier",
       "path",
       "example",
       "example_search",


### PR DESCRIPTION
NG /yaml-schema rejects some project-scoped Service/Infrastructure requests without an identifier (scopedIdentifierConfig is null). Auto-send a dummy identifier for generic create-time schemas; allow optional identifier on harness_schema for entity-specific update flows.

## Description
<!-- What does this PR do? -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [ ] `pnpm test` passes
- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes
- [ ] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [ ] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
If this PR adds or changes Harness API coverage:
- [ ] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [ ] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [ ] `operationPolicy` on every new/changed endpoint
- [ ] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [ ] `identifierFields` and `scope` declared on new resources
- [ ] No `console.log()` in `src/` (stdio JSON-RPC safety)
