### PR TITLE
fix: Fix harness_list on iacm_module

### DIFF
--- a/src/registry/toolsets/iacm.ts
+++ b/src/registry/toolsets/iacm.ts
@@ -376,6 +376,7 @@ export const iacmToolset: ToolsetDefinition = {
             page: "page",
             size: "size",
           },
+          pageOneIndexed: true,
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           responseExtractor: moduleListExtract,
           description:

--- a/tests/registry/iacm.test.ts
+++ b/tests/registry/iacm.test.ts
@@ -76,6 +76,10 @@ describe("iacmToolset structure", () => {
     expect(findResource("iacm_module").scope).toBe("account");
   });
 
+  it("iacm_module list has pageOneIndexed=true", () => {
+    expect(getOp("iacm_module", "list").pageOneIndexed).toBe(true);
+  });
+
   it("iacm_workspace, iacm_resource, iacm_workspace_costs, iacm_activity_resource_change are project-scoped", () => {
     for (const type of ["iacm_workspace", "iacm_resource", "iacm_workspace_costs", "iacm_activity_resource_change"]) {
       expect(findResource(type).scope).toBe("project");
@@ -371,6 +375,34 @@ describe("iacm registry dispatch", () => {
 
     const request = mockRequest.mock.calls[0]![0] as { path: string };
     expect(request.path).toBe("/iacm/api/modules/4640");
+  });
+
+  it("iacm_module list converts harness_list page 0 to API page 1", async () => {
+    const mockRequest = vi.fn().mockResolvedValue([]);
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+
+    await registry.dispatch(makeClient(mockRequest), "iacm_module", "list", {
+      page: 0,
+      size: 20,
+    });
+
+    const request = mockRequest.mock.calls[0]![0] as { path: string; params: Record<string, unknown> };
+    expect(request.path).toBe("/iacm/api/modules");
+    expect(request.params.page).toBe(1);
+    expect(request.params.size).toBe(20);
+  });
+
+  it("iacm_module list converts harness_list page 1 to API page 2", async () => {
+    const mockRequest = vi.fn().mockResolvedValue([]);
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+
+    await registry.dispatch(makeClient(mockRequest), "iacm_module", "list", {
+      page: 1,
+      size: 20,
+    });
+
+    const request = mockRequest.mock.calls[0]![0] as { params: Record<string, unknown> };
+    expect(request.params.page).toBe(2);
   });
 
   it("dispatches activity resource changes by activity id", async () => {


### PR DESCRIPTION
## Summary

Fixes `harness_list` failures for `iacm_module` when callers use the default first page (`page=0`). The IaCM module registry API expects 1-based pagination; the registry now converts MCP’s 0-based page the same way as other IaCM list endpoints.

## What changed

- Set `pageOneIndexed: true` on `iacm_module.list` in `src/registry/toolsets/iacm.ts`.
- Added regression coverage in `tests/registry/iacm.test.ts`:
  - structural check that `pageOneIndexed` is enabled
  - dispatch tests: MCP `page: 0` → API `page=1`, MCP `page: 1` → API `page=2`

## Why

Production traces showed repeated errors on external MCP (`page must be greater or equal than 1 but got value 0`) for `harness_list` × `iacm_module`. This was not scope/IaCM enablement—`iacm_workspace` and `iacm_resource` already had `pageOneIndexed`; `iacm_module` was missing it despite docs stating API `page >= 1`.

## Verification

- [x] `pnpm test tests/registry/iacm.test.ts`
- [x] Manual smoke via **harness-local** MCP after rebuild/reload: `harness_list(resource_type=iacm_module, resource_scope=account, page=0)` succeeds (empty module list on test account; no pagination error)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] `pnpm test` passes (targeted IaCM registry tests)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes
- [ ] `pnpm standards:check` passes
- [ ] `pnpm docs:check` passes (registry/tool counts unchanged)

## Coding standards (registry-driven MCP model)

- [x] No new `server.registerTool()` calls — toolset definition only
- [x] `operationPolicy` unchanged on existing endpoint
- [x] No `console.log()` in `src/`

## Related issues

- [IAC-7857](https://harness.atlassian.net/browse/IAC-7857)

[IAC-7857]: https://harness.atlassian.net/browse/IAC-7857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