### PR TITLE
feat: add Evidence Vault attestation list toolset

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![MCP Toplist](https://mcptoplist.com/badge/glama%2Fharness%2Fmcp-server.svg)](https://mcptoplist.com/server/glama%2Fharness%2Fmcp-server)
 
-An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 219 resource types.
+An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 220 resource types.
 
 ## Why Use This MCP Server
 
@@ -10,8 +10,8 @@ Most MCP servers map one tool per API endpoint. For a platform as broad as Harne
 
 This server is built differently:
 
-- **11 tools, 219 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
-- **Full platform coverage.** 37 default toolsets spanning CI/CD, GitOps, Feature Flags, Cloud Cost Management, Security Testing, Chaos Engineering, Database DevOps, Internal Developer Portal, Software Supply Chain, Infrastructure as Code Management, Governance, Service Overrides, Knowledge Graph, and more. Opt-in Ansible coverage is available when you need inventory and playbook data.
+- **11 tools, 220 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
+- **Full platform coverage.** 38 default toolsets spanning CI/CD, GitOps, Feature Flags, Cloud Cost Management, Security Testing, Chaos Engineering, Database DevOps, Internal Developer Portal, Software Supply Chain, Infrastructure as Code Management, Governance, Service Overrides, Knowledge Graph, and more. Opt-in Ansible coverage is available when you need inventory and playbook data.
 - **Multi-project workflows out of the box.** Agents discover organizations and projects dynamically — no hardcoded env vars needed. Ask "show failed executions across all projects" and the agent can navigate the full account hierarchy.
 - **34 prompt templates.** Pre-built prompts for common workflows: build & deploy apps end-to-end, debug failed pipelines, review DORA metrics, triage vulnerabilities, optimize cloud costs, audit access control, plan feature flag rollouts, review pull requests, approve pending pipelines, and more.
 - **Works everywhere.** Stdio transport for local clients (Claude Desktop, Cursor, Devin Desktop), HTTP transport for remote/shared deployments, Docker and Kubernetes ready.
@@ -1199,7 +1199,7 @@ Harness pipelines can be stored in three ways:
 
 ## Resource Types
 
-219 resource types organized across 37 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
+220 resource types organized across 38 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
 
 ### Platform
 
@@ -1600,6 +1600,17 @@ SEI resources are consolidated for token efficiency. Use `metric` or `aspect` pa
 | `scs_sbom`                 |      | x   |        |        |        |                 |
 
 
+### Evidence Vault
+
+Evidence Vault stores in-toto attestations (SDLC evidences). List supports account/org/project scope via `resource_scope`. Singular free-text filters (pipeline, artifact alone, gitoid) use `search_term`; an additional Name constraint uses `filters.subject_name`; subject content digest uses `filters.subject_digest`. Requires feature flag `SCS_EVIDENCE_VAULT`.
+
+
+| Resource Type | List | Get | Create | Update | Delete | Execute Actions |
+| ------------- | ---- | --- | ------ | ------ | ------ | --------------- |
+| `attestation` | x    |     |        |        |        |                 |
+
+
+
 ### Security Testing Orchestration (STO)
 
 
@@ -1745,7 +1756,7 @@ Security exemption execute workflow:
 
 ## Toolset Filtering
 
-By default, 37 of 38 toolsets are enabled. One toolset is opt-in and excluded from the defaults:
+By default, 38 of 39 toolsets are enabled. One toolset is opt-in and excluded from the defaults:
 
 - **`ansible`** — Harness Ansible (inventories, playbooks, hosts, activity). Opt-in because it is project-scoped and adds concepts many users do not need.
 
@@ -1812,6 +1823,7 @@ Available toolset names:
 | `ccm`                   | cost_perspective, cost_breakdown, cost_timeseries, cost_summary, cost_recommendation, cost_anomaly, cost_anomaly_summary, cost_category, cost_account_overview, cost_filter_value, cost_recommendation_stats, cost_recommendation_detail, cost_commitment                                       |
 | `sei`                   | sei_metric, sei_productivity_metric, sei_dora_metric, sei_team, sei_team_detail, sei_org_tree, sei_org_tree_detail, sei_business_alignment, sei_ai_usage, sei_ai_adoption, sei_ai_impact, sei_ai_raw_metric                                                                                     |
 | `scs`                   | scs_artifact_source, artifact_security, scs_artifact_component, scs_artifact_remediation, scs_chain_of_custody, scs_compliance_result, code_repo_security, scs_sbom                                                                                                                             |
+| `evidence-vault`        | attestation                                                                                                                                                                                                                                                                                     |
 | `sto`                   | security_issue, security_issue_filter, security_exemption, sast_remediation_diff                                                                                                                                                                                                                |
 | `dbops`                 | database_schema, database_instance, database_snapshot_object, database_llm_authoring_pipeline                                                                                                                                                                                                   |
 | `access_control`        | user, user_group, service_account, role, role_assignment, resource_group, permission                                                                                                                                                                                                            |
@@ -1841,8 +1853,8 @@ Available toolset names:
                           |
                  +--------v---------+
                 |    Registry       |  <-- Declarative resource definitions
-                |  37 Toolsets      |      (data files, not code)
-                |  219 Resource Types|
+                |  38 Toolsets      |      (data files, not code)
+                |  220 Resource Types|
                  +--------+---------+
                           |
                  +--------v---------+

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -33,6 +33,7 @@ import { chaosToolset } from "./toolsets/chaos.js";
 import { ccmToolset } from "./toolsets/ccm.js";
 import { seiToolset } from "./toolsets/sei.js";
 import { scsToolset } from "./toolsets/scs.js";
+import { evidenceVaultToolset } from "./toolsets/evidence-vault.js";
 import { stoToolset } from "./toolsets/sto.js";
 import { dbopsToolset } from "./toolsets/dbops.js";
 import { accessControlToolset } from "./toolsets/access-control.js";
@@ -147,6 +148,7 @@ const ALL_TOOLSETS: ToolsetDefinition[] = [
   ccmToolset,
   seiToolset,
   scsToolset,
+  evidenceVaultToolset,
   stoToolset,
   dbopsToolset,
   accessControlToolset,

--- a/src/registry/toolsets/evidence-vault.ts
+++ b/src/registry/toolsets/evidence-vault.ts
@@ -1,0 +1,204 @@
+import type { ToolsetDefinition } from "../types.js";
+import { isRecord, asString, asNumber, asRecord } from "../../utils/type-guards.js";
+
+const SCS = "/ssca-manager";
+const SEARCH_MAX_LEN = 100;
+
+const ATTESTATION_TYPES = [
+  "Code",
+  "Build",
+  "Test",
+  "Security",
+  "SecurityScan",
+  "Deploy",
+  "Custom",
+  "AIAgent",
+] as const;
+
+const ATTESTATION_SOURCES = [
+  "Harness",
+  "GithubActions",
+  "Jenkins",
+  "Gitlab",
+  "Others",
+] as const;
+
+function ensureArray(val: unknown): unknown[] | undefined {
+  if (val === undefined || val === null || val === "") return undefined;
+  return Array.isArray(val) ? val : [val];
+}
+
+function asEpochMs(val: unknown): number | undefined {
+  if (typeof val === "number" && Number.isFinite(val)) return val;
+  if (typeof val === "string" && val.trim() !== "") {
+    const n = Number(val);
+    if (Number.isFinite(n)) return n;
+  }
+  return undefined;
+}
+
+/** Cap search_term so queryParams (`search_term` → `search`) match backend's 100-char limit. */
+function normalizeSearchTerm(input: Record<string, unknown>): void {
+  const raw = input.search_term;
+  if (typeof raw !== "string") return;
+  const trimmed = raw.trim();
+  input.search_term = trimmed.length > SEARCH_MAX_LEN ? trimmed.slice(0, SEARCH_MAX_LEN) : trimmed;
+  if (input.search_term === "") delete input.search_term;
+}
+
+/** Build list body. Singular free-text stays on query `search` via search_term. */
+export function buildAttestationListBody(input: Record<string, unknown>): Record<string, unknown> {
+  normalizeSearchTerm(input);
+
+  const subjectFilter: Array<Record<string, string>> = [];
+  const subjectName = asString(input.subject_name);
+  if (subjectName) {
+    subjectFilter.push({ field_name: "Name", operator: "Contains", value: subjectName });
+  }
+  const subjectDigest = asString(input.subject_digest);
+  if (subjectDigest) {
+    subjectFilter.push({ field_name: "Digest", operator: "Equals", value: subjectDigest });
+  }
+
+  const body: Record<string, unknown> = {};
+  const types = ensureArray(input.types);
+  if (types) body.types = types;
+  const sources = ensureArray(input.sources);
+  if (sources) body.sources = sources;
+  const startTime = asEpochMs(input.start_time);
+  const endTime = asEpochMs(input.end_time);
+  if (startTime !== undefined) body.start_time = startTime;
+  if (endTime !== undefined) body.end_time = endTime;
+  if (subjectFilter.length > 0) body.subject_filter = subjectFilter;
+  if (isRecord(input.scopes)) body.scopes = input.scopes;
+  return body;
+}
+
+/** Slim list row — drops status, updated_at, raw subjects/execution_context. */
+function projectAttestationListItem(raw: unknown): Record<string, unknown> {
+  if (!isRecord(raw)) return {};
+  const subject = asRecord(raw.subject);
+  const digest = subject ? asRecord(subject.digest) : undefined;
+  const exec = asRecord(raw.execution_context);
+
+  const out: Record<string, unknown> = {};
+  if (raw.id !== undefined) out.id = raw.id;
+  if (raw.type !== undefined) out.type = raw.type;
+  if (raw.source !== undefined) out.source = raw.source;
+  if (asString(raw.description)) out.description = raw.description;
+  if (asNumber(raw.created_at) !== undefined) out.created_at = raw.created_at;
+  if (asString(raw.org)) out.org = raw.org;
+  if (asString(raw.project)) out.project = raw.project;
+
+  const subjectName = asString(raw.subject_name) ?? (subject ? asString(subject.name) : undefined);
+  if (subjectName) out.subject_name = subjectName;
+
+  const subjectDigest =
+    asString(raw.subject_digest) ??
+    (digest ? asString(digest.value) : undefined) ??
+    (subject ? asString(subject.sha256) : undefined);
+  if (subjectDigest) out.subject_digest = subjectDigest;
+
+  if (asNumber(raw.additional_subject_count) !== undefined) {
+    out.additional_subject_count = raw.additional_subject_count;
+  }
+  if (asString(raw.gitoid_sha256)) out.gitoid_sha256 = raw.gitoid_sha256;
+
+  const pipelineId = asString(raw.pipeline_id) ?? (exec ? asString(exec.pipeline_id) : undefined);
+  if (pipelineId) out.pipeline_id = pipelineId;
+  const pipelineName = asString(raw.pipeline_name) ?? (exec ? asString(exec.pipeline_name) : undefined);
+  if (pipelineName) out.pipeline_name = pipelineName;
+  const pipelineExecutionId =
+    asString(raw.pipeline_execution_id) ?? (exec ? asString(exec.pipeline_execution_id) : undefined);
+  if (pipelineExecutionId) out.pipeline_execution_id = pipelineExecutionId;
+
+  return out;
+}
+
+/** Bare array → `{ items, total }` with slim rows (page-length total). */
+export function attestationListExtract(raw: unknown): {
+  items: unknown[];
+  total: number;
+  _display_hint: string;
+} {
+  const items = (Array.isArray(raw) ? raw : []).map(projectAttestationListItem);
+  return {
+    items,
+    total: items.length,
+    _display_hint:
+      "When showing attestations in a table, ALWAYS include gitoid_sha256 as a column "
+      + "(plus type, source, org, project, created_at, description; subject_name when present). "
+      + "Never omit gitoid_sha256.",
+  };
+}
+
+export const evidenceVaultToolset: ToolsetDefinition = {
+  name: "evidence-vault",
+  displayName: "Evidence Vault",
+  description:
+    "Harness Evidence Vault — in-toto attestations (evidences) for SDLC processes "
+    + "(build, PR, security scans, signing, deployment, and more).",
+  resources: [
+    {
+      resourceType: "attestation",
+      displayName: "Attestation",
+      description:
+        "Evidence Vault attestation (in-toto evidence). List only — retain `gitoid_sha256` for follow-ups. "
+        + "When listing, always show gitoid_sha256 in any table. "
+        + "Singular free-text (pipeline, artifact alone, gitoid) → search_term; additional Name → filters.subject_name; "
+        + "subject digest → filters.subject_digest (not gitoid). Use item `description` to explain a single attestation. "
+        + "Default scope is account; pass resource_scope org/project as needed. Requires SCS_EVIDENCE_VAULT.",
+      searchAliases: [
+        "evidence vault",
+        "attestation",
+        "evidence",
+        "in-toto",
+        "SDLC evidence",
+        "gitoid",
+      ],
+      toolset: "evidence-vault",
+      scope: "account",
+      supportedScopes: ["account", "org", "project"],
+      scopeParams: { org: "org", project: "project" },
+      identifierFields: ["attestation_id"],
+      listFilterFields: [
+        { name: "search_term", description: "Singular free-text filter (pipeline, artifact, gitoid, keyword) → query search" },
+        { name: "subject_name", description: "Additional Name filter → subject_filter Name/Contains" },
+        { name: "subject_digest", description: "Subject content digest → subject_filter Digest/Equals (not gitoid)" },
+        { name: "types", description: "Filter by attestation type(s)", enum: [...ATTESTATION_TYPES] },
+        { name: "sources", description: "Filter by attestation source(s)", enum: [...ATTESTATION_SOURCES] },
+        { name: "start_time", type: "number", description: "Inclusive creation-time start (epoch ms UTC)" },
+        { name: "end_time", type: "number", description: "Inclusive creation-time end (epoch ms UTC)" },
+        {
+          name: "scopes",
+          description: "Account/org narrow: org id → project id arrays (empty array = all projects under org)",
+        },
+        { name: "sort", description: "Sort field", enum: ["created_at", "updated_at"] },
+        { name: "order", description: "Sort order", enum: ["ASC", "DESC"] },
+      ],
+      compactItem: projectAttestationListItem,
+      operations: {
+        list: {
+          method: "POST",
+          path: `${SCS}/v2/attestations`,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          skipScopeBodyInjection: true,
+          queryParams: {
+            page: "page",
+            size: "limit",
+            search_term: "search",
+            sort: "sort",
+            order: "order",
+          },
+          defaultQueryParams: {
+            sort: "created_at",
+            order: "DESC",
+          },
+          bodyBuilder: buildAttestationListBody,
+          responseExtractor: attestationListExtract,
+          description: "List attestations (default sort created_at DESC)",
+        },
+      },
+    },
+  ],
+};

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -137,6 +137,7 @@ export type ToolsetName =
   | "ccm"
   | "sei"
   | "scs"
+  | "evidence-vault"
   | "sto"
   | "dbops"
   | "access_control"

--- a/tests/registry/evidence-vault.test.ts
+++ b/tests/registry/evidence-vault.test.ts
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2026 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  evidenceVaultToolset,
+  buildAttestationListBody,
+  attestationListExtract,
+} from "../../src/registry/toolsets/evidence-vault.js";
+import { Registry } from "../../src/registry/index.js";
+import type { Config } from "../../src/config.js";
+import type { HarnessClient } from "../../src/client/harness-client.js";
+import type { EndpointSpec, ResourceDefinition } from "../../src/registry/types.js";
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    HARNESS_API_KEY: "pat.test-account.token.secret",
+    HARNESS_ACCOUNT_ID: "test-account",
+    HARNESS_BASE_URL: "https://app.harness.io",
+    HARNESS_ORG: undefined,
+    HARNESS_PROJECT: undefined,
+    HARNESS_API_TIMEOUT_MS: 30000,
+    HARNESS_MAX_RETRIES: 3,
+    LOG_LEVEL: "info",
+    HARNESS_MAX_BODY_SIZE_MB: 10,
+    HARNESS_RATE_LIMIT_RPS: 10,
+    HARNESS_READ_ONLY: false,
+    HARNESS_SKIP_ELICITATION: false,
+    HARNESS_ALLOW_HTTP: false,
+    HARNESS_FME_BASE_URL: "https://api.split.io",
+    ...overrides,
+  } as Config;
+}
+
+function makeClient(requestFn?: (...args: unknown[]) => unknown): HarnessClient {
+  return {
+    request: requestFn ?? vi.fn().mockResolvedValue([]),
+    account: "test-account",
+  } as unknown as HarnessClient;
+}
+
+function findResource(type: string): ResourceDefinition {
+  const res = evidenceVaultToolset.resources.find((r) => r.resourceType === type);
+  if (!res) throw new Error(`Resource type "${type}" not found`);
+  return res;
+}
+
+function getListOp(): EndpointSpec {
+  const spec = findResource("attestation").operations.list;
+  if (!spec) throw new Error("list operation missing on attestation");
+  return spec;
+}
+
+describe("evidence-vault toolset", () => {
+  it("registers attestation list against /ssca-manager/v2/attestations", () => {
+    expect(evidenceVaultToolset.name).toBe("evidence-vault");
+    const resource = findResource("attestation");
+    expect(resource.scope).toBe("account");
+    expect(resource.supportedScopes).toEqual(["account", "org", "project"]);
+    expect(resource.scopeParams).toEqual({ org: "org", project: "project" });
+
+    const list = getListOp();
+    expect(list.method).toBe("POST");
+    expect(list.path).toBe("/ssca-manager/v2/attestations");
+    expect(list.skipScopeBodyInjection).toBe(true);
+    expect(list.defaultQueryParams).toMatchObject({ sort: "created_at", order: "DESC" });
+    expect(list.queryParams).toMatchObject({
+      page: "page",
+      size: "limit",
+      search_term: "search",
+    });
+  });
+
+  it("loads into Registry by default", () => {
+    const registry = new Registry(makeConfig());
+    expect(registry.getResource("attestation").resourceType).toBe("attestation");
+  });
+});
+
+describe("buildAttestationListBody", () => {
+  it("returns empty body when no filters", () => {
+    expect(buildAttestationListBody({})).toEqual({});
+  });
+
+  it("does not put singular search into body (search is a query param)", () => {
+    const input: Record<string, unknown> = { search_term: "ci-build" };
+    const body = buildAttestationListBody(input);
+    expect(body).toEqual({});
+    expect(input.search_term).toBe("ci-build");
+  });
+
+  it("maps subject_name to Name/Contains subject_filter", () => {
+    expect(buildAttestationListBody({ subject_name: "my-image:latest" })).toEqual({
+      subject_filter: [{ field_name: "Name", operator: "Contains", value: "my-image:latest" }],
+    });
+  });
+
+  it("maps subject_digest to Digest/Equals subject_filter", () => {
+    expect(buildAttestationListBody({ subject_digest: "sha256:abc" })).toEqual({
+      subject_filter: [{ field_name: "Digest", operator: "Equals", value: "sha256:abc" }],
+    });
+  });
+
+  it("combines search_term (query) with subject_name and subject_digest", () => {
+    const input: Record<string, unknown> = {
+      search_term: "ci-build",
+      subject_name: "artifact-foo",
+      subject_digest: "sha256:abc",
+      types: "Build",
+      sources: ["Harness"],
+      start_time: 1000,
+      end_time: 2000,
+    };
+    const body = buildAttestationListBody(input);
+    expect(body).toEqual({
+      types: ["Build"],
+      sources: ["Harness"],
+      start_time: 1000,
+      end_time: 2000,
+      subject_filter: [
+        { field_name: "Name", operator: "Contains", value: "artifact-foo" },
+        { field_name: "Digest", operator: "Equals", value: "sha256:abc" },
+      ],
+    });
+    expect(body).not.toHaveProperty("data_source");
+    expect(input.search_term).toBe("ci-build");
+  });
+
+  it("truncates search_term to 100 characters", () => {
+    const long = "x".repeat(150);
+    const input: Record<string, unknown> = { search_term: `  ${long}  ` };
+    buildAttestationListBody(input);
+    expect((input.search_term as string).length).toBe(100);
+  });
+
+  it("passes scopes through", () => {
+    const scopes = { myOrg: ["projA"] };
+    expect(buildAttestationListBody({ scopes })).toEqual({ scopes });
+  });
+});
+
+describe("attestationListExtract", () => {
+  const rawItem = {
+    id: "att-1",
+    gitoid_sha256: "gid123",
+    created_at: 1700000000000,
+    updated_at: 1700000001000,
+    type: "Build",
+    source: "Harness",
+    status: "INDEXED",
+    description: "Build attestation for container image",
+    org: "SSCA",
+    project: "Sanity",
+    additional_subject_count: 1,
+    subject: {
+      name: "registry/app:1.0",
+      digest: { algorithm: "sha256", value: "deadbeef" },
+    },
+    subjects: [{ name: "extra" }],
+    execution_context: {
+      type: "harness",
+      pipeline_id: "ci-build",
+      pipeline_name: "CI Build",
+      pipeline_execution_id: "exec-9",
+      stage_id: "build",
+    },
+  };
+
+  it("projects slim fields and drops status/updated_at/raw context", () => {
+    const result = attestationListExtract([rawItem]);
+    expect(result.items[0]).toEqual({
+      id: "att-1",
+      type: "Build",
+      source: "Harness",
+      description: "Build attestation for container image",
+      created_at: 1700000000000,
+      org: "SSCA",
+      project: "Sanity",
+      subject_name: "registry/app:1.0",
+      subject_digest: "deadbeef",
+      additional_subject_count: 1,
+      gitoid_sha256: "gid123",
+      pipeline_id: "ci-build",
+      pipeline_name: "CI Build",
+      pipeline_execution_id: "exec-9",
+    });
+    const projected = result.items[0] as Record<string, unknown>;
+    expect(projected).not.toHaveProperty("status");
+    expect(projected).not.toHaveProperty("updated_at");
+    expect(projected).not.toHaveProperty("execution_context");
+    expect(projected).not.toHaveProperty("subjects");
+  });
+
+  it("wraps bare array as { items, total } using page length", () => {
+    const result = attestationListExtract([rawItem, { id: "att-2", type: "Deploy" }]);
+    expect(result.total).toBe(2);
+    expect(result.items).toHaveLength(2);
+    expect((result.items[0] as Record<string, unknown>).id).toBe("att-1");
+    expect(result._display_hint).toMatch(/gitoid_sha256/);
+  });
+
+  it("is idempotent under compactItem re-application (harness_list default compact)", () => {
+    const compactItem = findResource("attestation").compactItem;
+    expect(compactItem).toBeTypeOf("function");
+    const once = attestationListExtract([rawItem]).items[0] as Record<string, unknown>;
+    const twice = compactItem!(once);
+    expect(twice).toEqual(once);
+    expect(twice.subject_name).toBe("registry/app:1.0");
+    expect(twice.subject_digest).toBe("deadbeef");
+    expect(twice.pipeline_id).toBe("ci-build");
+    expect(twice.pipeline_name).toBe("CI Build");
+    expect(twice.pipeline_execution_id).toBe("exec-9");
+  });
+});
+
+describe("attestation list dispatch", () => {
+  it("sends account-scoped list without org/project query params", async () => {
+    const request = vi.fn().mockResolvedValue([]);
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "evidence-vault" }));
+    await registry.dispatch(makeClient(request), "attestation", "list", {
+      resource_scope: "account",
+      page: 0,
+      size: 20,
+      search_term: "my-pipeline",
+    });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    const opts = request.mock.calls[0]![0] as {
+      method: string;
+      path: string;
+      params: Record<string, unknown>;
+      body: Record<string, unknown>;
+    };
+    expect(opts.method).toBe("POST");
+    expect(opts.path).toBe("/ssca-manager/v2/attestations");
+    expect(opts.params.org).toBeUndefined();
+    expect(opts.params.project).toBeUndefined();
+    expect(opts.params.search).toBe("my-pipeline");
+    expect(opts.params.sort).toBe("created_at");
+    expect(opts.params.order).toBe("DESC");
+    expect(opts.params.page).toBe(0);
+    expect(opts.params.limit).toBe(20);
+    expect(opts.body).toEqual({});
+    expect(opts.params).not.toHaveProperty("data_source");
+  });
+
+  it("injects org/project query params at project scope with subject_filter", async () => {
+    const request = vi.fn().mockResolvedValue([]);
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "evidence-vault" }));
+    await registry.dispatch(makeClient(request), "attestation", "list", {
+      resource_scope: "project",
+      org_id: "SSCA",
+      project_id: "Sanity",
+      search_term: "ci-build",
+      subject_name: "artifact-foo",
+    });
+
+    const opts = request.mock.calls[0]![0] as {
+      params: Record<string, unknown>;
+      body: Record<string, unknown>;
+    };
+    expect(opts.params.org).toBe("SSCA");
+    expect(opts.params.project).toBe("Sanity");
+    expect(opts.params.search).toBe("ci-build");
+    expect(opts.body).toEqual({
+      subject_filter: [{ field_name: "Name", operator: "Contains", value: "artifact-foo" }],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a new `evidence-vault` toolset with list-only attestation support via POST `/ssca-manager/v2/attestations`.
- Wires agent-friendly filters: singular free-text → search_term; additional Name → subject_name; subject digest → subject_digest.
- Returns a slim projected list (including `gitoid_sha256` and flattened pipeline fields) and keeps projection idempotent under default compact: true.
- Supports account/org/project scope through optional org/project query params (default account).

## Test plan
- [x] Inspector / Cursor: harness_list(resource_type="attestation", resource_scope="account") returns slim rows with gitoid_sha256
- [x] Singular filter: search_term maps to query search
- [x] Combined: search_term + filters.subject_name sends Name/Contains subject_filter
- [x] filters.subject_digest sends Digest/Equals subject_filter
- [x] Confirm flattened subject_name / pipeline fields survive default compact mode

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [x] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
If this PR adds or changes Harness API coverage:
- [x] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [x] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [x] `operationPolicy` on every new/changed endpoint
- [x] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [x] `identifierFields` and `scope` declared on new resources
- [x] No `console.log()` in `src/` (stdio JSON-RPC safety)
