### PR TITLE
feat: add Evidence Vault attestation get by gitoid endpointspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1602,12 +1602,12 @@ SEI resources are consolidated for token efficiency. Use `metric` or `aspect` pa
 
 ### Evidence Vault
 
-Evidence Vault stores in-toto attestations (SDLC evidences). List supports account/org/project scope via `resource_scope`. Singular free-text filters (pipeline, artifact alone, gitoid) use `search_term`; an additional Name constraint uses `filters.subject_name`; subject content digest uses `filters.subject_digest`. Requires feature flag `SCS_EVIDENCE_VAULT`.
+Evidence Vault stores in-toto attestations (SDLC evidences). List supports account/org/project scope via `resource_scope`. Singular free-text filters (pipeline, artifact alone, gitoid) use `search_term`; an additional Name constraint uses `filters.subject_name`; subject content digest uses `filters.subject_digest`. Get looks up by `gitoid_sha256` and requires `org_id`/`project_id` (from the list row). Requires feature flag `SCS_EVIDENCE_VAULT`.
 
 
 | Resource Type | List | Get | Create | Update | Delete | Execute Actions |
 | ------------- | ---- | --- | ------ | ------ | ------ | --------------- |
-| `attestation` | x    |     |        |        |        |                 |
+| `attestation` | x    | x   |        |        |        |                 |
 
 
 

--- a/src/registry/toolsets/evidence-vault.ts
+++ b/src/registry/toolsets/evidence-vault.ts
@@ -132,6 +132,46 @@ export function attestationListExtract(raw: unknown): {
   };
 }
 
