### PR TITLE
Align AI Evals LLM configuration metadata

### DIFF
--- a/src/registry/toolsets/ai-evals.ts
+++ b/src/registry/toolsets/ai-evals.ts
@@ -147,7 +147,9 @@ const triggerEvalRunSchema: BodySchema = {
       name: "run_inputs",
       type: "object",
       required: false,
-      description: "RunInputs overrides: { llm_connector_ref?, target_id?, dataset_id?, metric_set_id?, variables? }",
+      description:
+        "RunInputs overrides: { llm_config? (preferred structured provider config), target_id?, dataset_id?, metric_set_id?, variables? }. " +
+        "llm_connector_ref, model_id, and model remain accepted but are DEPRECATED; use llm_config instead.",
     },
     { name: "input_set_id", type: "string", required: false, description: "Saved input set id" },
     { name: "branch", type: "string", required: false, description: "Override git branch (e.g. run against a PR branch)" },
@@ -176,7 +178,7 @@ const createMetricSchema: BodySchema = {
       description:
         "Metric config — structure depends on type/kind. " +
         "Heuristic: { kind, threshold?, case_sensitive?, ... }. " +
-        "LLM: { rubric?, criteria?, judge_llm_connector_ref? (Harness LLM connector identifier) }. " +
+        "LLM: { rubric?, criteria?, judge_llm_config? (preferred structured provider config), judge_llm_connector_ref? (DEPRECATED) }. " +
         "Composite: { metrics: [{ metric_id, weight }], aggregation: 'average'|'weighted_average'|'min'|'max'|'all_pass' }. " +
         "Use harness_execute(resource_type='eval_metric', action='suggestions') to discover appropriate metrics for a target type.",
     },
