### PR TITLE
feat:Harness MCP integration of AIT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,10 +97,11 @@ HARNESS_MCP_LOG_FILE=
 # by default): ansible. Use +name to add alongside defaults, or list
 # explicitly for an allowlist. Use -name to remove defaults. The legacy name
 # agent-pipelines is accepted as agents.
-# Available: pipelines,agents,services,environments,infrastructure,connectors,secrets,logs,audit,delegates,repositories,registries,templates,dashboards,idp,pull-requests,feature-flags,gitops,chaos,ccm,sei,scs,sto,dbops,access_control,settings,platform,governance,freeze,overrides,ai-evals,iacm,ansible
+# Available: pipelines,agents,services,environments,infrastructure,connectors,secrets,logs,audit,delegates,repositories,registries,templates,dashboards,idp,pull-requests,feature-flags,gitops,chaos,ccm,sei,scs,sto,dbops,access_control,settings,platform,governance,freeze,overrides,ai-evals,iacm,ansible,ait
 # Project-scoped IaCM/Ansible calls require HARNESS_ORG and HARNESS_PROJECT,
 # or explicit org_id/project_id per call. Opt-in toolsets:
 #   ansible — Ansible inventories, playbooks, hosts, and activity history
+#   ait     — AI Test Automation: list apps, tests, environments; create and run tests
 HARNESS_TOOLSETS=
 
 # Audit sinks — all optional

--- a/README.md
+++ b/README.md
@@ -1756,7 +1756,7 @@ Security exemption execute workflow:
 
 ## Toolset Filtering
 
-By default, 38 of 39 toolsets are enabled. One toolset is opt-in and excluded from the defaults:
+By default, 38 of 40 toolsets are enabled. One toolset is opt-in and excluded from the defaults:
 
 - **`ansible`** — Harness Ansible (inventories, playbooks, hosts, activity). Opt-in because it is project-scoped and adds concepts many users do not need.
 

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -51,6 +51,7 @@ import { semanticLayerToolset } from "./toolsets/semantic-layer.js";
 import { ansibleToolset } from "./toolsets/ansible.js";
 import { incidentsToolset } from "./toolsets/incidents.js";
 import { deploysToolset } from "./toolsets/deploys.js";
+import { aitToolset } from "./toolsets/ait.js";
 
 const log = createLogger("registry");
 
@@ -166,6 +167,7 @@ const ALL_TOOLSETS: ToolsetDefinition[] = [
   ansibleToolset,
   incidentsToolset,
   deploysToolset,
+  aitToolset,
 ];
 
 /** All available toolset names — used by docs generation to discover opt-in toolsets. */

--- a/src/registry/toolsets/ait.ts
+++ b/src/registry/toolsets/ait.ts
@@ -4,19 +4,20 @@ import type { ToolsetDefinition } from "../types.js";
  * AIT (AI Test Automation) toolset.
  * Base path: /ait/api/v1/...
  * Hosted on the Harness platform and authenticated via standard Harness PAT.
+ *
+ * Resources:
+ *   ait_app              — list applications
+ *   ait_test_environment — list test environments for an app
+ *   ait_test             — list, create (AI), and execute (run) tests
  */
 
-// ─── Reusable response extractors for AIT APIs ─────────────────────────────
-// AIT APIs follow these response patterns:
-//   1. TableResponse<T> — paginated lists: { data: T[], totalPages, totalItems, itemsPerPage, currentPage }
-//   2. Single object   — direct entity (e.g. TestNew, TestNewExtended)
-//   3. Simple values   — string, string[], { success: boolean }
-//
-// Each new endpoint picks the appropriate extractor or uses passthrough for
-// single-object / simple-value responses.
+// ─── Response extractors ────────────────────────────────────────────────────
 