+function projectAttestationSubject(raw: unknown): Record<string, unknown> {
+  if (!isRecord(raw)) return {};
+  const out: Record<string, unknown> = {};
+  if (asString(raw.name)) out.name = raw.name;
+  const digest = asRecord(raw.digest);
+  if (!digest) return out;
+  const algorithm = asString(digest.algorithm);
+  const value = asString(digest.value);
+  if (algorithm) out.digest_algorithm = algorithm;
+  if (value) out.digest_value = value;
+  return out;
+}
+
+/** Slim details — all subjects + signature; pipeline flatten like list; drops artifact_id/payload_type/updated_at. */
+export function attestationDetailsExtract(raw: unknown): Record<string, unknown> {
+  if (!isRecord(raw)) return {};
+  const exec = asRecord(raw.execution_context);
+
+  const out: Record<string, unknown> = {};
+  if (raw.type !== undefined) out.type = raw.type;
+  if (raw.source !== undefined) out.source = raw.source;
+  if (asString(raw.description)) out.description = raw.description;
+  if (asString(raw.gitoid_sha256)) out.gitoid_sha256 = raw.gitoid_sha256;
+  if (asNumber(raw.created_at) !== undefined) out.created_at = raw.created_at;
+  if (asString(raw.signature)) out.signature = raw.signature;
+
+  const subjectsRaw = Array.isArray(raw.subjects) ? raw.subjects : [];
+  out.subjects = subjectsRaw.map(projectAttestationSubject);
+
+  const pipelineId = asString(raw.pipeline_id) ?? (exec ? asString(exec.pipeline_id) : undefined);
+  if (pipelineId) out.pipeline_id = pipelineId;
+  const pipelineName = asString(raw.pipeline_name) ?? (exec ? asString(exec.pipeline_name) : undefined);
+  if (pipelineName) out.pipeline_name = pipelineName;
+  const pipelineExecutionId =
+    asString(raw.pipeline_execution_id) ?? (exec ? asString(exec.pipeline_execution_id) : undefined);
+  if (pipelineExecutionId) out.pipeline_execution_id = pipelineExecutionId;
+
+  return out;
+}
+
 export const evidenceVaultToolset: ToolsetDefinition = {
   name: "evidence-vault",
   displayName: "Evidence Vault",
@@ -143,11 +183,12 @@ export const evidenceVaultToolset: ToolsetDefinition = {
       resourceType: "attestation",
       displayName: "Attestation",
       description:
-        "Evidence Vault attestation (in-toto evidence). List only — retain `gitoid_sha256` for follow-ups. "
-        + "When listing, always show gitoid_sha256 in any table. "
+        "Evidence Vault attestation (in-toto evidence). "
+        + "List: always show gitoid_sha256 in tables; retain gitoid_sha256 + org + project for get. "
+        + "Get: harness_get(resource_id=<gitoid_sha256>, org_id, project_id) — lookup by gitoid only. "
         + "Singular free-text (pipeline, artifact alone, gitoid) → search_term; additional Name → filters.subject_name; "
         + "subject digest → filters.subject_digest (not gitoid). Use item `description` to explain a single attestation. "
-        + "Default scope is account; pass resource_scope org/project as needed. Requires SCS_EVIDENCE_VAULT.",
+        + "Default list scope is account; get requires org_id and project_id. Requires SCS_EVIDENCE_VAULT.",
       searchAliases: [
         "evidence vault",
         "attestation",
@@ -160,7 +201,7 @@ export const evidenceVaultToolset: ToolsetDefinition = {
       scope: "account",
       supportedScopes: ["account", "org", "project"],
       scopeParams: { org: "org", project: "project" },
-      identifierFields: ["attestation_id"],
+      identifierFields: ["gitoid_sha256"],
       listFilterFields: [
         { name: "search_term", description: "Singular free-text filter (pipeline, artifact, gitoid, keyword) → query search" },
         { name: "subject_name", description: "Additional Name filter → subject_filter Name/Contains" },
@@ -197,6 +238,19 @@ export const evidenceVaultToolset: ToolsetDefinition = {
           bodyBuilder: buildAttestationListBody,
           responseExtractor: attestationListExtract,
           description: "List attestations (default sort created_at DESC)",
+        },
+        get: {
+          method: "GET",
+          path: `${SCS}/v2/orgs/{org}/projects/{project}/attestations/{attestation}/details`,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          pathParams: {
+            org_id: "org",
+            project_id: "project",
+            gitoid_sha256: "attestation",
+          },
+          defaultQueryParams: { identifier_type: "gitoid_sha256" },
+          responseExtractor: attestationDetailsExtract,
+          description: "Get attestation details by gitoid_sha256",
         },
       },
     },

--- a/tests/registry/evidence-vault.test.ts
+++ b/tests/registry/evidence-vault.test.ts
@@ -1,15 +1,9 @@
-/*
- * Copyright 2026 Harness Inc. All rights reserved.
- * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
- * that can be found in the licenses directory at the root of this repository, also available at
- * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
- */
-
 import { describe, it, expect, vi } from "vitest";
 import {
   evidenceVaultToolset,
   buildAttestationListBody,
   attestationListExtract,
+  attestationDetailsExtract,
 } from "../../src/registry/toolsets/evidence-vault.js";
 import { Registry } from "../../src/registry/index.js";
 import type { Config } from "../../src/config.js";
@@ -55,6 +49,12 @@ function getListOp(): EndpointSpec {
   return spec;
 }
 
+function getGetOp(): EndpointSpec {
+  const spec = findResource("attestation").operations.get;
+  if (!spec) throw new Error("get operation missing on attestation");
+  return spec;
+}
+
 describe("evidence-vault toolset", () => {
   it("registers attestation list against /ssca-manager/v2/attestations", () => {
     expect(evidenceVaultToolset.name).toBe("evidence-vault");
@@ -62,6 +62,7 @@ describe("evidence-vault toolset", () => {
     expect(resource.scope).toBe("account");
     expect(resource.supportedScopes).toEqual(["account", "org", "project"]);
     expect(resource.scopeParams).toEqual({ org: "org", project: "project" });
+    expect(resource.identifierFields).toEqual(["gitoid_sha256"]);
 
     const list = getListOp();
     expect(list.method).toBe("POST");
@@ -73,6 +74,21 @@ describe("evidence-vault toolset", () => {
       size: "limit",
       search_term: "search",
     });
+  });
+
+  it("registers attestation get by gitoid against details path", () => {
+    const get = getGetOp();
+    expect(get.method).toBe("GET");
+    expect(get.path).toBe(
+      "/ssca-manager/v2/orgs/{org}/projects/{project}/attestations/{attestation}/details",
+    );
+    expect(get.pathParams).toEqual({
+      org_id: "org",
+      project_id: "project",
+      gitoid_sha256: "attestation",
+    });
+    expect(get.defaultQueryParams).toEqual({ identifier_type: "gitoid_sha256" });
+    expect(get.operationPolicy).toEqual({ risk: "read", retryPolicy: "safe" });
   });
 
   it("loads into Registry by default", () => {
@@ -269,5 +285,89 @@ describe("attestation list dispatch", () => {
     expect(opts.body).toEqual({
       subject_filter: [{ field_name: "Name", operator: "Contains", value: "artifact-foo" }],
     });
+  });
+});
+
+describe("attestationDetailsExtract", () => {
+  const rawDetails = {
+    type: "Build",
+    source: "Harness",
+    description: "Build attestation for container image",
+    gitoid_sha256: "gid123",
+    artifact_id: "art-1",
+    payload_type: "application/vnd.in-toto+json",
+    created_at: 1700000000000,
+    updated_at: 1700000001000,
+    signature: "sig-bytes",
+    subjects: [
+      { name: "registry/app:1.0", digest: { algorithm: "sha256", value: "deadbeef" } },
+      { name: "extra", digest: { algorithm: "sha256", value: "cafebabe" } },
+    ],
+    execution_context: {
+      type: "harness",
+      pipeline_id: "ci-build",
+      pipeline_name: "CI Build",
+      pipeline_execution_id: "exec-9",
+      stage_id: "build",
+    },
+  };
+
+  it("projects subjects and pipeline fields; drops artifact_id/payload_type/updated_at", () => {
+    const result = attestationDetailsExtract(rawDetails);
+    expect(result).toEqual({
+      type: "Build",
+      source: "Harness",
+      description: "Build attestation for container image",
+      gitoid_sha256: "gid123",
+      created_at: 1700000000000,
+      signature: "sig-bytes",
+      subjects: [
+        { name: "registry/app:1.0", digest_algorithm: "sha256", digest_value: "deadbeef" },
+        { name: "extra", digest_algorithm: "sha256", digest_value: "cafebabe" },
+      ],
+      pipeline_id: "ci-build",
+      pipeline_name: "CI Build",
+      pipeline_execution_id: "exec-9",
+    });
+    expect(result).not.toHaveProperty("updated_at");
+    expect(result).not.toHaveProperty("artifact_id");
+    expect(result).not.toHaveProperty("payload_type");
+    expect(result).not.toHaveProperty("execution_context");
+  });
+});
+
+describe("attestation get dispatch", () => {
+  it("GETs details path with gitoid path param and identifier_type query", async () => {
+    const request = vi.fn().mockResolvedValue({
+      type: "Build",
+      source: "Harness",
+      gitoid_sha256: "gid123",
+      subjects: [],
+    });
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "evidence-vault" }));
+    await registry.dispatch(makeClient(request), "attestation", "get", {
+      org_id: "SSCA",
+      project_id: "Sanity",
+      gitoid_sha256: "gid123",
+    });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    const opts = request.mock.calls[0]![0] as {
+      method: string;
+      path: string;
+      params: Record<string, unknown>;
+    };
+    expect(opts.method).toBe("GET");
+    expect(opts.path).toBe(
+      "/ssca-manager/v2/orgs/SSCA/projects/Sanity/attestations/gid123/details",
+    );
+    expect(opts.params.identifier_type).toBe("gitoid_sha256");
+  });
+
+  it("requires org_id and project_id for get", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "evidence-vault" }));
+    await expect(
+      registry.dispatch(makeClient(), "attestation", "get", { gitoid_sha256: "gid123" }),
+    ).rejects.toThrow(/org_id/);
   });
 });


### PR DESCRIPTION
## Summary
- Add `harness_get` for Evidence Vault `attestation` via `GET /ssca-manager/v2/orgs/{org}/projects/{project}/attestations/{attestation}/details`
- Lookup is gitoid-only (`identifier_type=gitoid_sha256`); agents pass `resource_id=<gitoid>` plus `org_id`/`project_id` from the list row
- Slim details projection: type/source/description/gitoid/created_at/signature, all subjects (`name` + digest), and flattened pipeline fields (same as list); drops `updated_at`, `artifact_id`, `payload_type`, and raw `execution_context`

## Test plan
- [x] `pnpm exec vitest run tests/registry/evidence-vault.test.ts`
- [x] `pnpm build && pnpm docs:check`
- [x] Against an env with Evidence Vault + this API: list attestations, then `harness_get` with `gitoid_sha256` + org/project from a list item
- [x] Confirm missing org/project fails loudly; missing FF returns 403 from backend

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [x] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
If this PR adds or changes Harness API coverage:
- [x] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [x] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [x] `operationPolicy` on every new/changed endpoint
- [x] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [x] `identifierFields` and `scope` declared on new resources
- [x] No `console.log()` in `src/` (stdio JSON-RPC safety)
