### PR TITLE
Document template paramsSchema for harness_describe

### DIFF
--- a/src/registry/toolsets/templates.ts
+++ b/src/registry/toolsets/templates.ts
@@ -7,6 +7,12 @@ import { SCOPE_BEHAVIOR_DOC, templateV1BasePathFromScope } from "../scope-utils.
 const TEMPLATE_V0_GET_PARAMS: ParamsSchema = {
   fields: [
     {
+      name: "global",
+      required: false,
+      description:
+        "When true, fetch from the global templates account. Pass via params.",
+    },
+    {
       name: "version_label",
       required: false,
       description: "Template version to fetch. Pass via params.",
@@ -15,6 +21,21 @@ const TEMPLATE_V0_GET_PARAMS: ParamsSchema = {
       name: "branch",
       required: false,
       description: "Git branch for remote/git-backed templates. Pass via params.",
+    },
+    {
+      name: "store_type",
+      required: false,
+      description: "Storage type (e.g. INLINE, REMOTE). Pass via params.",
+    },
+    {
+      name: "connector_ref",
+      required: false,
+      description: "Git connector ref for remote templates. Pass via params.",
+    },
+    {
+      name: "repo_name",
+      required: false,
+      description: "Git repo name for remote templates. Pass via params.",
     },
   ],
 };
@@ -26,6 +47,57 @@ const TEMPLATE_V0_UPDATE_PARAMS: ParamsSchema = {
       required: true,
       description: "Template version label to update. Pass via params.",
     },
+    {
+      name: "store_type",
+      required: false,
+      description:
+        "Storage type. Use REMOTE for git-backed templates. Pass via params.",
+    },
+    {
+      name: "branch",
+      required: false,
+      description:
+        "Git branch for remote updates. Required when store_type=REMOTE. Pass via params.",
+    },
+    {
+      name: "connector_ref",
+      required: false,
+      description:
+        "Git connector ref for external remote templates. Pass via params.",
+    },
+    {
+      name: "repo_name",
+      required: false,
+      description: "Git repo name for remote templates. Pass via params.",
+    },
+    {
+      name: "file_path",
+      required: false,
+      description: "Path to the template file in the repo. Pass via params.",
+    },
+    {
+      name: "is_harness_code_repo",
+      required: false,
+      description:
+        "When true, use Harness Code (no connector_ref). Pass via params.",
+    },
+    {
+      name: "last_object_id",
+      required: false,
+      description:
+        "Git objectId from GET response gitDetails — required for remote updates. Pass via params.",
+    },
+    {
+      name: "last_commit_id",
+      required: false,
+      description:
+        "Git commitId from GET response gitDetails — required for remote updates. Pass via params.",
+    },
+    {
+      name: "comments",
+      required: false,
+      description: "Optional update comment. Pass via params.",
+    },
   ],
 };
 
@@ -36,6 +108,16 @@ const TEMPLATE_V0_DELETE_PARAMS: ParamsSchema = {
       required: false,
       description:
         "Version to delete. Omit to delete all versions (may require force_delete). Pass via params.",
+    },
+    {
+      name: "force_delete",
+      required: false,
+      description: "Force delete when removing all versions or in-use templates. Pass via params.",
+    },
+    {
+      name: "comments",
+      required: false,
+      description: "Optional delete comment. Pass via params.",
     },
   ],
 };