-/** Extract applications list (simple array pattern): normalize camelCase fields to snake_case items */
-const aitAppsForOrgExtract = (raw: unknown): unknown => {
+/** Extract applications list: normalize camelCase fields to snake_case */
+const aitAppListExtract = (raw: unknown): unknown => {
+  if (!Array.isArray(raw)) {
+    throw new Error("ait_app: expected array response from API, got " + typeof raw);
+  }
   const arr = raw as Array<{
     appId?: string;
     appName?: string;
@@ -42,8 +43,11 @@ const aitAppsForOrgExtract = (raw: unknown): unknown => {
   return { items, total: items.length };
 };
 
-/** Extract test environments list (simple array pattern): normalize camelCase fields to snake_case items */
-const aitTestEnvironmentsExtract = (raw: unknown): unknown => {
+/** Extract test environments list: normalize camelCase fields to snake_case */
+const aitTestEnvironmentListExtract = (raw: unknown): unknown => {
+  if (!Array.isArray(raw)) {
+    throw new Error("ait_test_environment: expected array response from API, got " + typeof raw);
+  }
   const arr = raw as Array<{
     id?: string;
     appId?: string;
@@ -60,14 +64,16 @@ const aitTestEnvironmentsExtract = (raw: unknown): unknown => {
     test: env.test,
     monitor: env.monitor,
     pre_release: env.preRelease,
-
     base_url: env.baseUrl ?? null,
   }));
   return { items, total: items.length };
 };
 
-/** Extract paginated TableResponse for test list: picks key fields per TestEntry item */
-const aitTestsListExtract = (raw: unknown): unknown => {
+/** Extract paginated TableResponse for test list */
+const aitTestListExtract = (raw: unknown): unknown => {
+  if (raw == null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("ait_test: expected paginated object response from API, got " + (Array.isArray(raw) ? "array" : typeof raw));
+  }
   const r = raw as {
     data?: Array<Record<string, unknown>>;
     totalPages?: number;
@@ -75,6 +81,9 @@ const aitTestsListExtract = (raw: unknown): unknown => {
     itemsPerPage?: number;
     currentPage?: number;
   };
+  if (r.data !== undefined && !Array.isArray(r.data)) {
+    throw new Error("ait_test: expected data field to be an array, got " + typeof r.data);
+  }
   const items = (r.data ?? []).map((t) => {
     const runDetailsList = t.lastKRunDetailsList as Array<Record<string, unknown>> | null | undefined;
     const latestRun = runDetailsList?.[0];
@@ -98,21 +107,20 @@ const aitTestsListExtract = (raw: unknown): unknown => {
   };
 };
 
-/** Extract imported copilot test response — normalizes camelCase testId/testVersionId to snake_case */
-const aitImportedCopilotTestExtract = (raw: unknown): unknown => {
+/** Extract create-test-using-AI response */
+const aitTestCreateExtract = (raw: unknown): unknown => {
   const r = raw as {
     testId: number;
     testVersionId: number;
   };
-
   return {
     test_id: r.testId,
     test_version_id: r.testVersionId,
   };
 };
 
-/** Extract run test response — picks key fields from the snake_case TestRunNew entity */
-const aitRunTestExtract = (raw: unknown): unknown => {
+/** Extract run-test response */
+const aitTestRunExtract = (raw: unknown): unknown => {
   const r = raw as {
     id: number;
     app_id: string;
@@ -124,19 +132,14 @@ const aitRunTestExtract = (raw: unknown): unknown => {
     start_epoch: number | null;
     error: string | null;
   };
-
-  const aitBaseUrl = (process.env.HARNESS_BASE_URL ?? "https://app.harness.io").replace(/\/$/, "");
-  const testRunUrl = `${aitBaseUrl}/ait/${r.app_id}/test/${r.test_id}/version/${r.test_version_id}/test-run/${r.id}?tab=overview`;
-
   return {
-    test_run_url: testRunUrl,
+    id: r.id,
     app_id: r.app_id,
     test_id: r.test_id,
     test_version_id: r.test_version_id,
     test_environment_id: r.test_environment_id,
     status: r.status,
     error: r.error,
-    _note: "Always display the test_run_url to the user.",
   };
 };
 
@@ -146,15 +149,17 @@ export const aitToolset: ToolsetDefinition = {
   name: "ait",
   displayName: "AI Test Automation (AIT)",
   description:
-    "Harness AI Test Automation (AIT) — list and manage automated tests for applications.",
+    "Harness AI Test Automation (AIT) — list and manage automated tests for applications. " +
+    "TERMINOLOGY MAPPING (AIT ↔ Harness): AIT \"org\" = Harness \"account\"; AIT \"app\" = Harness \"project\".",
   optIn: true,
   resources: [
+    // ── ait_app ─────────────────────────────────────────────────────────────
     {
-      resourceType: "ait_apps_for_org",
-      displayName: "AIT Apps for Org",
+      resourceType: "ait_app",
+      displayName: "AIT Application",
       description:
-        "List all applications for the current organization. Returns app IDs, names, and metadata. " +
-        "Use this to discover app_id values needed for other AIT operations.",
+        "An application (also called 'project' in Harness) in the AIT module. List applications to discover app_id values " +
+        "needed for other AIT operations (tests, environments).",
       toolset: "ait",
       scope: "account",
       identifierFields: [],
@@ -163,20 +168,20 @@ export const aitToolset: ToolsetDefinition = {
           method: "GET",
           path: "/ait/api/v1/application",
           operationPolicy: { risk: "read", retryPolicy: "safe" },
-          responseExtractor: aitAppsForOrgExtract,
+          responseExtractor: aitAppListExtract,
           skipCompact: true,
           description:
             "List all apps for the organization. Returns app details including app_id, app_name, workspace_id, and created_at.",
         },
       },
     },
+    // ── ait_test_environment ────────────────────────────────────────────────
     {
-      resourceType: "ait_test_environments",
-      displayName: "AIT Test Environments",
+      resourceType: "ait_test_environment",
+      displayName: "AIT Test Environment",
       description:
-        "List test environments for a given application. Returns environment IDs, names, " +
-        "base URLs, and flags (test, monitor, pre_release). Use this to discover env_id " +
-        "values needed for running copilot tests.",
+        "A test environment for an AIT application. List environments to discover " +
+        "environment IDs needed for creating and running tests.",
       toolset: "ait",
       scope: "account",
       identifierFields: ["app_id"],
@@ -195,22 +200,23 @@ export const aitToolset: ToolsetDefinition = {
           queryParams: {
             app_id: "appId",
           },
-          responseExtractor: aitTestEnvironmentsExtract,
+          responseExtractor: aitTestEnvironmentListExtract,
           description:
             "List all test environments for an application. Requires app_id in filters. " +
             "Returns environment details including id, env_name, base_url, and type flags.",
         },
       },
     },
+    // ── ait_test ────────────────────────────────────────────────────────────
     {
-      resourceType: "ait_tests_list",
-      displayName: "AIT Tests List",
+      resourceType: "ait_test",
+      displayName: "AIT Test",
       description:
-        "An automated test in the AIT module. List tests for an application by appId. " +
-        "Supports filtering by activation status, run status, and pagination.",
+        "An automated test in the AIT module. Supports listing tests for an app, " +
+        "creating a test using AI (copilot), and executing a test run.",
       toolset: "ait",
       scope: "account",
-      identifierFields: ["app_id"],
+      identifierFields: ["test_id", "test_version_id"],
       listFilterFields: [
         {
           name: "app_id",
@@ -257,7 +263,7 @@ export const aitToolset: ToolsetDefinition = {
             sort_by: "sortBy",
             sort_order: "sortOrder",
             page: "page",
-            limit: "limit",
+            size: "limit",
             filter: "filter",
             should_hide_disabled_flows: "shouldHideDisabledFlows",
             is_debug_mode: "isDebugMode",
@@ -272,41 +278,32 @@ export const aitToolset: ToolsetDefinition = {
             isDebugMode: "false",
             runStatusesPerTest: "5",
           },
-          responseExtractor: aitTestsListExtract,
+          responseExtractor: aitTestListExtract,
           skipCompact: true,
           description:
             "List all tests for an application. Requires app_id in filters. " +
             "Returns paginated test entries with name, created_by, created_at, display_status, and tags.",
         },
-      },
-    },
-    {
-      resourceType: "ait_create_test_using_ai",
-      displayName: "AIT Create Test Using AI",
-      description:
-        "Create test using AI in AIT. Provide an appId, envId, and a test description. " +
-        "The API creates a test and returns the test ID and version ID of the created test. " +
-        "Optionally specify authType ('auth' or 'no_auth') and an entryUrl.",
-      toolset: "ait",
-      scope: "account",
-      identifierFields: ["app_id"],
-      operations: {
         create: {
           method: "POST",
           path: "/ait/api/v1/testNew/copilotTest/import",
           operationPolicy: { risk: "medium_write", retryPolicy: "do_not_retry" },
           bodyBuilder: (input) => {
             const b = (input.body ?? input) as Record<string, unknown>;
+            const appId = (b.app_id ?? b.appId) as string;
+            const envId = (b.env_id ?? b.envId) as string;
+            const authType = b.auth_type ?? b.authType;
+            const entryUrl = b.entry_url ?? b.entryUrl;
             return {
-              appId: b.appId,
-              envId: b.envId,
+              appId,
+              envId,
               description: b.description,
-              ...(b.authType !== undefined ? { authType: b.authType } : {}),
-              ...(b.entryUrl !== undefined ? { entryUrl: b.entryUrl } : {}),
+              ...(authType !== undefined ? { authType: authType as string } : {}),
+              ...(entryUrl !== undefined ? { entryUrl: entryUrl as string } : {}),
             };
           },
           bodySchema: {
-            description: "Create a test using AI",
+            description: "Create a test using AI (copilot)",
             fields: [
               { name: "appId", type: "string", required: true, description: "Application ID" },
               { name: "envId", type: "string", required: true, description: "Environment ID" },
@@ -315,25 +312,11 @@ export const aitToolset: ToolsetDefinition = {
               { name: "entryUrl", type: "string", required: false, description: "Optional entry URL for the test" },
             ],
           },
-          responseExtractor: aitImportedCopilotTestExtract,
+          responseExtractor: aitTestCreateExtract,
           description:
-            "Create a test using AI. Returns test_id and test_version_id.",
+            "Create a test using AI. Provide app_id, env_id, and a description. Returns test_id and test_version_id.",
         },
       },
-    },
-    {
-      resourceType: "ait_run_test",
-      displayName: "AIT Run Test",
-      description:
-        "Execute a test with a given test ID and test version. " +
-        "Requires appId (UUID — look up via ait_apps_for_org if only name is known) and " +
-        "environmentId (UUID — look up via ait_test_environments if only name is known). " +
-        "Pass test_id and test_version_id via params (e.g. params: { test_id: 80, test_version_id: 91 }). " +
-        "Returns the scheduled TestRun details including id, status, test_session_id, and test run URL.",
-      toolset: "ait",
-      scope: "account",
-      identifierFields: ["test_id", "test_version_id"],
-      operations: {},
       executeActions: {
         run: {
           method: "POST",
@@ -342,23 +325,25 @@ export const aitToolset: ToolsetDefinition = {
           operationPolicy: { risk: "medium_write", retryPolicy: "do_not_retry" },
           bodyBuilder: (input: Record<string, unknown>) => {
             const b = (input.body ?? input) as Record<string, unknown>;
+            const appId = (b.app_id ?? b.appId) as string;
+            const environmentId = (b.environment_id ?? b.environmentId) as string;
             return {
-              appId: b.appId,
-              environmentId: b.environmentId,
+              appId,
+              environmentId,
               params: b.params ?? '{"RUN_MODE":"no-mock","TestExecutorNamespace.fastExecutorMode":"false"}',
             };
           },
           bodySchema: {
             description: "Execute a test run",
             fields: [
-              { name: "appId", type: "string", required: true, description: "Application UUID (e.g. ecaab215-65cd-45d6-8426-09ba1e04eabb). Look up via ait_apps_for_org if only app name is known." },
-              { name: "environmentId", type: "string", required: true, description: "Environment UUID (e.g. 1289b517-5f1b-4927-b30b-6f2e895dae8e). Look up via ait_test_environments if only env name is known." },
+              { name: "appId", type: "string", required: true, description: "Application UUID (e.g. ecaab215-65cd-45d6-8426-09ba1e04eabb). Look up via ait_app if only app name is known." },
+              { name: "environmentId", type: "string", required: true, description: "Environment UUID (e.g. 1289b517-5f1b-4927-b30b-6f2e895dae8e). Look up via ait_test_environment if only env name is known." },
               { name: "params", type: "string", required: false, description: "Test params — JSON stringified Map<string, string>. Defaults to '{\"RUN_MODE\":\"no-mock\",\"TestExecutorNamespace.fastExecutorMode\":\"false\"}'" },
             ],
           },
-          responseExtractor: aitRunTestExtract,
+          responseExtractor: aitTestRunExtract,
           actionDescription:
-            "Execute a test. Returns TestRun details including id, status, test_session_id, and start_epoch.",
+            "Execute a test. Returns TestRun details including id, status, and error.",
         },
       },
     },

--- a/src/registry/toolsets/ait.ts
+++ b/src/registry/toolsets/ait.ts
@@ -1,4 +1,4 @@
-import type { ToolsetDefinition } from "../types.js";
+import type { ToolsetDefinition, PreflightContext } from "../types.js";
 
 /**
  * AIT (AI Test Automation) toolset.
@@ -6,28 +6,44 @@ import type { ToolsetDefinition } from "../types.js";
  * Hosted on the Harness platform and authenticated via standard Harness PAT.
  *
  * Resources:
- *   ait_app              — list applications
- *   ait_test_environment — list test environments for an app
- *   ait_test             — list, create (AI), and execute (run) tests
+ *   ait_project          — list projects with AIT enabled
+ *   ait_test_environment — list AIT test environments for a project
+ *   ait_test             — list, create (AI), and execute (run) AIT tests
  */
+
+// ─── Preflight guards ───────────────────────────────────────────────────────
+
+/**
+ * Throws a clear error when the caller passes org_id or project_id to an AIT resource.
+ * AIT APIs use app_id for scoping — org_id and project_id are silently ignored by the API,
+ * leading to incorrect results.
+ */
+const rejectProjectScope = async (ctx: PreflightContext): Promise<void> => {
+  const passed: string[] = [];
+  if (ctx.input["org_id"]) passed.push("org_id");
+  if (ctx.input["project_id"]) passed.push("project_id");
+  if (ctx.input["account_id"]) passed.push("account_id");
+  if (passed.length > 0) {
+    throw new Error(
+      `Invalid parameter(s) for AIT: ${passed.join(", ")}. ` +
+        "AIT uses app_id as its project scope (1:1 mapping with Harness project_id but different values — cannot substitute one for the other). " +
+        "WORKFLOW: First call harness_list(resource_type='ait_project') with no scope params, match app_name to the Harness project name, then use that app_id.",
+    );
+  }
+};
 
 // ─── Response extractors ────────────────────────────────────────────────────
 
 /** Extract applications list: normalize camelCase fields to snake_case */
 const aitAppListExtract = (raw: unknown): unknown => {
   if (!Array.isArray(raw)) {
-    throw new Error("ait_app: expected array response from API, got " + typeof raw);
+    throw new Error("ait_project: expected array response from API, got " + typeof raw);
   }
   const arr = raw as Array<{
     appId?: string;
     appName?: string;
     createdAt?: string;
-    updatedAt?: string;
-    version?: string;
-    workspaceId?: number;
     isDeleted?: boolean;
-    sandbox?: boolean;
-    hasSessions?: boolean;
   }>;
   const items = arr
     .filter((app) => !app.isDeleted)
@@ -35,10 +51,6 @@ const aitAppListExtract = (raw: unknown): unknown => {
       app_id: app.appId,
       app_name: app.appName,
       created_at: app.createdAt,
-      updated_at: app.updatedAt,
-      workspace_id: app.workspaceId,
-      sandbox: app.sandbox,
-      has_sessions: app.hasSessions,
     }));
   return { items, total: items.length };
 };
@@ -50,20 +62,12 @@ const aitTestEnvironmentListExtract = (raw: unknown): unknown => {
   }
   const arr = raw as Array<{
     id?: string;
-    appId?: string;
     envName?: string;
-    test?: boolean;
-    monitor?: boolean;
-    preRelease?: boolean;
     baseUrl?: string | null;
   }>;
   const items = arr.map((env) => ({
     id: env.id,
-    app_id: env.appId,
     env_name: env.envName,
-    test: env.test,
-    monitor: env.monitor,
-    pre_release: env.preRelease,
     base_url: env.baseUrl ?? null,
   }));
   return { items, total: items.length };
@@ -95,7 +99,6 @@ const aitTestListExtract = (raw: unknown): unknown => {
       display_status: latestRun?.displayStatus ?? null,
       last_run_id: t.lastRunId,
       test_version_id: t.testVersionId,
-      tags: t.tags,
     };
   });
   return {
@@ -149,17 +152,20 @@ export const aitToolset: ToolsetDefinition = {
   name: "ait",
   displayName: "AI Test Automation (AIT)",
   description:
-    "Harness AI Test Automation (AIT) — list and manage automated tests for applications. " +
-    "TERMINOLOGY MAPPING (AIT ↔ Harness): AIT \"org\" = Harness \"account\"; AIT \"app\" = Harness \"project\".",
+    "Harness AI Test Automation (AIT) — list and manage AIT tests for projects. " +
+    "SCOPING: AIT APIs do NOT accept org_id, project_id, or account_id. Instead, AIT uses app_id as its project scope. " + 
+    "app_id is AIT's equivalent of a Harness project ID (they have a 1:1 mapping but their values are different — you cannot use project_id in place of app_id). " +
+    "All AIT API calls use app_id, not project_id. Do NOT pass org_id or project_id to any AIT resource. " +
+    "WORKFLOW: To interact with AIT resources for a Harness project, first list ait_project, match app_name to the project name, then use that app_id for subsequent AIT operations.",
   optIn: true,
   resources: [
-    // ── ait_app ─────────────────────────────────────────────────────────────
+    // ── ait_project ─────────────────────────────────────────────────────────────
     {
-      resourceType: "ait_app",
-      displayName: "AIT Application",
+      resourceType: "ait_project",
+      displayName: "AIT Project",
       description:
-        "An application (also called 'project' in Harness) in the AIT module. List applications to discover app_id values " +
-        "needed for other AIT operations (tests, environments).",
+        "A Harness project onboarded to AIT. Created when a user sets up their first AIT environment for that project — not all Harness projects appear here. " +
+        "The app_name field IS the Harness project name. Match app_name to find the app_id needed for all other AIT operations.",
       toolset: "ait",
       scope: "account",
       identifierFields: [],
@@ -167,11 +173,12 @@ export const aitToolset: ToolsetDefinition = {
         list: {
           method: "GET",
           path: "/ait/api/v1/application",
+          preflight: rejectProjectScope,
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           responseExtractor: aitAppListExtract,
-          skipCompact: true,
           description:
-            "List all apps for the organization. Returns app details including app_id, app_name, workspace_id, and created_at.",
+            "List all Harness projects onboarded to AIT. " +
+            "Returns app_id (needed for all other AIT operations), app_name (= Harness project name), workspace_id, and created_at.",
         },
       },
     },
@@ -180,15 +187,15 @@ export const aitToolset: ToolsetDefinition = {
       resourceType: "ait_test_environment",
       displayName: "AIT Test Environment",
       description:
-        "A test environment for an AIT application. List environments to discover " +
-        "environment IDs needed for creating and running tests.",
+        "An AIT test environment for a project. Requires app_id filter. " +
+        "List environments to discover environment IDs needed for creating and running tests.",
       toolset: "ait",
       scope: "account",
       identifierFields: ["app_id"],
       listFilterFields: [
         {
           name: "app_id",
-          description: "Application ID (required)",
+          description: "app_id (required, from ait_project list)",
           required: true,
         },
       ],
@@ -196,14 +203,15 @@ export const aitToolset: ToolsetDefinition = {
         list: {
           method: "GET",
           path: "/ait/api/v1/testEnvironments",
+          preflight: rejectProjectScope,
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           queryParams: {
             app_id: "appId",
           },
           responseExtractor: aitTestEnvironmentListExtract,
           description:
-            "List all test environments for an application. Requires app_id in filters. " +
-            "Returns environment details including id, env_name, base_url, and type flags.",
+            "List all AIT test environments for a project. Requires app_id in filters. " +
+            "Returns id, env_name, base_url, and type flags.",
         },
       },
     },
@@ -212,42 +220,16 @@ export const aitToolset: ToolsetDefinition = {
       resourceType: "ait_test",
       displayName: "AIT Test",
       description:
-        "An automated test in the AIT module. Supports listing tests for an app, " +
-        "creating a test using AI (copilot), and executing a test run.",
+        "A test in the AIT module. Requires app_id filter. " +
+        "Supports listing tests, creating a test using AI (copilot), and executing a test run.",
       toolset: "ait",
       scope: "account",
       identifierFields: ["test_id", "test_version_id"],
       listFilterFields: [
         {
           name: "app_id",
-          description: "Application ID (required)",
+          description: "app_id (required, from ait_project list)",
           required: true,
-        },
-        {
-          name: "activation_status",
-          description: "Filter by activation status",
-        },
-        {
-          name: "run_status",
-          description: "Filter by test run status",
-        },
-        {
-          name: "sort_by",
-          description: "Field to sort by (e.g. createdAt)",
-        },
-        {
-          name: "sort_order",
-          description: "Sort order: ASC or DESC",
-          enum: ["ASC", "DESC"],
-        },
-        {
-          name: "filter",
-          description: "Text filter for test name",
-        },
-        {
-          name: "should_hide_disabled_flows",
-          description: "Whether to hide disabled flows",
-          type: "boolean",
         },
       ],
       operations: {
@@ -255,38 +237,20 @@ export const aitToolset: ToolsetDefinition = {
           method: "GET",
           path: "/ait/api/v1/testNew",
           pageOneIndexed: true,
+          preflight: rejectProjectScope,
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           queryParams: {
             app_id: "appId",
-            activation_status: "activationStatus",
-            run_status: "runStatus",
-            sort_by: "sortBy",
-            sort_order: "sortOrder",
-            page: "page",
-            size: "limit",
-            filter: "filter",
-            should_hide_disabled_flows: "shouldHideDisabledFlows",
-            is_debug_mode: "isDebugMode",
-            last_run_start_epoch_ms: "lastRunStartEpochMs",
-            run_statuses_per_test: "runStatusesPerTest",
-          },
-          defaultQueryParams: {
-            sortOrder: "DESC",
-            page: "1",
-            limit: "20",
-            shouldHideDisabledFlows: "true",
-            isDebugMode: "false",
-            runStatusesPerTest: "5",
           },
           responseExtractor: aitTestListExtract,
-          skipCompact: true,
           description:
-            "List all tests for an application. Requires app_id in filters. " +
+            "List all AIT tests for a project. Requires app_id in filters. " +
             "Returns paginated test entries with name, created_by, created_at, display_status, and tags.",
         },
         create: {
           method: "POST",
           path: "/ait/api/v1/testNew/copilotTest/import",
+          preflight: rejectProjectScope,
           operationPolicy: { risk: "medium_write", retryPolicy: "do_not_retry" },
           bodyBuilder: (input) => {
             const b = (input.body ?? input) as Record<string, unknown>;
@@ -303,9 +267,9 @@ export const aitToolset: ToolsetDefinition = {
             };
           },
           bodySchema: {
-            description: "Create a test using AI (copilot)",
+            description: "Create an AIT test using AI (copilot)",
             fields: [
-              { name: "appId", type: "string", required: true, description: "Application ID" },
+              { name: "appId", type: "string", required: true, description: "app_id (from ait_project list)" },
               { name: "envId", type: "string", required: true, description: "Environment ID" },
               { name: "description", type: "string", required: true, description: "Copilot task description (also used as the test name)" },
               { name: "authType", type: "string", required: false, description: "Auth type: 'auth' (default) or 'no_auth'" },
@@ -314,7 +278,7 @@ export const aitToolset: ToolsetDefinition = {
           },
           responseExtractor: aitTestCreateExtract,
           description:
-            "Create a test using AI. Provide app_id, env_id, and a description. Returns test_id and test_version_id.",
+            "Create an AIT test using AI. Provide app_id, env_id, and a description. Returns test_id and test_version_id.",
         },
       },
       executeActions: {
@@ -322,6 +286,7 @@ export const aitToolset: ToolsetDefinition = {
           method: "POST",
           path: "/ait/api/v1/testNew/{test_id}/version/{test_version_id}/run",
           pathParams: { test_id: "test_id", test_version_id: "test_version_id" },
+          preflight: rejectProjectScope,
           operationPolicy: { risk: "medium_write", retryPolicy: "do_not_retry" },
           bodyBuilder: (input: Record<string, unknown>) => {
             const b = (input.body ?? input) as Record<string, unknown>;
@@ -334,16 +299,16 @@ export const aitToolset: ToolsetDefinition = {
             };
           },
           bodySchema: {
-            description: "Execute a test run",
+            description: "Execute an AIT test run",
             fields: [
-              { name: "appId", type: "string", required: true, description: "Application UUID (e.g. ecaab215-65cd-45d6-8426-09ba1e04eabb). Look up via ait_app if only app name is known." },
+              { name: "appId", type: "string", required: true, description: "app_id (from ait_project list)" },
               { name: "environmentId", type: "string", required: true, description: "Environment UUID (e.g. 1289b517-5f1b-4927-b30b-6f2e895dae8e). Look up via ait_test_environment if only env name is known." },
               { name: "params", type: "string", required: false, description: "Test params — JSON stringified Map<string, string>. Defaults to '{\"RUN_MODE\":\"no-mock\",\"TestExecutorNamespace.fastExecutorMode\":\"false\"}'" },
             ],
           },
           responseExtractor: aitTestRunExtract,
           actionDescription:
-            "Execute a test. Returns TestRun details including id, status, and error.",
+            "Execute an AIT test. Returns TestRun details including id, status, and error.",
         },
       },
     },

--- a/src/registry/toolsets/ait.ts
+++ b/src/registry/toolsets/ait.ts
@@ -1,0 +1,366 @@
+import type { ToolsetDefinition } from "../types.js";
+
+/**
+ * AIT (AI Test Automation) toolset.
+ * Base path: /ait/api/v1/...
+ * Hosted on the Harness platform and authenticated via standard Harness PAT.
+ */
+
+// ─── Reusable response extractors for AIT APIs ─────────────────────────────
+// AIT APIs follow these response patterns:
+//   1. TableResponse<T> — paginated lists: { data: T[], totalPages, totalItems, itemsPerPage, currentPage }
+//   2. Single object   — direct entity (e.g. TestNew, TestNewExtended)
+//   3. Simple values   — string, string[], { success: boolean }
+//
+// Each new endpoint picks the appropriate extractor or uses passthrough for
+// single-object / simple-value responses.
+
+/** Extract applications list (simple array pattern): normalize camelCase fields to snake_case items */
+const aitAppsForOrgExtract = (raw: unknown): unknown => {
+  const arr = raw as Array<{
+    appId?: string;
+    appName?: string;
+    createdAt?: string;
+    updatedAt?: string;
+    version?: string;
+    workspaceId?: number;
+    isDeleted?: boolean;
+    sandbox?: boolean;
+    hasSessions?: boolean;
+  }>;
+  const items = arr
+    .filter((app) => !app.isDeleted)
+    .map((app) => ({
+      app_id: app.appId,
+      app_name: app.appName,
+      created_at: app.createdAt,
+      updated_at: app.updatedAt,
+      workspace_id: app.workspaceId,
+      sandbox: app.sandbox,
+      has_sessions: app.hasSessions,
+    }));
+  return { items, total: items.length };
+};
+
+/** Extract test environments list (simple array pattern): normalize camelCase fields to snake_case items */
+const aitTestEnvironmentsExtract = (raw: unknown): unknown => {
+  const arr = raw as Array<{
+    id?: string;
+    appId?: string;
+    envName?: string;
+    test?: boolean;
+    monitor?: boolean;
+    preRelease?: boolean;
+    baseUrl?: string | null;
+  }>;
+  const items = arr.map((env) => ({
+    id: env.id,
+    app_id: env.appId,
+    env_name: env.envName,
+    test: env.test,
+    monitor: env.monitor,
+    pre_release: env.preRelease,
+
+    base_url: env.baseUrl ?? null,
+  }));
+  return { items, total: items.length };
+};
+
+/** Extract paginated TableResponse for test list: picks key fields per TestEntry item */
+const aitTestsListExtract = (raw: unknown): unknown => {
+  const r = raw as {
+    data?: Array<Record<string, unknown>>;
+    totalPages?: number;
+    totalItems?: number;
+    itemsPerPage?: number;
+    currentPage?: number;
+  };
+  const items = (r.data ?? []).map((t) => {
+    const runDetailsList = t.lastKRunDetailsList as Array<Record<string, unknown>> | null | undefined;
+    const latestRun = runDetailsList?.[0];
+    return {
+      test_id: t.testId,
+      name: t.testName,
+      created_by: t.createdByNickname ?? t.createdBy,
+      created_at: t.createdAt,
+      display_status: latestRun?.displayStatus ?? null,
+      last_run_id: t.lastRunId,
+      test_version_id: t.testVersionId,
+      tags: t.tags,
+    };
+  });
+  return {
+    items,
+    total: r.totalItems ?? items.length,
+    totalPages: r.totalPages ?? 0,
+    currentPage: r.currentPage ?? 1,
+    itemsPerPage: r.itemsPerPage ?? 20,
+  };
+};
+
+/** Extract imported copilot test response — normalizes camelCase testId/testVersionId to snake_case */
+const aitImportedCopilotTestExtract = (raw: unknown): unknown => {
+  const r = raw as {
+    testId: number;
+    testVersionId: number;
+  };
+
+  return {
+    test_id: r.testId,
+    test_version_id: r.testVersionId,
+  };
+};
+
+/** Extract run test response — picks key fields from the snake_case TestRunNew entity */
+const aitRunTestExtract = (raw: unknown): unknown => {
+  const r = raw as {
+    id: number;
+    app_id: string;
+    test_id: number;
+    test_version_id: number;
+    test_environment_id: string;
+    status: string | null;
+    test_session_id: string | null;
+    start_epoch: number | null;
+    error: string | null;
+  };
+
+  const aitBaseUrl = (process.env.HARNESS_BASE_URL ?? "https://app.harness.io").replace(/\/$/, "");
+  const testRunUrl = `${aitBaseUrl}/ait/${r.app_id}/test/${r.test_id}/version/${r.test_version_id}/test-run/${r.id}?tab=overview`;
+
+  return {
+    test_run_url: testRunUrl,
+    app_id: r.app_id,
+    test_id: r.test_id,
+    test_version_id: r.test_version_id,
+    test_environment_id: r.test_environment_id,
+    status: r.status,
+    error: r.error,
+    _note: "Always display the test_run_url to the user.",
+  };
+};
+
+// ─── Toolset definition ─────────────────────────────────────────────────────
+
+export const aitToolset: ToolsetDefinition = {
+  name: "ait",
+  displayName: "AI Test Automation (AIT)",
+  description:
+    "Harness AI Test Automation (AIT) — list and manage automated tests for applications.",
+  optIn: true,
+  resources: [
+    {
+      resourceType: "ait_apps_for_org",
+      displayName: "AIT Apps for Org",
+      description:
+        "List all applications for the current organization. Returns app IDs, names, and metadata. " +
+        "Use this to discover app_id values needed for other AIT operations.",
+      toolset: "ait",
+      scope: "account",
+      identifierFields: [],
+      operations: {
+        list: {
+          method: "GET",
+          path: "/ait/api/v1/application",
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          responseExtractor: aitAppsForOrgExtract,
+          skipCompact: true,
+          description:
+            "List all apps for the organization. Returns app details including app_id, app_name, workspace_id, and created_at.",
+        },
+      },
+    },
+    {
+      resourceType: "ait_test_environments",
+      displayName: "AIT Test Environments",
+      description:
+        "List test environments for a given application. Returns environment IDs, names, " +
+        "base URLs, and flags (test, monitor, pre_release). Use this to discover env_id " +
+        "values needed for running copilot tests.",
+      toolset: "ait",
+      scope: "account",
+      identifierFields: ["app_id"],
+      listFilterFields: [
+        {
+          name: "app_id",
+          description: "Application ID (required)",
+          required: true,
+        },
+      ],
+      operations: {
+        list: {
+          method: "GET",
+          path: "/ait/api/v1/testEnvironments",
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          queryParams: {
+            app_id: "appId",
+          },
+          responseExtractor: aitTestEnvironmentsExtract,
+          description:
+            "List all test environments for an application. Requires app_id in filters. " +
+            "Returns environment details including id, env_name, base_url, and type flags.",
+        },
+      },
+    },
+    {
+      resourceType: "ait_tests_list",
+      displayName: "AIT Tests List",
+      description:
+        "An automated test in the AIT module. List tests for an application by appId. " +
+        "Supports filtering by activation status, run status, and pagination.",
+      toolset: "ait",
+      scope: "account",
+      identifierFields: ["app_id"],
+      listFilterFields: [
+        {
+          name: "app_id",
+          description: "Application ID (required)",
+          required: true,
+        },
+        {
+          name: "activation_status",
+          description: "Filter by activation status",
+        },
+        {
+          name: "run_status",
+          description: "Filter by test run status",
+        },
+        {
+          name: "sort_by",
+          description: "Field to sort by (e.g. createdAt)",
+        },
+        {
+          name: "sort_order",
+          description: "Sort order: ASC or DESC",
+          enum: ["ASC", "DESC"],
+        },
+        {
+          name: "filter",
+          description: "Text filter for test name",
+        },
+        {
+          name: "should_hide_disabled_flows",
+          description: "Whether to hide disabled flows",
+          type: "boolean",
+        },
+      ],
+      operations: {
+        list: {
+          method: "GET",
+          path: "/ait/api/v1/testNew",
+          pageOneIndexed: true,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          queryParams: {
+            app_id: "appId",
+            activation_status: "activationStatus",
+            run_status: "runStatus",
+            sort_by: "sortBy",
+            sort_order: "sortOrder",
+            page: "page",
+            limit: "limit",
+            filter: "filter",
+            should_hide_disabled_flows: "shouldHideDisabledFlows",
+            is_debug_mode: "isDebugMode",
+            last_run_start_epoch_ms: "lastRunStartEpochMs",
+            run_statuses_per_test: "runStatusesPerTest",
+          },
+          defaultQueryParams: {
+            sortOrder: "DESC",
+            page: "1",
+            limit: "20",
+            shouldHideDisabledFlows: "true",
+            isDebugMode: "false",
+            runStatusesPerTest: "5",
+          },
+          responseExtractor: aitTestsListExtract,
+          skipCompact: true,
+          description:
+            "List all tests for an application. Requires app_id in filters. " +
+            "Returns paginated test entries with name, created_by, created_at, display_status, and tags.",
+        },
+      },
+    },
+    {
+      resourceType: "ait_create_test_using_ai",
+      displayName: "AIT Create Test Using AI",
+      description:
+        "Create test using AI in AIT. Provide an appId, envId, and a test description. " +
+        "The API creates a test and returns the test ID and version ID of the created test. " +
+        "Optionally specify authType ('auth' or 'no_auth') and an entryUrl.",
+      toolset: "ait",
+      scope: "account",
+      identifierFields: ["app_id"],
+      operations: {
+        create: {
+          method: "POST",
+          path: "/ait/api/v1/testNew/copilotTest/import",
+          operationPolicy: { risk: "medium_write", retryPolicy: "do_not_retry" },
+          bodyBuilder: (input) => {
+            const b = (input.body ?? input) as Record<string, unknown>;
+            return {
+              appId: b.appId,
+              envId: b.envId,
+              description: b.description,
+              ...(b.authType !== undefined ? { authType: b.authType } : {}),
+              ...(b.entryUrl !== undefined ? { entryUrl: b.entryUrl } : {}),
+            };
+          },
+          bodySchema: {
+            description: "Create a test using AI",
+            fields: [
+              { name: "appId", type: "string", required: true, description: "Application ID" },
+              { name: "envId", type: "string", required: true, description: "Environment ID" },
+              { name: "description", type: "string", required: true, description: "Copilot task description (also used as the test name)" },
+              { name: "authType", type: "string", required: false, description: "Auth type: 'auth' (default) or 'no_auth'" },
+              { name: "entryUrl", type: "string", required: false, description: "Optional entry URL for the test" },
+            ],
+          },
+          responseExtractor: aitImportedCopilotTestExtract,
+          description:
+            "Create a test using AI. Returns test_id and test_version_id.",
+        },
+      },
+    },
+    {
+      resourceType: "ait_run_test",
+      displayName: "AIT Run Test",
+      description:
+        "Execute a test with a given test ID and test version. " +
+        "Requires appId (UUID — look up via ait_apps_for_org if only name is known) and " +
+        "environmentId (UUID — look up via ait_test_environments if only name is known). " +
+        "Pass test_id and test_version_id via params (e.g. params: { test_id: 80, test_version_id: 91 }). " +
+        "Returns the scheduled TestRun details including id, status, test_session_id, and test run URL.",
+      toolset: "ait",
+      scope: "account",
+      identifierFields: ["test_id", "test_version_id"],
+      operations: {},
+      executeActions: {
+        run: {
+          method: "POST",
+          path: "/ait/api/v1/testNew/{test_id}/version/{test_version_id}/run",
+          pathParams: { test_id: "test_id", test_version_id: "test_version_id" },
+          operationPolicy: { risk: "medium_write", retryPolicy: "do_not_retry" },
+          bodyBuilder: (input: Record<string, unknown>) => {
+            const b = (input.body ?? input) as Record<string, unknown>;
+            return {
+              appId: b.appId,
+              environmentId: b.environmentId,
+              params: b.params ?? '{"RUN_MODE":"no-mock","TestExecutorNamespace.fastExecutorMode":"false"}',
+            };
+          },
+          bodySchema: {
+            description: "Execute a test run",
+            fields: [
+              { name: "appId", type: "string", required: true, description: "Application UUID (e.g. ecaab215-65cd-45d6-8426-09ba1e04eabb). Look up via ait_apps_for_org if only app name is known." },
+              { name: "environmentId", type: "string", required: true, description: "Environment UUID (e.g. 1289b517-5f1b-4927-b30b-6f2e895dae8e). Look up via ait_test_environments if only env name is known." },
+              { name: "params", type: "string", required: false, description: "Test params — JSON stringified Map<string, string>. Defaults to '{\"RUN_MODE\":\"no-mock\",\"TestExecutorNamespace.fastExecutorMode\":\"false\"}'" },
+            ],
+          },
+          responseExtractor: aitRunTestExtract,
+          actionDescription:
+            "Execute a test. Returns TestRun details including id, status, test_session_id, and start_epoch.",
+        },
+      },
+    },
+  ],
+};

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -154,7 +154,8 @@ export type ToolsetName =
   | "incidents"
   | "deploys"
   | "knowledge-graph"
-  | "semantic-layer";
+  | "semantic-layer"
+  | "ait";
 
 export type ProductName = "harness" | "fme";
 

--- a/tests/registry/ait.test.ts
+++ b/tests/registry/ait.test.ts
@@ -64,7 +64,7 @@ describe("aitToolset structure", () => {
 
   it("registers 3 noun-oriented resource types", () => {
     const types = aitToolset.resources.map((r) => r.resourceType);
-    expect(types).toContain("ait_app");
+    expect(types).toContain("ait_project");
     expect(types).toContain("ait_test_environment");
     expect(types).toContain("ait_test");
     expect(types).toHaveLength(3);
@@ -100,27 +100,27 @@ describe("aitToolset structure", () => {
 describe("ait opt-in with Registry", () => {
   it("is NOT present when HARNESS_TOOLSETS is unset (all defaults)", () => {
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: undefined }));
-    expect(registry.getAllResourceTypes()).not.toContain("ait_app");
+    expect(registry.getAllResourceTypes()).not.toContain("ait_project");
   });
 
   it("IS present when explicitly enabled with HARNESS_TOOLSETS=+ait", () => {
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "+ait" }));
-    expect(registry.getAllResourceTypes()).toContain("ait_app");
+    expect(registry.getAllResourceTypes()).toContain("ait_project");
     expect(registry.getAllResourceTypes()).toContain("ait_test_environment");
     expect(registry.getAllResourceTypes()).toContain("ait_test");
   });
 
   it("IS present when listed explicitly in HARNESS_TOOLSETS=ait", () => {
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ait" }));
-    expect(registry.getAllResourceTypes()).toContain("ait_app");
+    expect(registry.getAllResourceTypes()).toContain("ait_project");
   });
 });
 
-// ─── Response extractor: ait_app list ───────────────────────────────────────
+// ─── Response extractor: ait_project list ───────────────────────────────────────
 
-describe("ait_app list extractor", () => {
+describe("ait_project list extractor", () => {
   function extract(raw: unknown) {
-    return getOp("ait_app", "list").responseExtractor!(raw);
+    return getOp("ait_project", "list").responseExtractor!(raw);
   }
 
   it("normalizes camelCase app fields to snake_case", () => {
@@ -142,10 +142,6 @@ describe("ait_app list extractor", () => {
       app_id: "abc-123",
       app_name: "my-app",
       created_at: "2026-01-01T00:00:00Z",
-      updated_at: "2026-01-02T00:00:00Z",
-      workspace_id: 1,
-      sandbox: false,
-      has_sessions: true,
     });
     expect(result.total).toBe(1);
   });
@@ -168,9 +164,9 @@ describe("ait_app list extractor", () => {
   });
 
   it("throws on non-array response", () => {
-    expect(() => extract({ error: "unauthorized" })).toThrow("ait_app: expected array response");
-    expect(() => extract("string")).toThrow("ait_app: expected array response");
-    expect(() => extract(null)).toThrow("ait_app: expected array response");
+    expect(() => extract({ error: "unauthorized" })).toThrow("ait_project: expected array response");
+    expect(() => extract("string")).toThrow("ait_project: expected array response");
+    expect(() => extract(null)).toThrow("ait_project: expected array response");
   });
 });
 
@@ -197,11 +193,7 @@ describe("ait_test_environment list extractor", () => {
     expect(result.items).toHaveLength(1);
     expect(result.items[0]).toEqual({
       id: "env-1",
-      app_id: "app-1",
       env_name: "production",
-      test: true,
-      monitor: false,
-      pre_release: true,
       base_url: "https://example.com",
     });
     expect(result.total).toBe(1);
@@ -264,7 +256,6 @@ describe("ait_test list extractor", () => {
       display_status: "PASSED",
       last_run_id: 10,
       test_version_id: 2,
-      tags: "[]",
     });
     expect(result.total).toBe(1);
     expect(result.totalPages).toBe(1);
@@ -373,8 +364,8 @@ describe("ait_test run extractor", () => {
 // ─── API paths ───────────────────────────────────────────────────────────────
 
 describe("endpoint paths", () => {
-  it("ait_app list uses /ait/api/v1/application", () => {
-    expect(getOp("ait_app", "list").path).toBe("/ait/api/v1/application");
+  it("ait_project list uses /ait/api/v1/application", () => {
+    expect(getOp("ait_project", "list").path).toBe("/ait/api/v1/application");
   });
 
   it("ait_test_environment list uses /ait/api/v1/testEnvironments", () => {
@@ -455,13 +446,13 @@ describe("ait_test run bodyBuilder", () => {
 // ─── Registry dispatch integration ─────────────────────────────────────────
 
 describe("ait registry dispatch", () => {
-  it("dispatches ait_app list", async () => {
+  it("dispatches ait_project list", async () => {
     const mockRequest = vi.fn().mockResolvedValue([
       { appId: "abc", appName: "test-app", isDeleted: false },
     ]);
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ait" }));
 
-    const result = await registry.dispatch(makeClient(mockRequest), "ait_app", "list", {});
+    const result = await registry.dispatch(makeClient(mockRequest), "ait_project", "list", {});
 
     const request = mockRequest.mock.calls[0]![0] as { path: string };
     expect(request.path).toBe("/ait/api/v1/application");
@@ -481,18 +472,6 @@ describe("ait registry dispatch", () => {
     expect(request.params.appId).toBe("abc-123");
   });
 
-  it("maps size parameter to limit query param for ait_test list", async () => {
-    const mockRequest = vi.fn().mockResolvedValue({ data: [], totalItems: 0 });
-    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ait" }));
-
-    await registry.dispatch(makeClient(mockRequest), "ait_test", "list", {
-      app_id: "abc-123",
-      size: 5,
-    });
-
-    const request = mockRequest.mock.calls[0]![0] as { path: string; params: Record<string, unknown> };
-    expect(request.params.limit).toBe(5);
-  });
 
   it("dispatches ait_test_environment list with app_id filter", async () => {
     const mockRequest = vi.fn().mockResolvedValue([]);

--- a/tests/registry/ait.test.ts
+++ b/tests/registry/ait.test.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect, vi } from "vitest";
+import { aitToolset } from "../../src/registry/toolsets/ait.js";
+import { Registry } from "../../src/registry/index.js";
+import type { Config } from "../../src/config.js";
+import type { HarnessClient } from "../../src/client/harness-client.js";
+import type { ResourceDefinition, EndpointSpec } from "../../src/registry/types.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    HARNESS_API_KEY: "pat.test",
+    HARNESS_ACCOUNT_ID: "test-account",
+    HARNESS_BASE_URL: "https://app.harness.io",
+    HARNESS_ORG: "default",
+    HARNESS_PROJECT: "Testim",
+    HARNESS_API_TIMEOUT_MS: 30000,
+    HARNESS_MAX_RETRIES: 3,
+    LOG_LEVEL: "info",
+    HARNESS_MAX_BODY_SIZE_MB: 10,
+    HARNESS_RATE_LIMIT_RPS: 10,
+    HARNESS_READ_ONLY: false,
+    HARNESS_SKIP_ELICITATION: false,
+    HARNESS_AUTO_APPROVE_RISK: "none",
+    HARNESS_ALLOW_HTTP: false,
+    HARNESS_FME_BASE_URL: "https://api.split.io",
+    HARNESS_LOG_UNSAFE_BODIES: false,
+    HARNESS_AUDIT_WEBHOOK_BATCH_SIZE: 10,
+    HARNESS_AUDIT_WEBHOOK_FLUSH_MS: 5000,
+    ...overrides,
+  } as Config;
+}
+
+function makeClient(requestFn?: (...args: unknown[]) => unknown): HarnessClient {
+  return {
+    request: requestFn ?? vi.fn().mockResolvedValue({}),
+    account: "test-account",
+  } as unknown as HarnessClient;
+}
+
+function findResource(type: string): ResourceDefinition {
+  const res = aitToolset.resources.find((r) => r.resourceType === type);
+  if (!res) throw new Error(`Resource type "${type}" not found in aitToolset`);
+  return res;
+}
+
+function getOp(type: string, op: "list" | "get"): EndpointSpec {
+  const res = findResource(type);
+  const spec = res.operations[op];
+  if (!spec) throw new Error(`Operation "${op}" not found on "${type}"`);
+  return spec;
+}
+
+// ─── Toolset structure ───────────────────────────────────────────────────────
+
+describe("aitToolset structure", () => {
+  it("has name 'ait'", () => {
+    expect(aitToolset.name).toBe("ait");
+  });
+
+  it("is opt-in (not loaded by default)", () => {
+    expect(aitToolset.optIn).toBe(true);
+  });
+
+  it("registers all 5 resource types", () => {
+    const types = aitToolset.resources.map((r) => r.resourceType);
+    expect(types).toContain("ait_apps_for_org");
+    expect(types).toContain("ait_test_environments");
+    expect(types).toContain("ait_tests_list");
+    expect(types).toContain("ait_create_test_using_ai");
+    expect(types).toContain("ait_run_test");
+    expect(types).toHaveLength(5);
+  });
+
+  it("all resources are account-scoped", () => {
+    for (const resource of aitToolset.resources) {
+      expect(resource.scope, `${resource.resourceType} should be account-scoped`).toBe("account");
+    }
+  });
+
+  it("all list/get endpoint specs have operationPolicy", () => {
+    for (const resource of aitToolset.resources) {
+      for (const [opName, spec] of Object.entries(resource.operations)) {
+        expect(
+          spec.operationPolicy,
+          `${resource.resourceType}.${opName} is missing operationPolicy`,
+        ).toBeDefined();
+      }
+    }
+  });
+});
+
+// ─── Registry opt-in behaviour ──────────────────────────────────────────────
+
+describe("ait opt-in with Registry", () => {
+  it("is NOT present when HARNESS_TOOLSETS is unset (all defaults)", () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: undefined }));
+    expect(registry.getAllResourceTypes()).not.toContain("ait_apps_for_org");
+  });
+
+  it("IS present when explicitly enabled with HARNESS_TOOLSETS=+ait", () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "+ait" }));
+    expect(registry.getAllResourceTypes()).toContain("ait_apps_for_org");
+    expect(registry.getAllResourceTypes()).toContain("ait_test_environments");
+    expect(registry.getAllResourceTypes()).toContain("ait_tests_list");
+    expect(registry.getAllResourceTypes()).toContain("ait_create_test_using_ai");
+    expect(registry.getAllResourceTypes()).toContain("ait_run_test");
+  });
+
+  it("IS present when listed explicitly in HARNESS_TOOLSETS=ait", () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ait" }));
+    expect(registry.getAllResourceTypes()).toContain("ait_apps_for_org");
+  });
+});
+
+// ─── Response extractor: aitAppsForOrgExtract ───────────────────────────────
+
+describe("aitAppsForOrgExtract", () => {
+  function extract(raw: unknown) {
+    return getOp("ait_apps_for_org", "list").responseExtractor!(raw);
+  }
+
+  it("normalizes camelCase app fields to snake_case", () => {
+    const raw = [
+      {
+        appId: "abc-123",
+        appName: "my-app",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-02T00:00:00Z",
+        workspaceId: 1,
+        isDeleted: false,
+        sandbox: false,
+        hasSessions: true,
+      },
+    ];
+    const result = extract(raw) as { items: Record<string, unknown>[]; total: number };
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toEqual({
+      app_id: "abc-123",
+      app_name: "my-app",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-02T00:00:00Z",
+      workspace_id: 1,
+      sandbox: false,
+      has_sessions: true,
+    });
+    expect(result.total).toBe(1);
+  });
+
+  it("filters out deleted apps", () => {
+    const raw = [
+      { appId: "a1", appName: "active", isDeleted: false },
+      { appId: "a2", appName: "deleted", isDeleted: true },
+    ];
+    const result = extract(raw) as { items: Record<string, unknown>[]; total: number };
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]!.app_id).toBe("a1");
+    expect(result.total).toBe(1);
+  });
+
+  it("handles empty array", () => {
+    const result = extract([]) as { items: unknown[]; total: number };
+    expect(result.items).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+});
+
+// ─── Response extractor: aitTestEnvironmentsExtract ─────────────────────────
+
+describe("aitTestEnvironmentsExtract", () => {
+  function extract(raw: unknown) {
+    return getOp("ait_test_environments", "list").responseExtractor!(raw);
+  }
+
+  it("normalizes camelCase env fields to snake_case", () => {
+    const raw = [
+      {
+        id: "env-1",
+        appId: "app-1",
+        envName: "production",
+        test: true,
+        monitor: false,
+        preRelease: true,
+        baseUrl: "https://example.com",
+      },
+    ];
+    const result = extract(raw) as { items: Record<string, unknown>[]; total: number };
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toEqual({
+      id: "env-1",
+      app_id: "app-1",
+      env_name: "production",
+      test: true,
+      monitor: false,
+      pre_release: true,
+      base_url: "https://example.com",
+    });
+    expect(result.total).toBe(1);
+  });
+
+  it("handles null baseUrl", () => {
+    const raw = [{ id: "env-1", baseUrl: null }];
+    const result = extract(raw) as { items: Record<string, unknown>[] };
+    expect(result.items[0]!.base_url).toBeNull();
+  });
+
+  it("handles empty array", () => {
+    const result = extract([]) as { items: unknown[]; total: number };
+    expect(result.items).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+});
+
+// ─── Response extractor: aitTestsListExtract ────────────────────────────────
+
+describe("aitTestsListExtract", () => {
+  function extract(raw: unknown) {
+    return getOp("ait_tests_list", "list").responseExtractor!(raw);
+  }
+
+  it("extracts paginated test list with key fields", () => {
+    const raw = {
+      data: [
+        {
+          testId: 1,
+          testName: "Login test",
+          createdBy: "user@example.com",
+          createdByNickname: "User",
+          createdAt: "2026-01-01T00:00:00Z",
+          lastRunId: 10,
+          testVersionId: 2,
+          tags: "[]",
+          lastKRunDetailsList: [{ displayStatus: "PASSED" }],
+        },
+      ],
+      totalPages: 1,
+      totalItems: 1,
+      itemsPerPage: 20,
+      currentPage: 1,
+    };
+    const result = extract(raw) as Record<string, unknown>;
+    const items = result.items as Record<string, unknown>[];
+    expect(items).toHaveLength(1);
+    expect(items[0]).toEqual({
+      test_id: 1,
+      name: "Login test",
+      created_by: "User",
+      created_at: "2026-01-01T00:00:00Z",
+      display_status: "PASSED",
+      last_run_id: 10,
+      test_version_id: 2,
+      tags: "[]",
+    });
+    expect(result.total).toBe(1);
+    expect(result.totalPages).toBe(1);
+    expect(result.currentPage).toBe(1);
+    expect(result.itemsPerPage).toBe(20);
+  });
+
+  it("falls back to createdBy when createdByNickname is absent", () => {
+    const raw = {
+      data: [{ testId: 1, testName: "Test", createdBy: "user@example.com" }],
+    };
+    const result = extract(raw) as { items: Record<string, unknown>[] };
+    expect(result.items[0]!.created_by).toBe("user@example.com");
+  });
+
+  it("display_status is null when lastKRunDetailsList is empty", () => {
+    const raw = {
+      data: [{ testId: 1, testName: "Test", lastKRunDetailsList: [] }],
+    };
+    const result = extract(raw) as { items: Record<string, unknown>[] };
+    expect(result.items[0]!.display_status).toBeNull();
+  });
+
+  it("handles empty data", () => {
+    const raw = { data: [], totalPages: 0, totalItems: 0, itemsPerPage: 20, currentPage: 1 };
+    const result = extract(raw) as Record<string, unknown>;
+    expect(result.items).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+});
+
+// ─── API paths ───────────────────────────────────────────────────────────────
+
+describe("endpoint paths", () => {
+  it("ait_apps_for_org list uses /ait/api/v1/application", () => {
+    expect(getOp("ait_apps_for_org", "list").path).toBe("/ait/api/v1/application");
+  });
+
+  it("ait_test_environments list uses /ait/api/v1/testEnvironments", () => {
+    expect(getOp("ait_test_environments", "list").path).toBe("/ait/api/v1/testEnvironments");
+  });
+
+  it("ait_tests_list list uses /ait/api/v1/testNew", () => {
+    expect(getOp("ait_tests_list", "list").path).toBe("/ait/api/v1/testNew");
+  });
+});
+
+// ─── Registry dispatch integration ─────────────────────────────────────────
+
+describe("ait registry dispatch", () => {
+  it("dispatches ait_apps_for_org list", async () => {
+    const mockRequest = vi.fn().mockResolvedValue([
+      { appId: "abc", appName: "test-app", isDeleted: false },
+    ]);
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ait" }));
+
+    const result = await registry.dispatch(makeClient(mockRequest), "ait_apps_for_org", "list", {});
+
+    const request = mockRequest.mock.calls[0]![0] as { path: string };
+    expect(request.path).toBe("/ait/api/v1/application");
+    expect((result as { items: unknown[] }).items).toHaveLength(1);
+  });
+
+  it("dispatches ait_tests_list list with app_id filter", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ data: [], totalItems: 0 });
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ait" }));
+
+    await registry.dispatch(makeClient(mockRequest), "ait_tests_list", "list", {
+      app_id: "abc-123",
+    });
+
+    const request = mockRequest.mock.calls[0]![0] as { path: string; params: Record<string, unknown> };
+    expect(request.path).toBe("/ait/api/v1/testNew");
+    expect(request.params.appId).toBe("abc-123");
+  });
+
+  it("dispatches ait_test_environments list with app_id filter", async () => {
+    const mockRequest = vi.fn().mockResolvedValue([]);
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ait" }));
+
+    await registry.dispatch(makeClient(mockRequest), "ait_test_environments", "list", {
+      app_id: "abc-123",
+    });
+
+    const request = mockRequest.mock.calls[0]![0] as { path: string; params: Record<string, unknown> };
+    expect(request.path).toBe("/ait/api/v1/testEnvironments");
+    expect(request.params.appId).toBe("abc-123");
+  });
+});

--- a/tests/registry/ait.test.ts
+++ b/tests/registry/ait.test.ts
@@ -44,7 +44,7 @@ function findResource(type: string): ResourceDefinition {
   return res;
 }
 
-function getOp(type: string, op: "list" | "get"): EndpointSpec {
+function getOp(type: string, op: "list" | "get" | "create"): EndpointSpec {
   const res = findResource(type);
   const spec = res.operations[op];
   if (!spec) throw new Error(`Operation "${op}" not found on "${type}"`);
@@ -62,14 +62,19 @@ describe("aitToolset structure", () => {
     expect(aitToolset.optIn).toBe(true);
   });
 
-  it("registers all 5 resource types", () => {
+  it("registers 3 noun-oriented resource types", () => {
     const types = aitToolset.resources.map((r) => r.resourceType);
-    expect(types).toContain("ait_apps_for_org");
-    expect(types).toContain("ait_test_environments");
-    expect(types).toContain("ait_tests_list");
-    expect(types).toContain("ait_create_test_using_ai");
-    expect(types).toContain("ait_run_test");
-    expect(types).toHaveLength(5);
+    expect(types).toContain("ait_app");
+    expect(types).toContain("ait_test_environment");
+    expect(types).toContain("ait_test");
+    expect(types).toHaveLength(3);
+  });
+
+  it("ait_test has list, create operations and run executeAction", () => {
+    const res = findResource("ait_test");
+    expect(res.operations.list).toBeDefined();
+    expect(res.operations.create).toBeDefined();
+    expect(res.executeActions?.run).toBeDefined();
   });
 
   it("all resources are account-scoped", () => {
@@ -78,7 +83,7 @@ describe("aitToolset structure", () => {
     }
   });
 
-  it("all list/get endpoint specs have operationPolicy", () => {
+  it("all list/get/create endpoint specs have operationPolicy", () => {
     for (const resource of aitToolset.resources) {
       for (const [opName, spec] of Object.entries(resource.operations)) {
         expect(
@@ -95,29 +100,27 @@ describe("aitToolset structure", () => {
 describe("ait opt-in with Registry", () => {
   it("is NOT present when HARNESS_TOOLSETS is unset (all defaults)", () => {
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: undefined }));
-    expect(registry.getAllResourceTypes()).not.toContain("ait_apps_for_org");
+    expect(registry.getAllResourceTypes()).not.toContain("ait_app");
   });
 
   it("IS present when explicitly enabled with HARNESS_TOOLSETS=+ait", () => {
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "+ait" }));
-    expect(registry.getAllResourceTypes()).toContain("ait_apps_for_org");
-    expect(registry.getAllResourceTypes()).toContain("ait_test_environments");
-    expect(registry.getAllResourceTypes()).toContain("ait_tests_list");
-    expect(registry.getAllResourceTypes()).toContain("ait_create_test_using_ai");
-    expect(registry.getAllResourceTypes()).toContain("ait_run_test");
+    expect(registry.getAllResourceTypes()).toContain("ait_app");
+    expect(registry.getAllResourceTypes()).toContain("ait_test_environment");
+    expect(registry.getAllResourceTypes()).toContain("ait_test");
   });
 
   it("IS present when listed explicitly in HARNESS_TOOLSETS=ait", () => {
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ait" }));
-    expect(registry.getAllResourceTypes()).toContain("ait_apps_for_org");
+    expect(registry.getAllResourceTypes()).toContain("ait_app");
   });
 });
 
-// ─── Response extractor: aitAppsForOrgExtract ───────────────────────────────
+// ─── Response extractor: ait_app list ───────────────────────────────────────
 
-describe("aitAppsForOrgExtract", () => {
+describe("ait_app list extractor", () => {
   function extract(raw: unknown) {
-    return getOp("ait_apps_for_org", "list").responseExtractor!(raw);
+    return getOp("ait_app", "list").responseExtractor!(raw);
   }
 
   it("normalizes camelCase app fields to snake_case", () => {
@@ -163,13 +166,19 @@ describe("aitAppsForOrgExtract", () => {
     expect(result.items).toEqual([]);
     expect(result.total).toBe(0);
   });
+
+  it("throws on non-array response", () => {
+    expect(() => extract({ error: "unauthorized" })).toThrow("ait_app: expected array response");
+    expect(() => extract("string")).toThrow("ait_app: expected array response");
+    expect(() => extract(null)).toThrow("ait_app: expected array response");
+  });
 });
 
-// ─── Response extractor: aitTestEnvironmentsExtract ─────────────────────────
+// ─── Response extractor: ait_test_environment list ──────────────────────────
 
-describe("aitTestEnvironmentsExtract", () => {
+describe("ait_test_environment list extractor", () => {
   function extract(raw: unknown) {
-    return getOp("ait_test_environments", "list").responseExtractor!(raw);
+    return getOp("ait_test_environment", "list").responseExtractor!(raw);
   }
 
   it("normalizes camelCase env fields to snake_case", () => {
@@ -209,13 +218,19 @@ describe("aitTestEnvironmentsExtract", () => {
     expect(result.items).toEqual([]);
     expect(result.total).toBe(0);
   });
+
+  it("throws on non-array response", () => {
+    expect(() => extract({ error: "unauthorized" })).toThrow("ait_test_environment: expected array response");
+    expect(() => extract("string")).toThrow("ait_test_environment: expected array response");
+    expect(() => extract(null)).toThrow("ait_test_environment: expected array response");
+  });
 });
 
-// ─── Response extractor: aitTestsListExtract ────────────────────────────────
+// ─── Response extractor: ait_test list ──────────────────────────────────────
 
-describe("aitTestsListExtract", () => {
+describe("ait_test list extractor", () => {
   function extract(raw: unknown) {
-    return getOp("ait_tests_list", "list").responseExtractor!(raw);
+    return getOp("ait_test", "list").responseExtractor!(raw);
   }
 
   it("extracts paginated test list with key fields", () => {
@@ -279,45 +294,185 @@ describe("aitTestsListExtract", () => {
     expect(result.items).toEqual([]);
     expect(result.total).toBe(0);
   });
+
+  it("throws on non-object response", () => {
+    expect(() => extract("string")).toThrow("ait_test: expected paginated object response");
+    expect(() => extract(null)).toThrow("ait_test: expected paginated object response");
+    expect(() => extract([1, 2, 3])).toThrow("ait_test: expected paginated object response");
+  });
+
+  it("throws when data field is not an array", () => {
+    expect(() => extract({ data: "not-array" })).toThrow("ait_test: expected data field to be an array");
+  });
+});
+
+// ─── Response extractor: ait_test create ────────────────────────────────────
+
+describe("ait_test create extractor", () => {
+  function extract(raw: unknown) {
+    return getOp("ait_test", "create").responseExtractor!(raw);
+  }
+
+  it("normalizes camelCase to snake_case", () => {
+    const raw = { testId: 42, testVersionId: 7 };
+    const result = extract(raw) as Record<string, unknown>;
+    expect(result).toEqual({ test_id: 42, test_version_id: 7 });
+  });
+});
+
+// ─── Response extractor: ait_test execute.run ───────────────────────────────
+
+describe("ait_test run extractor", () => {
+  function extract(raw: unknown) {
+    const res = findResource("ait_test");
+    return res.executeActions!.run.responseExtractor!(raw);
+  }
+
+  it("extracts key fields from run response", () => {
+    const raw = {
+      id: 99,
+      app_id: "app-uuid",
+      test_id: 10,
+      test_version_id: 20,
+      test_environment_id: "env-uuid",
+      status: "RUNNING",
+      test_session_id: "sess-1",
+      start_epoch: 1700000000,
+      error: null,
+    };
+    const result = extract(raw) as Record<string, unknown>;
+    expect(result).toEqual({
+      id: 99,
+      app_id: "app-uuid",
+      test_id: 10,
+      test_version_id: 20,
+      test_environment_id: "env-uuid",
+      status: "RUNNING",
+      error: null,
+    });
+  });
+
+  it("does not include process.env-dependent URLs or _note", () => {
+    const raw = {
+      id: 1,
+      app_id: "a",
+      test_id: 2,
+      test_version_id: 3,
+      test_environment_id: "e",
+      status: null,
+      test_session_id: null,
+      start_epoch: null,
+      error: null,
+    };
+    const result = extract(raw) as Record<string, unknown>;
+    expect(result).not.toHaveProperty("test_run_url");
+    expect(result).not.toHaveProperty("_note");
+  });
 });
 
 // ─── API paths ───────────────────────────────────────────────────────────────
 
 describe("endpoint paths", () => {
-  it("ait_apps_for_org list uses /ait/api/v1/application", () => {
-    expect(getOp("ait_apps_for_org", "list").path).toBe("/ait/api/v1/application");
+  it("ait_app list uses /ait/api/v1/application", () => {
+    expect(getOp("ait_app", "list").path).toBe("/ait/api/v1/application");
   });
 
-  it("ait_test_environments list uses /ait/api/v1/testEnvironments", () => {
-    expect(getOp("ait_test_environments", "list").path).toBe("/ait/api/v1/testEnvironments");
+  it("ait_test_environment list uses /ait/api/v1/testEnvironments", () => {
+    expect(getOp("ait_test_environment", "list").path).toBe("/ait/api/v1/testEnvironments");
   });
 
-  it("ait_tests_list list uses /ait/api/v1/testNew", () => {
-    expect(getOp("ait_tests_list", "list").path).toBe("/ait/api/v1/testNew");
+  it("ait_test list uses /ait/api/v1/testNew", () => {
+    expect(getOp("ait_test", "list").path).toBe("/ait/api/v1/testNew");
+  });
+
+  it("ait_test create uses /ait/api/v1/testNew/copilotTest/import", () => {
+    expect(getOp("ait_test", "create").path).toBe("/ait/api/v1/testNew/copilotTest/import");
+  });
+
+  it("ait_test execute.run uses /ait/api/v1/testNew/{test_id}/version/{test_version_id}/run", () => {
+    const res = findResource("ait_test");
+    expect(res.executeActions!.run.path).toBe("/ait/api/v1/testNew/{test_id}/version/{test_version_id}/run");
+  });
+});
+
+// ─── bodyBuilder snake_case acceptance ──────────────────────────────────────
+
+describe("ait_test create bodyBuilder", () => {
+  function getBodyBuilder() {
+    return getOp("ait_test", "create").bodyBuilder!;
+  }
+
+  it("accepts snake_case fields and maps to camelCase wire format", () => {
+    const builder = getBodyBuilder();
+    const result = builder({ body: { app_id: "a1", env_id: "e1", description: "test desc", auth_type: "no_auth", entry_url: "https://example.com" } });
+    expect(result).toEqual({
+      appId: "a1",
+      envId: "e1",
+      description: "test desc",
+      authType: "no_auth",
+      entryUrl: "https://example.com",
+    });
+  });
+
+  it("accepts camelCase fields as aliases", () => {
+    const builder = getBodyBuilder();
+    const result = builder({ body: { appId: "a1", envId: "e1", description: "test desc" } });
+    expect(result).toEqual({
+      appId: "a1",
+      envId: "e1",
+      description: "test desc",
+    });
+  });
+});
+
+describe("ait_test run bodyBuilder", () => {
+  function getBodyBuilder() {
+    const res = findResource("ait_test");
+    return res.executeActions!.run.bodyBuilder!;
+  }
+
+  it("accepts snake_case fields and maps to camelCase wire format", () => {
+    const builder = getBodyBuilder();
+    const result = builder({ body: { app_id: "a1", environment_id: "e1" } });
+    expect(result).toEqual({
+      appId: "a1",
+      environmentId: "e1",
+      params: '{"RUN_MODE":"no-mock","TestExecutorNamespace.fastExecutorMode":"false"}',
+    });
+  });
+
+  it("accepts camelCase fields as aliases", () => {
+    const builder = getBodyBuilder();
+    const result = builder({ body: { appId: "a1", environmentId: "e1", params: '{"custom":"value"}' } });
+    expect(result).toEqual({
+      appId: "a1",
+      environmentId: "e1",
+      params: '{"custom":"value"}',
+    });
   });
 });
 
 // ─── Registry dispatch integration ─────────────────────────────────────────
 
 describe("ait registry dispatch", () => {
-  it("dispatches ait_apps_for_org list", async () => {
+  it("dispatches ait_app list", async () => {
     const mockRequest = vi.fn().mockResolvedValue([
       { appId: "abc", appName: "test-app", isDeleted: false },
     ]);
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ait" }));
 
-    const result = await registry.dispatch(makeClient(mockRequest), "ait_apps_for_org", "list", {});
+    const result = await registry.dispatch(makeClient(mockRequest), "ait_app", "list", {});
 
     const request = mockRequest.mock.calls[0]![0] as { path: string };
     expect(request.path).toBe("/ait/api/v1/application");
     expect((result as { items: unknown[] }).items).toHaveLength(1);
   });
 
-  it("dispatches ait_tests_list list with app_id filter", async () => {
+  it("dispatches ait_test list with app_id filter", async () => {
     const mockRequest = vi.fn().mockResolvedValue({ data: [], totalItems: 0 });
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ait" }));
 
-    await registry.dispatch(makeClient(mockRequest), "ait_tests_list", "list", {
+    await registry.dispatch(makeClient(mockRequest), "ait_test", "list", {
       app_id: "abc-123",
     });
 
@@ -326,11 +481,24 @@ describe("ait registry dispatch", () => {
     expect(request.params.appId).toBe("abc-123");
   });
 
-  it("dispatches ait_test_environments list with app_id filter", async () => {
+  it("maps size parameter to limit query param for ait_test list", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ data: [], totalItems: 0 });
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ait" }));
+
+    await registry.dispatch(makeClient(mockRequest), "ait_test", "list", {
+      app_id: "abc-123",
+      size: 5,
+    });
+
+    const request = mockRequest.mock.calls[0]![0] as { path: string; params: Record<string, unknown> };
+    expect(request.params.limit).toBe(5);
+  });
+
+  it("dispatches ait_test_environment list with app_id filter", async () => {
     const mockRequest = vi.fn().mockResolvedValue([]);
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ait" }));
 
-    await registry.dispatch(makeClient(mockRequest), "ait_test_environments", "list", {
+    await registry.dispatch(makeClient(mockRequest), "ait_test_environment", "list", {
       app_id: "abc-123",
     });
 


### PR DESCRIPTION
## Summary

  - Adds a new opt-in `ait` toolset that exposes Harness AI Test Automation (AIT) capabilities through the MCP server
  - Registers 5 resource types: `ait_apps_for_org`, `ait_test_environments`, `ait_tests_list`, `ait_create_test_using_ai`, and `ait_run_test`
  - Includes response extractors that normalize AIT's camelCase API responses to snake_case for consistency with the rest of the MCP server

  ## What's included

  | Resource | Operation | Description |
  |----------|-----------|-------------|
  | `ait_apps_for_org` | list | List all applications for the organization |
  | `ait_test_environments` | list | List test environments for a given app |
  | `ait_tests_list` | list | Paginated list of tests with filters (status, sort, search) |
  | `ait_create_test_using_ai` | create | Create a test via AI using a natural language description |
  | `ait_run_test` | execute (run) | Execute a test and return the run URL |

  The toolset is **opt-in** — users must enable it via `HARNESS_TOOLSETS=+ait` or by including `ait` in their explicit toolset list.

  ## Test plan

  - TypeScript typecheck passes (`pnpm typecheck`)
  - All existing tests pass (2678 tests, 123 files)
  - New `tests/registry/ait.test.ts` covers:
    - Toolset structure validation (name, opt-in flag, resource count, scopes, operation policies)
    - Registry opt-in behavior (excluded by default, included with `+ait` or explicit `ait`)
    - Response extractors for all list endpoints (snake_case normalization, deleted-app filtering, pagination, null handling)
    - Registry dispatch integration (correct API paths, query param mapping)