### PR TITLE
AI-2692 Harness MCP: AIT knowledge-base toolset (crawl, pages, artifacts)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,10 +97,11 @@ HARNESS_MCP_LOG_FILE=
 # by default): ansible. Use +name to add alongside defaults, or list
 # explicitly for an allowlist. Use -name to remove defaults. The legacy name
 # agent-pipelines is accepted as agents.
-# Available: pipelines,agents,services,environments,infrastructure,connectors,secrets,logs,audit,delegates,repositories,registries,templates,dashboards,idp,pull-requests,feature-flags,gitops,chaos,ccm,sei,scs,sto,dbops,access_control,settings,platform,governance,freeze,overrides,ai-evals,iacm,ansible
+# Available: pipelines,agents,services,environments,infrastructure,connectors,secrets,logs,audit,delegates,repositories,registries,templates,dashboards,idp,pull-requests,feature-flags,gitops,chaos,ccm,sei,scs,sto,dbops,access_control,settings,platform,governance,freeze,overrides,ai-evals,iacm,ansible,ait
 # Project-scoped IaCM/Ansible calls require HARNESS_ORG and HARNESS_PROJECT,
 # or explicit org_id/project_id per call. Opt-in toolsets:
 #   ansible — Ansible inventories, playbooks, hosts, and activity history
+#   ait     — AI Test Automation: list apps, tests, environments; create and run tests
 HARNESS_TOOLSETS=
 
 # Audit sinks — all optional

--- a/README.md
+++ b/README.md
@@ -1743,9 +1743,10 @@ Security exemption execute workflow:
 
 ## Toolset Filtering
 
-By default, 37 of 38 toolsets are enabled. One toolset is opt-in and excluded from the defaults:
+By default, 37 of 39 toolsets are enabled. Two toolsets are opt-in and excluded from the defaults:
 
 - **`ansible`** — Harness Ansible (inventories, playbooks, hosts, activity). Opt-in because it is project-scoped and adds concepts many users do not need.
+- **`ait`** — AIT knowledge base (crawl an application environment, read crawled pages and artifacts). Opt-in because it requires the AIT service behind the same base URL.
 
 ### Adding toolsets with `+` prefix
 
@@ -1822,6 +1823,7 @@ Available toolset names:
 | `ai-evals`              | eval_dataset, eval_dataset_item, evaluation, eval_run, eval_run_item, eval_run_by_eval, eval_metric, eval_metric_set, eval_metric_set_entry, eval_suite, eval_suite_evaluation, eval_suite_run, eval_target, eval_annotation, eval_analytics, eval_git_settings, eval_registry_item, eval_git_registration, online_eval |
 | `iacm`                  | iacm_workspace, iacm_resource, iacm_module, iacm_workspace_costs, iacm_activity_resource_change                                                                                                                                                                                                 |
 | `ansible` *(opt-in)*    | ansible_inventory, ansible_playbook, ansible_host, ansible_host_activity, ansible_activity                                                                                                                                                                                                      |
+| `ait` *(opt-in)*        | kb_crawl, kb_crawl_page, kb_page_artifact                                                                                                                                                                                                                                                      |
 
 
 ## Architecture

--- a/scripts/kb-local-smoke.mjs
+++ b/scripts/kb-local-smoke.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * Smoke-test KB resources against HARNESS_BASE_URL (default local relicx).
+ *
+ *   pnpm exec node scripts/kb-local-smoke.mjs [test_environment_id]
+ */
+import { Registry } from "../build/registry/index.js";
+import { HarnessClient } from "../build/client/harness-client.js";
+
+const ENV_ID = process.argv[2] ?? "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+
+const config = {
+  HARNESS_API_KEY: process.env.HARNESS_API_KEY ?? "pat.kbLocalAcct123.local.secret",
+  HARNESS_ACCOUNT_ID: process.env.HARNESS_ACCOUNT_ID ?? "kbLocalAcct123",
+  HARNESS_BASE_URL: process.env.HARNESS_BASE_URL ?? "http://localhost:30082",
+  HARNESS_ALLOW_HTTP: process.env.HARNESS_ALLOW_HTTP !== "false",
+  HARNESS_ORG: "default",
+  HARNESS_PROJECT: "test",
+  HARNESS_TOOLSETS: "+ait",
+  HARNESS_API_TIMEOUT_MS: 30000,
+  HARNESS_MAX_RETRIES: 1,
+  LOG_LEVEL: "error",
+  HARNESS_AUTO_APPROVE_RISK: "high_write",
+  HARNESS_READ_ONLY: false,
+  HARNESS_SKIP_ELICITATION: true,
+  HARNESS_MAX_BODY_SIZE_MB: 10,
+  HARNESS_RATE_LIMIT_RPS: 10,
+  HARNESS_FME_BASE_URL: "https://api.split.io",
+  HARNESS_LOG_UNSAFE_BODIES: false,
+  HARNESS_AUDIT_WEBHOOK_BATCH_SIZE: 10,
+  HARNESS_AUDIT_WEBHOOK_FLUSH_MS: 5000,
+};
+
+const client = new HarnessClient(config);
+const registry = new Registry(config);
+
+const history = await registry.dispatch(client, "kb_crawl", "list", {
+  test_environment_id: ENV_ID,
+  size: 3,
+});
+console.log("kb_crawl list:", JSON.stringify(history, null, 2));
+
+const first = history.items?.[0];
+if (first && typeof first === "object" && first !== null && "crawl_run_id" in first) {
+  const run = await registry.dispatch(client, "kb_crawl", "get", {
+    crawl_run_id: first.crawl_run_id,
+  });
+  console.log("kb_crawl get:", JSON.stringify(run, null, 2));
+}

--- a/src/prompts/explore-knowledge-base.ts
+++ b/src/prompts/explore-knowledge-base.ts
@@ -1,0 +1,70 @@
+import * as z from "zod/v4";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+/**
+ * Prescriptive workflow for AIT Knowledge Base crawls/pages/artifacts.
+ * Ships with the MCP server so every client (Claude Code, Cursor, etc.) gets
+ * the same "use harness_* only" guidance without a per-repo CLAUDE.md.
+ */
+export function registerExploreKnowledgeBasePrompt(server: McpServer): void {
+  server.registerPrompt(
+    "explore-knowledge-base",
+    {
+      description:
+        "Explore or crawl an AIT knowledge base via MCP only (kb_crawl / kb_crawl_page / kb_page_artifact). Use for list crawls, page Q&A, and screenshots.",
+      argsSchema: {
+        goal: z
+          .string()
+          .describe(
+            "What the user wants (e.g. list pages from the latest crawl, share a screenshot of a URL, start a 10-page crawl)",
+          ),
+        test_environment_id: z
+          .string()
+          .optional()
+          .describe("Test environment UUID when known (list kb_crawl history)"),
+        crawl_run_id: z.string().optional().describe("Crawl run UUID when known"),
+        page_id: z.string().optional().describe("Crawl page UUID when known"),
+      },
+    },
+    async ({ goal, test_environment_id, crawl_run_id, page_id }) => ({
+      messages: [
+        {
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text: `Help with the AIT Knowledge Base using Harness MCP tools only.
+
+## Goal
+${goal}
+
+## Known IDs (use when provided; otherwise discover via harness_list)
+${test_environment_id ? `- test_environment_id=${test_environment_id}` : "- test_environment_id: unknown — list crawls only after the user gives an env id, or ask once"}
+${crawl_run_id ? `- crawl_run_id=${crawl_run_id}` : "- crawl_run_id: discover from kb_crawl list (newest completed first)"}
+${page_id ? `- page_id=${page_id}` : "- page_id: discover from kb_crawl_page list (filter with query=URL or title)"}
+
+## HARD RULES (do not violate)
+1. Use **only** \`harness_list\` / \`harness_get\` / \`harness_create\` / \`harness_execute\` / \`harness_describe\` with resource types \`kb_crawl\`, \`kb_crawl_page\`, \`kb_page_artifact\`. Use \`ait_app\` only if you must map an app name → app_id for create.
+2. **Do not** use \`ait_test_environment\` to discover IDs for KB work. That list hits legacy Java (\`/ait/api/v1/testEnvironments\` → \`ait-java-api-service\`). On node-api-only local stacks it returns ENOTFOUND/500 even when KB is healthy. If \`test_environment_id\` is unknown, **ask the user once** — do not chase Java, curl, psql, or kubectl.
+3. **Do not** use Bash curl, wget, psql, TypeORM, kubectl, aws/gcloud/gsutil, or open storage buckets for KB data.
+4. **Do not** call \`/ait/api/apps\` or other unmatched paths. Unmatched node-api routes proxy to **ait-java-api-service** — unrelated to KB.
+5. If a kb_* tool call fails, call \`harness_describe(resource_type=...)\` and retry. An \`ait_test_environment\` failure must not be reported as "AIT/KB is down."
+6. Prefer calling \`harness_describe(toolset="ait")\` once at the start if unsure which resources exist.
+
+## Steps
+1. **Need test_environment_id** — use the argument if provided; otherwise ask the user. Do not list \`ait_test_environment\` for KB.
+2. **Latest crawl** — \`harness_list(resource_type="kb_crawl", params={ test_environment_id, size: 5 })\`. Newest first; prefer \`completed\`.
+3. **Pages** — \`harness_list(resource_type="kb_crawl_page", params={ crawl_run_id, query?: "<url or title>", size: 20 })\`.
+4. **Page + screenshot** — \`harness_get(resource_type="kb_crawl_page", resource_id=<page_id>, params={ crawl_run_id, include: "screenshot" })\`.
+5. **Single artifact** — \`harness_get(resource_type="kb_page_artifact", resource_id="screenshot"|..., params={ crawl_run_id, page_id })\`.
+6. **Start a crawl** — \`harness_create(resource_type="kb_crawl", body={ app_id, test_environment_id, max_pages?, ... })\` then poll \`harness_get\` on \`kb_crawl\`.
+
+## Notes
+- Enable the opt-in toolset: \`HARNESS_TOOLSETS=+ait\`.
+- Local relicx: \`HARNESS_BASE_URL=http://localhost:30082\` and \`HARNESS_ALLOW_HTTP=true\`. Cloud QA often needs a \`/prod1\` prefix on the base URL for AIT — still go through MCP, not curl.
+- Screenshots expire (~5 minutes); re-get if the signed URL is stale.`,
+          },
+        },
+      ],
+    }),
+  );
+}