@@ -375,7 +457,8 @@ export const templatesToolset: ToolsetDefinition = {
           responseExtractor: ngExtract,
           paramsSchema: TEMPLATE_V0_GET_PARAMS,
           description:
-            "Get template details and YAML. Use global=true for global templates account. For remote/git-backed templates, pass branch to specify which branch to read from. The response gitDetails.objectId and gitDetails.commitId are needed as last_object_id/last_commit_id when updating a remote template.",
+            "Get template details and YAML. Use global=true for global templates account. For remote/git-backed templates, pass branch to specify which branch to read from. The response gitDetails.objectId and gitDetails.commitId are needed as last_object_id/last_commit_id when updating a remote template. " +
+            "Pass global, version_label, and git fields via params (see harness_describe).",
         },
         create: {
           method: "POST",

--- a/src/registry/toolsets/templates.ts
+++ b/src/registry/toolsets/templates.ts
@@ -1,7 +1,71 @@
 import YAML from "yaml";
-import type { BodySchema, PathBuilderConfig, ToolsetDefinition } from "../types.js";
+import type { BodySchema, ParamsSchema, PathBuilderConfig, ToolsetDefinition } from "../types.js";
 import { ngExtract, pageExtract, passthrough, v1ListExtract } from "../extractors.js";
 import { SCOPE_BEHAVIOR_DOC, templateV1BasePathFromScope } from "../scope-utils.js";
+
+/** Pass via harness_get/update/delete `params` — not top-level tool fields. */
+const TEMPLATE_V0_GET_PARAMS: ParamsSchema = {
+  fields: [
+    {
+      name: "version_label",
+      required: false,
+      description: "Template version to fetch. Pass via params.",
+    },
+    {
+      name: "branch",
+      required: false,
+      description: "Git branch for remote/git-backed templates. Pass via params.",
+    },
+  ],
+};
+
+const TEMPLATE_V0_UPDATE_PARAMS: ParamsSchema = {
+  fields: [
+    {
+      name: "version_label",
+      required: true,
+      description: "Template version label to update. Pass via params.",
+    },
+  ],
+};
+
+const TEMPLATE_V0_DELETE_PARAMS: ParamsSchema = {
+  fields: [
+    {
+      name: "version_label",
+      required: false,
+      description:
+        "Version to delete. Omit to delete all versions (may require force_delete). Pass via params.",
+    },
+  ],
+};
+
+const TEMPLATE_V1_GET_PARAMS: ParamsSchema = {
+  fields: [
+    {
+      name: "global",
+      required: false,
+      description:
+        "When true, fetch a built-in global catalog template (routes to /v1/templates). Pass via params.",
+    },
+    {
+      name: "version_label",
+      required: false,
+      description:
+        "Template version to fetch. Omit for stable/default; set to pin a specific version. Pass via params.",
+    },
+  ],
+};
+
+const TEMPLATE_V1_VERSION_PARAMS: ParamsSchema = {
+  fields: [
+    {
+      name: "version_label",
+      required: true,
+      description: "Template version label to update or delete. Pass via params.",
+    },
+  ],
+};
 
 function getTemplateYamlFromInput(input: Record<string, unknown>): string {
   const b = (input.body as Record<string, unknown>) ?? {};
@@ -309,6 +373,7 @@ export const templatesToolset: ToolsetDefinition = {
             repo_name: "repoName",
           },
           responseExtractor: ngExtract,
+          paramsSchema: TEMPLATE_V0_GET_PARAMS,
           description:
             "Get template details and YAML. Use global=true for global templates account. For remote/git-backed templates, pass branch to specify which branch to read from. The response gitDetails.objectId and gitDetails.commitId are needed as last_object_id/last_commit_id when updating a remote template.",
         },
@@ -362,6 +427,7 @@ export const templatesToolset: ToolsetDefinition = {
           bodyBuilder: (input) => buildTemplateYamlBody(input),
           bodySchema: templateV0UpdateSchema,
           responseExtractor: ngExtract,
+          paramsSchema: TEMPLATE_V0_UPDATE_PARAMS,
           description:
             "Update a v0 template version via NG API. Requires template_id and version_label. Body is full v0 template YAML. For remote/git-backed templates, pass store_type='REMOTE' with git details (branch, connector_ref, repo_name, file_path) and last_object_id/last_commit_id from the GET response's gitDetails (objectId/commitId) — without branch the API fails with 'No branch provided for modifying the file'. For Harness Code: add is_harness_code_repo=true (no connector_ref needed).",
         },
@@ -375,6 +441,7 @@ export const templatesToolset: ToolsetDefinition = {
             force_delete: "forceDelete",
           },
           responseExtractor: ngExtract,
+          paramsSchema: TEMPLATE_V0_DELETE_PARAMS,
           description:
             "Delete a template. Provide version_label to delete one version; omit to delete all versions (may require force_delete).",
         },
@@ -430,10 +497,12 @@ export const templatesToolset: ToolsetDefinition = {
             global: "global_template",
           },
           responseExtractor: passthrough,