@@ -191,6 +193,7 @@ const updateMetricSchema: BodySchema = {
   fields: [
     { name: "name", type: "string", required: false, description: "Name" },
     { name: "description", type: "string", required: false, description: "Description" },
+    { name: "dimension", type: "string", required: false, description: "Evaluation dimension: correctness | groundedness | safety | trajectory | performance" },
     { name: "config", type: "object", required: false, description: "Config" },
     { name: "default_threshold", type: "number", required: false, description: "Threshold 0-1" },
     { name: "tags", type: "array", required: false, description: "Tags", itemType: "string" },
@@ -204,7 +207,24 @@ const createMetricSetSchema: BodySchema = {
     { name: "name", type: "string", required: true, description: "Name" },
     { name: "description", type: "string", required: false, description: "Description" },
     { name: "tags", type: "array", required: false, description: "Tags", itemType: "string" },
-    { name: "judge_llm_connector_ref", type: "string", required: false, description: "Harness LLM connector identifier for judge model" },
+    {
+      name: "judge_llm_config",
+      type: "object",
+      required: false,
+      description: "Preferred structured LLM provider configuration for the judge model",
+    },
+    {
+      name: "judge_model_id",
+      type: "string",
+      required: false,
+      description: "DEPRECATED — use judge_llm_config. UUID of the registered judge model",
+    },
+    {
+      name: "judge_llm_connector_ref",
+      type: "string",
+      required: false,
+      description: "DEPRECATED — use judge_llm_config. Harness LLM connector identifier for judge model",
+    },
     {
       name: "entries",
       type: "array",
@@ -223,7 +243,24 @@ const updateMetricSetSchema: BodySchema = {
     { name: "name", type: "string", required: false, description: "Name" },
     { name: "description", type: "string", required: false, description: "Description" },
     { name: "tags", type: "array", required: false, description: "Tags", itemType: "string" },
-    { name: "judge_llm_connector_ref", type: "string", required: false, description: "Harness LLM connector identifier for judge model" },
+    {
+      name: "judge_llm_config",
+      type: "object",
+      required: false,
+      description: "Preferred structured LLM provider configuration for the judge model",
+    },
+    {
+      name: "judge_model_id",
+      type: "string",
+      required: false,
+      description: "DEPRECATED — use judge_llm_config. UUID of the registered judge model",
+    },
+    {
+      name: "judge_llm_connector_ref",
+      type: "string",
+      required: false,
+      description: "DEPRECATED — use judge_llm_config. Harness LLM connector identifier for judge model",
+    },
   ],
 };
 
@@ -320,7 +357,9 @@ const triggerSuiteRunSchema: BodySchema = {
       name: "run_inputs",
       type: "object",
       required: false,
-      description: "RunInputs overrides: { llm_connector_ref?, target_id?, dataset_id?, metric_set_id?, variables? }",
+      description:
+        "RunInputs overrides: { llm_config? (preferred structured provider config), target_id?, dataset_id?, metric_set_id?, variables? }. " +
+        "llm_connector_ref, model_id, and model remain accepted but are DEPRECATED; use llm_config instead.",
     },
     { name: "input_set_id", type: "string", required: false, description: "Saved input set id" },
     {
@@ -479,7 +518,24 @@ const generateDatasetItemsSchema: BodySchema = {
       description: "Generation strategy: use_case | rephrase | adversarial | complexity_ladder",
     },
     { name: "count", type: "number", required: true, description: "Number of items to generate (1-200)" },
-    { name: "llm_connector_ref", type: "string", required: true, description: "Harness LLM connector identifier for the generation model" },
+    {
+      name: "llm_config",
+      type: "object",
+      required: false,
+      description: "Preferred structured LLM provider configuration for dataset generation",
+    },
+    {
+      name: "model_id",
+      type: "string",
+      required: false,
+      description: "DEPRECATED — use llm_config. UUID of the registered AI model",
+    },
+    {
+      name: "llm_connector_ref",
+      type: "string",
+      required: false,
+      description: "DEPRECATED — use llm_config. Harness LLM connector identifier for the generation model",
+    },
     {
       name: "description",
       type: "string",
@@ -540,7 +596,24 @@ const evaluateTraceSchema: BodySchema = {
         "At least one of metric_set_id or metrics is required.",
       itemType: "object",
     },
-    { name: "judge_llm_connector_ref", type: "string", required: false, description: "Harness LLM connector identifier for judge model" },
+    {
+      name: "judge_llm_config",
+      type: "object",
+      required: false,
+      description: "Preferred structured LLM provider configuration for the judge model",
+    },
+    {
+      name: "judge_model_id",
+      type: "string",
+      required: false,
+      description: "DEPRECATED — use judge_llm_config. UUID of the registered judge model",
+    },
+    {
+      name: "judge_llm_connector_ref",
+      type: "string",
+      required: false,
+      description: "DEPRECATED — use judge_llm_config. Harness LLM connector identifier for judge model",
+    },
     {
       name: "options",
       type: "object",
@@ -1080,7 +1153,8 @@ export const aiEvalsToolset: ToolsetDefinition = {
       diagnosticHint:
         "Before creating a metric set, list available metrics with harness_list(resource_type='eval_metric'). " +
         "Use harness_execute(resource_type='eval_metric', action='suggestions') to discover metrics appropriate for a target type. " +
-        "If using LLM metrics (llm-as-judge), set judge_llm_connector_ref to a Harness LLM connector identifier.",
+        "If using LLM metrics (llm-as-judge), set judge_llm_config to a structured provider configuration. " +
+        "judge_llm_connector_ref remains accepted but is DEPRECATED.",
       relatedResources: [
         { resourceType: "eval_metric_set_entry", relationship: "contains", description: "Metric membership entries with thresholds" },
         { resourceType: "eval_metric", relationship: "uses", description: "Entries reference metrics by metric_id" },

--- a/tests/registry/ai-evals.test.ts
+++ b/tests/registry/ai-evals.test.ts
@@ -193,14 +193,20 @@ describe("AI Evals online_eval resource", () => {
     expect(res.diagnosticHint).toContain("trace");
   });
 
-  it("evaluate schema uses metric_set_id and judge_llm_connector_ref, not deprecated metric_ids", () => {
+  it("evaluate schema prefers judge_llm_config and retains its deprecated connector alias", () => {
     const res = findResource("online_eval");
     const action = res.executeActions!.evaluate;
-    const fields = fieldNames(action.bodySchema!.fields);
+    const fields = action.bodySchema!.fields;
+    const fieldNames = fields.map((field) => field.name);
 
-    expect(fields).toContain("metric_set_id");
-    expect(fields).toContain("judge_llm_connector_ref");
-    expect(fields).not.toContain("metric_ids");
+    expect(fieldNames).toContain("metric_set_id");
+    expect(fieldNames).toContain("judge_llm_config");
+    expect(fieldNames).toContain("judge_model_id");
+    expect(fieldNames).toContain("judge_llm_connector_ref");
+    expect(fieldNames).not.toContain("metric_ids");
+    expect(fields.find((field) => field.name === "judge_llm_config")).toMatchObject({ type: "object" });
+    expect(fields.find((field) => field.name === "judge_model_id")?.description).toContain("DEPRECATED");
+    expect(fields.find((field) => field.name === "judge_llm_connector_ref")?.description).toContain("DEPRECATED");
   });
 
   it("evaluate metadata no longer references metric_ids", () => {
@@ -353,26 +359,25 @@ describe("AI Evals eval_target test action", () => {
 
 // ─── LLM connector ref in body schemas ─────────────────────────────────────
 
-describe("AI Evals LLM connector ref migration", () => {
-  it("metric set create body schema uses judge_llm_connector_ref not judge_model_id", () => {
+describe("AI Evals structured LLM config migration", () => {
+  it("metric set schemas prefer judge_llm_config and retain connector aliases as deprecated", () => {
     const res = findResource("eval_metric_set");
-    const createOp = res.operations.create!;
-    const fields = createOp.bodySchema!.fields;
-    const hasConnectorRef = fields.some((f) => f.name === "judge_llm_connector_ref");
-    const hasModelId = fields.some((f) => f.name === "judge_model_id");
-    expect(hasConnectorRef).toBe(true);
-    expect(hasModelId).toBe(false);
+    for (const operation of [res.operations.create!, res.operations.update!]) {
+      const fields = operation.bodySchema!.fields;
+      expect(fields.find((field) => field.name === "judge_llm_config")).toMatchObject({ type: "object" });
+      expect(fields.find((field) => field.name === "judge_model_id")?.description).toContain("DEPRECATED");
+      expect(fields.find((field) => field.name === "judge_llm_connector_ref")?.description).toContain("DEPRECATED");
+    }
   });
 
-  it("dataset generate body schema uses llm_connector_ref not model_id", () => {
+  it("dataset generation prefers llm_config and retains connector alias as deprecated", () => {
     const res = findResource("eval_dataset");
     const action = res.executeActions?.generate;
     expect(action).toBeDefined();
     const fields = action!.bodySchema!.fields;
-    const hasConnectorRef = fields.some((f) => f.name === "llm_connector_ref");
-    const hasModelId = fields.some((f) => f.name === "model_id");
-    expect(hasConnectorRef).toBe(true);
-    expect(hasModelId).toBe(false);
+    expect(fields.find((field) => field.name === "llm_config")).toMatchObject({ type: "object" });
+    expect(fields.find((field) => field.name === "model_id")?.description).toContain("DEPRECATED");
+    expect(fields.find((field) => field.name === "llm_connector_ref")?.description).toContain("DEPRECATED");
   });
 });
 
@@ -389,6 +394,35 @@ describe("AI Evals control-plane API drift", () => {
       type: "string",
       required: true,
     });
+  });
+
+  it("metric update body schema exposes optional dimension", () => {
+    const res = findResource("eval_metric");
+    const dimensionField = res.operations.update!.bodySchema!.fields.find((field) => field.name === "dimension");
+
+    expect(dimensionField).toMatchObject({
+      name: "dimension",
+      type: "string",
+      required: false,
+    });
+  });
+
+  it("metric update dispatch preserves dimension in the API body", async () => {
+    const registry = new Registry(makeConfig());
+    const mockRequest = vi.fn().mockResolvedValue({ id: "metric-1" });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "eval_metric", "update", {
+      org_id: "myorg",
+      project_id: "myproj",
+      metric_id: "metric-1",
+      body: { dimension: "safety" },
+    });
+
+    const call = mockRequest.mock.calls[0][0];
+    expect(call.method).toBe("PATCH");
+    expect(call.path).toBe("/gateway/ai-evals/api/v1/orgs/myorg/projects/myproj/metrics/metric-1");
+    expect(call.body).toEqual({ dimension: "safety" });
   });
 
   it("metric create dispatch preserves dimension in the API body", async () => {


### PR DESCRIPTION
## Summary
- Promote structured LLM provider configuration fields in AI Evals discovery metadata.
- Retain legacy model and connector fields with explicit deprecation guidance.
- Expose and test optional metric dimensions on updates.

## Test plan
- [x] `pnpm build`
- [x] `pnpm test`
- [x] `pnpm standards:check`
- [x] `pnpm typecheck`
- [x] `pnpm docs:check`
- [x] All CI smoke-test configurations
- [x] npm consumer security checks

Made with [Cursor](https://cursor.com)