### PR TITLE
fix: parse YAML string bodies for trigger create/update

### DIFF
--- a/src/registry/toolsets/pipelines.ts
+++ b/src/registry/toolsets/pipelines.ts
@@ -2,27 +2,53 @@ import type { ToolsetDefinition, BodySchema, ParamsSchema } from "../types.js";
 import { ngExtract, pageExtract, passthrough, v1ListExtract, runtimeInputExtract, executionInputsExtract, dynamicExecutionExtract } from "../extractors.js";
 import YAML from "yaml";
 
+function coerceTriggerBodyRecord(body: unknown): Record<string, unknown> {
+  if (body == null || body === "") {
+    throw new Error("body must be a JSON object or YAML object for trigger.");
+  }
+  if (typeof body === "string") {
+    let parsed: unknown;
+    try {
+      parsed = YAML.parse(body);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `body must be a JSON object or YAML object for trigger. Failed to parse YAML body: ${detail}`,
+      );
+    }
+    if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("body must be a JSON object or YAML object for trigger.");
+    }
+    return parsed as Record<string, unknown>;
+  }
+  if (typeof body === "object" && !Array.isArray(body)) {
+    return body as Record<string, unknown>;
+  }
+  throw new Error("body must be a JSON object or YAML object for trigger.");
+}
+
 /**
  * Normalize a trigger body into the canonical `{ trigger: { ... } }` shape,
  * hoist `pipelineIdentifier` onto `input.pipeline_id` for the query param,
  * and ensure it ends up inside the trigger object for YAML serialization.
  *
- * Handles three caller-provided shapes:
+ * Handles caller-provided shapes (JSON object or YAML string):
  *  1. Flat:    `{ name, identifier, pipelineIdentifier, ... }`
  *  2. Wrapped: `{ trigger: { ..., pipelineIdentifier } }`
  *  3. Sibling: `{ trigger: { ... }, pipelineIdentifier }`
  */
 function normalizeTriggerBody(
-  body: Record<string, unknown>,
+  body: unknown,
   input: Record<string, unknown>,
 ): Record<string, unknown> {
-  const hasWrapper = body.trigger && typeof body.trigger === "object";
+  const record = coerceTriggerBodyRecord(body);
+  const hasWrapper = record.trigger && typeof record.trigger === "object";
   const inner = hasWrapper
-    ? (body.trigger as Record<string, unknown>)
-    : body;
+    ? (record.trigger as Record<string, unknown>)
+    : record;
 
   // Resolve pipelineIdentifier: prefer inner, fall back to root-level sibling
-  const pipelineId = (inner.pipelineIdentifier ?? body.pipelineIdentifier) as string | undefined;
+  const pipelineId = (inner.pipelineIdentifier ?? record.pipelineIdentifier) as string | undefined;
   if (pipelineId && !input.pipeline_id) {
     input.pipeline_id = pipelineId;
   }
@@ -32,11 +58,11 @@ function normalizeTriggerBody(
     if (!inner.pipelineIdentifier && pipelineId) {
       inner.pipelineIdentifier = pipelineId;
     }
-    delete body.pipelineIdentifier;
-    return body;
+    delete record.pipelineIdentifier;
+    return record;
   }
   // Flat shape: auto-wrap
-  return { trigger: body };
+  return { trigger: record };
 }
 
 // ---------------------------------------------------------------------------