+          paramsSchema: TEMPLATE_V1_GET_PARAMS,
           description:
             "Get unified v1 template YAML including its full inputs schema. " +
             "Use global=true to fetch a built-in global template by identifier — the response `yaml` field contains the `inputs:` block listing all valid `with:` params. " +
-            "Omit version_label for stable; pass version_label for a specific version.",
+            "Omit version_label for stable; pass version_label for a specific version. " +
+            "Pass global and version_label via params (see harness_describe).",
         },
         create: {
           method: "POST",
@@ -454,8 +523,9 @@ export const templatesToolset: ToolsetDefinition = {
           bodyBuilder: buildV1TemplateBody,
           bodySchema: templateV1UpdateSchema,
           responseExtractor: passthrough,
+          paramsSchema: TEMPLATE_V1_VERSION_PARAMS,
           description:
-            "Update a unified v1 template version via v1 REST API. Requires template_id and version_label. Body is JSON with template_yaml.",
+            "Update a unified v1 template version via v1 REST API. Requires template_id and version_label (via params). Body is JSON with template_yaml.",
         },
         delete: {
           method: "DELETE",
@@ -467,7 +537,9 @@ export const templatesToolset: ToolsetDefinition = {
             force_delete: "force_delete",
           },
           responseExtractor: passthrough,
-          description: "Delete a v1 template version. Requires template_id and version_label.",
+          paramsSchema: TEMPLATE_V1_VERSION_PARAMS,
+          description:
+            "Delete a v1 template version. Requires template_id and version_label (via params).",
         },
       },
     },

--- a/src/tools/harness-update.ts
+++ b/src/tools/harness-update.ts
@@ -110,12 +110,12 @@ export function registerUpdateTool(server: McpServer, registry: Registry, client
           );
           return errorResult(describeElicitationFailure(elicit));
         }
+        // Lift version_label from body when callers put it there instead of params.
+        // Do not invent a default — template update requires an explicit version_label
+        // (see paramsSchema / harness_describe); a silent "v1" default masked omissions.
         const versionLabel = asString(input.version_label);
-        if (versionLabel) { /* already set via params */ }
-        else if (isRecord(args.body) && "version_label" in args.body) {
+        if (!versionLabel && isRecord(args.body) && "version_label" in args.body) {
           input.version_label = args.body.version_label;
-        } else if (args.resource_type === "template") {
-          input.version_label = "v1";
         }
 
         const result = await registry.dispatch(client, args.resource_type, "update", input, { tool: "harness_update", confirmation: elicit.method, resource_id: resolvedResourceId });

--- a/tests/registry/templates.test.ts
+++ b/tests/registry/templates.test.ts
@@ -277,13 +277,82 @@ describe("template paramsSchema for harness_describe", () => {
     }
   });
 