--- a/src/prompts/explore-knowledge-base.ts
+++ b/src/prompts/explore-knowledge-base.ts
@@ -56,7 +56,8 @@ ${page_id ? `- page_id=${page_id}` : "- page_id: discover from kb_crawl_page lis
 3. **Pages** — \`harness_list(resource_type="kb_crawl_page", params={ crawl_run_id, query?: "<url or title>", size: 20 })\`.
 4. **Page + screenshot** — \`harness_get(resource_type="kb_crawl_page", resource_id=<page_id>, params={ crawl_run_id, include: "screenshot" })\`.
 5. **Single artifact** — \`harness_get(resource_type="kb_page_artifact", resource_id="screenshot"|..., params={ crawl_run_id, page_id })\`.
-6. **Start a crawl** — \`harness_create(resource_type="kb_crawl", body={ app_id, test_environment_id, max_pages?, ... })\` then poll \`harness_get\` on \`kb_crawl\`.
+6. **Start a crawl** — \`harness_create(resource_type="kb_crawl", body={ app_id, test_environment_id, config: { max_pages? } })\` then poll \`harness_get\` on \`kb_crawl\`. Retain the requested \`max_pages\` for progress reporting.
+7. **Report progress** — while status is running, report \`pages_discovered\` and elapsed time since \`started_at\`. Once at least 5 pages are discovered and \`max_pages\` is known, show an approximate remaining time: \`elapsed_ms * (max_pages - pages_discovered) / pages_discovered\`. The crawl can finish early when its frontier empties.
 
 ## Notes
 - Enable the opt-in toolset: \`HARNESS_TOOLSETS=+ait\`.

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -51,6 +51,9 @@ import { registerAddMetricPrompt } from "./add-metric.js";
 import { registerRunEvaluationPrompt } from "./run-evaluation.js";
 import { registerCreateEvalSuitePrompt } from "./create-eval-suite.js";
 
+// AIT Knowledge Base
+import { registerExploreKnowledgeBasePrompt } from "./explore-knowledge-base.js";
+
 export function registerAllPrompts(server: McpServer): void {
   // Existing prompts
   registerDebugPipelinePrompt(server);
@@ -103,4 +106,7 @@ export function registerAllPrompts(server: McpServer): void {
   registerAddMetricPrompt(server);
   registerRunEvaluationPrompt(server);
   registerCreateEvalSuitePrompt(server);
+
+  // AIT Knowledge Base
+  registerExploreKnowledgeBasePrompt(server);
 }

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -776,17 +776,31 @@ export class Registry {
     // Validate required fields if bodySchema is defined.
     // When the API body is transformed into a raw array, validate the caller's
     // canonical object-shaped input body so registry behavior matches harness_describe.
+    // When a bodyBuilder rewrites field names for the wire, validate the agent payload
+    // (input.body, or top-level input fields) rather than the built body.
     // Multipart validation is enforced inside the resource bodyBuilder.
-    if (spec.bodySchema && body && typeof body === "object" && !isFormDataBody(body)) {
-      const payload = this.getBodySchemaValidationPayload(spec, input, body);
-      const missing = spec.bodySchema.fields
-        .filter(f => f.required && payload[f.name] === undefined)
-        .map(f => f.name);
-      if (missing.length > 0) {
-        throw new Error(
-          `Missing required fields for ${def.resourceType}: ${missing.join(", ")}. ` +
-          `Use harness_describe(resource_type="${def.resourceType}") to see the schema.`
-        );
+    if (spec.bodySchema) {
+      let validationTarget: unknown = body;
+      if (
+        spec.bodyBuilder &&
+        input.body != null &&
+        typeof input.body === "object" &&
+        !Array.isArray(input.body) &&
+        !isFormDataBody(input.body)
+      ) {
+        validationTarget = input.body;
+      }
+      if (validationTarget && typeof validationTarget === "object" && !isFormDataBody(validationTarget)) {
+        const payload = this.getBodySchemaValidationPayload(spec, input, validationTarget as object);
+        const missing = spec.bodySchema.fields
+          .filter(f => f.required && payload[f.name] === undefined)
+          .map(f => f.name);
+        if (missing.length > 0) {
+          throw new Error(
+            `Missing required fields for ${def.resourceType}: ${missing.join(", ")}. ` +
+            `Use harness_describe(resource_type="${def.resourceType}") to see the schema.`
+          );
+        }
       }
     }
 

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -49,6 +49,7 @@ import { semanticLayerToolset } from "./toolsets/semantic-layer.js";
 import { ansibleToolset } from "./toolsets/ansible.js";
 import { incidentsToolset } from "./toolsets/incidents.js";
 import { deploysToolset } from "./toolsets/deploys.js";
+import { aitToolset } from "./toolsets/ait.js";
 
 const log = createLogger("registry");
 
@@ -163,6 +164,7 @@ const ALL_TOOLSETS: ToolsetDefinition[] = [
   ansibleToolset,
   incidentsToolset,
   deploysToolset,
+  aitToolset,
 ];
 
 /** All available toolset names — used by docs generation to discover opt-in toolsets. */

--- a/src/registry/toolsets/ait.ts
+++ b/src/registry/toolsets/ait.ts
@@ -4,19 +4,20 @@ import type { ToolsetDefinition } from "../types.js";
  * AIT (AI Test Automation) toolset.
  * Base path: /ait/api/v1/...
  * Hosted on the Harness platform and authenticated via standard Harness PAT.
+ *
+ * Resources:
+ *   ait_app              — list applications
+ *   ait_test_environment — list test environments for an app
+ *   ait_test             — list, create (AI), and execute (run) tests
  */
 
-// ─── Reusable response extractors for AIT APIs ─────────────────────────────
-// AIT APIs follow these response patterns:
-//   1. TableResponse<T> — paginated lists: { data: T[], totalPages, totalItems, itemsPerPage, currentPage }
-//   2. Single object   — direct entity (e.g. TestNew, TestNewExtended)
-//   3. Simple values   — string, string[], { success: boolean }
-//
-// Each new endpoint picks the appropriate extractor or uses passthrough for
-// single-object / simple-value responses.
+// ─── Response extractors ────────────────────────────────────────────────────
 
-/** Extract applications list (simple array pattern): normalize camelCase fields to snake_case items */
-const aitAppsForOrgExtract = (raw: unknown): unknown => {
+/** Extract applications list: normalize camelCase fields to snake_case */
+const aitAppListExtract = (raw: unknown): unknown => {
+  if (!Array.isArray(raw)) {
+    throw new Error("ait_app: expected array response from API, got " + typeof raw);
+  }
   const arr = raw as Array<{
     appId?: string;
     appName?: string;
@@ -42,8 +43,11 @@ const aitAppsForOrgExtract = (raw: unknown): unknown => {
   return { items, total: items.length };
 };
 
-/** Extract test environments list (simple array pattern): normalize camelCase fields to snake_case items */
-const aitTestEnvironmentsExtract = (raw: unknown): unknown => {
+/** Extract test environments list: normalize camelCase fields to snake_case */
+const aitTestEnvironmentListExtract = (raw: unknown): unknown => {
+  if (!Array.isArray(raw)) {
+    throw new Error("ait_test_environment: expected array response from API, got " + typeof raw);
+  }
   const arr = raw as Array<{
     id?: string;
     appId?: string;
@@ -60,14 +64,16 @@ const aitTestEnvironmentsExtract = (raw: unknown): unknown => {
     test: env.test,
     monitor: env.monitor,
     pre_release: env.preRelease,
-
     base_url: env.baseUrl ?? null,
   }));
   return { items, total: items.length };
 };
 
-/** Extract paginated TableResponse for test list: picks key fields per TestEntry item */
-const aitTestsListExtract = (raw: unknown): unknown => {
+/** Extract paginated TableResponse for test list */
+const aitTestListExtract = (raw: unknown): unknown => {
+  if (raw == null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("ait_test: expected paginated object response from API, got " + (Array.isArray(raw) ? "array" : typeof raw));
+  }
   const r = raw as {
     data?: Array<Record<string, unknown>>;
     totalPages?: number;
@@ -75,6 +81,9 @@ const aitTestsListExtract = (raw: unknown): unknown => {
     itemsPerPage?: number;
     currentPage?: number;
   };
+  if (r.data !== undefined && !Array.isArray(r.data)) {
+    throw new Error("ait_test: expected data field to be an array, got " + typeof r.data);
+  }
   const items = (r.data ?? []).map((t) => {
     const runDetailsList = t.lastKRunDetailsList as Array<Record<string, unknown>> | null | undefined;
     const latestRun = runDetailsList?.[0];
@@ -98,21 +107,20 @@ const aitTestsListExtract = (raw: unknown): unknown => {
   };
 };
 
-/** Extract imported copilot test response — normalizes camelCase testId/testVersionId to snake_case */
-const aitImportedCopilotTestExtract = (raw: unknown): unknown => {
+/** Extract create-test-using-AI response */
+const aitTestCreateExtract = (raw: unknown): unknown => {
   const r = raw as {
     testId: number;
     testVersionId: number;
   };
-
   return {
     test_id: r.testId,
     test_version_id: r.testVersionId,
   };
 };
 
-/** Extract run test response — picks key fields from the snake_case TestRunNew entity */
-const aitRunTestExtract = (raw: unknown): unknown => {
+/** Extract run-test response */
+const aitTestRunExtract = (raw: unknown): unknown => {
   const r = raw as {
     id: number;
     app_id: string;
@@ -124,19 +132,14 @@ const aitRunTestExtract = (raw: unknown): unknown => {
     start_epoch: number | null;
     error: string | null;
   };
-
-  const aitBaseUrl = (process.env.HARNESS_BASE_URL ?? "https://app.harness.io").replace(/\/$/, "");
-  const testRunUrl = `${aitBaseUrl}/ait/${r.app_id}/test/${r.test_id}/version/${r.test_version_id}/test-run/${r.id}?tab=overview`;
-
   return {
-    test_run_url: testRunUrl,
+    id: r.id,
     app_id: r.app_id,
     test_id: r.test_id,
     test_version_id: r.test_version_id,
     test_environment_id: r.test_environment_id,
     status: r.status,
     error: r.error,
-    _note: "Always display the test_run_url to the user.",
   };
 };
 
@@ -146,15 +149,17 @@ export const aitToolset: ToolsetDefinition = {
   name: "ait",
   displayName: "AI Test Automation (AIT)",
   description:
-    "Harness AI Test Automation (AIT) — list and manage automated tests for applications.",
+    "Harness AI Test Automation (AIT) — list and manage automated tests for applications. " +
+    "TERMINOLOGY MAPPING (AIT ↔ Harness): AIT \"org\" = Harness \"account\"; AIT \"app\" = Harness \"project\".",
   optIn: true,
   resources: [
+    // ── ait_app ─────────────────────────────────────────────────────────────
     {
-      resourceType: "ait_apps_for_org",
-      displayName: "AIT Apps for Org",
+      resourceType: "ait_app",
+      displayName: "AIT Application",
       description:
-        "List all applications for the current organization. Returns app IDs, names, and metadata. " +
-        "Use this to discover app_id values needed for other AIT operations.",
+        "An application (also called 'project' in Harness) in the AIT module. List applications to discover app_id values " +
+        "needed for other AIT operations (tests, environments).",
       toolset: "ait",
       scope: "account",
       identifierFields: [],
@@ -163,20 +168,20 @@ export const aitToolset: ToolsetDefinition = {
           method: "GET",
           path: "/ait/api/v1/application",
           operationPolicy: { risk: "read", retryPolicy: "safe" },
-          responseExtractor: aitAppsForOrgExtract,
+          responseExtractor: aitAppListExtract,
           skipCompact: true,
           description:
             "List all apps for the organization. Returns app details including app_id, app_name, workspace_id, and created_at.",
         },
       },
     },
+    // ── ait_test_environment ────────────────────────────────────────────────
     {
-      resourceType: "ait_test_environments",
-      displayName: "AIT Test Environments",
+      resourceType: "ait_test_environment",
+      displayName: "AIT Test Environment",
       description:
-        "List test environments for a given application. Returns environment IDs, names, " +
-        "base URLs, and flags (test, monitor, pre_release). Use this to discover env_id " +
-        "values needed for running copilot tests.",
+        "A test environment for an AIT application. List environments to discover " +
+        "environment IDs needed for creating and running tests.",
       toolset: "ait",
       scope: "account",
       identifierFields: ["app_id"],
@@ -195,22 +200,23 @@ export const aitToolset: ToolsetDefinition = {
           queryParams: {
             app_id: "appId",
           },
-          responseExtractor: aitTestEnvironmentsExtract,
+          responseExtractor: aitTestEnvironmentListExtract,
           description:
             "List all test environments for an application. Requires app_id in filters. " +
             "Returns environment details including id, env_name, base_url, and type flags.",
         },
       },
     },
+    // ── ait_test ────────────────────────────────────────────────────────────
     {
-      resourceType: "ait_tests_list",
-      displayName: "AIT Tests List",
+      resourceType: "ait_test",
+      displayName: "AIT Test",
       description:
-        "An automated test in the AIT module. List tests for an application by appId. " +
-        "Supports filtering by activation status, run status, and pagination.",
+        "An automated test in the AIT module. Supports listing tests for an app, " +
+        "creating a test using AI (copilot), and executing a test run.",
       toolset: "ait",
       scope: "account",
-      identifierFields: ["app_id"],
+      identifierFields: ["test_id", "test_version_id"],
       listFilterFields: [
         {
           name: "app_id",
@@ -257,7 +263,7 @@ export const aitToolset: ToolsetDefinition = {
             sort_by: "sortBy",
             sort_order: "sortOrder",
             page: "page",
-            limit: "limit",
+            size: "limit",
             filter: "filter",
             should_hide_disabled_flows: "shouldHideDisabledFlows",
             is_debug_mode: "isDebugMode",
@@ -272,41 +278,32 @@ export const aitToolset: ToolsetDefinition = {
             isDebugMode: "false",
             runStatusesPerTest: "5",
           },
-          responseExtractor: aitTestsListExtract,
+          responseExtractor: aitTestListExtract,
           skipCompact: true,
           description:
             "List all tests for an application. Requires app_id in filters. " +
             "Returns paginated test entries with name, created_by, created_at, display_status, and tags.",
         },
-      },
-    },
-    {
-      resourceType: "ait_create_test_using_ai",
-      displayName: "AIT Create Test Using AI",
-      description:
-        "Create test using AI in AIT. Provide an appId, envId, and a test description. " +
-        "The API creates a test and returns the test ID and version ID of the created test. " +
-        "Optionally specify authType ('auth' or 'no_auth') and an entryUrl.",
-      toolset: "ait",
-      scope: "account",
-      identifierFields: ["app_id"],
-      operations: {
         create: {
           method: "POST",
           path: "/ait/api/v1/testNew/copilotTest/import",
           operationPolicy: { risk: "medium_write", retryPolicy: "do_not_retry" },
           bodyBuilder: (input) => {
             const b = (input.body ?? input) as Record<string, unknown>;
+            const appId = (b.app_id ?? b.appId) as string;
+            const envId = (b.env_id ?? b.envId) as string;
+            const authType = b.auth_type ?? b.authType;
+            const entryUrl = b.entry_url ?? b.entryUrl;
             return {
-              appId: b.appId,
-              envId: b.envId,
+              appId,
+              envId,
               description: b.description,
-              ...(b.authType !== undefined ? { authType: b.authType } : {}),
-              ...(b.entryUrl !== undefined ? { entryUrl: b.entryUrl } : {}),
+              ...(authType !== undefined ? { authType: authType as string } : {}),
+              ...(entryUrl !== undefined ? { entryUrl: entryUrl as string } : {}),
             };
           },
           bodySchema: {
-            description: "Create a test using AI",
+            description: "Create a test using AI (copilot)",
             fields: [
               { name: "appId", type: "string", required: true, description: "Application ID" },
               { name: "envId", type: "string", required: true, description: "Environment ID" },
@@ -315,25 +312,11 @@ export const aitToolset: ToolsetDefinition = {
               { name: "entryUrl", type: "string", required: false, description: "Optional entry URL for the test" },
             ],
           },
-          responseExtractor: aitImportedCopilotTestExtract,
+          responseExtractor: aitTestCreateExtract,
           description:
-            "Create a test using AI. Returns test_id and test_version_id.",
+            "Create a test using AI. Provide app_id, env_id, and a description. Returns test_id and test_version_id.",
         },
       },
-    },
-    {
-      resourceType: "ait_run_test",
-      displayName: "AIT Run Test",
-      description:
-        "Execute a test with a given test ID and test version. " +
-        "Requires appId (UUID — look up via ait_apps_for_org if only name is known) and " +
-        "environmentId (UUID — look up via ait_test_environments if only name is known). " +
-        "Pass test_id and test_version_id via params (e.g. params: { test_id: 80, test_version_id: 91 }). " +
-        "Returns the scheduled TestRun details including id, status, test_session_id, and test run URL.",
-      toolset: "ait",
-      scope: "account",
-      identifierFields: ["test_id", "test_version_id"],
-      operations: {},
       executeActions: {
         run: {
           method: "POST",
@@ -342,23 +325,25 @@ export const aitToolset: ToolsetDefinition = {
           operationPolicy: { risk: "medium_write", retryPolicy: "do_not_retry" },
           bodyBuilder: (input: Record<string, unknown>) => {
             const b = (input.body ?? input) as Record<string, unknown>;
+            const appId = (b.app_id ?? b.appId) as string;
+            const environmentId = (b.environment_id ?? b.environmentId) as string;
             return {
-              appId: b.appId,
-              environmentId: b.environmentId,
+              appId,
+              environmentId,
               params: b.params ?? '{"RUN_MODE":"no-mock","TestExecutorNamespace.fastExecutorMode":"false"}',
             };
           },
           bodySchema: {
             description: "Execute a test run",
             fields: [
-              { name: "appId", type: "string", required: true, description: "Application UUID (e.g. ecaab215-65cd-45d6-8426-09ba1e04eabb). Look up via ait_apps_for_org if only app name is known." },
-              { name: "environmentId", type: "string", required: true, description: "Environment UUID (e.g. 1289b517-5f1b-4927-b30b-6f2e895dae8e). Look up via ait_test_environments if only env name is known." },
+              { name: "appId", type: "string", required: true, description: "Application UUID (e.g. ecaab215-65cd-45d6-8426-09ba1e04eabb). Look up via ait_app if only app name is known." },
+              { name: "environmentId", type: "string", required: true, description: "Environment UUID (e.g. 1289b517-5f1b-4927-b30b-6f2e895dae8e). Look up via ait_test_environment if only env name is known." },
               { name: "params", type: "string", required: false, description: "Test params — JSON stringified Map<string, string>. Defaults to '{\"RUN_MODE\":\"no-mock\",\"TestExecutorNamespace.fastExecutorMode\":\"false\"}'" },
             ],
           },
-          responseExtractor: aitRunTestExtract,
+          responseExtractor: aitTestRunExtract,
           actionDescription:
-            "Execute a test. Returns TestRun details including id, status, test_session_id, and start_epoch.",
+            "Execute a test. Returns TestRun details including id, status, and error.",
         },
       },
     },

--- a/src/registry/toolsets/ait.ts
+++ b/src/registry/toolsets/ait.ts
@@ -1,5 +1,4 @@
 import type { BodySchema, ToolsetDefinition } from "../types.js";
-import { passthrough } from "../extractors.js";
 import { isRecord } from "../../utils/type-guards.js";
 
 
@@ -62,8 +61,10 @@ const aitTestEnvironmentListExtract = (raw: unknown): unknown => {
     preRelease?: boolean;
     baseUrl?: string | null;
   }>;
+  // Java exposes the PK as `id` (column test_environment_id). Emit test_environment_id
+  // so agents can pass the same field into kb_crawl / create / run without renaming.
   const items = arr.map((env) => ({
-    id: env.id,
+    test_environment_id: env.id,
     app_id: env.appId,
     env_name: env.envName,
     test: env.test,
@@ -152,57 +153,100 @@ const aitTestRunExtract = (raw: unknown): unknown => {
 
 const KB = "/ait/api/v1/kb";
 
-/** Fields of a crawl page that are useful without fetching artifacts. */
+function kbIsoTimestamp(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (value instanceof Date) return value.toISOString();
+  return undefined;
+}
+
+/** Crawl run or create-crawl response: camelCase wire → snake_case for agents. */
+const kbCrawlRunExtract = (raw: unknown): Record<string, unknown> => {
+  if (!isRecord(raw)) {
+    throw new Error("kb_crawl: expected object response from API, got " + typeof raw);
+  }
+  const out: Record<string, unknown> = {};
+  if (typeof raw.crawlRunId === "string") out.crawl_run_id = raw.crawlRunId;
+  if (typeof raw.knowledgeSourceId === "string") out.knowledge_source_id = raw.knowledgeSourceId;
+  if (typeof raw.testEnvironmentId === "string") out.test_environment_id = raw.testEnvironmentId;
+  if (typeof raw.startUrl === "string") out.start_url = raw.startUrl;
+  if (raw.trigger !== undefined) out.trigger = raw.trigger;
+  if (raw.status !== undefined) out.status = raw.status;
+  if (typeof raw.pagesDiscovered === "number") out.pages_discovered = raw.pagesDiscovered;
+  if (typeof raw.total === "number") out.total = raw.total;
+  if (typeof raw.error === "string") out.error = raw.error;
+  if (typeof raw.temporalWorkflowId === "string") out.temporal_workflow_id = raw.temporalWorkflowId;
+  const startedAt = kbIsoTimestamp(raw.startedAt);
+  if (startedAt) out.started_at = startedAt;
+  const finishedAt = kbIsoTimestamp(raw.finishedAt);
+  if (finishedAt) out.finished_at = finishedAt;
+  return out;
+};
+
+/** Page list item: project key crawl/page fields to snake_case. */
 function projectPageSummary(item: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {};
-  for (const key of ["pageId", "crawlRunId", "url", "title", "summary", "capturedAt"]) {
+  if (typeof item.pageId === "string") out.page_id = item.pageId;
+  if (typeof item.crawlRunId === "string") out.crawl_run_id = item.crawlRunId;
+  for (const key of ["url", "title", "summary"] as const) {
     if (typeof item[key] === "string") out[key] = item[key];
   }
   if (typeof item.depth === "number") out.depth = item.depth;
+  const capturedAt = kbIsoTimestamp(item.capturedAt);
+  if (capturedAt) out.captured_at = capturedAt;
   if (isRecord(item.artifacts)) out.artifacts = item.artifacts;
   return out;
 }
 
-/**
- * Cursor-paginated AIT list: `{ items, nextCursor }`. `total` is set from the
- * page length because the API deliberately does not count the full history.
- */
-const kbCursorListExtract = (raw: unknown): { items: unknown[]; total: number; nextCursor?: string } => {
+const kbCrawlHistoryListExtract = (raw: unknown): unknown => {
   if (!isRecord(raw)) return { items: [], total: 0 };
-  const items = Array.isArray(raw.items) ? raw.items : [];
+  const wireItems = Array.isArray(raw.items) ? raw.items : [];
+  const items = wireItems.map((item) => kbCrawlRunExtract(item));
   return {
     items,
     total: items.length,
-    ...(typeof raw.nextCursor === "string" ? { nextCursor: raw.nextCursor } : {}),
+    ...(typeof raw.nextCursor === "string" ? { next_cursor: raw.nextCursor } : {}),
   };
 };
 
-/**
- * Page detail. `structure`, `links`, and `testableFeatures` are the grounding
- * surface, so they are kept whole; `includedArtifacts` is only present when the
- * caller asked for it via the `include` param.
- */
+const kbPageListExtract = (raw: unknown): unknown => {
+  if (!isRecord(raw)) return { items: [], total: 0 };
+  const wireItems = Array.isArray(raw.items) ? raw.items : [];
+  const items = wireItems.filter(isRecord).map((item) => projectPageSummary(item));
+  return {
+    items,
+    total: items.length,
+    ...(typeof raw.nextCursor === "string" ? { next_cursor: raw.nextCursor } : {}),
+  };
+};
+
 const kbPageExtract = (raw: unknown): unknown => {
   if (!isRecord(raw)) return raw;
   const out = projectPageSummary(raw);
   if (Array.isArray(raw.links)) out.links = raw.links;
   if (isRecord(raw.structure)) out.structure = raw.structure;
-  if (Array.isArray(raw.testableFeatures)) out.testableFeatures = raw.testableFeatures;
-  if (isRecord(raw.includedArtifacts)) out.includedArtifacts = raw.includedArtifacts;
+  if (Array.isArray(raw.testableFeatures)) out.testable_features = raw.testableFeatures;
+  if (isRecord(raw.includedArtifacts)) {
+    const included: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(raw.includedArtifacts)) {
+      included[key] = kbArtifactExtract(value);
+    }
+    out.included_artifacts = included;
+  }
   return out;
 };
 
-/**
- * Artifact payload. Text artifacts can carry up to 128 KiB, so nothing beyond
- * the content and its provenance is worth spending context on — the digest and
- * any backend envelope fields are dropped.
- */
+/** Artifact payload: snake_case for agents; digest and other backend fields dropped. */
 const kbArtifactExtract = (raw: unknown): unknown => {
   if (!isRecord(raw)) return raw;
   const out: Record<string, unknown> = {};
-  for (const key of ["pageId", "crawlRunId", "kind", "contentType", "text", "signedUrl", "expiresAt"]) {
-    if (typeof raw[key] === "string") out[key] = raw[key];
-  }
+  if (typeof raw.pageId === "string") out.page_id = raw.pageId;
+  if (typeof raw.crawlRunId === "string") out.crawl_run_id = raw.crawlRunId;
+  if (typeof raw.kind === "string") out.kind = raw.kind;
+  if (typeof raw.contentType === "string") out.content_type = raw.contentType;
+  if (typeof raw.text === "string") out.text = raw.text;
+  if (typeof raw.signedUrl === "string") out.signed_url = raw.signedUrl;
+  const expiresAt = kbIsoTimestamp(raw.expiresAt);
+  if (expiresAt) out.expires_at = expiresAt;
   if (typeof raw.truncated === "boolean") out.truncated = raw.truncated;
   return out;
 };
@@ -214,15 +258,17 @@ const kbArtifactExtract = (raw: unknown): unknown => {
  */
 function buildCreateCrawlBody(input: Record<string, unknown>): unknown {
   const body = isRecord(input.body) ? input.body : {};
-  const appId = body.appId ?? input.app_id;
+  const appId = (body.app_id ?? body.appId ?? input.app_id) as string | undefined;
   if (typeof appId !== "string" || !appId) {
-    throw new Error("body.appId is required — the AIT application the knowledge base belongs to.");
+    throw new Error("body.app_id is required — the AIT application the knowledge base belongs to.");
   }
-  const testEnvironmentId = body.testEnvironmentId ?? input.test_environment_id;
-  const startUrl = body.startUrl;
+  const testEnvironmentId = (body.test_environment_id ?? body.testEnvironmentId ?? input.test_environment_id) as
+    | string
+    | undefined;
+  const startUrl = (body.start_url ?? body.startUrl) as string | undefined;
   if (!testEnvironmentId && !startUrl) {
     throw new Error(
-      "Provide body.testEnvironmentId to crawl an existing environment, or body.startUrl to create an ad-hoc one.",
+      "Provide body.test_environment_id to crawl an existing environment, or body.start_url to create an ad-hoc one.",
     );
   }
   const out: Record<string, unknown> = { appId };
@@ -231,15 +277,19 @@ function buildCreateCrawlBody(input: Record<string, unknown>): unknown {
 
   if (isRecord(body.config)) {
     const config: Record<string, unknown> = {};
-    for (const key of ["maxDepth", "maxPages"]) {
-      if (typeof body.config[key] === "number") config[key] = body.config[key];
-    }
-    if (typeof body.config.autoLogin === "boolean") config.autoLogin = body.config.autoLogin;
-    for (const key of ["tunnelName", "crawlInstructionsAddendum"]) {
-      if (typeof body.config[key] === "string") config[key] = body.config[key];
-    }
+    const maxDepth = body.config.max_depth ?? body.config.maxDepth;
+    const maxPages = body.config.max_pages ?? body.config.maxPages;
+    if (typeof maxDepth === "number") config.maxDepth = maxDepth;
+    if (typeof maxPages === "number") config.maxPages = maxPages;
+    const autoLogin = body.config.auto_login ?? body.config.autoLogin;
+    if (typeof autoLogin === "boolean") config.autoLogin = autoLogin;
+    const tunnelName = body.config.tunnel_name ?? body.config.tunnelName;
+    if (typeof tunnelName === "string") config.tunnelName = tunnelName;
+    const addendum = body.config.crawl_instructions_addendum ?? body.config.crawlInstructionsAddendum;
+    if (typeof addendum === "string") config.crawlInstructionsAddendum = addendum;
     if (isRecord(body.config.recurring)) {
-      const { startDate, repeat } = body.config.recurring;
+      const startDate = body.config.recurring.start_date ?? body.config.recurring.startDate;
+      const repeat = body.config.recurring.repeat;
       if (typeof startDate === "string" && typeof repeat === "string") {
         config.recurring = { startDate, repeat };
       }
@@ -252,36 +302,63 @@ function buildCreateCrawlBody(input: Record<string, unknown>): unknown {
 function buildRecrawlBody(input: Record<string, unknown>): unknown {
   const body = isRecord(input.body) ? input.body : {};
   const out: Record<string, unknown> = {};
-  for (const key of ["maxDepth", "maxPages"]) {
-    if (typeof body[key] === "number") out[key] = body[key];
-  }
+  const maxDepth = body.max_depth ?? body.maxDepth;
+  const maxPages = body.max_pages ?? body.maxPages;
+  if (typeof maxDepth === "number") out.maxDepth = maxDepth;
+  if (typeof maxPages === "number") out.maxPages = maxPages;
   return out;
 }
 
 const createCrawlSchema: BodySchema = {
-  description: "Crawl to define (CreateCrawlBody). Give either testEnvironmentId or startUrl.",
+  description: "Crawl to define. Give either test_environment_id or start_url.",
   fields: [
-    { name: "appId", type: "string", required: true, description: "AIT application the knowledge base belongs to" },
-    { name: "testEnvironmentId", type: "string", required: false, description: "Existing test environment to crawl; its BASE_URL variable becomes the start URL" },
-    { name: "startUrl", type: "string", required: false, description: "Ad-hoc URL to crawl; creates a test environment with this BASE_URL" },
+    { name: "app_id", type: "string", required: true, description: "AIT application the knowledge base belongs to" },
+    {
+      name: "test_environment_id",
+      type: "string",
+      required: false,
+      description: "Existing test environment to crawl; its BASE_URL variable becomes the start URL",
+    },
+    {
+      name: "start_url",
+      type: "string",
+      required: false,
+      description: "Ad-hoc URL to crawl; creates a test environment with this BASE_URL",
+    },
     {
       name: "config",
       type: "object",
       required: false,
       description: "Crawl limits, auth, steering, and schedule",
       fields: [
-        { name: "maxDepth", type: "number", required: false, description: "Maximum link depth from the start URL" },
-        { name: "maxPages", type: "number", required: false, description: "Maximum number of pages to capture" },
-        { name: "autoLogin", type: "boolean", required: false, description: "Log in using the environment's AUTO_LOGIN_* variables before crawling" },
-        { name: "tunnelName", type: "string", required: false, description: "Named AIT tunnel to route the crawl through, for apps that are not publicly reachable" },
-        { name: "crawlInstructionsAddendum", type: "string", required: false, description: "Natural-language steering appended to the knowledge base's shared crawl instructions (e.g. 'only crawl under /docs')" },
+        { name: "max_depth", type: "number", required: false, description: "Maximum link depth from the start URL" },
+        { name: "max_pages", type: "number", required: false, description: "Maximum number of pages to capture" },
+        {
+          name: "auto_login",
+          type: "boolean",
+          required: false,
+          description: "Log in using the environment's AUTO_LOGIN_* variables before crawling",
+        },
+        {
+          name: "tunnel_name",
+          type: "string",
+          required: false,
+          description: "Named AIT tunnel to route the crawl through, for apps that are not publicly reachable",
+        },
+        {
+          name: "crawl_instructions_addendum",
+          type: "string",
+          required: false,
+          description:
+            "Natural-language steering appended to the knowledge base's shared crawl instructions (e.g. 'only crawl under /docs')",
+        },
         {
           name: "recurring",
           type: "object",
           required: false,
           description: "Schedule for repeat crawls",
           fields: [
-            { name: "startDate", type: "string", required: true, description: "ISO-8601 date the schedule starts" },
+            { name: "start_date", type: "string", required: true, description: "ISO-8601 date the schedule starts" },
             { name: "repeat", type: "string", required: true, description: "Repeat interval (e.g. daily, weekly)" },
           ],
         },
@@ -291,10 +368,10 @@ const createCrawlSchema: BodySchema = {
 };
 
 const recrawlSchema: BodySchema = {
-  description: "Optional overrides for the new crawl run (RecrawlBody). Send an empty object to reuse the stored config.",
+  description: "Optional overrides for the new crawl run. Send an empty object to reuse the stored config.",
   fields: [
-    { name: "maxDepth", type: "number", required: false, description: "Maximum link depth from the start URL" },
-    { name: "maxPages", type: "number", required: false, description: "Maximum number of pages to capture" },
+    { name: "max_depth", type: "number", required: false, description: "Maximum link depth from the start URL" },
+    { name: "max_pages", type: "number", required: false, description: "Maximum number of pages to capture" },
   ],
 };
 
@@ -305,8 +382,14 @@ export const aitToolset: ToolsetDefinition = {
   name: "ait",
   displayName: "AI Test Automation (AIT)",
   description:
-    "Harness AI Test Automation (AIT) — list and manage automated tests for applications. " +
-    "TERMINOLOGY MAPPING (AIT ↔ Harness): AIT \"org\" = Harness \"account\"; AIT \"app\" = Harness \"project\".",
+    "Harness AI Test Automation (AIT) — apps, environments, tests, and Knowledge Base crawls. " +
+    "TERMINOLOGY: AIT \"org\" = Harness \"account\"; AIT \"app\" = Harness \"project\". " +
+    "KNOWLEDGE BASE (kb_crawl, kb_crawl_page, kb_page_artifact): for any crawl/page/screenshot/artifact question, " +
+    "use harness_list/harness_get/harness_create/harness_execute only. " +
+    "Do NOT curl the AIT API, query Postgres, use kubectl, or fetch GCS/S3. " +
+    "Do NOT call /ait/api/apps or other unmatched paths — those proxy to ait-java-api-service (legacy Java), which is unrelated to KB. " +
+    "Do NOT use ait_test_environment to discover IDs for KB on node-api-only stacks (that list is Java-backed and will 500 locally). Ask for test_environment_id, then call kb_crawl. " +
+    "Prefer the explore-knowledge-base MCP prompt for crawl/page Q&A workflows.",
   optIn: true,
   resources: [
     // ── ait_app ─────────────────────────────────────────────────────────────
@@ -337,10 +420,17 @@ export const aitToolset: ToolsetDefinition = {
       displayName: "AIT Test Environment",
       description:
         "A test environment for an AIT application. List environments to discover " +
-        "environment IDs needed for creating and running tests.",
+        "test_environment_id values (same UUID as KB crawls use). " +
+        "WARNING: GET /ait/api/v1/testEnvironments is still served by the legacy Java API (ait-java-api-service). " +
+        "On laptop Helm stacks that only run node-api, this list returns ENOTFOUND/500 — that does NOT mean KB is down. " +
+        "For Knowledge Base crawls when this list fails, ask the user for test_environment_id and call kb_crawl directly.",
       toolset: "ait",
       scope: "account",
-      identifierFields: ["app_id"],
+      identifierFields: ["test_environment_id"],
+      diagnosticHint:
+        "testEnvironments is a Java catch-all route. ENOTFOUND ait-java-api-service means Java is not deployed locally, " +
+        "not that node-api/KB is unavailable. For kb_crawl, obtain test_environment_id from the user and call " +
+        "harness_list(resource_type='kb_crawl', params={test_environment_id}) — never fall back to curl/psql.",
       listFilterFields: [
         {
           name: "app_id",
@@ -358,8 +448,9 @@ export const aitToolset: ToolsetDefinition = {
           },
           responseExtractor: aitTestEnvironmentListExtract,
           description:
-            "List all test environments for an application. Requires app_id in filters. " +
-            "Returns environment details including id, env_name, base_url, and type flags.",
+            "List test environments for an application. Requires app_id in filters. " +
+            "Each item includes test_environment_id (use this same field for kb_crawl), env_name, and base_url. " +
+            "Requires Java AIT API; skip this for local KB-only stacks.",
         },
       },
     },
@@ -447,7 +538,7 @@ export const aitToolset: ToolsetDefinition = {
           bodyBuilder: (input) => {
             const b = (input.body ?? input) as Record<string, unknown>;
             const appId = (b.app_id ?? b.appId) as string;
-            const envId = (b.env_id ?? b.envId) as string;
+            const envId = (b.test_environment_id ?? b.testEnvironmentId ?? b.env_id ?? b.envId) as string;
             const authType = b.auth_type ?? b.authType;
             const entryUrl = b.entry_url ?? b.entryUrl;
             return {
@@ -461,16 +552,21 @@ export const aitToolset: ToolsetDefinition = {
           bodySchema: {
             description: "Create a test using AI (copilot)",
             fields: [
-              { name: "appId", type: "string", required: true, description: "Application ID" },
-              { name: "envId", type: "string", required: true, description: "Environment ID" },
+              { name: "app_id", type: "string", required: true, description: "Application ID" },
+              {
+                name: "test_environment_id",
+                type: "string",
+                required: true,
+                description: "Test environment UUID (same field as kb_crawl / ait_test_environment list)",
+              },
               { name: "description", type: "string", required: true, description: "Copilot task description (also used as the test name)" },
-              { name: "authType", type: "string", required: false, description: "Auth type: 'auth' (default) or 'no_auth'" },
-              { name: "entryUrl", type: "string", required: false, description: "Optional entry URL for the test" },
+              { name: "auth_type", type: "string", required: false, description: "Auth type: 'auth' (default) or 'no_auth'" },
+              { name: "entry_url", type: "string", required: false, description: "Optional entry URL for the test" },
             ],
           },
           responseExtractor: aitTestCreateExtract,
           description:
-            "Create a test using AI. Provide app_id, env_id, and a description. Returns test_id and test_version_id.",
+            "Create a test using AI. Provide app_id, test_environment_id, and a description. Returns test_id and test_version_id.",
         },
       },
       executeActions: {
@@ -482,7 +578,12 @@ export const aitToolset: ToolsetDefinition = {
           bodyBuilder: (input: Record<string, unknown>) => {
             const b = (input.body ?? input) as Record<string, unknown>;
             const appId = (b.app_id ?? b.appId) as string;
-            const environmentId = (b.environment_id ?? b.environmentId) as string;
+            const environmentId = (
+              b.test_environment_id ??
+              b.testEnvironmentId ??
+              b.environment_id ??
+              b.environmentId
+            ) as string;
             return {
               appId,
               environmentId,
@@ -492,9 +593,26 @@ export const aitToolset: ToolsetDefinition = {
           bodySchema: {
             description: "Execute a test run",
             fields: [
-              { name: "appId", type: "string", required: true, description: "Application UUID (e.g. ecaab215-65cd-45d6-8426-09ba1e04eabb). Look up via ait_app if only app name is known." },
-              { name: "environmentId", type: "string", required: true, description: "Environment UUID (e.g. 1289b517-5f1b-4927-b30b-6f2e895dae8e). Look up via ait_test_environment if only env name is known." },
-              { name: "params", type: "string", required: false, description: "Test params — JSON stringified Map<string, string>. Defaults to '{\"RUN_MODE\":\"no-mock\",\"TestExecutorNamespace.fastExecutorMode\":\"false\"}'" },
+              {
+                name: "app_id",
+                type: "string",
+                required: true,
+                description: "Application UUID. Look up via ait_app if only app name is known.",
+              },
+              {
+                name: "test_environment_id",
+                type: "string",
+                required: true,
+                description:
+                  "Test environment UUID (same as ait_test_environment.test_environment_id and kb_crawl params).",
+              },
+              {
+                name: "params",
+                type: "string",
+                required: false,
+                description:
+                  "Test params — JSON stringified Map<string, string>. Defaults to '{\"RUN_MODE\":\"no-mock\",\"TestExecutorNamespace.fastExecutorMode\":\"false\"}'",
+              },
             ],
           },
           responseExtractor: aitTestRunExtract,
@@ -508,13 +626,20 @@ export const aitToolset: ToolsetDefinition = {
           resourceType: "kb_crawl",
           displayName: "AIT Crawl Run",
           description:
-            "One crawl of a test environment. Create a crawl to populate the knowledge base, then poll the run until status is completed or failed.",
+            "One crawl of a test environment. Create a crawl to populate the knowledge base, then poll the run until status is completed or failed. " +
+            "ALWAYS use harness_list/get/create for crawls — never curl, psql, or kubectl. " +
+            "List requires params.test_environment_id. Newest runs first.",
           toolset: "ait",
           scope: "account",
           headerBasedScoping: true,
           identifierFields: ["crawl_run_id"],
+          searchAliases: ["knowledge base crawl", "kb crawl", "crawl run", "crawl history", "recrawl"],
+          diagnosticHint:
+            "KB crawls are served by node-api at /ait/api/v1/kb/... via MCP. " +
+            "If you see ENOTFOUND ait-java-api-service, you hit an unmatched route that proxies to legacy Java — stop curling and use harness_list(resource_type='kb_crawl', params={test_environment_id}). " +
+            "Ensure HARNESS_TOOLSETS includes +ait and HARNESS_BASE_URL points at the AIT ingress (local: http://localhost:30082).",
           listFilterFields: [
-            { name: "cursor", description: "Continue a previous page of history — pass the nextCursor from the last response" },
+            { name: "cursor", description: "Continue a previous page of history — pass next_cursor from the last response" },
           ],
           relatedResources: [
             {
@@ -532,7 +657,8 @@ export const aitToolset: ToolsetDefinition = {
               operationPolicy: { risk: "read", retryPolicy: "safe" },
               pathParams: { test_environment_id: "testEnvironmentId" },
               queryParams: { size: "limit", cursor: "cursor" },
-              responseExtractor: kbCursorListExtract,
+              responseExtractor: kbCrawlHistoryListExtract,
+              skipCompact: true,
               description: "List crawl history for a test environment, newest first",
               paramsSchema: {
                 fields: [
@@ -545,9 +671,7 @@ export const aitToolset: ToolsetDefinition = {
               path: `${KB}/crawls/{crawlRunId}`,
               operationPolicy: { risk: "read", retryPolicy: "safe" },
               pathParams: { crawl_run_id: "crawlRunId" },
-              // The crawl-run DTO is hand-written and already agent-facing: no
-              // envelope, no backend-internal keys.
-              responseExtractor: passthrough,
+              responseExtractor: kbCrawlRunExtract,
               description: "Get a crawl run's status, page count, and error message",
             },
             create: {
@@ -557,8 +681,8 @@ export const aitToolset: ToolsetDefinition = {
               bodyBuilder: buildCreateCrawlBody,
               bodySchema: createCrawlSchema,
               skipScopeBodyInjection: true,
-              responseExtractor: passthrough,
-              description: "Define a crawl and queue it — returns the crawlRunId to poll",
+              responseExtractor: kbCrawlRunExtract,
+              description: "Define a crawl and queue it — returns crawl_run_id to poll",
             },
           },
           executeActions: {
@@ -570,7 +694,7 @@ export const aitToolset: ToolsetDefinition = {
               bodyBuilder: buildRecrawlBody,
               bodySchema: recrawlSchema,
               skipScopeBodyInjection: true,
-              responseExtractor: passthrough,
+              responseExtractor: kbCrawlRunExtract,
               actionDescription:
                 "Recrawl a test environment with its stored crawl source. Cancels the crawl workflow still running for that environment, if any, and replaces its pages with the new run's.",
             },
@@ -579,7 +703,7 @@ export const aitToolset: ToolsetDefinition = {
               path: `${KB}/{testEnvironmentId}/crawl/status`,
               operationPolicy: { risk: "read", retryPolicy: "safe" },
               pathParams: { test_environment_id: "testEnvironmentId" },
-              responseExtractor: passthrough,
+              responseExtractor: kbCrawlRunExtract,
               actionDescription: "Get the most recent crawl run for a test environment without knowing its crawlRunId.",
             },
           },
@@ -588,23 +712,30 @@ export const aitToolset: ToolsetDefinition = {
           resourceType: "kb_crawl_page",
           displayName: "AIT Crawl Page",
           description:
-            "A page captured by a crawl run, with its structure, links, and testable features. Use this to ground test authoring in what the application actually renders.",
+            "A page captured by a crawl run, with its structure, links, and testable features. Use this to ground test authoring in what the application actually renders. " +
+            "ALWAYS use harness_list/get — never curl or open storage. " +
+            "List needs params.crawl_run_id; get needs resource_id=page_id plus params.crawl_run_id. " +
+            "For screenshots prefer include=screenshot on get (returns signed_url + MCP image block).",
           toolset: "ait",
           scope: "account",
           headerBasedScoping: true,
           // Parent-first, resource last: harness_get maps resource_id to the final
           // field, so resource_id is the page and crawl_run_id comes from params.
           identifierFields: ["crawl_run_id", "page_id"],
-          compactItem: projectPageSummary,
+          searchAliases: ["crawl page", "kb page", "page screenshot", "crawled url"],
+          diagnosticHint:
+            "Use harness_list(resource_type='kb_crawl_page', params={crawl_run_id, query?}). " +
+            "Do not curl localhost or proxy paths that resolve ait-java-api-service.",
           listFilterFields: [
             { name: "query", description: "Match against page title, URL, and summary" },
-            { name: "cursor", description: "Continue a previous page of results — pass the nextCursor from the last response" },
+            { name: "cursor", description: "Continue a previous page of results — pass next_cursor from the last response" },
           ],
           relatedResources: [
             {
               resourceType: "kb_page_artifact",
               relationship: "children",
-              description: "Accessibility tree, markdown, metadata, or screenshot for a page",
+              description:
+                "Single artifact get. Prefer include=screenshot on kb_crawl_page when you only need to show a screenshot; use kb_page_artifact when you need one kind by itself.",
             },
           ],
           operations: {
@@ -614,7 +745,8 @@ export const aitToolset: ToolsetDefinition = {
               operationPolicy: { risk: "read", retryPolicy: "safe" },
               pathParams: { crawl_run_id: "crawlRunId" },
               queryParams: { query: "query", size: "limit", cursor: "cursor" },
-              responseExtractor: kbCursorListExtract,
+              responseExtractor: kbPageListExtract,
+              skipCompact: true,
               description: "List the pages a crawl run captured, optionally filtered by a text query",
               paramsSchema: {
                 fields: [{ name: "crawl_run_id", required: true, description: "Crawl run whose pages to list" }],
@@ -628,12 +760,18 @@ export const aitToolset: ToolsetDefinition = {
               queryParams: { include: "include" },
               responseExtractor: kbPageExtract,
               description:
-                "Get one page. Pass include as a comma-separated list of accessibility, markdown, metadata, or screenshot to inline those artifacts.",
+                "Get one page. Pass include as a comma-separated list of accessibility, markdown, metadata, or screenshot. " +
+                "For 'show/share the screenshot', prefer include=screenshot — harness_get returns JSON plus an MCP image content block when the signed URL is fetchable. " +
+                "Do not curl the relicx API or open GCS/S3 directly.",
               paramsSchema: {
                 fields: [
-                  { name: "crawl_run_id", required: true, description: "Crawl run the page belongs to" },
-                  { name: "page_id", required: true, description: "Page to fetch" },
-                  { name: "include", required: false, description: "Artifacts to inline: accessibility, markdown, metadata, screenshot" },
+                  { name: "crawl_run_id", required: true, description: "Crawl run the page belongs to (params.crawl_run_id)" },
+                  { name: "page_id", required: true, description: "Page to fetch — also harness_get resource_id" },
+                  {
+                    name: "include",
+                    required: false,
+                    description: "Comma-separated artifacts to inline: accessibility, markdown, metadata, screenshot",
+                  },
                 ],
               },
             },
@@ -643,13 +781,21 @@ export const aitToolset: ToolsetDefinition = {
           resourceType: "kb_page_artifact",
           displayName: "AIT Page Artifact",
           description:
-            "One captured artifact for a page. Text kinds return inline content capped at 128 KiB; screenshot returns a short-lived signed URL. Raw HTML is not exposed.",
+            "One captured artifact for a crawl page. Text kinds (accessibility, markdown, metadata) return inline content capped at 128 KiB. " +
+            "kind=screenshot returns signed_url (+ expires_at) and harness_get also attaches an MCP image content block when the URL is fetchable. " +
+            "Raw HTML is never exposed. Do not curl the relicx API or fetch storage buckets yourself. " +
+            "harness_get example: resource_type=kb_page_artifact, resource_id=screenshot (kind — last identifier field), " +
+            "params={ crawl_run_id: \"<uuid>\", page_id: \"<uuid>\" }. All three of crawl_run_id, page_id, and kind are required.",
           toolset: "ait",
           scope: "account",
           headerBasedScoping: true,
           // An artifact is identified within its page by kind, so that is the last
           // field and therefore what resource_id means for this type.
           identifierFields: ["crawl_run_id", "page_id", "kind"],
+          searchAliases: ["page artifact", "accessibility tree", "screenshot signed url", "page markdown"],
+          diagnosticHint:
+            "resource_id must be the artifact kind (screenshot|accessibility|markdown|metadata); pass crawl_run_id and page_id in params. " +
+            "Prefer kb_crawl_page get with include=screenshot for sharing images. Never curl or use S3/GCS CLIs.",
           operations: {
             get: {
               method: "GET",
@@ -657,12 +803,27 @@ export const aitToolset: ToolsetDefinition = {
               operationPolicy: { risk: "read", retryPolicy: "safe" },
               pathParams: { crawl_run_id: "crawlRunId", page_id: "pageId", kind: "kind" },
               responseExtractor: kbArtifactExtract,
-              description: "Fetch one artifact for a page: accessibility, markdown, metadata, or screenshot",
+              description:
+                "Fetch one artifact. resource_id must be the kind (accessibility | markdown | metadata | screenshot). " +
+                "Always pass crawl_run_id and page_id in params. Example: resource_id=screenshot, params={ crawl_run_id, page_id }.",
               paramsSchema: {
                 fields: [
-                  { name: "crawl_run_id", required: true, description: "Crawl run the page belongs to" },
-                  { name: "page_id", required: true, description: "Page whose artifact to fetch" },
-                  { name: "kind", required: true, description: "accessibility, markdown, metadata, or screenshot" },
+                  {
+                    name: "crawl_run_id",
+                    required: true,
+                    description: "Crawl run UUID — required in params (not resource_id)",
+                  },
+                  {
+                    name: "page_id",
+                    required: true,
+                    description: "Page UUID — required in params (not resource_id)",
+                  },
+                  {
+                    name: "kind",
+                    required: true,
+                    description:
+                      "accessibility | markdown | metadata | screenshot — usually passed as harness_get resource_id",
+                  },
                 ],
               },
             },

--- a/src/registry/toolsets/ait.ts
+++ b/src/registry/toolsets/ait.ts
@@ -1,0 +1,337 @@
+/**
+ * AIT (AI Test) knowledge-base toolset — crawl an application environment and read
+ * the crawled pages back as grounding for test authoring.
+ *
+ * Served by the AIT API behind the Harness gateway at {HARNESS_BASE_URL}/ait/api/v1/kb/…
+ * AIT resolves the owning organization from the PAT itself (Harness account →
+ * AIT org), so these resources scope through the Harness-Account header only:
+ * headerBasedScoping keeps accountIdentifier out of the query string and keeps
+ * org/project out of write bodies, which the AIT routes reject as unknown fields.
+ *
+ * Pagination is cursor-based, not page-based: pass `size` for the page size and
+ * the `cursor` filter (from a previous response's `nextCursor`) to continue.
+ */
+import type { BodySchema, ToolsetDefinition } from "../types.js";
+import { passthrough } from "../extractors.js";
+import { isRecord } from "../../utils/type-guards.js";
+
+const KB = "/ait/api/v1/kb";
+
+/** Fields of a crawl page that are useful without fetching artifacts. */
+function projectPageSummary(item: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of ["pageId", "crawlRunId", "url", "title", "summary", "capturedAt"]) {
+    if (typeof item[key] === "string") out[key] = item[key];
+  }
+  if (typeof item.depth === "number") out.depth = item.depth;
+  if (isRecord(item.artifacts)) out.artifacts = item.artifacts;
+  return out;
+}
+
+/**
+ * Cursor-paginated AIT list: `{ items, nextCursor }`. `total` is set from the
+ * page length because the API deliberately does not count the full history.
+ */
+const kbCursorListExtract = (raw: unknown): { items: unknown[]; total: number; nextCursor?: string } => {
+  if (!isRecord(raw)) return { items: [], total: 0 };
+  const items = Array.isArray(raw.items) ? raw.items : [];
+  return {
+    items,
+    total: items.length,
+    ...(typeof raw.nextCursor === "string" ? { nextCursor: raw.nextCursor } : {}),
+  };
+};
+
+/**
+ * Page detail. `structure`, `links`, and `testableFeatures` are the grounding
+ * surface, so they are kept whole; `includedArtifacts` is only present when the
+ * caller asked for it via the `include` param.
+ */
+const kbPageExtract = (raw: unknown): unknown => {
+  if (!isRecord(raw)) return raw;
+  const out = projectPageSummary(raw);
+  if (Array.isArray(raw.links)) out.links = raw.links;
+  if (isRecord(raw.structure)) out.structure = raw.structure;
+  if (Array.isArray(raw.testableFeatures)) out.testableFeatures = raw.testableFeatures;
+  if (isRecord(raw.includedArtifacts)) out.includedArtifacts = raw.includedArtifacts;
+  return out;
+};
+
+/**
+ * Artifact payload. Text artifacts can carry up to 128 KiB, so nothing beyond
+ * the content and its provenance is worth spending context on — the digest and
+ * any backend envelope fields are dropped.
+ */
+const kbArtifactExtract = (raw: unknown): unknown => {
+  if (!isRecord(raw)) return raw;
+  const out: Record<string, unknown> = {};
+  for (const key of ["pageId", "crawlRunId", "kind", "contentType", "text", "signedUrl", "expiresAt"]) {
+    if (typeof raw[key] === "string") out[key] = raw[key];
+  }
+  if (typeof raw.truncated === "boolean") out.truncated = raw.truncated;
+  return out;
+};
+
+/**
+ * AIT bodies are validated against explicit tsoa interfaces that reject unknown
+ * fields, so both builders below map a fixed field list instead of forwarding
+ * whatever the agent supplied.
+ */
+function buildCreateCrawlBody(input: Record<string, unknown>): unknown {
+  const body = isRecord(input.body) ? input.body : {};
+  const appId = body.appId ?? input.app_id;
+  if (typeof appId !== "string" || !appId) {
+    throw new Error("body.appId is required — the AIT application the knowledge base belongs to.");
+  }
+  const testEnvironmentId = body.testEnvironmentId ?? input.test_environment_id;
+  const startUrl = body.startUrl;
+  if (!testEnvironmentId && !startUrl) {
+    throw new Error(
+      "Provide body.testEnvironmentId to crawl an existing environment, or body.startUrl to create an ad-hoc one.",
+    );
+  }
+  const out: Record<string, unknown> = { appId };
+  if (typeof testEnvironmentId === "string") out.testEnvironmentId = testEnvironmentId;
+  if (typeof startUrl === "string") out.startUrl = startUrl;
+
+  if (isRecord(body.config)) {
+    const config: Record<string, unknown> = {};
+    for (const key of ["maxDepth", "maxPages"]) {
+      if (typeof body.config[key] === "number") config[key] = body.config[key];
+    }
+    if (typeof body.config.autoLogin === "boolean") config.autoLogin = body.config.autoLogin;
+    for (const key of ["tunnelName", "crawlInstructionsAddendum"]) {
+      if (typeof body.config[key] === "string") config[key] = body.config[key];
+    }
+    if (isRecord(body.config.recurring)) {
+      const { startDate, repeat } = body.config.recurring;
+      if (typeof startDate === "string" && typeof repeat === "string") {
+        config.recurring = { startDate, repeat };
+      }
+    }
+    if (Object.keys(config).length > 0) out.config = config;
+  }
+  return out;
+}
+
+function buildRecrawlBody(input: Record<string, unknown>): unknown {
+  const body = isRecord(input.body) ? input.body : {};
+  const out: Record<string, unknown> = {};
+  for (const key of ["maxDepth", "maxPages"]) {
+    if (typeof body[key] === "number") out[key] = body[key];
+  }
+  return out;
+}
+
+const createCrawlSchema: BodySchema = {
+  description: "Crawl to define (CreateCrawlBody). Give either testEnvironmentId or startUrl.",
+  fields: [
+    { name: "appId", type: "string", required: true, description: "AIT application the knowledge base belongs to" },
+    { name: "testEnvironmentId", type: "string", required: false, description: "Existing test environment to crawl; its BASE_URL variable becomes the start URL" },
+    { name: "startUrl", type: "string", required: false, description: "Ad-hoc URL to crawl; creates a test environment with this BASE_URL" },
+    {
+      name: "config",
+      type: "object",
+      required: false,
+      description: "Crawl limits, auth, steering, and schedule",
+      fields: [
+        { name: "maxDepth", type: "number", required: false, description: "Maximum link depth from the start URL" },
+        { name: "maxPages", type: "number", required: false, description: "Maximum number of pages to capture" },
+        { name: "autoLogin", type: "boolean", required: false, description: "Log in using the environment's AUTO_LOGIN_* variables before crawling" },
+        { name: "tunnelName", type: "string", required: false, description: "Named AIT tunnel to route the crawl through, for apps that are not publicly reachable" },
+        { name: "crawlInstructionsAddendum", type: "string", required: false, description: "Natural-language steering appended to the knowledge base's shared crawl instructions (e.g. 'only crawl under /docs')" },
+        {
+          name: "recurring",
+          type: "object",
+          required: false,
+          description: "Schedule for repeat crawls",
+          fields: [
+            { name: "startDate", type: "string", required: true, description: "ISO-8601 date the schedule starts" },
+            { name: "repeat", type: "string", required: true, description: "Repeat interval (e.g. daily, weekly)" },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const recrawlSchema: BodySchema = {
+  description: "Optional overrides for the new crawl run (RecrawlBody). Send an empty object to reuse the stored config.",
+  fields: [
+    { name: "maxDepth", type: "number", required: false, description: "Maximum link depth from the start URL" },
+    { name: "maxPages", type: "number", required: false, description: "Maximum number of pages to capture" },
+  ],
+};
+
+export const aitToolset: ToolsetDefinition = {
+  name: "ait",
+  displayName: "AIT Knowledge Base",
+  description: "AIT knowledge base — define crawls of an application environment and read the crawled pages and artifacts",
+  optIn: true,
+  resources: [
+    {
+      resourceType: "kb_crawl",
+      displayName: "AIT Crawl Run",
+      description:
+        "One crawl of a test environment. Create a crawl to populate the knowledge base, then poll the run until status is completed or failed.",
+      toolset: "ait",
+      scope: "account",
+      headerBasedScoping: true,
+      identifierFields: ["crawl_run_id"],
+      listFilterFields: [
+        { name: "cursor", description: "Continue a previous page of history — pass the nextCursor from the last response" },
+      ],
+      relatedResources: [
+        {
+          resourceType: "kb_crawl_page",
+          relationship: "children",
+          description: "Pages captured by a completed crawl run",
+        },
+      ],
+      executeHint:
+        "Poll a run with harness_get(resource_type='kb_crawl', resource_id=<crawl_run_id>) until status is completed or failed. Use the recrawl action to refresh an environment; it cancels any crawl still running for that environment first.",
+      operations: {
+        list: {
+          method: "GET",
+          path: `${KB}/{testEnvironmentId}/crawls`,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          pathParams: { test_environment_id: "testEnvironmentId" },
+          queryParams: { size: "limit", cursor: "cursor" },
+          responseExtractor: kbCursorListExtract,
+          description: "List crawl history for a test environment, newest first",
+          paramsSchema: {
+            fields: [
+              { name: "test_environment_id", required: true, description: "Test environment whose crawl history to list" },
+            ],
+          },
+        },
+        get: {
+          method: "GET",
+          path: `${KB}/crawls/{crawlRunId}`,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          pathParams: { crawl_run_id: "crawlRunId" },
+          // The crawl-run DTO is hand-written and already agent-facing: no
+          // envelope, no backend-internal keys.
+          responseExtractor: passthrough,
+          description: "Get a crawl run's status, page count, and error message",
+        },
+        create: {
+          method: "POST",
+          path: `${KB}/crawls`,
+          operationPolicy: { risk: "low_write", retryPolicy: "do_not_retry" },
+          bodyBuilder: buildCreateCrawlBody,
+          bodySchema: createCrawlSchema,
+          skipScopeBodyInjection: true,
+          responseExtractor: passthrough,
+          description: "Define a crawl and queue it — returns the crawlRunId to poll",
+        },
+      },
+      executeActions: {
+        recrawl: {
+          method: "POST",
+          path: `${KB}/{testEnvironmentId}/recrawl`,
+          operationPolicy: { risk: "high_write", retryPolicy: "do_not_retry" },
+          pathParams: { test_environment_id: "testEnvironmentId" },
+          bodyBuilder: buildRecrawlBody,
+          bodySchema: recrawlSchema,
+          skipScopeBodyInjection: true,
+          responseExtractor: passthrough,
+          actionDescription:
+            "Recrawl a test environment with its stored crawl source. Cancels the crawl workflow still running for that environment, if any, and replaces its pages with the new run's.",
+        },
+        latest_status: {
+          method: "GET",
+          path: `${KB}/{testEnvironmentId}/crawl/status`,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          pathParams: { test_environment_id: "testEnvironmentId" },
+          responseExtractor: passthrough,
+          actionDescription: "Get the most recent crawl run for a test environment without knowing its crawlRunId.",
+        },
+      },
+    },
+    {
+      resourceType: "kb_crawl_page",
+      displayName: "AIT Crawl Page",
+      description:
+        "A page captured by a crawl run, with its structure, links, and testable features. Use this to ground test authoring in what the application actually renders.",
+      toolset: "ait",
+      scope: "account",
+      headerBasedScoping: true,
+      // Parent-first, resource last: harness_get maps resource_id to the final
+      // field, so resource_id is the page and crawl_run_id comes from params.
+      identifierFields: ["crawl_run_id", "page_id"],
+      compactItem: projectPageSummary,
+      listFilterFields: [
+        { name: "query", description: "Match against page title, URL, and summary" },
+        { name: "cursor", description: "Continue a previous page of results — pass the nextCursor from the last response" },
+      ],
+      relatedResources: [
+        {
+          resourceType: "kb_page_artifact",
+          relationship: "children",
+          description: "Accessibility tree, markdown, metadata, or screenshot for a page",
+        },
+      ],
+      operations: {
+        list: {
+          method: "GET",
+          path: `${KB}/crawls/{crawlRunId}/pages`,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          pathParams: { crawl_run_id: "crawlRunId" },
+          queryParams: { query: "query", size: "limit", cursor: "cursor" },
+          responseExtractor: kbCursorListExtract,
+          description: "List the pages a crawl run captured, optionally filtered by a text query",
+          paramsSchema: {
+            fields: [{ name: "crawl_run_id", required: true, description: "Crawl run whose pages to list" }],
+          },
+        },
+        get: {
+          method: "GET",
+          path: `${KB}/crawls/{crawlRunId}/pages/{pageId}`,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          pathParams: { crawl_run_id: "crawlRunId", page_id: "pageId" },
+          queryParams: { include: "include" },
+          responseExtractor: kbPageExtract,
+          description:
+            "Get one page. Pass include as a comma-separated list of accessibility, markdown, metadata, or screenshot to inline those artifacts.",
+          paramsSchema: {
+            fields: [
+              { name: "crawl_run_id", required: true, description: "Crawl run the page belongs to" },
+              { name: "page_id", required: true, description: "Page to fetch" },
+              { name: "include", required: false, description: "Artifacts to inline: accessibility, markdown, metadata, screenshot" },
+            ],
+          },
+        },
+      },
+    },
+    {
+      resourceType: "kb_page_artifact",
+      displayName: "AIT Page Artifact",
+      description:
+        "One captured artifact for a page. Text kinds return inline content capped at 128 KiB; screenshot returns a short-lived signed URL. Raw HTML is not exposed.",
+      toolset: "ait",
+      scope: "account",
+      headerBasedScoping: true,
+      // An artifact is identified within its page by kind, so that is the last
+      // field and therefore what resource_id means for this type.
+      identifierFields: ["crawl_run_id", "page_id", "kind"],
+      operations: {
+        get: {
+          method: "GET",
+          path: `${KB}/crawls/{crawlRunId}/pages/{pageId}/artifacts/{kind}`,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          pathParams: { crawl_run_id: "crawlRunId", page_id: "pageId", kind: "kind" },
+          responseExtractor: kbArtifactExtract,
+          description: "Fetch one artifact for a page: accessibility, markdown, metadata, or screenshot",
+          paramsSchema: {
+            fields: [
+              { name: "crawl_run_id", required: true, description: "Crawl run the page belongs to" },
+              { name: "page_id", required: true, description: "Page whose artifact to fetch" },
+              { name: "kind", required: true, description: "accessibility, markdown, metadata, or screenshot" },
+            ],
+          },
+        },
+      },
+    },
+  ],
+};

--- a/src/registry/toolsets/ait.ts
+++ b/src/registry/toolsets/ait.ts
@@ -1,0 +1,366 @@
+import type { ToolsetDefinition } from "../types.js";
+
+/**
+ * AIT (AI Test Automation) toolset.
+ * Base path: /ait/api/v1/...
+ * Hosted on the Harness platform and authenticated via standard Harness PAT.
+ */
+
+// ─── Reusable response extractors for AIT APIs ─────────────────────────────
+// AIT APIs follow these response patterns:
+//   1. TableResponse<T> — paginated lists: { data: T[], totalPages, totalItems, itemsPerPage, currentPage }
+//   2. Single object   — direct entity (e.g. TestNew, TestNewExtended)
+//   3. Simple values   — string, string[], { success: boolean }
+//
+// Each new endpoint picks the appropriate extractor or uses passthrough for
+// single-object / simple-value responses.
+
+/** Extract applications list (simple array pattern): normalize camelCase fields to snake_case items */
+const aitAppsForOrgExtract = (raw: unknown): unknown => {
+  const arr = raw as Array<{
+    appId?: string;
+    appName?: string;
+    createdAt?: string;
+    updatedAt?: string;
+    version?: string;
+    workspaceId?: number;
+    isDeleted?: boolean;
+    sandbox?: boolean;
+    hasSessions?: boolean;
+  }>;
+  const items = arr
+    .filter((app) => !app.isDeleted)
+    .map((app) => ({
+      app_id: app.appId,
+      app_name: app.appName,
+      created_at: app.createdAt,
+      updated_at: app.updatedAt,
+      workspace_id: app.workspaceId,
+      sandbox: app.sandbox,
+      has_sessions: app.hasSessions,
+    }));
+  return { items, total: items.length };
+};
+
+/** Extract test environments list (simple array pattern): normalize camelCase fields to snake_case items */
+const aitTestEnvironmentsExtract = (raw: unknown): unknown => {
+  const arr = raw as Array<{
+    id?: string;
+    appId?: string;
+    envName?: string;
+    test?: boolean;
+    monitor?: boolean;
+    preRelease?: boolean;
+    baseUrl?: string | null;
+  }>;
+  const items = arr.map((env) => ({
+    id: env.id,
+    app_id: env.appId,
+    env_name: env.envName,
+    test: env.test,
+    monitor: env.monitor,
+    pre_release: env.preRelease,
+
+    base_url: env.baseUrl ?? null,
+  }));
+  return { items, total: items.length };
+};
+
+/** Extract paginated TableResponse for test list: picks key fields per TestEntry item */
+const aitTestsListExtract = (raw: unknown): unknown => {
+  const r = raw as {
+    data?: Array<Record<string, unknown>>;
+    totalPages?: number;
+    totalItems?: number;
+    itemsPerPage?: number;
+    currentPage?: number;
+  };
+  const items = (r.data ?? []).map((t) => {
+    const runDetailsList = t.lastKRunDetailsList as Array<Record<string, unknown>> | null | undefined;
+    const latestRun = runDetailsList?.[0];
+    return {
+      test_id: t.testId,
+      name: t.testName,
+      created_by: t.createdByNickname ?? t.createdBy,
+      created_at: t.createdAt,
+      display_status: latestRun?.displayStatus ?? null,
+      last_run_id: t.lastRunId,
+      test_version_id: t.testVersionId,
+      tags: t.tags,
+    };
+  });
+  return {
+    items,
+    total: r.totalItems ?? items.length,
+    totalPages: r.totalPages ?? 0,
+    currentPage: r.currentPage ?? 1,
+    itemsPerPage: r.itemsPerPage ?? 20,
+  };
+};
+
+/** Extract imported copilot test response — normalizes camelCase testId/testVersionId to snake_case */
+const aitImportedCopilotTestExtract = (raw: unknown): unknown => {
+  const r = raw as {
+    testId: number;
+    testVersionId: number;
+  };
+
+  return {
+    test_id: r.testId,
+    test_version_id: r.testVersionId,
+  };
+};
+
+/** Extract run test response — picks key fields from the snake_case TestRunNew entity */
+const aitRunTestExtract = (raw: unknown): unknown => {
+  const r = raw as {
+    id: number;
+    app_id: string;
+    test_id: number;
+    test_version_id: number;
+    test_environment_id: string;
+    status: string | null;
+    test_session_id: string | null;
+    start_epoch: number | null;
+    error: string | null;
+  };
+
+  const aitBaseUrl = (process.env.HARNESS_BASE_URL ?? "https://app.harness.io").replace(/\/$/, "");
+  const testRunUrl = `${aitBaseUrl}/ait/${r.app_id}/test/${r.test_id}/version/${r.test_version_id}/test-run/${r.id}?tab=overview`;
+
+  return {
+    test_run_url: testRunUrl,
+    app_id: r.app_id,
+    test_id: r.test_id,
+    test_version_id: r.test_version_id,
+    test_environment_id: r.test_environment_id,
+    status: r.status,
+    error: r.error,
+    _note: "Always display the test_run_url to the user.",
+  };
+};
+
+// ─── Toolset definition ─────────────────────────────────────────────────────
+
+export const aitToolset: ToolsetDefinition = {
+  name: "ait",
+  displayName: "AI Test Automation (AIT)",
+  description:
+    "Harness AI Test Automation (AIT) — list and manage automated tests for applications.",
+  optIn: true,
+  resources: [
+    {
+      resourceType: "ait_apps_for_org",
+      displayName: "AIT Apps for Org",
+      description:
+        "List all applications for the current organization. Returns app IDs, names, and metadata. " +
+        "Use this to discover app_id values needed for other AIT operations.",
+      toolset: "ait",
+      scope: "account",
+      identifierFields: [],
+      operations: {
+        list: {
+          method: "GET",
+          path: "/ait/api/v1/application",
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          responseExtractor: aitAppsForOrgExtract,
+          skipCompact: true,
+          description:
+            "List all apps for the organization. Returns app details including app_id, app_name, workspace_id, and created_at.",
+        },
+      },
+    },
+    {
+      resourceType: "ait_test_environments",
+      displayName: "AIT Test Environments",
+      description:
+        "List test environments for a given application. Returns environment IDs, names, " +
+        "base URLs, and flags (test, monitor, pre_release). Use this to discover env_id " +
+        "values needed for running copilot tests.",
+      toolset: "ait",
+      scope: "account",
+      identifierFields: ["app_id"],
+      listFilterFields: [
+        {
+          name: "app_id",
+          description: "Application ID (required)",
+          required: true,
+        },
+      ],
+      operations: {
+        list: {
+          method: "GET",
+          path: "/ait/api/v1/testEnvironments",
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          queryParams: {
+            app_id: "appId",
+          },
+          responseExtractor: aitTestEnvironmentsExtract,
+          description:
+            "List all test environments for an application. Requires app_id in filters. " +
+            "Returns environment details including id, env_name, base_url, and type flags.",
+        },
+      },
+    },
+    {
+      resourceType: "ait_tests_list",
+      displayName: "AIT Tests List",
+      description:
+        "An automated test in the AIT module. List tests for an application by appId. " +
+        "Supports filtering by activation status, run status, and pagination.",
+      toolset: "ait",
+      scope: "account",
+      identifierFields: ["app_id"],
+      listFilterFields: [
+        {
+          name: "app_id",
+          description: "Application ID (required)",
+          required: true,
+        },
+        {
+          name: "activation_status",
+          description: "Filter by activation status",
+        },
+        {
+          name: "run_status",
+          description: "Filter by test run status",
+        },
+        {
+          name: "sort_by",
+          description: "Field to sort by (e.g. createdAt)",
+        },
+        {
+          name: "sort_order",
+          description: "Sort order: ASC or DESC",
+          enum: ["ASC", "DESC"],
+        },
+        {
+          name: "filter",
+          description: "Text filter for test name",
+        },
+        {
+          name: "should_hide_disabled_flows",
+          description: "Whether to hide disabled flows",
+          type: "boolean",
+        },
+      ],
+      operations: {
+        list: {
+          method: "GET",
+          path: "/ait/api/v1/testNew",
+          pageOneIndexed: true,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          queryParams: {
+            app_id: "appId",
+            activation_status: "activationStatus",
+            run_status: "runStatus",
+            sort_by: "sortBy",
+            sort_order: "sortOrder",
+            page: "page",
+            limit: "limit",
+            filter: "filter",
+            should_hide_disabled_flows: "shouldHideDisabledFlows",
+            is_debug_mode: "isDebugMode",
+            last_run_start_epoch_ms: "lastRunStartEpochMs",
+            run_statuses_per_test: "runStatusesPerTest",
+          },
+          defaultQueryParams: {
+            sortOrder: "DESC",
+            page: "1",
+            limit: "20",
+            shouldHideDisabledFlows: "true",
+            isDebugMode: "false",
+            runStatusesPerTest: "5",
+          },
+          responseExtractor: aitTestsListExtract,
+          skipCompact: true,
+          description:
+            "List all tests for an application. Requires app_id in filters. " +
+            "Returns paginated test entries with name, created_by, created_at, display_status, and tags.",
+        },
+      },
+    },
+    {
+      resourceType: "ait_create_test_using_ai",
+      displayName: "AIT Create Test Using AI",
+      description:
+        "Create test using AI in AIT. Provide an appId, envId, and a test description. " +
+        "The API creates a test and returns the test ID and version ID of the created test. " +
+        "Optionally specify authType ('auth' or 'no_auth') and an entryUrl.",
+      toolset: "ait",
+      scope: "account",
+      identifierFields: ["app_id"],
+      operations: {
+        create: {
+          method: "POST",
+          path: "/ait/api/v1/testNew/copilotTest/import",
+          operationPolicy: { risk: "medium_write", retryPolicy: "do_not_retry" },
+          bodyBuilder: (input) => {
+            const b = (input.body ?? input) as Record<string, unknown>;
+            return {
+              appId: b.appId,
+              envId: b.envId,
+              description: b.description,
+              ...(b.authType !== undefined ? { authType: b.authType } : {}),
+              ...(b.entryUrl !== undefined ? { entryUrl: b.entryUrl } : {}),
+            };
+          },
+          bodySchema: {
+            description: "Create a test using AI",
+            fields: [
+              { name: "appId", type: "string", required: true, description: "Application ID" },
+              { name: "envId", type: "string", required: true, description: "Environment ID" },
+              { name: "description", type: "string", required: true, description: "Copilot task description (also used as the test name)" },
+              { name: "authType", type: "string", required: false, description: "Auth type: 'auth' (default) or 'no_auth'" },
+              { name: "entryUrl", type: "string", required: false, description: "Optional entry URL for the test" },
+            ],
+          },
+          responseExtractor: aitImportedCopilotTestExtract,
+          description:
+            "Create a test using AI. Returns test_id and test_version_id.",
+        },
+      },
+    },
+    {
+      resourceType: "ait_run_test",
+      displayName: "AIT Run Test",
+      description:
+        "Execute a test with a given test ID and test version. " +
+        "Requires appId (UUID — look up via ait_apps_for_org if only name is known) and " +
+        "environmentId (UUID — look up via ait_test_environments if only name is known). " +
+        "Pass test_id and test_version_id via params (e.g. params: { test_id: 80, test_version_id: 91 }). " +
+        "Returns the scheduled TestRun details including id, status, test_session_id, and test run URL.",
+      toolset: "ait",
+      scope: "account",
+      identifierFields: ["test_id", "test_version_id"],
+      operations: {},
+      executeActions: {
+        run: {
+          method: "POST",
+          path: "/ait/api/v1/testNew/{test_id}/version/{test_version_id}/run",
+          pathParams: { test_id: "test_id", test_version_id: "test_version_id" },
+          operationPolicy: { risk: "medium_write", retryPolicy: "do_not_retry" },
+          bodyBuilder: (input: Record<string, unknown>) => {
+            const b = (input.body ?? input) as Record<string, unknown>;
+            return {
+              appId: b.appId,
+              environmentId: b.environmentId,
+              params: b.params ?? '{"RUN_MODE":"no-mock","TestExecutorNamespace.fastExecutorMode":"false"}',
+            };
+          },
+          bodySchema: {
+            description: "Execute a test run",
+            fields: [
+              { name: "appId", type: "string", required: true, description: "Application UUID (e.g. ecaab215-65cd-45d6-8426-09ba1e04eabb). Look up via ait_apps_for_org if only app name is known." },
+              { name: "environmentId", type: "string", required: true, description: "Environment UUID (e.g. 1289b517-5f1b-4927-b30b-6f2e895dae8e). Look up via ait_test_environments if only env name is known." },
+              { name: "params", type: "string", required: false, description: "Test params — JSON stringified Map<string, string>. Defaults to '{\"RUN_MODE\":\"no-mock\",\"TestExecutorNamespace.fastExecutorMode\":\"false\"}'" },
+            ],
+          },
+          responseExtractor: aitRunTestExtract,
+          actionDescription:
+            "Execute a test. Returns TestRun details including id, status, test_session_id, and start_epoch.",
+        },
+      },
+    },
+  ],
+};

--- a/src/registry/toolsets/ait.ts
+++ b/src/registry/toolsets/ait.ts
@@ -153,6 +153,12 @@ const aitTestRunExtract = (raw: unknown): unknown => {
 
 const KB = "/ait/api/v1/kb";
 
+const KB_CRAWL_PROGRESS_GUIDANCE =
+  "While polling a running crawl, report pages_discovered and elapsed time since started_at. " +
+  "When max_pages is known from the create/recrawl request and pages_discovered >= 5, estimate " +
+  "remaining time as elapsed_ms * (max_pages - pages_discovered) / pages_discovered. " +
+  "Label the ETA approximate: the crawl can finish before max_pages when its frontier empties.";
+
 function kbIsoTimestamp(value: unknown): string | undefined {
   if (typeof value === "string") return value;
   if (value instanceof Date) return value.toISOString();
@@ -649,7 +655,9 @@ export const aitToolset: ToolsetDefinition = {
             },
           ],
           executeHint:
-            "Poll a run with harness_get(resource_type='kb_crawl', resource_id=<crawl_run_id>) until status is completed or failed. Use the recrawl action to refresh an environment; it cancels any crawl still running for that environment first.",
+            "Poll a run with harness_get(resource_type='kb_crawl', resource_id=<crawl_run_id>) until status is completed or failed. " +
+            KB_CRAWL_PROGRESS_GUIDANCE +
+            " Use the recrawl action to refresh an environment; it cancels any crawl still running for that environment first.",
           operations: {
             list: {
               method: "GET",
@@ -672,7 +680,9 @@ export const aitToolset: ToolsetDefinition = {
               operationPolicy: { risk: "read", retryPolicy: "safe" },
               pathParams: { crawl_run_id: "crawlRunId" },
               responseExtractor: kbCrawlRunExtract,
-              description: "Get a crawl run's status, page count, and error message",
+              description:
+                "Get a crawl run's status, page count, and error message. " +
+                KB_CRAWL_PROGRESS_GUIDANCE,
             },
             create: {
               method: "POST",
@@ -704,7 +714,9 @@ export const aitToolset: ToolsetDefinition = {
               operationPolicy: { risk: "read", retryPolicy: "safe" },
               pathParams: { test_environment_id: "testEnvironmentId" },
               responseExtractor: kbCrawlRunExtract,
-              actionDescription: "Get the most recent crawl run for a test environment without knowing its crawlRunId.",
+              actionDescription:
+                "Get the most recent crawl run for a test environment without knowing its crawlRunId. " +
+                KB_CRAWL_PROGRESS_GUIDANCE,
             },
           },
         },

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -153,7 +153,8 @@ export type ToolsetName =
   | "incidents"
   | "deploys"
   | "knowledge-graph"
-  | "semantic-layer";
+  | "semantic-layer"
+  | "ait";
 
 export type ProductName = "harness" | "fme";
 

--- a/src/tools/harness-get.ts
+++ b/src/tools/harness-get.ts
@@ -3,6 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Registry } from "../registry/index.js";
 import type { HarnessClient } from "../client/harness-client.js";
 import { jsonResult, errorResult } from "../utils/response-formatter.js";
+import { jsonResultWithKbScreenshots } from "../utils/kb-screenshot-content.js";
 import { isUserError, isUserFixableApiError, toMcpError, enrichErrorWithHint, HarnessApiError } from "../utils/errors.js";
 import { applyUrlDefaults } from "../utils/url-parser.js";
 import { asString, coerceRecord } from "../utils/type-guards.js";
@@ -128,6 +129,11 @@ export function registerGetTool(server: McpServer, registry: Registry, client: H
               metadata: buildEntityMetadata(resourceType, identifier, String(item["name"] ?? ""), entityScope),
             }).catch(() => { /* never surface indexing errors */ });
           }
+        }
+
+        // KB screenshots: keep signed_url in JSON and attach an MCP image block when fetchable.
+        if (resourceType === "kb_page_artifact" || resourceType === "kb_crawl_page") {
+          return await jsonResultWithKbScreenshots(resourceType, result);
         }
 
         return jsonResult(result);

--- a/src/utils/fetch-image-content.ts
+++ b/src/utils/fetch-image-content.ts
@@ -1,0 +1,65 @@
+/**
+ * Fetch a remote image into an MCP image content block (base64).
+ * Fail-open: returns undefined on network/size/type errors so callers can
+ * still return JSON (e.g. signed_url) without failing the tool call.
+ */
+
+import type { ImageContentItem } from "./response-formatter.js";
+
+const DEFAULT_MAX_BYTES = 2 * 1024 * 1024; // 2 MiB
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+function normalizeMimeType(raw: string | null): string | undefined {
+  if (!raw) return undefined;
+  const mime = raw.split(";")[0]?.trim().toLowerCase();
+  if (!mime) return undefined;
+  if (mime === "image/png" || mime === "image/jpeg" || mime === "image/webp" || mime === "image/gif") {
+    return mime;
+  }
+  return undefined;
+}
+
+/**
+ * Download `url` and return an MCP `{ type: "image", data, mimeType }` block.
+ * Caps response size so tool payloads stay within practical MCP limits.
+ */
+export async function fetchImageContentBlock(
+  url: string,
+  options?: { maxBytes?: number; timeoutMs?: number },
+): Promise<ImageContentItem | undefined> {
+  if (!url || typeof url !== "string") return undefined;
+
+  const maxBytes = options?.maxBytes ?? DEFAULT_MAX_BYTES;
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      signal: controller.signal,
+      redirect: "follow",
+    });
+    if (!response.ok) return undefined;
+
+    const mimeType = normalizeMimeType(response.headers.get("content-type")) ?? "image/png";
+    const lengthHeader = response.headers.get("content-length");
+    if (lengthHeader) {
+      const declared = Number(lengthHeader);
+      if (Number.isFinite(declared) && declared > maxBytes) return undefined;
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.byteLength === 0 || buffer.byteLength > maxBytes) return undefined;
+
+    return {
+      type: "image",
+      data: buffer.toString("base64"),
+      mimeType,
+    };
+  } catch {
+    return undefined;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/utils/kb-screenshot-content.ts
+++ b/src/utils/kb-screenshot-content.ts
@@ -1,0 +1,53 @@
+/**
+ * Attach crawl screenshot bytes as MCP image content when harness_get returns
+ * a signed URL (kb_page_artifact or kb_crawl_page with include=screenshot).
+ */
+
+import { isRecord } from "./type-guards.js";
+import { fetchImageContentBlock } from "./fetch-image-content.js";
+import type { ContentItem, ToolResult } from "./response-formatter.js";
+import { jsonResult } from "./response-formatter.js";
+
+function signedScreenshotUrl(value: unknown): string | undefined {
+  if (!isRecord(value)) return undefined;
+  if (value.kind !== undefined && value.kind !== "screenshot") return undefined;
+  return typeof value.signed_url === "string" ? value.signed_url : undefined;
+}
+
+/** Collect signed screenshot URLs from KB get responses (snake_case extractors). */
+export function collectKbScreenshotUrls(resourceType: string, result: unknown): string[] {
+  if (!isRecord(result)) return [];
+
+  if (resourceType === "kb_page_artifact") {
+    const url = signedScreenshotUrl(result);
+    return url ? [url] : [];
+  }
+
+  if (resourceType === "kb_crawl_page") {
+    const included = result.included_artifacts;
+    if (!isRecord(included)) return [];
+    const url = signedScreenshotUrl(included.screenshot);
+    return url ? [url] : [];
+  }
+
+  return [];
+}
+
+/**
+ * Return jsonResult, optionally appending MCP image blocks for KB screenshots.
+ * Image fetch failures are ignored — JSON (including signed_url) still returns.
+ */
+export async function jsonResultWithKbScreenshots(
+  resourceType: string,
+  result: unknown,
+): Promise<ToolResult> {
+  const urls = collectKbScreenshotUrls(resourceType, result);
+  if (urls.length === 0) return jsonResult(result);
+
+  const images: ContentItem[] = [];
+  for (const url of urls) {
+    const image = await fetchImageContentBlock(url);
+    if (image) images.push(image);
+  }
+  return jsonResult(result, images);
+}

--- a/src/utils/response-formatter.ts
+++ b/src/utils/response-formatter.ts
@@ -5,7 +5,9 @@
  * Errors keep minimal formatting for readability in tool-call error surfaces.
  */
 
-export type ContentItem = { type: "text"; text: string };
+export type TextContentItem = { type: "text"; text: string };
+export type ImageContentItem = { type: "image"; data: string; mimeType: string };
+export type ContentItem = TextContentItem | ImageContentItem;
 
 export interface ToolResult {
   /** Required: MCP SDK's CallToolResult extends Result which has an index signature. */
@@ -57,9 +59,9 @@ export function normalizeHarnessListPayload(
   return result;
 }
 
-export function jsonResult(data: unknown): ToolResult {
+export function jsonResult(data: unknown, extraContent: ContentItem[] = []): ToolResult {
   return {
-    content: [{ type: "text", text: JSON.stringify(data) }],
+    content: [{ type: "text", text: JSON.stringify(data) }, ...extraContent],
     // MCP structuredContent must be an object; arrays and primitives are intentionally excluded.
     ...(data !== null && typeof data === "object" && !Array.isArray(data)
       ? { structuredContent: data as Record<string, unknown> }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,16 @@
 # Lessons Learned
 
+## Make Native Harness MCP Changes in `mcp-server`
+- **Issue**: Client guidance for a native Harness MCP feature was initially
+  edited in the standalone AIT-NL repository, even though the delivery target
+  is the opt-in AIT toolset in `harness/mcp-server`.
+- **Fix**: Locate the native resource first (`kb_crawl` in
+  `src/registry/toolsets/ait.ts`) and use its actual response contract and
+  guidance surfaces.
+- **Rule**: When the end goal is a Harness MCP contribution, implement client
+  guidance in `mcp-server` registry metadata and prompts. The local AIT-NL
+  repository must not be a client runtime dependency.
+
 ## Historical Test Helpers Must Be Revalidated Against Current Runtime Architecture
 - **Issue**: Issue #119 and its original `fullRegistryV0` / `fullRegistryV1` helpers were created when `HARNESS_PIPELINE_VERSION` filtered one pipeline type out of the Registry. A later change made `pipeline` and `pipeline_v1` simultaneously available and reduced the config to a default preference, but the first implementation treated the stale helpers as two real variants, duplicated every invariant over identical objects, inferred opt-in resources from default/full set differences, and used a hand-built array instead of an end-to-end Registry fixture.
 - **Fix**: Trace current constructor behavior and relevant history before preserving an old helper. Use one full Registry for the current architecture, derive opt-in coverage from `ToolsetDefinition.optIn`, and inject malformed regression definitions through `RegistryOptions.additionalToolsets` so fixtures traverse the same Registry and validator path as production definitions.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,30 @@
 # Harness MCP Server — Task Tracking
 
+## AIT Crawl ETA Client Guidance (2026-08-18)
+- [x] Confirm the native Harness MCP crawl resource and polling response shape
+- [x] Add ETA guidance to `kb_crawl` metadata and the KB workflow prompt
+- [x] Add focused regression coverage
+- [x] Run focused tests, typecheck, and diff checks
+
+### Plan
+- Keep ETA client-computed; do not add an API-computed ETA field.
+- Use `pages_discovered`, `started_at`, and `max_pages` retained from the
+  create/recrawl request.
+- Start showing ETA after five pages using
+  `elapsed_ms * (max_pages - pages_discovered) / pages_discovered`.
+- State that a crawl may finish before `max_pages` when its frontier empties.
+
+### Review
+- Added client-computed ETA guidance to `kb_crawl` describe metadata for direct
+  run polling and latest-status polling.
+- Updated the shipped `explore-knowledge-base` prompt to retain request-time
+  `max_pages`, report page count and elapsed time, and calculate approximate
+  remaining time after five pages.
+- Kept the MCP response contract unchanged; QA remains accessed directly through
+  Harness MCP's `/ait/api/v1/kb/...` routes.
+- Verification passed: focused Vitest (2 files, 48 tests), `pnpm typecheck`, and
+  `git diff --check`.
+
 ## Issue #119 — Full Registry Structural Invariants (2026-07-21)
 - [x] Confirm Issue #119 is unassigned, unclaimed by another contributor, has no Development branch/PR, and remains unresolved on current main
 - [x] Audit every invariant in `tests/registry/structural-validation.test.ts` against default, opt-in, and both pipeline resource types

--- a/tests/prompts/explore-knowledge-base.test.ts
+++ b/tests/prompts/explore-knowledge-base.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from "vitest";
+import { registerExploreKnowledgeBasePrompt } from "../../src/prompts/explore-knowledge-base.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+describe("explore-knowledge-base prompt", () => {
+  it("registers a prescriptive MCP-only workflow prompt", async () => {
+    const prompts = new Map<string, { description?: string; handler: (args: Record<string, string>) => Promise<{ messages: Array<{ content: { text: string } }> }> }>();
+    const server = {
+      registerPrompt: vi.fn((name: string, meta: { description?: string }, handler: (args: Record<string, string>) => Promise<{ messages: Array<{ content: { text: string } }> }>) => {
+        prompts.set(name, { description: meta.description, handler });
+      }),
+    } as unknown as McpServer;
+
+    registerExploreKnowledgeBasePrompt(server);
+    expect(prompts.has("explore-knowledge-base")).toBe(true);
+
+    const entry = prompts.get("explore-knowledge-base")!;
+    expect(entry.description).toMatch(/kb_crawl/);
+    const result = await entry.handler({
+      goal: "list pages from the latest crawl",
+      test_environment_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    });
+    const text = result.messages[0]!.content.text;
+    expect(text).toContain("HARD RULES");
+    expect(text).toContain("ait-java-api-service");
+    expect(text).toContain("ait_test_environment");
+    expect(text).toContain("Do not");
+    expect(text).toContain("harness_list");
+    expect(text).toContain("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+  });
+});

--- a/tests/prompts/explore-knowledge-base.test.ts
+++ b/tests/prompts/explore-knowledge-base.test.ts
@@ -27,5 +27,11 @@ describe("explore-knowledge-base prompt", () => {
     expect(text).toContain("Do not");
     expect(text).toContain("harness_list");
     expect(text).toContain("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    expect(text).toContain("pages_discovered");
+    expect(text).toContain("started_at");
+    expect(text).toContain(
+      "elapsed_ms * (max_pages - pages_discovered) / pages_discovered",
+    );
+    expect(text).toContain("finish early");
   });
 });

--- a/tests/registry/ait.test.ts
+++ b/tests/registry/ait.test.ts
@@ -200,7 +200,7 @@ describe("ait_test_environment list extractor", () => {
     const result = extract(raw) as { items: Record<string, unknown>[]; total: number };
     expect(result.items).toHaveLength(1);
     expect(result.items[0]).toEqual({
-      id: "env-1",
+      test_environment_id: "env-1",
       app_id: "app-1",
       env_name: "production",
       test: true,
@@ -215,6 +215,7 @@ describe("ait_test_environment list extractor", () => {
     const raw = [{ id: "env-1", baseUrl: null }];
     const result = extract(raw) as { items: Record<string, unknown>[] };
     expect(result.items[0]!.base_url).toBeNull();
+    expect(result.items[0]!.test_environment_id).toBe("env-1");
   });
 
   it("handles empty array", () => {
@@ -418,6 +419,18 @@ describe("ait_test create bodyBuilder", () => {
     });
   });
 
+  it("accepts test_environment_id as the preferred env field", () => {
+    const builder = getBodyBuilder();
+    const result = builder({
+      body: { app_id: "a1", test_environment_id: "e1", description: "test desc" },
+    });
+    expect(result).toEqual({
+      appId: "a1",
+      envId: "e1",
+      description: "test desc",
+    });
+  });
+
   it("accepts camelCase fields as aliases", () => {
     const builder = getBodyBuilder();
     const result = builder({ body: { appId: "a1", envId: "e1", description: "test desc" } });
@@ -438,6 +451,16 @@ describe("ait_test run bodyBuilder", () => {
   it("accepts snake_case fields and maps to camelCase wire format", () => {
     const builder = getBodyBuilder();
     const result = builder({ body: { app_id: "a1", environment_id: "e1" } });
+    expect(result).toEqual({
+      appId: "a1",
+      environmentId: "e1",
+      params: '{"RUN_MODE":"no-mock","TestExecutorNamespace.fastExecutorMode":"false"}',
+    });
+  });
+
+  it("accepts test_environment_id as the preferred env field", () => {
+    const builder = getBodyBuilder();
+    const result = builder({ body: { app_id: "a1", test_environment_id: "e1" } });
     expect(result).toEqual({
       appId: "a1",
       environmentId: "e1",
@@ -509,5 +532,125 @@ describe("ait registry dispatch", () => {
     const request = mockRequest.mock.calls[0]![0] as { path: string; params: Record<string, unknown> };
     expect(request.path).toBe("/ait/api/v1/testEnvironments");
     expect(request.params.appId).toBe("abc-123");
+  });
+});
+
+// ─── Knowledge base response extractors ──────────────────────────────────────
+
+describe("kb_crawl list extractor", () => {
+  function extract(raw: unknown) {
+    return getOp("kb_crawl", "list").responseExtractor!(raw);
+  }
+
+  it("maps crawl history items and next_cursor to snake_case", () => {
+    const raw = {
+      items: [
+        {
+          crawlRunId: "run-1",
+          testEnvironmentId: "env-1",
+          status: "completed",
+          pagesDiscovered: 3,
+        },
+      ],
+      nextCursor: "cursor-token",
+    };
+    const result = extract(raw) as { items: Record<string, unknown>[]; next_cursor: string; total: number };
+    expect(result.items[0]).toEqual({
+      crawl_run_id: "run-1",
+      test_environment_id: "env-1",
+      status: "completed",
+      pages_discovered: 3,
+    });
+    expect(result.next_cursor).toBe("cursor-token");
+    expect(result.total).toBe(1);
+  });
+});
+
+describe("kb_crawl get extractor", () => {
+  function extract(raw: unknown) {
+    return getOp("kb_crawl", "get").responseExtractor!(raw);
+  }
+
+  it("projects crawl run fields to snake_case", () => {
+    const result = extract({
+      crawlRunId: "run-1",
+      knowledgeSourceId: "src-1",
+      temporalWorkflowId: "wf-1",
+      pagesDiscovered: 2,
+      startedAt: "2026-01-01T00:00:00.000Z",
+    }) as Record<string, unknown>;
+    expect(result).toEqual({
+      crawl_run_id: "run-1",
+      knowledge_source_id: "src-1",
+      temporal_workflow_id: "wf-1",
+      pages_discovered: 2,
+      started_at: "2026-01-01T00:00:00.000Z",
+    });
+  });
+});
+
+describe("kb_crawl create bodyBuilder", () => {
+  function getBodyBuilder() {
+    return getOp("kb_crawl", "create").bodyBuilder!;
+  }
+
+  it("accepts snake_case fields and maps to camelCase wire format", () => {
+    const builder = getBodyBuilder();
+    const result = builder({
+      body: {
+        app_id: "app-1",
+        test_environment_id: "env-1",
+        config: { max_depth: 2, tunnel_name: "t1" },
+      },
+    });
+    expect(result).toEqual({
+      appId: "app-1",
+      testEnvironmentId: "env-1",
+      config: { maxDepth: 2, tunnelName: "t1" },
+    });
+  });
+});
+
+describe("kb_crawl_page list extractor", () => {
+  function extract(raw: unknown) {
+    return getOp("kb_crawl_page", "list").responseExtractor!(raw);
+  }
+
+  it("maps page summaries to snake_case", () => {
+    const result = extract({
+      items: [{ pageId: "p1", crawlRunId: "r1", url: "https://a", capturedAt: "2026-01-01T00:00:00.000Z" }],
+    }) as { items: Record<string, unknown>[] };
+    expect(result.items[0]).toEqual({
+      page_id: "p1",
+      crawl_run_id: "r1",
+      url: "https://a",
+      captured_at: "2026-01-01T00:00:00.000Z",
+    });
+  });
+});
+
+describe("kb_page_artifact get extractor", () => {
+  function extract(raw: unknown) {
+    return getOp("kb_page_artifact", "get").responseExtractor!(raw);
+  }
+
+  it("maps artifact fields to snake_case and drops sha256", () => {
+    const result = extract({
+      pageId: "p1",
+      crawlRunId: "r1",
+      kind: "markdown",
+      contentType: "text/plain",
+      text: "hello",
+      sha256: "deadbeef",
+      truncated: true,
+    }) as Record<string, unknown>;
+    expect(result).toEqual({
+      page_id: "p1",
+      crawl_run_id: "r1",
+      kind: "markdown",
+      content_type: "text/plain",
+      text: "hello",
+      truncated: true,
+    });
   });
 });

--- a/tests/registry/ait.test.ts
+++ b/tests/registry/ait.test.ts
@@ -80,6 +80,24 @@ describe("aitToolset structure", () => {
     expect(res.executeActions?.run).toBeDefined();
   });
 
+  it("guides clients to report crawl progress and estimate time remaining", () => {
+    const crawl = findResource("kb_crawl");
+    const guidance = crawl.executeHint ?? "";
+    expect(guidance).toContain("pages_discovered");
+    expect(guidance).toContain("started_at");
+    expect(guidance).toContain("pages_discovered >= 5");
+    expect(guidance).toContain(
+      "elapsed_ms * (max_pages - pages_discovered) / pages_discovered",
+    );
+    expect(guidance).toContain("finish before max_pages");
+    expect(crawl.operations.get?.description).toContain(
+      "elapsed_ms * (max_pages - pages_discovered) / pages_discovered",
+    );
+    expect(crawl.executeActions?.latest_status?.actionDescription).toContain(
+      "estimate remaining time",
+    );
+  });
+
   it("all resources are account-scoped", () => {
     for (const resource of aitToolset.resources) {
       expect(resource.scope, `${resource.resourceType} should be account-scoped`).toBe("account");

--- a/tests/registry/ait.test.ts
+++ b/tests/registry/ait.test.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect, vi } from "vitest";
+import { aitToolset } from "../../src/registry/toolsets/ait.js";
+import { Registry } from "../../src/registry/index.js";
+import type { Config } from "../../src/config.js";
+import type { HarnessClient } from "../../src/client/harness-client.js";
+import type { ResourceDefinition, EndpointSpec } from "../../src/registry/types.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    HARNESS_API_KEY: "pat.test",
+    HARNESS_ACCOUNT_ID: "test-account",
+    HARNESS_BASE_URL: "https://app.harness.io",
+    HARNESS_ORG: "default",
+    HARNESS_PROJECT: "Testim",
+    HARNESS_API_TIMEOUT_MS: 30000,
+    HARNESS_MAX_RETRIES: 3,
+    LOG_LEVEL: "info",
+    HARNESS_MAX_BODY_SIZE_MB: 10,
+    HARNESS_RATE_LIMIT_RPS: 10,
+    HARNESS_READ_ONLY: false,
+    HARNESS_SKIP_ELICITATION: false,
+    HARNESS_AUTO_APPROVE_RISK: "none",
+    HARNESS_ALLOW_HTTP: false,
+    HARNESS_FME_BASE_URL: "https://api.split.io",
+    HARNESS_LOG_UNSAFE_BODIES: false,
+    HARNESS_AUDIT_WEBHOOK_BATCH_SIZE: 10,
+    HARNESS_AUDIT_WEBHOOK_FLUSH_MS: 5000,
+    ...overrides,
+  } as Config;
+}
+
+function makeClient(requestFn?: (...args: unknown[]) => unknown): HarnessClient {
+  return {
+    request: requestFn ?? vi.fn().mockResolvedValue({}),
+    account: "test-account",
+  } as unknown as HarnessClient;
+}
+
+function findResource(type: string): ResourceDefinition {
+  const res = aitToolset.resources.find((r) => r.resourceType === type);
+  if (!res) throw new Error(`Resource type "${type}" not found in aitToolset`);
+  return res;
+}
+
+function getOp(type: string, op: "list" | "get"): EndpointSpec {
+  const res = findResource(type);
+  const spec = res.operations[op];
+  if (!spec) throw new Error(`Operation "${op}" not found on "${type}"`);
+  return spec;
+}
+
+// ─── Toolset structure ───────────────────────────────────────────────────────
+
+describe("aitToolset structure", () => {
+  it("has name 'ait'", () => {
+    expect(aitToolset.name).toBe("ait");
+  });
+
+  it("is opt-in (not loaded by default)", () => {
+    expect(aitToolset.optIn).toBe(true);
+  });
+
+  it("registers all 5 resource types", () => {
+    const types = aitToolset.resources.map((r) => r.resourceType);
+    expect(types).toContain("ait_apps_for_org");
+    expect(types).toContain("ait_test_environments");
+    expect(types).toContain("ait_tests_list");
+    expect(types).toContain("ait_create_test_using_ai");
+    expect(types).toContain("ait_run_test");
+    expect(types).toHaveLength(5);
+  });
+
+  it("all resources are account-scoped", () => {
+    for (const resource of aitToolset.resources) {
+      expect(resource.scope, `${resource.resourceType} should be account-scoped`).toBe("account");
+    }
+  });
+
+  it("all list/get endpoint specs have operationPolicy", () => {
+    for (const resource of aitToolset.resources) {
+      for (const [opName, spec] of Object.entries(resource.operations)) {
+        expect(
+          spec.operationPolicy,
+          `${resource.resourceType}.${opName} is missing operationPolicy`,
+        ).toBeDefined();
+      }
+    }
+  });
+});
+
+// ─── Registry opt-in behaviour ──────────────────────────────────────────────
+
+describe("ait opt-in with Registry", () => {
+  it("is NOT present when HARNESS_TOOLSETS is unset (all defaults)", () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: undefined }));
+    expect(registry.getAllResourceTypes()).not.toContain("ait_apps_for_org");
+  });
+
+  it("IS present when explicitly enabled with HARNESS_TOOLSETS=+ait", () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "+ait" }));
+    expect(registry.getAllResourceTypes()).toContain("ait_apps_for_org");
+    expect(registry.getAllResourceTypes()).toContain("ait_test_environments");
+    expect(registry.getAllResourceTypes()).toContain("ait_tests_list");
+    expect(registry.getAllResourceTypes()).toContain("ait_create_test_using_ai");
+    expect(registry.getAllResourceTypes()).toContain("ait_run_test");
+  });
+
+  it("IS present when listed explicitly in HARNESS_TOOLSETS=ait", () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ait" }));
+    expect(registry.getAllResourceTypes()).toContain("ait_apps_for_org");
+  });
+});
+
+// ─── Response extractor: aitAppsForOrgExtract ───────────────────────────────
+
+describe("aitAppsForOrgExtract", () => {
+  function extract(raw: unknown) {
+    return getOp("ait_apps_for_org", "list").responseExtractor!(raw);
+  }
+
+  it("normalizes camelCase app fields to snake_case", () => {
+    const raw = [
+      {
+        appId: "abc-123",
+        appName: "my-app",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-02T00:00:00Z",
+        workspaceId: 1,
+        isDeleted: false,
+        sandbox: false,
+        hasSessions: true,
+      },
+    ];
+    const result = extract(raw) as { items: Record<string, unknown>[]; total: number };
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toEqual({
+      app_id: "abc-123",
+      app_name: "my-app",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-02T00:00:00Z",
+      workspace_id: 1,
+      sandbox: false,
+      has_sessions: true,
+    });
+    expect(result.total).toBe(1);
+  });
+
+  it("filters out deleted apps", () => {
+    const raw = [
+      { appId: "a1", appName: "active", isDeleted: false },
+      { appId: "a2", appName: "deleted", isDeleted: true },
+    ];
+    const result = extract(raw) as { items: Record<string, unknown>[]; total: number };
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]!.app_id).toBe("a1");
+    expect(result.total).toBe(1);
+  });
+
+  it("handles empty array", () => {
+    const result = extract([]) as { items: unknown[]; total: number };
+    expect(result.items).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+});
+
+// ─── Response extractor: aitTestEnvironmentsExtract ─────────────────────────
+
+describe("aitTestEnvironmentsExtract", () => {
+  function extract(raw: unknown) {
+    return getOp("ait_test_environments", "list").responseExtractor!(raw);
+  }
+
+  it("normalizes camelCase env fields to snake_case", () => {
+    const raw = [
+      {
+        id: "env-1",
+        appId: "app-1",
+        envName: "production",
+        test: true,
+        monitor: false,
+        preRelease: true,
+        baseUrl: "https://example.com",
+      },
+    ];
+    const result = extract(raw) as { items: Record<string, unknown>[]; total: number };
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toEqual({
+      id: "env-1",
+      app_id: "app-1",
+      env_name: "production",
+      test: true,
+      monitor: false,
+      pre_release: true,
+      base_url: "https://example.com",
+    });
+    expect(result.total).toBe(1);
+  });
+
+  it("handles null baseUrl", () => {
+    const raw = [{ id: "env-1", baseUrl: null }];
+    const result = extract(raw) as { items: Record<string, unknown>[] };
+    expect(result.items[0]!.base_url).toBeNull();
+  });
+
+  it("handles empty array", () => {
+    const result = extract([]) as { items: unknown[]; total: number };
+    expect(result.items).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+});
+
+// ─── Response extractor: aitTestsListExtract ────────────────────────────────
+
+describe("aitTestsListExtract", () => {
+  function extract(raw: unknown) {
+    return getOp("ait_tests_list", "list").responseExtractor!(raw);
+  }
+
+  it("extracts paginated test list with key fields", () => {
+    const raw = {
+      data: [
+        {
+          testId: 1,
+          testName: "Login test",
+          createdBy: "user@example.com",
+          createdByNickname: "User",
+          createdAt: "2026-01-01T00:00:00Z",
+          lastRunId: 10,
+          testVersionId: 2,
+          tags: "[]",
+          lastKRunDetailsList: [{ displayStatus: "PASSED" }],
+        },
+      ],
+      totalPages: 1,
+      totalItems: 1,
+      itemsPerPage: 20,
+      currentPage: 1,
+    };
+    const result = extract(raw) as Record<string, unknown>;
+    const items = result.items as Record<string, unknown>[];
+    expect(items).toHaveLength(1);
+    expect(items[0]).toEqual({
+      test_id: 1,
+      name: "Login test",
+      created_by: "User",
+      created_at: "2026-01-01T00:00:00Z",
+      display_status: "PASSED",
+      last_run_id: 10,
+      test_version_id: 2,
+      tags: "[]",
+    });
+    expect(result.total).toBe(1);
+    expect(result.totalPages).toBe(1);
+    expect(result.currentPage).toBe(1);
+    expect(result.itemsPerPage).toBe(20);
+  });
+
+  it("falls back to createdBy when createdByNickname is absent", () => {
+    const raw = {
+      data: [{ testId: 1, testName: "Test", createdBy: "user@example.com" }],
+    };
+    const result = extract(raw) as { items: Record<string, unknown>[] };
+    expect(result.items[0]!.created_by).toBe("user@example.com");
+  });
+
+  it("display_status is null when lastKRunDetailsList is empty", () => {
+    const raw = {
+      data: [{ testId: 1, testName: "Test", lastKRunDetailsList: [] }],
+    };
+    const result = extract(raw) as { items: Record<string, unknown>[] };
+    expect(result.items[0]!.display_status).toBeNull();
+  });
+
+  it("handles empty data", () => {
+    const raw = { data: [], totalPages: 0, totalItems: 0, itemsPerPage: 20, currentPage: 1 };
+    const result = extract(raw) as Record<string, unknown>;
+    expect(result.items).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+});
+
+// ─── API paths ───────────────────────────────────────────────────────────────
+
+describe("endpoint paths", () => {
+  it("ait_apps_for_org list uses /ait/api/v1/application", () => {
+    expect(getOp("ait_apps_for_org", "list").path).toBe("/ait/api/v1/application");
+  });
+
+  it("ait_test_environments list uses /ait/api/v1/testEnvironments", () => {
+    expect(getOp("ait_test_environments", "list").path).toBe("/ait/api/v1/testEnvironments");
+  });
+
+  it("ait_tests_list list uses /ait/api/v1/testNew", () => {
+    expect(getOp("ait_tests_list", "list").path).toBe("/ait/api/v1/testNew");
+  });
+});
+
+// ─── Registry dispatch integration ─────────────────────────────────────────
+
+describe("ait registry dispatch", () => {
+  it("dispatches ait_apps_for_org list", async () => {
+    const mockRequest = vi.fn().mockResolvedValue([
+      { appId: "abc", appName: "test-app", isDeleted: false },
+    ]);
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ait" }));
+
+    const result = await registry.dispatch(makeClient(mockRequest), "ait_apps_for_org", "list", {});
+
+    const request = mockRequest.mock.calls[0]![0] as { path: string };
+    expect(request.path).toBe("/ait/api/v1/application");
+    expect((result as { items: unknown[] }).items).toHaveLength(1);
+  });
+
+  it("dispatches ait_tests_list list with app_id filter", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ data: [], totalItems: 0 });
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ait" }));
+
+    await registry.dispatch(makeClient(mockRequest), "ait_tests_list", "list", {
+      app_id: "abc-123",
+    });
+
+    const request = mockRequest.mock.calls[0]![0] as { path: string; params: Record<string, unknown> };
+    expect(request.path).toBe("/ait/api/v1/testNew");
+    expect(request.params.appId).toBe("abc-123");
+  });
+
+  it("dispatches ait_test_environments list with app_id filter", async () => {
+    const mockRequest = vi.fn().mockResolvedValue([]);
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ait" }));
+
+    await registry.dispatch(makeClient(mockRequest), "ait_test_environments", "list", {
+      app_id: "abc-123",
+    });
+
+    const request = mockRequest.mock.calls[0]![0] as { path: string; params: Record<string, unknown> };
+    expect(request.path).toBe("/ait/api/v1/testEnvironments");
+    expect(request.params.appId).toBe("abc-123");
+  });
+});

--- a/tests/registry/ait.test.ts
+++ b/tests/registry/ait.test.ts
@@ -44,7 +44,7 @@ function findResource(type: string): ResourceDefinition {
   return res;
 }
 
-function getOp(type: string, op: "list" | "get"): EndpointSpec {
+function getOp(type: string, op: "list" | "get" | "create"): EndpointSpec {
   const res = findResource(type);
   const spec = res.operations[op];
   if (!spec) throw new Error(`Operation "${op}" not found on "${type}"`);
@@ -62,14 +62,19 @@ describe("aitToolset structure", () => {
     expect(aitToolset.optIn).toBe(true);
   });
 
-  it("registers all 5 resource types", () => {
+  it("registers 3 noun-oriented resource types", () => {
     const types = aitToolset.resources.map((r) => r.resourceType);
-    expect(types).toContain("ait_apps_for_org");
-    expect(types).toContain("ait_test_environments");
-    expect(types).toContain("ait_tests_list");
-    expect(types).toContain("ait_create_test_using_ai");
-    expect(types).toContain("ait_run_test");
-    expect(types).toHaveLength(5);
+    expect(types).toContain("ait_app");
+    expect(types).toContain("ait_test_environment");
+    expect(types).toContain("ait_test");
+    expect(types).toHaveLength(3);
+  });
+
+  it("ait_test has list, create operations and run executeAction", () => {
+    const res = findResource("ait_test");
+    expect(res.operations.list).toBeDefined();
+    expect(res.operations.create).toBeDefined();
+    expect(res.executeActions?.run).toBeDefined();
   });
 
   it("all resources are account-scoped", () => {
@@ -78,7 +83,7 @@ describe("aitToolset structure", () => {
     }
   });
 
-  it("all list/get endpoint specs have operationPolicy", () => {
+  it("all list/get/create endpoint specs have operationPolicy", () => {
     for (const resource of aitToolset.resources) {
       for (const [opName, spec] of Object.entries(resource.operations)) {
         expect(
@@ -95,29 +100,27 @@ describe("aitToolset structure", () => {
 describe("ait opt-in with Registry", () => {
   it("is NOT present when HARNESS_TOOLSETS is unset (all defaults)", () => {
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: undefined }));
-    expect(registry.getAllResourceTypes()).not.toContain("ait_apps_for_org");
+    expect(registry.getAllResourceTypes()).not.toContain("ait_app");
   });
 
   it("IS present when explicitly enabled with HARNESS_TOOLSETS=+ait", () => {
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "+ait" }));
-    expect(registry.getAllResourceTypes()).toContain("ait_apps_for_org");
-    expect(registry.getAllResourceTypes()).toContain("ait_test_environments");
-    expect(registry.getAllResourceTypes()).toContain("ait_tests_list");
-    expect(registry.getAllResourceTypes()).toContain("ait_create_test_using_ai");
-    expect(registry.getAllResourceTypes()).toContain("ait_run_test");
+    expect(registry.getAllResourceTypes()).toContain("ait_app");
+    expect(registry.getAllResourceTypes()).toContain("ait_test_environment");
+    expect(registry.getAllResourceTypes()).toContain("ait_test");
   });
 
   it("IS present when listed explicitly in HARNESS_TOOLSETS=ait", () => {
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ait" }));
-    expect(registry.getAllResourceTypes()).toContain("ait_apps_for_org");
+    expect(registry.getAllResourceTypes()).toContain("ait_app");
   });
 });
 
-// ─── Response extractor: aitAppsForOrgExtract ───────────────────────────────
+// ─── Response extractor: ait_app list ───────────────────────────────────────
 
-describe("aitAppsForOrgExtract", () => {
+describe("ait_app list extractor", () => {
   function extract(raw: unknown) {
-    return getOp("ait_apps_for_org", "list").responseExtractor!(raw);
+    return getOp("ait_app", "list").responseExtractor!(raw);
   }
 
   it("normalizes camelCase app fields to snake_case", () => {
@@ -163,13 +166,19 @@ describe("aitAppsForOrgExtract", () => {
     expect(result.items).toEqual([]);
     expect(result.total).toBe(0);
   });
+
+  it("throws on non-array response", () => {
+    expect(() => extract({ error: "unauthorized" })).toThrow("ait_app: expected array response");
+    expect(() => extract("string")).toThrow("ait_app: expected array response");
+    expect(() => extract(null)).toThrow("ait_app: expected array response");
+  });
 });
 
-// ─── Response extractor: aitTestEnvironmentsExtract ─────────────────────────
+// ─── Response extractor: ait_test_environment list ──────────────────────────
 
-describe("aitTestEnvironmentsExtract", () => {
+describe("ait_test_environment list extractor", () => {
   function extract(raw: unknown) {
-    return getOp("ait_test_environments", "list").responseExtractor!(raw);
+    return getOp("ait_test_environment", "list").responseExtractor!(raw);
   }
 
   it("normalizes camelCase env fields to snake_case", () => {
@@ -209,13 +218,19 @@ describe("aitTestEnvironmentsExtract", () => {
     expect(result.items).toEqual([]);
     expect(result.total).toBe(0);
   });
+
+  it("throws on non-array response", () => {
+    expect(() => extract({ error: "unauthorized" })).toThrow("ait_test_environment: expected array response");
+    expect(() => extract("string")).toThrow("ait_test_environment: expected array response");
+    expect(() => extract(null)).toThrow("ait_test_environment: expected array response");
+  });
 });
 
-// ─── Response extractor: aitTestsListExtract ────────────────────────────────
+// ─── Response extractor: ait_test list ──────────────────────────────────────
 
-describe("aitTestsListExtract", () => {
+describe("ait_test list extractor", () => {
   function extract(raw: unknown) {
-    return getOp("ait_tests_list", "list").responseExtractor!(raw);
+    return getOp("ait_test", "list").responseExtractor!(raw);
   }
 
   it("extracts paginated test list with key fields", () => {
@@ -279,45 +294,185 @@ describe("aitTestsListExtract", () => {
     expect(result.items).toEqual([]);
     expect(result.total).toBe(0);
   });
+
+  it("throws on non-object response", () => {
+    expect(() => extract("string")).toThrow("ait_test: expected paginated object response");
+    expect(() => extract(null)).toThrow("ait_test: expected paginated object response");
+    expect(() => extract([1, 2, 3])).toThrow("ait_test: expected paginated object response");
+  });
+
+  it("throws when data field is not an array", () => {
+    expect(() => extract({ data: "not-array" })).toThrow("ait_test: expected data field to be an array");
+  });
+});
+
+// ─── Response extractor: ait_test create ────────────────────────────────────
+
+describe("ait_test create extractor", () => {
+  function extract(raw: unknown) {
+    return getOp("ait_test", "create").responseExtractor!(raw);
+  }
+
+  it("normalizes camelCase to snake_case", () => {
+    const raw = { testId: 42, testVersionId: 7 };
+    const result = extract(raw) as Record<string, unknown>;
+    expect(result).toEqual({ test_id: 42, test_version_id: 7 });
+  });
+});
+
+// ─── Response extractor: ait_test execute.run ───────────────────────────────
+
+describe("ait_test run extractor", () => {
+  function extract(raw: unknown) {
+    const res = findResource("ait_test");
+    return res.executeActions!.run.responseExtractor!(raw);
+  }
+
+  it("extracts key fields from run response", () => {
+    const raw = {
+      id: 99,
+      app_id: "app-uuid",
+      test_id: 10,
+      test_version_id: 20,
+      test_environment_id: "env-uuid",
+      status: "RUNNING",
+      test_session_id: "sess-1",
+      start_epoch: 1700000000,
+      error: null,
+    };
+    const result = extract(raw) as Record<string, unknown>;
+    expect(result).toEqual({
+      id: 99,
+      app_id: "app-uuid",
+      test_id: 10,
+      test_version_id: 20,
+      test_environment_id: "env-uuid",
+      status: "RUNNING",
+      error: null,
+    });
+  });
+
+  it("does not include process.env-dependent URLs or _note", () => {
+    const raw = {
+      id: 1,
+      app_id: "a",
+      test_id: 2,
+      test_version_id: 3,
+      test_environment_id: "e",
+      status: null,
+      test_session_id: null,
+      start_epoch: null,
+      error: null,
+    };
+    const result = extract(raw) as Record<string, unknown>;
+    expect(result).not.toHaveProperty("test_run_url");
+    expect(result).not.toHaveProperty("_note");
+  });
 });
 
 // ─── API paths ───────────────────────────────────────────────────────────────
 
 describe("endpoint paths", () => {
-  it("ait_apps_for_org list uses /ait/api/v1/application", () => {
-    expect(getOp("ait_apps_for_org", "list").path).toBe("/ait/api/v1/application");
+  it("ait_app list uses /ait/api/v1/application", () => {
+    expect(getOp("ait_app", "list").path).toBe("/ait/api/v1/application");
   });
 
-  it("ait_test_environments list uses /ait/api/v1/testEnvironments", () => {
-    expect(getOp("ait_test_environments", "list").path).toBe("/ait/api/v1/testEnvironments");
+  it("ait_test_environment list uses /ait/api/v1/testEnvironments", () => {
+    expect(getOp("ait_test_environment", "list").path).toBe("/ait/api/v1/testEnvironments");
   });
 
-  it("ait_tests_list list uses /ait/api/v1/testNew", () => {
-    expect(getOp("ait_tests_list", "list").path).toBe("/ait/api/v1/testNew");
+  it("ait_test list uses /ait/api/v1/testNew", () => {
+    expect(getOp("ait_test", "list").path).toBe("/ait/api/v1/testNew");
+  });
+
+  it("ait_test create uses /ait/api/v1/testNew/copilotTest/import", () => {
+    expect(getOp("ait_test", "create").path).toBe("/ait/api/v1/testNew/copilotTest/import");
+  });
+
+  it("ait_test execute.run uses /ait/api/v1/testNew/{test_id}/version/{test_version_id}/run", () => {
+    const res = findResource("ait_test");
+    expect(res.executeActions!.run.path).toBe("/ait/api/v1/testNew/{test_id}/version/{test_version_id}/run");
+  });
+});
+
+// ─── bodyBuilder snake_case acceptance ──────────────────────────────────────
+
+describe("ait_test create bodyBuilder", () => {
+  function getBodyBuilder() {
+    return getOp("ait_test", "create").bodyBuilder!;
+  }
+
+  it("accepts snake_case fields and maps to camelCase wire format", () => {
+    const builder = getBodyBuilder();
+    const result = builder({ body: { app_id: "a1", env_id: "e1", description: "test desc", auth_type: "no_auth", entry_url: "https://example.com" } });
+    expect(result).toEqual({
+      appId: "a1",
+      envId: "e1",
+      description: "test desc",
+      authType: "no_auth",
+      entryUrl: "https://example.com",
+    });
+  });
+
+  it("accepts camelCase fields as aliases", () => {
+    const builder = getBodyBuilder();
+    const result = builder({ body: { appId: "a1", envId: "e1", description: "test desc" } });
+    expect(result).toEqual({
+      appId: "a1",
+      envId: "e1",
+      description: "test desc",
+    });
+  });
+});
+
+describe("ait_test run bodyBuilder", () => {
+  function getBodyBuilder() {
+    const res = findResource("ait_test");
+    return res.executeActions!.run.bodyBuilder!;
+  }
+
+  it("accepts snake_case fields and maps to camelCase wire format", () => {
+    const builder = getBodyBuilder();
+    const result = builder({ body: { app_id: "a1", environment_id: "e1" } });
+    expect(result).toEqual({
+      appId: "a1",
+      environmentId: "e1",
+      params: '{"RUN_MODE":"no-mock","TestExecutorNamespace.fastExecutorMode":"false"}',
+    });
+  });
+
+  it("accepts camelCase fields as aliases", () => {
+    const builder = getBodyBuilder();
+    const result = builder({ body: { appId: "a1", environmentId: "e1", params: '{"custom":"value"}' } });
+    expect(result).toEqual({
+      appId: "a1",
+      environmentId: "e1",
+      params: '{"custom":"value"}',
+    });
   });
 });
 
 // ─── Registry dispatch integration ─────────────────────────────────────────
 
 describe("ait registry dispatch", () => {
-  it("dispatches ait_apps_for_org list", async () => {
+  it("dispatches ait_app list", async () => {
     const mockRequest = vi.fn().mockResolvedValue([
       { appId: "abc", appName: "test-app", isDeleted: false },
     ]);
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ait" }));
 
-    const result = await registry.dispatch(makeClient(mockRequest), "ait_apps_for_org", "list", {});
+    const result = await registry.dispatch(makeClient(mockRequest), "ait_app", "list", {});
 
     const request = mockRequest.mock.calls[0]![0] as { path: string };
     expect(request.path).toBe("/ait/api/v1/application");
     expect((result as { items: unknown[] }).items).toHaveLength(1);
   });
 
-  it("dispatches ait_tests_list list with app_id filter", async () => {
+  it("dispatches ait_test list with app_id filter", async () => {
     const mockRequest = vi.fn().mockResolvedValue({ data: [], totalItems: 0 });
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ait" }));
 
-    await registry.dispatch(makeClient(mockRequest), "ait_tests_list", "list", {
+    await registry.dispatch(makeClient(mockRequest), "ait_test", "list", {
       app_id: "abc-123",
     });
 
@@ -326,11 +481,24 @@ describe("ait registry dispatch", () => {
     expect(request.params.appId).toBe("abc-123");
   });
 
-  it("dispatches ait_test_environments list with app_id filter", async () => {
+  it("maps size parameter to limit query param for ait_test list", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ data: [], totalItems: 0 });
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ait" }));
+
+    await registry.dispatch(makeClient(mockRequest), "ait_test", "list", {
+      app_id: "abc-123",
+      size: 5,
+    });
+
+    const request = mockRequest.mock.calls[0]![0] as { path: string; params: Record<string, unknown> };
+    expect(request.params.limit).toBe(5);
+  });
+
+  it("dispatches ait_test_environment list with app_id filter", async () => {
     const mockRequest = vi.fn().mockResolvedValue([]);
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ait" }));
 
-    await registry.dispatch(makeClient(mockRequest), "ait_test_environments", "list", {
+    await registry.dispatch(makeClient(mockRequest), "ait_test_environment", "list", {
       app_id: "abc-123",
     });
 

--- a/tests/tools/ait.test.ts
+++ b/tests/tools/ait.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Tests for the AIT knowledge-base toolset (`kb_crawl`, `kb_crawl_page`,
+ * `kb_page_artifact`).
+ *
+ * Verifies the /ait/api/v1/kb/… paths, cursor pagination, header-only scoping
+ * (AIT resolves the org from the PAT, and its routes reject unknown body
+ * fields), body mapping on create/recrawl, artifact compaction, and that the
+ * toolset stays out of the default registry — all with a mocked client.request
+ * so no real API is hit.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Config } from "../../src/config.js";
+import type { HarnessClient } from "../../src/client/harness-client.js";
+import type { ToolResult } from "../../src/utils/response-formatter.js";
+import { Registry } from "../../src/registry/index.js";
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    HARNESS_API_KEY: "pat.test.abc.xyz",
+    HARNESS_ACCOUNT_ID: "test-account",
+    HARNESS_BASE_URL: "https://app.harness.io",
+    HARNESS_ORG: "default",
+    HARNESS_PROJECT: "test-project",
+    HARNESS_API_TIMEOUT_MS: 30000,
+    HARNESS_MAX_RETRIES: 3,
+    LOG_LEVEL: "info",
+    HARNESS_AUTO_APPROVE_RISK: "high_write",
+    HARNESS_TOOLSETS: "ait",
+    ...overrides,
+  } as Config;
+}
+
+function makeClient(requestFn?: (...args: unknown[]) => unknown): HarnessClient {
+  return {
+    request: requestFn ?? vi.fn().mockResolvedValue({}),
+    account: "test-account",
+  } as unknown as HarnessClient;
+}
+
+function makeMcpServer() {
+  const tools = new Map<string, { handler: (...args: unknown[]) => Promise<ToolResult> }>();
+  return {
+    server: {
+      getClientCapabilities: () => ({ elicitation: { form: {} } }),
+      elicitInput: vi.fn().mockResolvedValue({ action: "accept" }),
+    },
+    registerTool: vi.fn((name: string, _schema: unknown, handler: (...args: unknown[]) => Promise<ToolResult>) => {
+      tools.set(name, { handler });
+    }),
+    async call(name: string, args: Record<string, unknown>, extra?: Record<string, unknown>): Promise<ToolResult> {
+      const tool = tools.get(name);
+      if (!tool) throw new Error(`Tool "${name}" not registered`);
+      const defaultExtra = { signal: new AbortController().signal, sendNotification: vi.fn(), _meta: {} };
+      return tool.handler(args, { ...defaultExtra, ...extra }) as Promise<ToolResult>;
+    },
+  } as any;
+}
+
+function parseResult(result: ToolResult): unknown {
+  const item = result.content[0]!;
+  if (item.type !== "text") throw new Error(`Expected text content, got "${item.type}"`);
+  return JSON.parse(item.text);
+}
+
+const ENV_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const RUN_ID = "63f312e3-b508-4492-849a-b3c0002bbaac";
+const PAGE_ID = "b8791282-95d8-4d69-8d24-44c9b886c43d";
+
+describe("kb_crawl — harness_list", () => {
+  let server: ReturnType<typeof makeMcpServer>;
+  let client: HarnessClient;
+  let mockRequest: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    server = makeMcpServer();
+    mockRequest = vi.fn().mockResolvedValue({
+      items: [{ crawlRunId: RUN_ID, status: "completed" }],
+      nextCursor: "eyJhdCI6IjIwMjYifQ",
+    });
+    client = makeClient(mockRequest);
+    const { registerListTool } = await import("../../src/tools/harness-list.js");
+    registerListTool(server, new Registry(makeConfig()), client);
+  });
+
+  it("lists an environment's crawl history and preserves nextCursor", async () => {
+    const result = await server.call("harness_list", {
+      resource_type: "kb_crawl",
+      params: { test_environment_id: ENV_ID },
+    });
+    expect(result.isError).toBeUndefined();
+    const data = parseResult(result) as { items: unknown[]; nextCursor: string };
+    expect(data.items).toHaveLength(1);
+    expect(data.nextCursor).toBe("eyJhdCI6IjIwMjYifQ");
+    const callArgs = mockRequest.mock.calls[0]![0] as { path: string };
+    expect(callArgs.path).toBe(`/ait/api/v1/kb/${ENV_ID}/crawls`);
+  });
+
+  it("maps size to limit and passes the cursor filter through", async () => {
+    await server.call("harness_list", {
+      resource_type: "kb_crawl",
+      params: { test_environment_id: ENV_ID },
+      size: 5,
+      filters: { cursor: "abc" },
+    });
+    const callArgs = mockRequest.mock.calls[0]![0] as { params: Record<string, unknown> };
+    expect(callArgs.params.limit).toBe(5);
+    expect(callArgs.params.cursor).toBe("abc");
+  });
+
+  it("scopes through the header only — no accountIdentifier or org/project params", async () => {
+    await server.call("harness_list", {
+      resource_type: "kb_crawl",
+      params: { test_environment_id: ENV_ID },
+    });
+    const callArgs = mockRequest.mock.calls[0]![0] as { params: Record<string, unknown> };
+    expect(callArgs.params.accountIdentifier).toBeUndefined();
+    expect(callArgs.params.orgIdentifier).toBeUndefined();
+    expect(callArgs.params.projectIdentifier).toBeUndefined();
+  });
+});
+
+describe("kb_crawl — harness_get", () => {
+  let server: ReturnType<typeof makeMcpServer>;
+  let mockRequest: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    server = makeMcpServer();
+    mockRequest = vi.fn().mockResolvedValue({ crawlRunId: RUN_ID, status: "running", pagesDiscovered: 1 });
+    const { registerGetTool } = await import("../../src/tools/harness-get.js");
+    registerGetTool(server, new Registry(makeConfig()), makeClient(mockRequest));
+  });
+
+  it("fetches a crawl run by id and returns its status verbatim", async () => {
+    const result = await server.call("harness_get", { resource_type: "kb_crawl", resource_id: RUN_ID });
+    const callArgs = mockRequest.mock.calls[0]![0] as { path: string };
+    expect(callArgs.path).toBe(`/ait/api/v1/kb/crawls/${RUN_ID}`);
+    const data = parseResult(result) as { status: string; pagesDiscovered: number };
+    expect(data.status).toBe("running");
+    expect(data.pagesDiscovered).toBe(1);
+  });
+});
+
+describe("kb_crawl — harness_create", () => {
+  let server: ReturnType<typeof makeMcpServer>;
+  let mockRequest: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    server = makeMcpServer();
+    mockRequest = vi.fn().mockResolvedValue({ crawlRunId: RUN_ID, testEnvironmentId: ENV_ID });
+    const { registerCreateTool } = await import("../../src/tools/harness-create.js");
+    registerCreateTool(server, new Registry(makeConfig()), makeClient(mockRequest), makeConfig());
+  });
+
+  it("posts to /kb/crawls with the environment and config fields AIT accepts", async () => {
+    const result = await server.call("harness_create", {
+      resource_type: "kb_crawl",
+      body: {
+        appId: "app-1",
+        testEnvironmentId: ENV_ID,
+        config: { maxPages: 10, tunnelName: "corp", crawlInstructionsAddendum: "only crawl under /docs" },
+      },
+    });
+    expect(result.isError).toBeUndefined();
+    const callArgs = mockRequest.mock.calls[0]![0] as { method: string; path: string; body: Record<string, unknown> };
+    expect(callArgs.method).toBe("POST");
+    expect(callArgs.path).toBe("/ait/api/v1/kb/crawls");
+    expect(callArgs.body).toEqual({
+      appId: "app-1",
+      testEnvironmentId: ENV_ID,
+      config: { maxPages: 10, tunnelName: "corp", crawlInstructionsAddendum: "only crawl under /docs" },
+    });
+  });
+
+  it("drops unknown body fields, which AIT's routes would reject", async () => {
+    await server.call("harness_create", {
+      resource_type: "kb_crawl",
+      body: { appId: "app-1", startUrl: "https://example.com", orgIdentifier: "default", nonsense: true },
+    });
+    const callArgs = mockRequest.mock.calls[0]![0] as { body: Record<string, unknown> };
+    expect(callArgs.body).toEqual({ appId: "app-1", startUrl: "https://example.com" });
+  });
+
+  it("errors when neither testEnvironmentId nor startUrl is given", async () => {
+    const result = await server.call("harness_create", {
+      resource_type: "kb_crawl",
+      body: { appId: "app-1" },
+    });
+    expect(result.isError).toBe(true);
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it("errors when appId is missing", async () => {
+    const result = await server.call("harness_create", {
+      resource_type: "kb_crawl",
+      body: { startUrl: "https://example.com" },
+    });
+    expect(result.isError).toBe(true);
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe("kb_crawl — harness_execute", () => {
+  let server: ReturnType<typeof makeMcpServer>;
+  let mockRequest: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    server = makeMcpServer();
+    mockRequest = vi.fn().mockResolvedValue({ crawlRunId: RUN_ID });
+    const { registerExecuteTool } = await import("../../src/tools/harness-execute.js");
+    registerExecuteTool(server, new Registry(makeConfig()), makeClient(mockRequest), makeConfig());
+  });
+
+  it("recrawl posts to the environment's recrawl path with the override body", async () => {
+    const result = await server.call("harness_execute", {
+      resource_type: "kb_crawl",
+      action: "recrawl",
+      params: { test_environment_id: ENV_ID },
+      body: { maxPages: 3 },
+    });
+    expect(result.isError).toBeUndefined();
+    const callArgs = mockRequest.mock.calls[0]![0] as { method: string; path: string; body: Record<string, unknown> };
+    expect(callArgs.method).toBe("POST");
+    expect(callArgs.path).toBe(`/ait/api/v1/kb/${ENV_ID}/recrawl`);
+    expect(callArgs.body).toEqual({ maxPages: 3 });
+  });
+
+  it("latest_status reads the environment's most recent run", async () => {
+    await server.call("harness_execute", {
+      resource_type: "kb_crawl",
+      action: "latest_status",
+      params: { test_environment_id: ENV_ID },
+    });
+    const callArgs = mockRequest.mock.calls[0]![0] as { method: string; path: string };
+    expect(callArgs.method).toBe("GET");
+    expect(callArgs.path).toBe(`/ait/api/v1/kb/${ENV_ID}/crawl/status`);
+  });
+});
+
+describe("kb_crawl_page", () => {
+  let server: ReturnType<typeof makeMcpServer>;
+  let mockRequest: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    server = makeMcpServer();
+    mockRequest = vi.fn();
+  });
+
+  it("filters pages by query and keeps the artifact availability map when compacting", async () => {
+    mockRequest.mockResolvedValue({
+      items: [
+        {
+          pageId: PAGE_ID,
+          crawlRunId: RUN_ID,
+          url: "https://playwright.dev/docs/intro",
+          title: "Installation",
+          depth: 1,
+          capturedAt: "2026-07-31T23:53:30.000Z",
+          artifacts: { accessibility: true, markdown: true, metadata: true, screenshot: true },
+          internalRowVersion: 7,
+        },
+      ],
+    });
+    const { registerListTool } = await import("../../src/tools/harness-list.js");
+    registerListTool(server, new Registry(makeConfig()), makeClient(mockRequest));
+
+    const result = await server.call("harness_list", {
+      resource_type: "kb_crawl_page",
+      params: { crawl_run_id: RUN_ID },
+      filters: { query: "install" },
+    });
+    const callArgs = mockRequest.mock.calls[0]![0] as { path: string; params: Record<string, unknown> };
+    expect(callArgs.path).toBe(`/ait/api/v1/kb/crawls/${RUN_ID}/pages`);
+    expect(callArgs.params.query).toBe("install");
+
+    const data = parseResult(result) as { items: Array<Record<string, unknown>> };
+    const page = data.items[0]!;
+    expect(page.pageId).toBe(PAGE_ID);
+    expect(page.artifacts).toEqual({ accessibility: true, markdown: true, metadata: true, screenshot: true });
+    expect(page.internalRowVersion).toBeUndefined();
+  });
+
+  it("passes include through on get and keeps the grounding surface", async () => {
+    mockRequest.mockResolvedValue({
+      pageId: PAGE_ID,
+      crawlRunId: RUN_ID,
+      url: "https://playwright.dev/docs/intro",
+      links: [{ href: "/docs/writing-tests" }],
+      structure: { forms: [] },
+      testableFeatures: ["install"],
+      includedArtifacts: { metadata: { kind: "metadata", text: "{}" } },
+    });
+    const { registerGetTool } = await import("../../src/tools/harness-get.js");
+    registerGetTool(server, new Registry(makeConfig()), makeClient(mockRequest));
+
+    const result = await server.call("harness_get", {
+      resource_type: "kb_crawl_page",
+      resource_id: PAGE_ID,
+      params: { crawl_run_id: RUN_ID, include: "metadata" },
+    });
+    const callArgs = mockRequest.mock.calls[0]![0] as { path: string; params: Record<string, unknown> };
+    expect(callArgs.path).toBe(`/ait/api/v1/kb/crawls/${RUN_ID}/pages/${PAGE_ID}`);
+    expect(callArgs.params.include).toBe("metadata");
+
+    const data = parseResult(result) as Record<string, unknown>;
+    expect(data.links).toEqual([{ href: "/docs/writing-tests" }]);
+    expect(data.structure).toEqual({ forms: [] });
+    expect(data.testableFeatures).toEqual(["install"]);
+    expect(data.includedArtifacts).toBeDefined();
+  });
+});
+
+describe("kb_page_artifact", () => {
+  let server: ReturnType<typeof makeMcpServer>;
+  let mockRequest: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    server = makeMcpServer();
+    mockRequest = vi.fn();
+  });
+
+  it("fetches a text artifact and keeps the truncation flag, dropping the digest", async () => {
+    mockRequest.mockResolvedValue({
+      pageId: PAGE_ID,
+      crawlRunId: RUN_ID,
+      kind: "accessibility",
+      contentType: "application/json",
+      text: "{\"role\":\"main\"}",
+      sha256: "b7e2…",
+      truncated: false,
+    });
+    const { registerGetTool } = await import("../../src/tools/harness-get.js");
+    registerGetTool(server, new Registry(makeConfig()), makeClient(mockRequest));
+
+    const result = await server.call("harness_get", {
+      resource_type: "kb_page_artifact",
+      resource_id: "accessibility",
+      params: { crawl_run_id: RUN_ID, page_id: PAGE_ID },
+    });
+    const callArgs = mockRequest.mock.calls[0]![0] as { path: string };
+    expect(callArgs.path).toBe(`/ait/api/v1/kb/crawls/${RUN_ID}/pages/${PAGE_ID}/artifacts/accessibility`);
+
+    const data = parseResult(result) as Record<string, unknown>;
+    expect(data.text).toBe("{\"role\":\"main\"}");
+    expect(data.truncated).toBe(false);
+    expect(data.sha256).toBeUndefined();
+  });
+
+  it("returns the signed URL and its expiry for a screenshot", async () => {
+    mockRequest.mockResolvedValue({
+      pageId: PAGE_ID,
+      crawlRunId: RUN_ID,
+      kind: "screenshot",
+      contentType: "image/png",
+      signedUrl: "https://storage.googleapis.com/bucket/shot.png?X-Goog-Expires=300",
+      expiresAt: "2026-08-01T00:00:00.000Z",
+      sha256: "c9f1…",
+    });
+    const { registerGetTool } = await import("../../src/tools/harness-get.js");
+    registerGetTool(server, new Registry(makeConfig()), makeClient(mockRequest));
+
+    const result = await server.call("harness_get", {
+      resource_type: "kb_page_artifact",
+      resource_id: "screenshot",
+      params: { crawl_run_id: RUN_ID, page_id: PAGE_ID },
+    });
+    const data = parseResult(result) as Record<string, unknown>;
+    expect(data.signedUrl).toContain("X-Goog-Expires=300");
+    expect(data.expiresAt).toBe("2026-08-01T00:00:00.000Z");
+  });
+});
+
+describe("ait toolset registration", () => {
+  it("is excluded from the default registry and enabled by HARNESS_TOOLSETS", () => {
+    const defaultRegistry = new Registry({ ...makeConfig(), HARNESS_TOOLSETS: undefined } as Config);
+    expect(defaultRegistry.getAllToolsets().some((t) => t.name === "ait")).toBe(false);
+
+    const optedIn = new Registry({ ...makeConfig(), HARNESS_TOOLSETS: "+ait" } as Config);
+    expect(optedIn.getAllToolsets().some((t) => t.name === "ait")).toBe(true);
+  });
+});

--- a/tests/tools/ait.test.ts
+++ b/tests/tools/ait.test.ts
@@ -4,11 +4,11 @@
  *
  * Verifies the /ait/api/v1/kb/… paths, cursor pagination, header-only scoping
  * (AIT resolves the org from the PAT, and its routes reject unknown body
- * fields), body mapping on create/recrawl, artifact compaction, and that the
- * toolset stays out of the default registry — all with a mocked client.request
- * so no real API is hit.
+ * fields), snake_case agent responses with camelCase on the wire, body mapping
+ * on create/recrawl, artifact projection, and that the toolset stays out of the
+ * default registry — all with a mocked client.request so no real API is hit.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Config } from "../../src/config.js";
 import type { HarnessClient } from "../../src/client/harness-client.js";
 import type { ToolResult } from "../../src/utils/response-formatter.js";
@@ -82,15 +82,17 @@ describe("kb_crawl — harness_list", () => {
     registerListTool(server, new Registry(makeConfig()), client);
   });
 
-  it("lists an environment's crawl history and preserves nextCursor", async () => {
+  it("lists an environment's crawl history and maps items to snake_case", async () => {
     const result = await server.call("harness_list", {
       resource_type: "kb_crawl",
       params: { test_environment_id: ENV_ID },
     });
     expect(result.isError).toBeUndefined();
-    const data = parseResult(result) as { items: unknown[]; nextCursor: string };
+    const data = parseResult(result) as { items: Array<Record<string, unknown>>; next_cursor: string };
     expect(data.items).toHaveLength(1);
-    expect(data.nextCursor).toBe("eyJhdCI6IjIwMjYifQ");
+    expect(data.items[0]!.crawl_run_id).toBe(RUN_ID);
+    expect(data.items[0]!.status).toBe("completed");
+    expect(data.next_cursor).toBe("eyJhdCI6IjIwMjYifQ");
     const callArgs = mockRequest.mock.calls[0]![0] as { path: string };
     expect(callArgs.path).toBe(`/ait/api/v1/kb/${ENV_ID}/crawls`);
   });
@@ -130,13 +132,14 @@ describe("kb_crawl — harness_get", () => {
     registerGetTool(server, new Registry(makeConfig()), makeClient(mockRequest));
   });
 
-  it("fetches a crawl run by id and returns its status verbatim", async () => {
+  it("fetches a crawl run by id and projects snake_case fields", async () => {
     const result = await server.call("harness_get", { resource_type: "kb_crawl", resource_id: RUN_ID });
     const callArgs = mockRequest.mock.calls[0]![0] as { path: string };
     expect(callArgs.path).toBe(`/ait/api/v1/kb/crawls/${RUN_ID}`);
-    const data = parseResult(result) as { status: string; pagesDiscovered: number };
+    const data = parseResult(result) as { status: string; pages_discovered: number; crawl_run_id: string };
     expect(data.status).toBe("running");
-    expect(data.pagesDiscovered).toBe(1);
+    expect(data.pages_discovered).toBe(1);
+    expect(data.crawl_run_id).toBe(RUN_ID);
   });
 });
 
@@ -151,13 +154,17 @@ describe("kb_crawl — harness_create", () => {
     registerCreateTool(server, new Registry(makeConfig()), makeClient(mockRequest), makeConfig());
   });
 
-  it("posts to /kb/crawls with the environment and config fields AIT accepts", async () => {
+  it("accepts snake_case body and posts camelCase wire JSON", async () => {
     const result = await server.call("harness_create", {
       resource_type: "kb_crawl",
       body: {
-        appId: "app-1",
-        testEnvironmentId: ENV_ID,
-        config: { maxPages: 10, tunnelName: "corp", crawlInstructionsAddendum: "only crawl under /docs" },
+        app_id: "app-1",
+        test_environment_id: ENV_ID,
+        config: {
+          max_pages: 10,
+          tunnel_name: "corp",
+          crawl_instructions_addendum: "only crawl under /docs",
+        },
       },
     });
     expect(result.isError).toBeUndefined();
@@ -169,30 +176,33 @@ describe("kb_crawl — harness_create", () => {
       testEnvironmentId: ENV_ID,
       config: { maxPages: 10, tunnelName: "corp", crawlInstructionsAddendum: "only crawl under /docs" },
     });
+    const data = parseResult(result) as { crawl_run_id: string; test_environment_id: string };
+    expect(data.crawl_run_id).toBe(RUN_ID);
+    expect(data.test_environment_id).toBe(ENV_ID);
   });
 
   it("drops unknown body fields, which AIT's routes would reject", async () => {
     await server.call("harness_create", {
       resource_type: "kb_crawl",
-      body: { appId: "app-1", startUrl: "https://example.com", orgIdentifier: "default", nonsense: true },
+      body: { app_id: "app-1", start_url: "https://example.com", orgIdentifier: "default", nonsense: true },
     });
     const callArgs = mockRequest.mock.calls[0]![0] as { body: Record<string, unknown> };
     expect(callArgs.body).toEqual({ appId: "app-1", startUrl: "https://example.com" });
   });
 
-  it("errors when neither testEnvironmentId nor startUrl is given", async () => {
+  it("errors when neither test_environment_id nor start_url is given", async () => {
     const result = await server.call("harness_create", {
       resource_type: "kb_crawl",
-      body: { appId: "app-1" },
+      body: { app_id: "app-1" },
     });
     expect(result.isError).toBe(true);
     expect(mockRequest).not.toHaveBeenCalled();
   });
 
-  it("errors when appId is missing", async () => {
+  it("errors when app_id is missing", async () => {
     const result = await server.call("harness_create", {
       resource_type: "kb_crawl",
-      body: { startUrl: "https://example.com" },
+      body: { start_url: "https://example.com" },
     });
     expect(result.isError).toBe(true);
     expect(mockRequest).not.toHaveBeenCalled();
@@ -210,18 +220,20 @@ describe("kb_crawl — harness_execute", () => {
     registerExecuteTool(server, new Registry(makeConfig()), makeClient(mockRequest), makeConfig());
   });
 
-  it("recrawl posts to the environment's recrawl path with the override body", async () => {
+  it("recrawl posts snake_case overrides as camelCase on the wire", async () => {
     const result = await server.call("harness_execute", {
       resource_type: "kb_crawl",
       action: "recrawl",
       params: { test_environment_id: ENV_ID },
-      body: { maxPages: 3 },
+      body: { max_pages: 3 },
     });
     expect(result.isError).toBeUndefined();
     const callArgs = mockRequest.mock.calls[0]![0] as { method: string; path: string; body: Record<string, unknown> };
     expect(callArgs.method).toBe("POST");
     expect(callArgs.path).toBe(`/ait/api/v1/kb/${ENV_ID}/recrawl`);
     expect(callArgs.body).toEqual({ maxPages: 3 });
+    const data = parseResult(result) as { crawl_run_id: string };
+    expect(data.crawl_run_id).toBe(RUN_ID);
   });
 
   it("latest_status reads the environment's most recent run", async () => {
@@ -245,7 +257,7 @@ describe("kb_crawl_page", () => {
     mockRequest = vi.fn();
   });
 
-  it("filters pages by query and keeps the artifact availability map when compacting", async () => {
+  it("filters pages by query and projects list items to snake_case", async () => {
     mockRequest.mockResolvedValue({
       items: [
         {
@@ -274,12 +286,14 @@ describe("kb_crawl_page", () => {
 
     const data = parseResult(result) as { items: Array<Record<string, unknown>> };
     const page = data.items[0]!;
-    expect(page.pageId).toBe(PAGE_ID);
+    expect(page.page_id).toBe(PAGE_ID);
+    expect(page.crawl_run_id).toBe(RUN_ID);
+    expect(page.captured_at).toBe("2026-07-31T23:53:30.000Z");
     expect(page.artifacts).toEqual({ accessibility: true, markdown: true, metadata: true, screenshot: true });
     expect(page.internalRowVersion).toBeUndefined();
   });
 
-  it("passes include through on get and keeps the grounding surface", async () => {
+  it("passes include through on get and keeps the grounding surface in snake_case", async () => {
     mockRequest.mockResolvedValue({
       pageId: PAGE_ID,
       crawlRunId: RUN_ID,
@@ -287,7 +301,17 @@ describe("kb_crawl_page", () => {
       links: [{ href: "/docs/writing-tests" }],
       structure: { forms: [] },
       testableFeatures: ["install"],
-      includedArtifacts: { metadata: { kind: "metadata", text: "{}" } },
+      includedArtifacts: {
+        metadata: {
+          pageId: PAGE_ID,
+          crawlRunId: RUN_ID,
+          kind: "metadata",
+          contentType: "application/json",
+          text: "{}",
+          sha256: "abc",
+          truncated: false,
+        },
+      },
     });
     const { registerGetTool } = await import("../../src/tools/harness-get.js");
     registerGetTool(server, new Registry(makeConfig()), makeClient(mockRequest));
@@ -302,10 +326,13 @@ describe("kb_crawl_page", () => {
     expect(callArgs.params.include).toBe("metadata");
 
     const data = parseResult(result) as Record<string, unknown>;
+    expect(data.page_id).toBe(PAGE_ID);
     expect(data.links).toEqual([{ href: "/docs/writing-tests" }]);
     expect(data.structure).toEqual({ forms: [] });
-    expect(data.testableFeatures).toEqual(["install"]);
-    expect(data.includedArtifacts).toBeDefined();
+    expect(data.testable_features).toEqual(["install"]);
+    const included = data.included_artifacts as Record<string, Record<string, unknown>>;
+    expect(included.metadata!.content_type).toBe("application/json");
+    expect(included.metadata!.sha256).toBeUndefined();
   });
 });
 
@@ -318,7 +345,11 @@ describe("kb_page_artifact", () => {
     mockRequest = vi.fn();
   });
 
-  it("fetches a text artifact and keeps the truncation flag, dropping the digest", async () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetches a text artifact and projects snake_case fields, dropping the digest", async () => {
     mockRequest.mockResolvedValue({
       pageId: PAGE_ID,
       crawlRunId: RUN_ID,
@@ -340,12 +371,23 @@ describe("kb_page_artifact", () => {
     expect(callArgs.path).toBe(`/ait/api/v1/kb/crawls/${RUN_ID}/pages/${PAGE_ID}/artifacts/accessibility`);
 
     const data = parseResult(result) as Record<string, unknown>;
+    expect(data.page_id).toBe(PAGE_ID);
+    expect(data.content_type).toBe("application/json");
     expect(data.text).toBe("{\"role\":\"main\"}");
     expect(data.truncated).toBe(false);
     expect(data.sha256).toBeUndefined();
   });
 
-  it("returns the signed URL and its expiry for a screenshot", async () => {
+  it("returns signed_url and attaches an MCP image block for a screenshot", async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        headers: { get: () => "image/png" },
+        arrayBuffer: async () => png.buffer.slice(png.byteOffset, png.byteOffset + png.byteLength),
+      }),
+    );
     mockRequest.mockResolvedValue({
       pageId: PAGE_ID,
       crawlRunId: RUN_ID,
@@ -364,8 +406,21 @@ describe("kb_page_artifact", () => {
       params: { crawl_run_id: RUN_ID, page_id: PAGE_ID },
     });
     const data = parseResult(result) as Record<string, unknown>;
-    expect(data.signedUrl).toContain("X-Goog-Expires=300");
-    expect(data.expiresAt).toBe("2026-08-01T00:00:00.000Z");
+    expect(String(data.signed_url)).toContain("X-Goog-Expires=300");
+    expect(data.expires_at).toBe("2026-08-01T00:00:00.000Z");
+    expect(result.content).toEqual([
+      { type: "text", text: JSON.stringify(data) },
+      { type: "image", mimeType: "image/png", data: png.toString("base64") },
+    ]);
+  });
+
+  it("documents the compound identifier example on the resource", () => {
+    const def = new Registry(makeConfig()).getResource("kb_page_artifact");
+    expect(def.description).toContain("resource_id=screenshot");
+    expect(def.description).toContain("crawl_run_id");
+    expect(def.description).toContain("page_id");
+    expect(def.description).toContain("MCP image content block");
+    expect(def.operations.get?.description).toContain("resource_id must be the kind");
   });
 });
 
@@ -376,5 +431,16 @@ describe("ait toolset registration", () => {
 
     const optedIn = new Registry({ ...makeConfig(), HARNESS_TOOLSETS: "+ait" } as Config);
     expect(optedIn.getAllToolsets().some((t) => t.name === "ait")).toBe(true);
+  });
+
+  it("prescribes MCP-only KB access and warns about the Java catch-all proxy", () => {
+    const toolset = new Registry(makeConfig()).getAllToolsets().find((t) => t.name === "ait");
+    expect(toolset?.description).toContain("harness_list");
+    expect(toolset?.description).toContain("ait-java-api-service");
+    expect(toolset?.description).toContain("explore-knowledge-base");
+
+    const crawl = new Registry(makeConfig()).getResource("kb_crawl");
+    expect(crawl.diagnosticHint).toContain("ait-java-api-service");
+    expect(crawl.searchAliases).toContain("crawl history");
   });
 });

--- a/tests/utils/kb-screenshot-content.test.ts
+++ b/tests/utils/kb-screenshot-content.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { fetchImageContentBlock } from "../../src/utils/fetch-image-content.js";
+import {
+  collectKbScreenshotUrls,
+  jsonResultWithKbScreenshots,
+} from "../../src/utils/kb-screenshot-content.js";
+
+describe("fetchImageContentBlock", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns a base64 image content block for a PNG response", async () => {
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        headers: { get: (name: string) => (name.toLowerCase() === "content-type" ? "image/png" : null) },
+        arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+      }),
+    );
+
+    const block = await fetchImageContentBlock("https://example.com/shot.png");
+    expect(block).toEqual({
+      type: "image",
+      mimeType: "image/png",
+      data: bytes.toString("base64"),
+    });
+  });
+
+  it("returns undefined when the response is too large", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        headers: { get: (name: string) => (name.toLowerCase() === "content-length" ? "99999999" : "image/png") },
+        arrayBuffer: async () => new ArrayBuffer(0),
+      }),
+    );
+    await expect(fetchImageContentBlock("https://example.com/big.png", { maxBytes: 1024 })).resolves.toBeUndefined();
+  });
+
+  it("returns undefined on fetch failure", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network")));
+    await expect(fetchImageContentBlock("https://example.com/shot.png")).resolves.toBeUndefined();
+  });
+});
+
+describe("collectKbScreenshotUrls", () => {
+  it("collects signed_url from kb_page_artifact screenshots", () => {
+    expect(
+      collectKbScreenshotUrls("kb_page_artifact", {
+        kind: "screenshot",
+        signed_url: "https://storage.example/a.png",
+      }),
+    ).toEqual(["https://storage.example/a.png"]);
+  });
+
+  it("ignores non-screenshot artifacts", () => {
+    expect(
+      collectKbScreenshotUrls("kb_page_artifact", {
+        kind: "accessibility",
+        text: "{}",
+      }),
+    ).toEqual([]);
+  });
+
+  it("collects nested screenshot from kb_crawl_page included_artifacts", () => {
+    expect(
+      collectKbScreenshotUrls("kb_crawl_page", {
+        page_id: "p1",
+        included_artifacts: {
+          screenshot: { kind: "screenshot", signed_url: "https://storage.example/b.png" },
+        },
+      }),
+    ).toEqual(["https://storage.example/b.png"]);
+  });
+});
+
+describe("jsonResultWithKbScreenshots", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("appends an image content block when the signed URL is fetchable", async () => {
+    const bytes = Buffer.from("png-bytes");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        headers: { get: () => "image/png" },
+        arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+      }),
+    );
+
+    const payload = {
+      kind: "screenshot",
+      signed_url: "https://storage.example/c.png",
+      expires_at: "2026-08-04T20:00:00.000Z",
+    };
+    const result = await jsonResultWithKbScreenshots("kb_page_artifact", payload);
+    expect(result.structuredContent).toEqual(payload);
+    expect(result.content[0]).toEqual({ type: "text", text: JSON.stringify(payload) });
+    expect(result.content[1]).toEqual({
+      type: "image",
+      mimeType: "image/png",
+      data: bytes.toString("base64"),
+    });
+  });
+
+  it("still returns JSON when image fetch fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("boom")));
+    const payload = { kind: "screenshot", signed_url: "https://storage.example/d.png" };
+    const result = await jsonResultWithKbScreenshots("kb_page_artifact", payload);
+    expect(result.content).toHaveLength(1);
+    expect(result.structuredContent).toEqual(payload);
+  });
+});

--- a/tests/utils/response-formatter.test.ts
+++ b/tests/utils/response-formatter.test.ts
@@ -36,6 +36,18 @@ describe("jsonResult", () => {
     });
   });
 
+  it("appends extra content items after the JSON text block", () => {
+    const result = jsonResult(
+      { ok: true },
+      [{ type: "image", data: "abc", mimeType: "image/png" }],
+    );
+    expect(result.content).toEqual([
+      { type: "text", text: JSON.stringify({ ok: true }) },
+      { type: "image", data: "abc", mimeType: "image/png" },
+    ]);
+    expect(result.structuredContent).toEqual({ ok: true });
+  });
+
   it("handles arrays without structuredContent", () => {
     const result = jsonResult([1, 2, 3]);
     expect(result.content[0].text).toBe(JSON.stringify([1, 2, 3]));


### PR DESCRIPTION
## Description
<!-- What does this PR do? -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [ ] `pnpm test` passes
- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes
- [ ] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [ ] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
If this PR adds or changes Harness API coverage:
- [ ] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [ ] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [ ] `operationPolicy` on every new/changed endpoint
- [ ] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [ ] `identifierFields` and `scope` declared on new resources
- [ ] No `console.log()` in `src/` (stdio JSON-RPC safety)
