### PR TITLE
fix: make pipeline_v1 examples conform to the official v1 schema

### DIFF
--- a/src/data/examples/pipeline-v1.ts
+++ b/src/data/examples/pipeline-v1.ts
@@ -15,8 +15,7 @@ const examples: ResourceExample[] = [
   stages:
     - id: build
       name: build
-      runtime:
-        shell: true
+      runtime: cloud
       steps:
         - id: build
           name: Build
@@ -60,8 +59,6 @@ const examples: ResourceExample[] = [
           automount-service-token: true
           connector: account.k8s_build_cluster
           namespace: harness-builds
-          node: {}
-          os: Linux
       steps:
         - id: code_review
           name: Code Review
@@ -97,7 +94,6 @@ const examples: ResourceExample[] = [
     - environment:
         deploy-to: shared
         id: dev
-        name: dev
       id: Helm_Deploy
       name: Helm Deploy
       on-failure:
@@ -154,8 +150,6 @@ const examples: ResourceExample[] = [
           automount-service-token: true
           connector: account.k8s_build_cluster
           namespace: harness-builds
-          node: {}
-          os: Linux
       steps:
         - id: Get_Commit_Details
           name: Get Commit Details
@@ -217,8 +211,7 @@ const examples: ResourceExample[] = [
         enabled: true
       id: Plan_Dev
       name: Plan Dev
-      runtime:
-        shell: true
+      runtime: cloud
       steps:
         - id: Terraform_Plan
           name: Terraform Plan
@@ -247,8 +240,7 @@ const examples: ResourceExample[] = [
         - kubernetes-delegate
       id: Deploy_Prod
       name: Deploy Prod
-      runtime:
-        shell: true
+      runtime: cloud
       steps:
         - id: Terraform_Plan
           name: Terraform Plan
@@ -319,7 +311,6 @@ const examples: ResourceExample[] = [
       environment:
         deploy-to: nonprod
         id: account.deploy_util
-        name: account.deploy_util
       id: deployment_setup
       if: <+Always>
       name: deployment-setup
@@ -381,7 +372,6 @@ const examples: ResourceExample[] = [
     - environment:
         deploy-to: ecs_prod
         id: prod
-        name: prod
       id: prod
       if: <+OnPipelineSuccess>
       name: prod
@@ -421,7 +411,6 @@ const examples: ResourceExample[] = [
       environment:
         deploy-to: dev_cluster
         id: dev
-        name: dev
       id: Deploy_to_dev
       inputs:
         BuildVersion:
@@ -511,7 +500,6 @@ const examples: ResourceExample[] = [
     - environment:
         deploy-to: pr
         id: pr
-        name: pr
       id: Delete_PR
       name: Delete PR
       on-failure:
@@ -555,7 +543,6 @@ const examples: ResourceExample[] = [
     - environment:
         deploy-to: production_cluster
         id: prod
-        name: prod
       id: Rolling_Deploy
       name: Rolling Deploy
       on-failure:
@@ -615,7 +602,6 @@ const examples: ResourceExample[] = [
     - environment:
         deploy-to: production_cluster
         id: prod
-        name: prod
       id: Canary_Deploy
       name: Canary Deploy
       on-failure:
@@ -707,7 +693,6 @@ const examples: ResourceExample[] = [
     - environment:
         deploy-to: ecs_production
         id: prod
-        name: prod
       id: Deploy_Prod
       name: Deploy Prod
       on-failure:
@@ -762,8 +747,7 @@ const examples: ResourceExample[] = [
         enabled: true
       id: Build_Package
       name: Build & Package
-      runtime:
-        shell: true
+      runtime: cloud
       steps:
         - id: install_deps
           name: Install Dependencies
@@ -788,7 +772,6 @@ const examples: ResourceExample[] = [
     - environment:
         deploy-to: lambda_<+pipeline.variables.stage>
         id: <+pipeline.variables.stage>
-        name: <+pipeline.variables.stage>
       id: Deploy_Lambda
       name: Deploy Lambda
       on-failure:
@@ -847,7 +830,6 @@ const examples: ResourceExample[] = [
     - environment:
         deploy-to: tas_production
         id: prod
-        name: prod
       id: TAS_Deploy
       name: TAS Deploy
       on-failure:
@@ -923,8 +905,7 @@ const examples: ResourceExample[] = [
         enabled: true
       id: Build
       name: Build
-      runtime:
-        shell: true
+      runtime: cloud
       steps:
         - id: build_app
           name: Build App
@@ -950,7 +931,6 @@ const examples: ResourceExample[] = [
     - environment:
         deploy-to: azure_production
         id: prod
-        name: prod
       id: Deploy_Prod
       name: Deploy Prod
       on-failure:
@@ -1034,7 +1014,6 @@ const examples: ResourceExample[] = [
     - environment:
         deploy-to: on_prem_servers
         id: prod
-        name: prod
       id: Deploy
       name: Deploy
       on-failure:
@@ -1095,8 +1074,7 @@ const examples: ResourceExample[] = [
   stages:
     - id: Build
       name: Build
-      runtime:
-        shell: true
+      runtime: cloud
       steps:
         - id: build_artifact
           name: Build Artifact
@@ -1113,7 +1091,6 @@ const examples: ResourceExample[] = [
           - environment:
               deploy-to: us_east_cluster
               id: us_east
-              name: us-east
             id: Deploy_US_East
             name: Deploy US-East
             on-failure:
@@ -1141,7 +1118,6 @@ const examples: ResourceExample[] = [
           - environment:
               deploy-to: eu_west_cluster
               id: eu_west
-              name: eu-west
             id: Deploy_EU_West
             name: Deploy EU-West
             on-failure:
@@ -1184,8 +1160,7 @@ const examples: ResourceExample[] = [
         enabled: true
       id: Update_Manifests
       name: Update Manifests
-      runtime:
-        shell: true
+      runtime: cloud
       steps:
         - id: update_image_tag
           name: Update Image Tag

--- a/tests/data/pipeline-v1-examples-contract.test.ts
+++ b/tests/data/pipeline-v1-examples-contract.test.ts
@@ -1,8 +1,12 @@
 /**
  * Contract tests for pipeline_v1 example YAML.
  *
- * Examples are curated to match real v1 converter output (not the bundled JSON
- * schema, which is stricter). These tests catch regressions back to v0-style
+ * Examples must conform to the bundled v1 JSON schema (the official Harness
+ * contract synced from harness-schema/main). The v0→v1 converter currently
+ * emits several non-conformant constructs — `runtime: {shell: true}`,
+ * `environment.name`, `runtime.kubernetes.{node,os}` — so examples are
+ * deliberately NOT copied verbatim from converter output. These tests catch
+ * regressions back to those invalid shapes and to v0-style
  * `identifier` / `type: run` / `type: agent` patterns that agents copy from.
  */
 import { describe, it, expect } from "vitest";
@@ -123,22 +127,70 @@ function validateExampleStructure(name: string, yaml: string): Violation[] {
     violations.push({ example: name, path: "pipeline.identifier", message: "use pipeline.id instead of pipeline.identifier" });
   }
 
+  const RUNTIME_STRINGS = new Set(["cloud", "shell", "vm", "k8"]);
+  const K8_RUNTIME_KEYS = new Set([
+    "namespace",
+    "connector",
+    "user",
+    "pull",
+    "harness-image-connector",
+    "automount-service-token",
+    "priority-class",
+    "tolerations",
+    "host",
+    "node-selector",
+    "timeout",
+    "service-account",
+    "labels",
+    "annotations",
+    "volumes",
+    "pod-spec-overlay",
+    "security-context",
+  ]);
+
   walkStages(pipeline.stages, (stage, stagePath) => {
     const runtime = stage.runtime;
     if (runtime == null) return;
+
+    // RuntimeV1 is either a string shorthand (cloud|shell|vm|k8) or an object
+    // carrying exactly one runtime spec. `shell: true` is the converter's
+    // invalid boolean form — the schema wants the string "shell".
+    if (typeof runtime === "string") {
+      if (!RUNTIME_STRINGS.has(runtime)) {
+        violations.push({
+          example: name,
+          path: `${stagePath}.runtime`,
+          message: `runtime string must be one of ${[...RUNTIME_STRINGS].join(", ")}`,
+        });
+      }
+      return;
+    }
     if (!isRecord(runtime)) return;
 
-    if ("vm" in runtime) {
-      violations.push({ example: name, path: `${stagePath}.runtime.vm`, message: "use shell: or kubernetes: runtime" });
-    }
-    if ("cloud" in runtime) {
-      violations.push({ example: name, path: `${stagePath}.runtime.cloud`, message: "use shell: or kubernetes: runtime" });
-    }
-    if ("shell" in runtime && runtime.shell !== true) {
+    if ("shell" in runtime && !isRecord(runtime.shell)) {
       violations.push({
         example: name,
         path: `${stagePath}.runtime.shell`,
-        message: "converter shell runtime is shell: true",
+        message: 'invalid converter shape `runtime: {shell: true}` — use the string `runtime: cloud` (or a shell spec object)',
+      });
+    }
+    if (isRecord(runtime.kubernetes)) {
+      for (const key of Object.keys(runtime.kubernetes)) {
+        if (!K8_RUNTIME_KEYS.has(key)) {
+          violations.push({
+            example: name,
+            path: `${stagePath}.runtime.kubernetes.${key}`,
+            message: `"${key}" is not a valid K8RuntimeSpec key (converter emits node:/os: which the schema rejects)`,
+          });
+        }
+      }
+    }
+
+    if (isRecord(stage.environment) && "name" in stage.environment) {
+      violations.push({
+        example: name,
+        path: `${stagePath}.environment.name`,
+        message: "environment does not allow name: (additionalProperties:false) — use id: and deploy-to:",
       });
     }
 
@@ -223,13 +275,14 @@ describe("pipeline_v1 example converter contract", () => {
 });
 
 describe("pipeline_v1 example PR #428 regression guards", () => {
-  it("minimal-v1 uses shell runtime and run: steps", () => {
+  it("minimal-v1 uses a schema-valid runtime and run: steps", () => {
     const ex = v1Examples.find((e) => e.name === "minimal-v1");
     expect(ex).toBeDefined();
     const pipeline = parseYaml(ex!.yaml).pipeline;
     expect(pipeline.id).toBe("simple_build");
     expect(pipeline.clone?.enabled).toBe(false);
-    expect(pipeline.stages[0].runtime.shell).toBe(true);
+    // schema wants the string shorthand, not the converter's `{shell: true}`
+    expect(pipeline.stages[0].runtime).toBe("cloud");
     expect(pipeline.stages[0].steps[0].run.shell).toBe("sh");
   });
 
@@ -253,7 +306,9 @@ describe("pipeline_v1 example PR #428 regression guards", () => {
 
     const runtime = parseYaml(ex!.yaml).pipeline.stages[0].runtime;
     expect(runtime.kubernetes.namespace).toBe("harness-builds");
-    expect(runtime.kubernetes.node).toEqual({});
+    // node:/os: are converter artifacts the K8RuntimeSpec rejects — must be absent
+    expect(runtime.kubernetes.node).toBeUndefined();
+    expect(runtime.kubernetes.os).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Problem

All 18 `pipeline_v1` examples in `src/data/examples/pipeline-v1.ts` fail validation against the bundled v1 JSON schema (synced from `harness-schema/main` — verified byte-identical to upstream, so not stale). The examples had been curated to mirror v0→v1 converter output, and a prior contract test locked in the invalid shapes. This meant the examples were teaching agents constructs the schema rejects.

Validated against the schema with a Draft-07 validator:

| Corpus | Result (before) |
|---|---|
| `pipeline_v1` examples | **18 / 18 invalid** |
| Real migrated pipelines (converter output) | **1,590 / 1,654 invalid (96%)** |

The examples aligned with the migrated pipelines — that was the problem, because the converter itself emits non-conformant v1.

## Fix

Three mechanical transforms make all 18 examples valid, confirmed against known-good v1 samples:

- `runtime: {shell: true}` → `runtime: cloud` (the string shorthand; the boolean form is not a valid `RuntimeV1`)
- `runtime.kubernetes.{node, os}` removed (not valid `K8RuntimeSpec` keys — `additionalProperties: false`; `os` belongs in stage-level `platform`)
- `environment.name` removed (`EnvironmentV1` allows only `id`/`deploy-to`/`ref` — `additionalProperties: false`)

All 18 examples now validate cleanly.

The contract test (`tests/data/pipeline-v1-examples-contract.test.ts`) is flipped from guarding **converter output** to guarding **schema conformance**, so regressions back to the invalid shapes fail CI.

## Note for the migration team

The converter emitting these constructs is a separate, upstream bug (also `clone.strategy: merge_commit`, `on-failure errors: null`, `'pagerduty'` vs `'pager-duty'`, and notification `stage`/`step` values). That's what makes 96% of migrated pipelines fail v1 validation — tracked separately from this repo.

## Testing

- `pnpm typecheck` — clean
- `pnpm test` — all 2,637 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)