-  it("template (v0) get/update/delete expose version_label via params", () => {
-    const def = registry.getResource("template");
-    expect(def.operations.get!.paramsSchema!.fields.some((f) => f.name === "version_label")).toBe(true);
-    expect(def.operations.update!.paramsSchema!.fields.find((f) => f.name === "version_label")?.required).toBe(
-      true,
+  it("template (v0) get documents global, version_label, and git fields via params", () => {
+    const get = registry.getResource("template").operations.get!;
+    const names = get.paramsSchema!.fields.map((f) => f.name);
+    expect(names).toEqual(
+      expect.arrayContaining(["global", "version_label", "branch", "store_type", "connector_ref", "repo_name"]),
     );
-    expect(def.operations.delete!.paramsSchema!.fields.some((f) => f.name === "version_label")).toBe(true);
+    expect(get.paramsSchema!.fields.find((f) => f.name === "global")?.required).toBe(false);
+  });
+
+  it("template (v0) update documents version_label and git-backed params", () => {
+    const update = registry.getResource("template").operations.update!;
+    const names = update.paramsSchema!.fields.map((f) => f.name);
+    expect(update.paramsSchema!.fields.find((f) => f.name === "version_label")?.required).toBe(true);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "version_label",
+        "store_type",
+        "branch",
+        "connector_ref",
+        "repo_name",
+        "file_path",
+        "is_harness_code_repo",
+        "last_object_id",
+        "last_commit_id",
+        "comments",
+      ]),
+    );
+  });
+
+  it("template (v0) delete documents version_label, force_delete, and comments", () => {
+    const del = registry.getResource("template").operations.delete!;
+    const names = del.paramsSchema!.fields.map((f) => f.name);
+    expect(names).toEqual(expect.arrayContaining(["version_label", "force_delete", "comments"]));
+  });
+});
+
+describe("template paramsSchema dispatch validation", () => {
+  const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "templates" }));
+  const client = makeClient(vi.fn());
+
+  it("rejects template_v1 update without version_label", async () => {
+    await expect(
+      registry.dispatch(client, "template_v1", "update", {
+        template_id: "my_tpl",
+        org_id: "default",
+        project_id: "proj",
+        body: {
+          template_yaml:
+            "version: 1\ntemplate:\n  identifier: my_tpl\n  name: My\n  step:\n    run:\n      script: echo hi\n",
+        },
+      }),
+    ).rejects.toThrow(/Missing required param\(s\) for template_v1\.update: version_label/);
+  });
+
+  it("rejects template_v1 delete without version_label", async () => {
+    await expect(
+      registry.dispatch(client, "template_v1", "delete", {
+        template_id: "my_tpl",
+        org_id: "default",
+        project_id: "proj",
+      }),
+    ).rejects.toThrow(/Missing required param\(s\) for template_v1\.delete: version_label/);
+  });
+
+  it("rejects template (v0) update without version_label", async () => {
+    await expect(
+      registry.dispatch(client, "template", "update", {
+        template_id: "my_tpl",
+        org_id: "default",
+        project_id: "proj",
+        body: {
+          template_yaml:
+            "template:\n  identifier: my_tpl\n  name: My\n  versionLabel: v2\n  type: Step\n  spec: {}\n",
+        },
+      }),
+    ).rejects.toThrow(/Missing required param\(s\) for template\.update: version_label/);
   });
 });
 

--- a/tests/registry/templates.test.ts
+++ b/tests/registry/templates.test.ts
@@ -258,6 +258,35 @@ describe("template_v1 list filter metadata", () => {
   });
 });
 
+describe("template paramsSchema for harness_describe", () => {
+  const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "templates" }));
+
+  it("template_v1 get documents global and version_label via params", () => {
+    const get = registry.getResource("template_v1").operations.get!;
+    const names = get.paramsSchema!.fields.map((f) => f.name);
+    expect(names).toEqual(expect.arrayContaining(["global", "version_label"]));
+    expect(get.paramsSchema!.fields.find((f) => f.name === "version_label")?.required).toBe(false);
+    expect(get.paramsSchema!.fields.find((f) => f.name === "global")?.required).toBe(false);
+  });
+
+  it("template_v1 update and delete require version_label via params", () => {
+    const def = registry.getResource("template_v1");
+    for (const op of ["update", "delete"] as const) {
+      const field = def.operations[op]!.paramsSchema!.fields.find((f) => f.name === "version_label");
+      expect(field?.required).toBe(true);
+    }
+  });
+
+  it("template (v0) get/update/delete expose version_label via params", () => {
+    const def = registry.getResource("template");
+    expect(def.operations.get!.paramsSchema!.fields.some((f) => f.name === "version_label")).toBe(true);
+    expect(def.operations.update!.paramsSchema!.fields.find((f) => f.name === "version_label")?.required).toBe(
+      true,
+    );
+    expect(def.operations.delete!.paramsSchema!.fields.some((f) => f.name === "version_label")).toBe(true);
+  });
+});
+
 describe("template_v1 create body builder", () => {
   it("preserves is_stable=false instead of dropping it via truthiness", async () => {
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "templates" }));


### PR DESCRIPTION
## Summary
- Add `paramsSchema` on `template` / `template_v1` get/update/delete so `harness_describe` documents `global`, `version_label`, and git-backed fields under `params`.
- Reject missing required `version_label` at dispatch with a clear describe-oriented error.
- Stop `harness_update` silently defaulting template `version_label` to `"v1"`.
## Test plan
- [x] `vitest run tests/registry/templates.test.ts`
- [x] `tsc --noEmit`
- [ ] Confirm `harness_describe(resource_type=template_v1)` shows `global` / `version_label` under params
- [ ] Confirm `harness_update` on `template` without `version_label` fails clearly (no silent `v1`)