@@ -735,15 +761,15 @@ export const pipelinesToolset: ToolsetDefinition = {
           operationPolicy: { risk: "low_write", retryPolicy: "do_not_retry" },
           queryParams: { pipeline_id: "targetIdentifier" },
           bodyBuilder: (input) => {
-            const body = input.body as Record<string, unknown> | undefined;
-            if (!body) return "";
+            const body = input.body;
+            if (body == null || body === "") return "";
             const triggerObj = normalizeTriggerBody(body, input);
             return YAML.stringify(triggerObj);
           },
           responseExtractor: ngExtract,
           description: "Create a new pipeline trigger. Requires pipeline_id to identify the target pipeline. Use harness_schema(resource_type='trigger') to discover the body structure.",
           bodySchema: {
-            description: "Trigger configuration as JSON — auto-converted to YAML for the API. Pass trigger fields directly (auto-wrapped in trigger envelope). Use harness_schema(resource_type='trigger') for the full schema. The pipeline_id is auto-extracted from pipelineIdentifier in the body.",
+            description: "Trigger configuration — auto-converted to YAML for the API. Pass a raw YAML string (including trigger: root), a JSON object with trigger fields (auto-wrapped in trigger envelope), or { trigger: { ... } }. Use harness_schema(resource_type='trigger') for the full schema. The pipeline_id query param is auto-extracted from pipelineIdentifier in the body when omitted.",
             fields: [
               { name: "trigger", type: "object", required: false, description: "Wrapper key (optional — body is auto-wrapped if not present). Inner fields: name (required), identifier (required), enabled (bool), pipelineIdentifier (required — target pipeline), source (required — e.g. { type: 'Scheduled', spec: { type: 'Cron', spec: { expression: '0 8 * * *' } } }), inputYaml (optional — runtime input YAML for triggered execution). Use harness_schema(resource_type='trigger', path='trigger_source') for source structure." },
             ],
@@ -756,15 +782,15 @@ export const pipelinesToolset: ToolsetDefinition = {
           pathParams: { trigger_id: "triggerIdentifier" },
           queryParams: { pipeline_id: "targetIdentifier" },
           bodyBuilder: (input) => {
-            const body = input.body as Record<string, unknown> | undefined;
-            if (!body) return "";
+            const body = input.body;
+            if (body == null || body === "") return "";
             const triggerObj = normalizeTriggerBody(body, input);
             return YAML.stringify(triggerObj);
           },
           responseExtractor: ngExtract,
           description: "Update a pipeline trigger. Use harness_schema(resource_type='trigger') to discover the body structure.",
           bodySchema: {
-            description: "Full trigger configuration (replaces existing). Pass trigger fields directly — auto-wrapped and converted to YAML. Use harness_schema(resource_type='trigger') for the full schema.",
+            description: "Full trigger configuration (replaces existing). Pass a raw YAML string, JSON trigger fields (auto-wrapped), or { trigger: { ... } } — converted to YAML for the API. Use harness_schema(resource_type='trigger') for the full schema.",
             fields: [
               { name: "trigger", type: "object", required: false, description: "Wrapper key (optional — body is auto-wrapped if not present). Inner fields: name, identifier, enabled, pipelineIdentifier, source, inputYaml. Use harness_schema for full structure." },
             ],

--- a/tests/registry/registry.test.ts
+++ b/tests/registry/registry.test.ts
@@ -1433,6 +1433,59 @@ describe("Registry", () => {
       expect(call.params.targetIdentifier).toBe("explicitPipeline");
     });
 
+    it("YAML string body with trigger root: parses and extracts pipelineIdentifier", async () => {
+      const mockRequest = vi.fn().mockResolvedValue({ status: "SUCCESS", data: {} });
+      const client = makeClient(mockRequest);
+      const yamlBody = [
+        "trigger:",
+        "  name: my-trigger",
+        "  identifier: myTrigger",
+        "  pipelineIdentifier: myPipeline",
+        "  source:",
+        "    type: Scheduled",
+      ].join("\n");
+      await registry.dispatch(client, "trigger", "create", {
+        pipeline_id: undefined,
+        body: yamlBody,
+      });
+      const call = mockRequest.mock.calls[0][0];
+      expect(call.params.targetIdentifier).toBe("myPipeline");
+      const outYaml = call.body as string;
+      expect(outYaml).toContain("pipelineIdentifier: myPipeline");
+      expect(outYaml).not.toMatch(/^trigger: \|\s/m);
+      expect(outYaml).not.toContain("trigger: |\n  trigger:");
+    });
+
+    it("YAML string body flat shape: auto-wraps and extracts pipelineIdentifier", async () => {
+      const mockRequest = vi.fn().mockResolvedValue({ status: "SUCCESS", data: {} });
+      const client = makeClient(mockRequest);
+      const yamlBody = [
+        "name: flat-trigger",
+        "identifier: flatTrigger",
+        "pipelineIdentifier: flatPipeline",
+        "source:",
+        "  type: Scheduled",
+      ].join("\n");
+      await registry.dispatch(client, "trigger", "create", {
+        pipeline_id: undefined,
+        body: yamlBody,
+      });
+      const call = mockRequest.mock.calls[0][0];
+      expect(call.params.targetIdentifier).toBe("flatPipeline");
+      const outYaml = call.body as string;
+      expect(outYaml).toContain("trigger:");
+      expect(outYaml).toContain("pipelineIdentifier: flatPipeline");
+    });
+
+    it("invalid YAML string body throws a clear error", async () => {
+      const client = makeClient();
+      await expect(
+        registry.dispatch(client, "trigger", "create", {
+          body: "trigger:\n  name: [unclosed",
+        }),
+      ).rejects.toThrow(/body must be a JSON object or YAML object for trigger/);
+    });
+
     it("list without pipeline_id throws a clear error", async () => {
       const client = makeClient();
       await expect(


### PR DESCRIPTION
## Summary

Fixes `harness_create` / `harness_update` for `resource_type: trigger` when agents pass the trigger definition as a **raw YAML string**. Previously the server wrapped the unparsed string as a YAML scalar, and Harness rejected the payload with `Cannot construct instance of NGTriggerConfigV2 ... from String value`.

## Problem

- `harness_create` accepts `body` as string or object; `coerceRecord()` only parses JSON, so YAML strings reached the trigger `bodyBuilder` unchanged.
- `normalizeTriggerBody()` treated a string as a flat object and emitted `{ trigger: "<entire yaml>" }`, which `YAML.stringify` serialized as a block scalar instead of a structured trigger document.


## What changed

- Added `coerceTriggerBodyRecord()` to parse YAML strings via `YAML.parse`, validate object shape, and return clear errors on invalid input.
- Updated `normalizeTriggerBody()` to accept `unknown`, parse first, then apply existing wrap / sibling-merge / `pipelineIdentifier` → `input.pipeline_id` logic.
- Trigger create and update `bodyBuilder`s pass through string or object bodies; `bodySchema` descriptions note raw YAML is supported.
- Registry tests: wrapped YAML string, flat YAML string (auto-wrap), and invalid YAML error path.

## Why this approach

Parsing at the trigger normalization layer matches how pipelines and input sets already treat YAML strings, keeps JSON object callers unchanged, and fixes create and update in one place without changing the public tool schema.

## Verification

- `pnpm typecheck`
- `pnpm exec vitest run tests/registry/registry.test.ts -t "trigger pipelineIdentifier"`
- Manual: created three triggers on pipeline `test` (org `default`, project `Prachi`) via local MCP using YAML string bodies—scheduled (wrapped), webhook (flat), and scheduled (disabled)—all succeeded with correct `targetIdentifier: test`.


Made with [Cursor](https://cursor.com)