### PR TITLE
fix: fail loud on missing scope for security_exemption list

### DIFF
--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -9,6 +9,7 @@ import { createLogger } from "../utils/logger.js";
 import { buildDeepLink, appendStoreType } from "../utils/deep-links.js";
 import { isFormDataBody } from "../utils/type-guards.js";
 import { canonicalizeListFilterEnums } from "./enum-utils.js";
+import { applyListFilterAliases, assertListScopeResolved } from "./list-filter-utils.js";
 
 // Import all toolsets
 import { pipelinesToolset } from "./toolsets/pipelines.js";
@@ -390,19 +391,29 @@ export class Registry {
       throw new Error(`Resource "${resourceType}" does not support "${operation}". Supported: ${supported}`);
     }
 
-    if (operation === "list" && def.listFilterFields) {
-      const missing = def.listFilterFields
-        .filter(f => f.required && input[f.name] === undefined)
-        .map(f => f.name);
-      if (missing.length > 0) {
-        throw new Error(
-          `Missing required filter(s) for listing ${resourceType}: ${missing.join(", ")}. ` +
-          `Pass them via filters (e.g. filters: { ${missing.map(n => `${n}: "..."`).join(", ")} }).`
-        );
+    if (operation === "list") {
+      applyListFilterAliases(input, def.listFilterAliases);
+      assertListScopeResolved(
+        resourceType,
+        def,
+        input,
+        this.config.HARNESS_ORG,
+        this.config.HARNESS_PROJECT,
+      );
+      if (def.listFilterFields) {
+        const missing = def.listFilterFields
+          .filter(f => f.required && input[f.name] === undefined)
+          .map(f => f.name);
+        if (missing.length > 0) {
+          throw new Error(
+            `Missing required filter(s) for listing ${resourceType}: ${missing.join(", ")}. ` +
+            `Pass them via filters (e.g. filters: { ${missing.map(n => `${n}: "..."`).join(", ")} }).`
+          );
+        }
+        // Rewrite case variants (e.g. "pending" → "Pending") to declared enum values
+        // so agents that skip harness_describe don't get opaque API 400s.
+        canonicalizeListFilterEnums(input, def.listFilterFields);
       }
-      // Rewrite case variants (e.g. "pending" → "Pending") to declared enum values
-      // so agents that skip harness_describe don't get opaque API 400s.
-      canonicalizeListFilterEnums(input, def.listFilterFields);
     }
 
     if (spec.paramsSchema) {

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -9,7 +9,7 @@ import { createLogger } from "../utils/logger.js";
 import { buildDeepLink, appendStoreType } from "../utils/deep-links.js";
 import { isFormDataBody } from "../utils/type-guards.js";
 import { canonicalizeListFilterEnums } from "./enum-utils.js";
-import { applyListFilterAliases, assertListScopeResolved } from "./list-filter-utils.js";
+import { assertListFilterMiskeys, assertListScopeResolved } from "./list-filter-utils.js";
 
 // Import all toolsets
 import { pipelinesToolset } from "./toolsets/pipelines.js";
@@ -392,7 +392,6 @@ export class Registry {
     }
 
     if (operation === "list") {
-      applyListFilterAliases(input, def.listFilterAliases);
       assertListScopeResolved(
         resourceType,
         def,
@@ -400,6 +399,7 @@ export class Registry {
         this.config.HARNESS_ORG,
         this.config.HARNESS_PROJECT,
       );
+      assertListFilterMiskeys(resourceType, input, def.listFilterMiskeys);
       if (def.listFilterFields) {
         const missing = def.listFilterFields
           .filter(f => f.required && input[f.name] === undefined)

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -9,7 +9,7 @@ import { createLogger } from "../utils/logger.js";
 import { buildDeepLink, appendStoreType } from "../utils/deep-links.js";
 import { isFormDataBody } from "../utils/type-guards.js";
 import { canonicalizeListFilterEnums } from "./enum-utils.js";
-import { assertListFilterMiskeys, assertListScopeResolved } from "./list-filter-utils.js";
+import { assertListScopeResolved } from "./list-filter-utils.js";
 
 // Import all toolsets
 import { pipelinesToolset } from "./toolsets/pipelines.js";
@@ -399,7 +399,6 @@ export class Registry {
         this.config.HARNESS_ORG,
         this.config.HARNESS_PROJECT,
       );
-      assertListFilterMiskeys(resourceType, input, def.listFilterMiskeys);
       if (def.listFilterFields) {
         const missing = def.listFilterFields
           .filter(f => f.required && input[f.name] === undefined)

--- a/src/registry/list-filter-utils.ts
+++ b/src/registry/list-filter-utils.ts
@@ -1,4 +1,4 @@
-import type { ResourceDefinition } from "./types.js";
+import type { ResourceDefinition, ResourceScope } from "./types.js";
 
 function resolveScopeId(
   inputValue: unknown,
@@ -11,6 +11,18 @@ function resolveScopeId(
     return configDefault.trim();
   }
   return undefined;
+}
+
+function getSupportedScopes(def: ResourceDefinition): readonly ResourceScope[] {
+  return def.supportedScopes?.length ? def.supportedScopes : [def.scope];
+}
+
+function scopeResolutionHint(def: ResourceDefinition): string {
+  const supported = getSupportedScopes(def);
+  if (supported.length > 1) {
+    return ` Supported scopes: ${supported.join(", ")} — pass resource_scope for account- or org-level lists.`;
+  }
+  return "";
 }
 
 /**
@@ -32,39 +44,25 @@ export function assertListScopeResolved(
   const rawScope = input.resource_scope;
   if (rawScope !== undefined && rawScope !== "") return;
 
-  const scopeKeywords = new Set(["org", "account", "project", "organization"]);
-  const rawOrg = input.org_id;
-  const orgFromInput =
-    typeof rawOrg === "string" && rawOrg.trim() !== "" && !scopeKeywords.has(rawOrg.toLowerCase())
-      ? rawOrg.trim()
-      : undefined;
-  const rawProject = input.project_id;
-  const projectFromInput =
-    typeof rawProject === "string" &&
-    rawProject.trim() !== "" &&
-    !scopeKeywords.has(rawProject.toLowerCase())
-      ? rawProject.trim()
-      : undefined;
+  const orgId = resolveScopeId(input.org_id, configOrg);
+  const projectId = resolveScopeId(input.project_id, configProject);
+  const hint = scopeResolutionHint(def);
 
   if (def.scope === "project") {
-    const orgId = orgFromInput ?? resolveScopeId(undefined, configOrg);
-    const projectId = projectFromInput ?? resolveScopeId(undefined, configProject);
     if (!orgId || !projectId) {
       throw new Error(
         `${resourceType}: listing requires project scope (org_id + project_id). ` +
-          `Pass both on the harness_list call, set HARNESS_ORG and HARNESS_PROJECT, or use a Harness project URL. ` +
-          `Do not pass resource_scope='account' or 'org' on list — those refer to approval scope on harness_execute.`,
+          `Pass both on the harness_list call, set HARNESS_ORG and HARNESS_PROJECT, or use a Harness project URL.${hint}`,
       );
     }
     return;
   }
 
   if (def.scope === "org") {
-    const orgId = orgFromInput ?? resolveScopeId(undefined, configOrg);
     if (!orgId) {
       throw new Error(
         `${resourceType}: listing requires org scope (org_id). ` +
-          `Pass org_id explicitly, set HARNESS_ORG, or use a Harness URL.`,
+          `Pass org_id explicitly, set HARNESS_ORG, or use a Harness URL.${hint}`,
       );
     }
   }

--- a/src/registry/list-filter-utils.ts
+++ b/src/registry/list-filter-utils.ts
@@ -27,6 +27,11 @@ export function assertListScopeResolved(
 ): void {
   if (def.scopeOptional) return;
 
+  // Explicit resource_scope is validated in executeSpec via getExplicitScopeValues,
+  // which supports account/org/project narrowing on multi-scope resources (e.g. connector).
+  const rawScope = input.resource_scope;
+  if (rawScope !== undefined && rawScope !== "") return;
+
   const scopeKeywords = new Set(["org", "account", "project", "organization"]);
   const rawOrg = input.org_id;
   const orgFromInput =

--- a/src/registry/list-filter-utils.ts
+++ b/src/registry/list-filter-utils.ts
@@ -1,0 +1,93 @@
+import type { ResourceDefinition } from "./types.js";
+
+/**
+ * Map common agent mistakes (e.g. security_issue field names on security_exemption)
+ * to the canonical list-filter keys declared on the resource.
+ */
+export function applyListFilterAliases(
+  input: Record<string, unknown>,
+  aliases: Record<string, string> | undefined,
+): void {
+  if (!aliases) return;
+
+  for (const [alias, target] of Object.entries(aliases)) {
+    if (input[target] !== undefined || input[alias] === undefined) continue;
+
+    const raw = input[alias];
+    if (Array.isArray(raw)) {
+      const first = raw.find((v) => v !== undefined && v !== null && String(v).trim() !== "");
+      if (first !== undefined) input[target] = typeof first === "string" ? first.trim() : first;
+    } else if (typeof raw === "string") {
+      const trimmed = raw.trim();
+      input[target] = trimmed.includes(",") ? trimmed.split(",")[0]!.trim() : trimmed;
+    } else {
+      input[target] = raw;
+    }
+    delete input[alias];
+  }
+}
+
+function resolveScopeId(
+  inputValue: unknown,
+  configDefault: string | undefined,
+): string | undefined {
+  if (typeof inputValue === "string" && inputValue.trim() !== "") {
+    return inputValue.trim();
+  }
+  if (configDefault && configDefault.trim() !== "") {
+    return configDefault.trim();
+  }
+  return undefined;
+}
+
+/**
+ * Fail loud before hitting APIs that 500 when org/project query params are omitted.
+ * Matches explicit `resource_scope` validation — implicit config fallback must
+ * actually resolve, not silently become `undefined` in the query string.
+ */
+export function assertListScopeResolved(
+  resourceType: string,
+  def: ResourceDefinition,
+  input: Record<string, unknown>,
+  configOrg: string | undefined,
+  configProject: string | undefined,
+): void {
+  if (def.scopeOptional) return;
+
+  const scopeKeywords = new Set(["org", "account", "project", "organization"]);
+  const rawOrg = input.org_id;
+  const orgFromInput =
+    typeof rawOrg === "string" && rawOrg.trim() !== "" && !scopeKeywords.has(rawOrg.toLowerCase())
+      ? rawOrg.trim()
+      : undefined;
+  const rawProject = input.project_id;
+  const projectFromInput =
+    typeof rawProject === "string" &&
+    rawProject.trim() !== "" &&
+    !scopeKeywords.has(rawProject.toLowerCase())
+      ? rawProject.trim()
+      : undefined;
+
+  if (def.scope === "project") {
+    const orgId = orgFromInput ?? resolveScopeId(undefined, configOrg);
+    const projectId = projectFromInput ?? resolveScopeId(undefined, configProject);
+    if (!orgId || !projectId) {
+      throw new Error(
+        `${resourceType}: listing requires project scope (org_id + project_id). ` +
+          `Pass both on the harness_list call, set HARNESS_ORG and HARNESS_PROJECT, or use a Harness project URL. ` +
+          `Do not pass resource_scope='account' or 'org' on list — those refer to approval scope on harness_execute.`,
+      );
+    }
+    return;
+  }
+
+  if (def.scope === "org") {
+    const orgId = orgFromInput ?? resolveScopeId(undefined, configOrg);
+    if (!orgId) {
+      throw new Error(
+        `${resourceType}: listing requires org scope (org_id). ` +
+          `Pass org_id explicitly, set HARNESS_ORG, or use a Harness URL.`,
+      );
+    }
+  }
+}

--- a/src/registry/list-filter-utils.ts
+++ b/src/registry/list-filter-utils.ts
@@ -1,32 +1,5 @@
 import type { ResourceDefinition } from "./types.js";
 
-/**
- * Map common agent mistakes (e.g. security_issue field names on security_exemption)
- * to the canonical list-filter keys declared on the resource.
- */
-export function applyListFilterAliases(
-  input: Record<string, unknown>,
-  aliases: Record<string, string> | undefined,
-): void {
-  if (!aliases) return;
-
-  for (const [alias, target] of Object.entries(aliases)) {
-    if (input[target] !== undefined || input[alias] === undefined) continue;
-
-    const raw = input[alias];
-    if (Array.isArray(raw)) {
-      const first = raw.find((v) => v !== undefined && v !== null && String(v).trim() !== "");
-      if (first !== undefined) input[target] = typeof first === "string" ? first.trim() : first;
-    } else if (typeof raw === "string") {
-      const trimmed = raw.trim();
-      input[target] = trimmed.includes(",") ? trimmed.split(",")[0]!.trim() : trimmed;
-    } else {
-      input[target] = raw;
-    }
-    delete input[alias];
-  }
-}
-
 function resolveScopeId(
   inputValue: unknown,
   configDefault: string | undefined,
@@ -38,6 +11,23 @@ function resolveScopeId(
     return configDefault.trim();
   }
   return undefined;
+}
+
+/**
+ * Reject filter keys that belong to a sibling resource type but are commonly
+ * sent by mistake (e.g. security_issue's exemption_statuses on security_exemption).
+ */
+export function assertListFilterMiskeys(
+  resourceType: string,
+  input: Record<string, unknown>,
+  miskeys: Record<string, string> | undefined,
+): void {
+  if (!miskeys) return;
+
+  for (const [wrongKey, hint] of Object.entries(miskeys)) {
+    if (input[wrongKey] === undefined) continue;
+    throw new Error(`${resourceType}: ${hint}`);
+  }
 }
 
 /**

--- a/src/registry/list-filter-utils.ts
+++ b/src/registry/list-filter-utils.ts
@@ -14,23 +14,6 @@ function resolveScopeId(
 }
 
 /**
- * Reject filter keys that belong to a sibling resource type but are commonly
- * sent by mistake (e.g. security_issue's exemption_statuses on security_exemption).
- */
-export function assertListFilterMiskeys(
-  resourceType: string,
-  input: Record<string, unknown>,
-  miskeys: Record<string, string> | undefined,
-): void {
-  if (!miskeys) return;
-
-  for (const [wrongKey, hint] of Object.entries(miskeys)) {
-    if (input[wrongKey] === undefined) continue;
-    throw new Error(`${resourceType}: ${hint}`);
-  }
-}
-
-/**
  * Fail loud before hitting APIs that 500 when org/project query params are omitted.
  * Matches explicit `resource_scope` validation — implicit config fallback must
  * actually resolve, not silently become `undefined` in the query string.

--- a/src/registry/toolsets/sto.ts
+++ b/src/registry/toolsets/sto.ts
@@ -336,16 +336,20 @@ export const stoToolset: ToolsetDefinition = {
       searchAliases: ["approve", "reject", "promote", "waiver", "exception", "exempt", "approval"],
       description: "Security issue exemption/waiver. THIS is the resource for exemption approval/rejection workflows — even when the user mentions a vulnerability title like 'SQL Injection'. Supports list (POST with status filter), create, and approve/reject actions. Approval with body.scope='ACCOUNT', 'ORG', or 'PROJECT' routes through STO promotion internally. " +
         "CRITICAL SCOPE DISTINCTION: There are TWO different scope concepts that must NOT be confused: " +
-        "(1) LISTING scope — security_exemption ALWAYS lists at project scope. NEVER pass resource_scope='account' or resource_scope='org' to harness_list — it will fail. Always list using project defaults. " +
+        "(1) LISTING scope — security_exemption ALWAYS lists at project scope. NEVER pass resource_scope='account' or resource_scope='org' to harness_list. " +
+        "When HARNESS_ORG / HARNESS_PROJECT defaults are unset (typical in Harness AI chat), pass org_id and project_id on every harness_list call — use the user's current org/project from context. " +
         "(2) APPROVAL scope — the scope the exemption is approved AT, passed as body.scope to harness_execute. This CAN be 'ACCOUNT', 'ORG', 'PROJECT', or 'CURRENT'. " +
-        "If harness_list returns an error about 'account scope not supported', that means you passed resource_scope='account' to the LIST call — NOT that account-level approval is impossible. Fix: remove resource_scope from the list call, keep project defaults, then approve with body={scope:'ACCOUNT'}. " +
-        "IMPORTANT: When listing exemptions, NEVER pass resource_scope, org_id, or project_id overrides. " +
-        "Phrases like 'for org' or 'for account' refer to the APPROVAL SCOPE (body.scope on execute), NOT to resource_scope or org_id on list. " +
+        "If harness_list returns an error about 'account scope not supported', that means you passed resource_scope='account' to the LIST call — NOT that account-level approval is impossible. Fix: remove resource_scope from the list call, keep project org_id/project_id, then approve with body={scope:'ACCOUNT'}. " +
+        "Phrases like 'for org' or 'for account' refer to the APPROVAL SCOPE (body.scope on execute), NOT to resource_scope on list. " +
+        "LIST FILTER: use filters.status (not exemption_statuses — that field belongs to security_issue). " +
         "PAGINATION CONTRACT: (1) Pass `size: 5` explicitly inside `filters` for the first call — the recommended default for this resource is 5, not the global 20. (2) Page is 0-indexed: page=0 → items 1–5, page=1 → items 6–10. (3) CRITICAL — `size` AND all other filters (status, search, …) MUST stay identical across every page in a session. The backend computes offset = page × size, so altering either silently shifts the dataset. (4) For 'next N' requests, increment `page` by 1 and keep `size` constant. If the user asks for 'next 10' after showing 5, make TWO sequential calls with the same size=5 — do NOT bump size mid-session. (5) After each response, read `_nextPageHint` — it spells out the exact follow-up call to make.",
       toolset: "sto",
       scope: "project",
       scopeParams: STO_SCOPE,
       identifierFields: ["exemption_id"],
+      listFilterAliases: {
+        exemption_statuses: "status",
+      },
       listFilterFields: [
         { name: "status", description: "Exemption status filter — SINGLE value only, not comma-separated. Make separate calls for each status.", enum: ["Pending", "Approved", "Rejected", "Expired", "Canceled"], required: true },
         { name: "search", description: "Free-text search for issue/exemption titles" },
@@ -416,7 +420,7 @@ export const stoToolset: ToolsetDefinition = {
           },
           responseExtractor: stoExemptionsExtract,
           skipCompact: true,
-          description: "List security exemptions filtered by status. ALWAYS uses project scope — NEVER pass resource_scope='account' or resource_scope='org', it will fail. 'For account' / 'for org' are approval scopes for harness_execute, not list scopes. Recommended `size`: 5 (pass explicitly via `filters` — the shared default of 20 is too large for this resource). Response includes items[], total, page, pageSize, totalPages and `_nextPageHint`. ALWAYS read `_nextPageHint` — it spells out the exact follow-up call, including all active filters. NEVER re-use the same page for a 'next' request, NEVER drop filters between pages, and NEVER change size mid-session.",
+          description: "List security exemptions filtered by status. ALWAYS uses project scope — NEVER pass resource_scope='account' or resource_scope='org'. When defaults are unset, pass org_id and project_id (from user context). Use filters.status, not exemption_statuses. Recommended `size`: 5 (pass explicitly via `filters` — the shared default of 20 is too large for this resource). Response includes items[], total, page, pageSize, totalPages and `_nextPageHint`. ALWAYS read `_nextPageHint` — it spells out the exact follow-up call, including all active filters. NEVER re-use the same page for a 'next' request, NEVER drop filters between pages, and NEVER change size mid-session.",
         },
         create: {
           method: "POST",

--- a/src/registry/toolsets/sto.ts
+++ b/src/registry/toolsets/sto.ts
@@ -337,7 +337,7 @@ export const stoToolset: ToolsetDefinition = {
       description: "Security issue exemption/waiver. THIS is the resource for exemption approval/rejection workflows — even when the user mentions a vulnerability title like 'SQL Injection'. Supports list (POST with status filter), create, and approve/reject actions. Approval with body.scope='ACCOUNT', 'ORG', or 'PROJECT' routes through STO promotion internally. " +
         "CRITICAL SCOPE DISTINCTION: There are TWO different scope concepts that must NOT be confused: " +
         "(1) LISTING scope — security_exemption ALWAYS lists at project scope. NEVER pass resource_scope='account' or resource_scope='org' to harness_list. " +
-        "When HARNESS_ORG / HARNESS_PROJECT defaults are unset (typical in Harness AI chat), pass org_id and project_id on every harness_list call — use the user's current org/project from context. " +
+        "When HARNESS_ORG / HARNESS_PROJECT defaults are unset (common in multi-user HTTP mode), pass org_id and project_id on every harness_list call — use the caller's current org/project when available. " +
         "(2) APPROVAL scope — the scope the exemption is approved AT, passed as body.scope to harness_execute. This CAN be 'ACCOUNT', 'ORG', 'PROJECT', or 'CURRENT'. " +
         "If harness_list returns an error about 'account scope not supported', that means you passed resource_scope='account' to the LIST call — NOT that account-level approval is impossible. Fix: remove resource_scope from the list call, keep project org_id/project_id, then approve with body={scope:'ACCOUNT'}. " +
         "Phrases like 'for org' or 'for account' refer to the APPROVAL SCOPE (body.scope on execute), NOT to resource_scope on list. " +
@@ -420,7 +420,7 @@ export const stoToolset: ToolsetDefinition = {
           },
           responseExtractor: stoExemptionsExtract,
           skipCompact: true,
-          description: "List security exemptions filtered by status. ALWAYS uses project scope — NEVER pass resource_scope='account' or resource_scope='org'. When defaults are unset, pass org_id and project_id (from user context). Use filters.status, not exemption_statuses. Recommended `size`: 5 (pass explicitly via `filters` — the shared default of 20 is too large for this resource). Response includes items[], total, page, pageSize, totalPages and `_nextPageHint`. ALWAYS read `_nextPageHint` — it spells out the exact follow-up call, including all active filters. NEVER re-use the same page for a 'next' request, NEVER drop filters between pages, and NEVER change size mid-session.",
+          description: "List security exemptions filtered by status. ALWAYS uses project scope — NEVER pass resource_scope='account' or resource_scope='org'. When defaults are unset, pass org_id and project_id explicitly. Use filters.status, not exemption_statuses. Recommended `size`: 5 (pass explicitly via `filters` — the shared default of 20 is too large for this resource). Response includes items[], total, page, pageSize, totalPages and `_nextPageHint`. ALWAYS read `_nextPageHint` — it spells out the exact follow-up call, including all active filters. NEVER re-use the same page for a 'next' request, NEVER drop filters between pages, and NEVER change size mid-session.",
         },
         create: {
           method: "POST",

--- a/src/registry/toolsets/sto.ts
+++ b/src/registry/toolsets/sto.ts
@@ -347,8 +347,9 @@ export const stoToolset: ToolsetDefinition = {
       scope: "project",
       scopeParams: STO_SCOPE,
       identifierFields: ["exemption_id"],
-      listFilterAliases: {
-        exemption_statuses: "status",
+      listFilterMiskeys: {
+        exemption_statuses:
+          "Invalid filter 'exemption_statuses' — use filters.status for security_exemption (that key is for security_issue).",
       },
       listFilterFields: [
         { name: "status", description: "Exemption status filter — SINGLE value only, not comma-separated. Make separate calls for each status.", enum: ["Pending", "Approved", "Rejected", "Expired", "Canceled"], required: true },

--- a/src/registry/toolsets/sto.ts
+++ b/src/registry/toolsets/sto.ts
@@ -347,10 +347,6 @@ export const stoToolset: ToolsetDefinition = {
       scope: "project",
       scopeParams: STO_SCOPE,
       identifierFields: ["exemption_id"],
-      listFilterMiskeys: {
-        exemption_statuses:
-          "Invalid filter 'exemption_statuses' — use filters.status for security_exemption (that key is for security_issue).",
-      },
       listFilterFields: [
         { name: "status", description: "Exemption status filter — SINGLE value only, not comma-separated. Make separate calls for each status.", enum: ["Pending", "Approved", "Rejected", "Expired", "Canceled"], required: true },
         { name: "search", description: "Free-text search for issue/exemption titles" },

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -391,10 +391,10 @@ export interface ResourceDefinition {
   /** Additional filter fields for list operations */
   listFilterFields?: FilterFieldSpec[];
   /**
-   * Rename mistaken list-filter keys before required-filter validation.
-   * Keys are wrong names agents send; values are canonical `listFilterFields` names.
+   * Reject commonly confused list-filter keys before required-filter validation.
+   * Keys are wrong names agents send; values are full error hints (no API call).
    */
-  listFilterAliases?: Record<string, string>;
+  listFilterMiskeys?: Record<string, string>;
   /**
    * Optional per-resource compaction override for list items. When set,
    * harness_list applies this instead of the generic key-name whitelist

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -391,6 +391,11 @@ export interface ResourceDefinition {
   /** Additional filter fields for list operations */
   listFilterFields?: FilterFieldSpec[];
   /**
+   * Rename mistaken list-filter keys before required-filter validation.
+   * Keys are wrong names agents send; values are canonical `listFilterFields` names.
+   */
+  listFilterAliases?: Record<string, string>;
+  /**
    * Optional per-resource compaction override for list items. When set,
    * harness_list applies this instead of the generic key-name whitelist
    * (utils/compact.ts) to each item in compact mode. Use when a resource's

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -391,11 +391,6 @@ export interface ResourceDefinition {
   /** Additional filter fields for list operations */
   listFilterFields?: FilterFieldSpec[];
   /**
-   * Reject commonly confused list-filter keys before required-filter validation.
-   * Keys are wrong names agents send; values are full error hints (no API call).
-   */
-  listFilterMiskeys?: Record<string, string>;
-  /**
    * Optional per-resource compaction override for list items. When set,
    * harness_list applies this instead of the generic key-name whitelist
    * (utils/compact.ts) to each item in compact mode. Use when a resource's

--- a/src/tools/harness-list.ts
+++ b/src/tools/harness-list.ts
@@ -14,11 +14,9 @@ import { resourceTypeSchema } from "./input-schemas.js";
 import { listOutputSchema } from "./output-schemas.js";
 
 export function registerListTool(server: McpServer, registry: Registry, client: HarnessClient, searchManager?: SearchManager): void {
-  // Build a dynamic description for the filters param from all enabled resource definitions
-  const allFilterNames = registry.getAllFilterFields().map((f) => f.name);
-  const filtersDesc = allFilterNames.length > 0
-    ? `Resource-specific filters as key-value pairs. Available keys across enabled resource types: ${allFilterNames.join(", ")}. Call harness_describe for filters available on a specific resource_type.`
-    : "Resource-specific filters as key-value pairs. Call harness_describe for available filters per resource_type.";
+  const filtersDesc =
+    "Resource-specific filters as key-value pairs. Valid keys depend on resource_type — " +
+    "call harness_describe(resource_type=\"<type>\") for filters, enums, and required fields for that type.";
 
   const listableTypes = registry.getTypesForOperation("list");
 

--- a/tests/registry/list-filter-utils.test.ts
+++ b/tests/registry/list-filter-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
-  applyListFilterAliases,
+  assertListFilterMiskeys,
   assertListScopeResolved,
 } from "../../src/registry/list-filter-utils.js";
 import type { ResourceDefinition } from "../../src/registry/types.js";
@@ -15,27 +15,32 @@ const projectScoped: ResourceDefinition = {
   operations: {},
 };
 
-describe("applyListFilterAliases", () => {
-  it("maps exemption_statuses array to status", () => {
-    const input: Record<string, unknown> = { exemption_statuses: ["pending"] };
-    applyListFilterAliases(input, { exemption_statuses: "status" });
-    expect(input.status).toBe("pending");
-    expect(input.exemption_statuses).toBeUndefined();
+describe("assertListFilterMiskeys", () => {
+  const miskeys = {
+    exemption_statuses:
+      "Invalid filter 'exemption_statuses' — use filters.status for security_exemption (that key is for security_issue).",
+  };
+
+  it("throws when a commonly confused filter key is present", () => {
+    expect(() =>
+      assertListFilterMiskeys(
+        "security_exemption",
+        { exemption_statuses: ["pending"] },
+        miskeys,
+      ),
+    ).toThrow(/use filters\.status for security_exemption/i);
   });
 
-  it("maps exemption_statuses string to status", () => {
-    const input: Record<string, unknown> = { exemption_statuses: "Pending" };
-    applyListFilterAliases(input, { exemption_statuses: "status" });
-    expect(input.status).toBe("Pending");
+  it("passes when only valid filter keys are present", () => {
+    expect(() =>
+      assertListFilterMiskeys("security_exemption", { status: "Pending" }, miskeys),
+    ).not.toThrow();
   });
 
-  it("does not overwrite an explicit status", () => {
-    const input: Record<string, unknown> = {
-      status: "Approved",
-      exemption_statuses: ["pending"],
-    };
-    applyListFilterAliases(input, { exemption_statuses: "status" });
-    expect(input.status).toBe("Approved");
+  it("no-ops when miskeys config is undefined", () => {
+    expect(() =>
+      assertListFilterMiskeys("security_exemption", { exemption_statuses: "Pending" }, undefined),
+    ).not.toThrow();
   });
 });
 

--- a/tests/registry/list-filter-utils.test.ts
+++ b/tests/registry/list-filter-utils.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyListFilterAliases,
+  assertListScopeResolved,
+} from "../../src/registry/list-filter-utils.js";
+import type { ResourceDefinition } from "../../src/registry/types.js";
+
+const projectScoped: ResourceDefinition = {
+  resourceType: "security_exemption",
+  displayName: "Security Exemption",
+  description: "test",
+  toolset: "sto",
+  scope: "project",
+  identifierFields: ["exemption_id"],
+  operations: {},
+};
+
+describe("applyListFilterAliases", () => {
+  it("maps exemption_statuses array to status", () => {
+    const input: Record<string, unknown> = { exemption_statuses: ["pending"] };
+    applyListFilterAliases(input, { exemption_statuses: "status" });
+    expect(input.status).toBe("pending");
+    expect(input.exemption_statuses).toBeUndefined();
+  });
+
+  it("maps exemption_statuses string to status", () => {
+    const input: Record<string, unknown> = { exemption_statuses: "Pending" };
+    applyListFilterAliases(input, { exemption_statuses: "status" });
+    expect(input.status).toBe("Pending");
+  });
+
+  it("does not overwrite an explicit status", () => {
+    const input: Record<string, unknown> = {
+      status: "Approved",
+      exemption_statuses: ["pending"],
+    };
+    applyListFilterAliases(input, { exemption_statuses: "status" });
+    expect(input.status).toBe("Approved");
+  });
+});
+
+describe("assertListScopeResolved", () => {
+  it("passes when org_id and project_id are on the input", () => {
+    expect(() =>
+      assertListScopeResolved(
+        "security_exemption",
+        projectScoped,
+        { org_id: "AI_Devops", project_id: "Sanity", status: "Pending" },
+        undefined,
+        undefined,
+      ),
+    ).not.toThrow();
+  });
+
+  it("passes when config defaults are set", () => {
+    expect(() =>
+      assertListScopeResolved(
+        "security_exemption",
+        projectScoped,
+        { status: "Pending" },
+        "AI_Devops",
+        "Sanity",
+      ),
+    ).not.toThrow();
+  });
+
+  it("throws a clear error when project scope cannot be resolved", () => {
+    expect(() =>
+      assertListScopeResolved(
+        "security_exemption",
+        projectScoped,
+        { status: "Pending" },
+        undefined,
+        undefined,
+      ),
+    ).toThrow(/requires project scope \(org_id \+ project_id\)/i);
+  });
+
+  it("ignores scope-keyword org_id values mistaken for identifiers", () => {
+    expect(() =>
+      assertListScopeResolved(
+        "security_exemption",
+        projectScoped,
+        { org_id: "account", project_id: "Sanity", status: "Pending" },
+        undefined,
+        undefined,
+      ),
+    ).toThrow(/requires project scope/i);
+  });
+});

--- a/tests/registry/list-filter-utils.test.ts
+++ b/tests/registry/list-filter-utils.test.ts
@@ -49,7 +49,7 @@ describe("assertListScopeResolved", () => {
     ).toThrow(/requires project scope \(org_id \+ project_id\)/i);
   });
 
-  it("ignores scope-keyword org_id values mistaken for identifiers", () => {
+  it("accepts org_id values that match scope keyword names when used as identifiers", () => {
     expect(() =>
       assertListScopeResolved(
         "security_exemption",
@@ -58,7 +58,44 @@ describe("assertListScopeResolved", () => {
         undefined,
         undefined,
       ),
-    ).toThrow(/requires project scope/i);
+    ).not.toThrow();
+  });
+
+  it("includes multi-scope hint for resources that support account/org/project", () => {
+    expect(() =>
+      assertListScopeResolved(
+        "connector",
+        {
+          ...projectScoped,
+          resourceType: "connector",
+          supportedScopes: ["account", "org", "project"],
+        },
+        { type: "Github" },
+        undefined,
+        undefined,
+      ),
+    ).toThrow(/Supported scopes: account, org, project/);
+  });
+
+  it("does not include multi-scope hint for project-only resources", () => {
+    expect(() =>
+      assertListScopeResolved(
+        "security_exemption",
+        projectScoped,
+        { status: "Pending" },
+        undefined,
+        undefined,
+      ),
+    ).toThrow(/requires project scope \(org_id \+ project_id\)/);
+    expect(() =>
+      assertListScopeResolved(
+        "security_exemption",
+        projectScoped,
+        { status: "Pending" },
+        undefined,
+        undefined,
+      ),
+    ).not.toThrow(/resource_scope/);
   });
 
   it("defers to executeSpec when resource_scope is explicit", () => {

--- a/tests/registry/list-filter-utils.test.ts
+++ b/tests/registry/list-filter-utils.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  assertListFilterMiskeys,
-  assertListScopeResolved,
-} from "../../src/registry/list-filter-utils.js";
+import { assertListScopeResolved } from "../../src/registry/list-filter-utils.js";
 import type { ResourceDefinition } from "../../src/registry/types.js";
 
 const projectScoped: ResourceDefinition = {
@@ -14,35 +11,6 @@ const projectScoped: ResourceDefinition = {
   identifierFields: ["exemption_id"],
   operations: {},
 };
-
-describe("assertListFilterMiskeys", () => {
-  const miskeys = {
-    exemption_statuses:
-      "Invalid filter 'exemption_statuses' — use filters.status for security_exemption (that key is for security_issue).",
-  };
-
-  it("throws when a commonly confused filter key is present", () => {
-    expect(() =>
-      assertListFilterMiskeys(
-        "security_exemption",
-        { exemption_statuses: ["pending"] },
-        miskeys,
-      ),
-    ).toThrow(/use filters\.status for security_exemption/i);
-  });
-
-  it("passes when only valid filter keys are present", () => {
-    expect(() =>
-      assertListFilterMiskeys("security_exemption", { status: "Pending" }, miskeys),
-    ).not.toThrow();
-  });
-
-  it("no-ops when miskeys config is undefined", () => {
-    expect(() =>
-      assertListFilterMiskeys("security_exemption", { exemption_statuses: "Pending" }, undefined),
-    ).not.toThrow();
-  });
-});
 
 describe("assertListScopeResolved", () => {
   it("passes when org_id and project_id are on the input", () => {

--- a/tests/registry/list-filter-utils.test.ts
+++ b/tests/registry/list-filter-utils.test.ts
@@ -60,4 +60,16 @@ describe("assertListScopeResolved", () => {
       ),
     ).toThrow(/requires project scope/i);
   });
+
+  it("defers to executeSpec when resource_scope is explicit", () => {
+    expect(() =>
+      assertListScopeResolved(
+        "connector",
+        { ...projectScoped, resourceType: "connector", supportedScopes: ["account", "org", "project"] },
+        { resource_scope: "org" },
+        undefined,
+        undefined,
+      ),
+    ).not.toThrow();
+  });
 });

--- a/tests/registry/sto-exemptions.test.ts
+++ b/tests/registry/sto-exemptions.test.ts
@@ -242,6 +242,34 @@ describe("security_exemption list — registry dispatch", () => {
     expect(requestSpy).not.toHaveBeenCalled();
   });
 
+  it("maps exemption_statuses to status before required-filter validation", async () => {
+    const requestSpy = vi.fn().mockResolvedValue(rawApiResponse);
+    const client = makeClient(requestSpy);
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "sto" }));
+
+    await registry.dispatch(client, "security_exemption", "list", {
+      exemption_statuses: ["pending"],
+      org_id: "AI_Devops",
+      project_id: "Sanity",
+    });
+
+    const callArgs = requestSpy.mock.calls[0]![0] as { params: Record<string, unknown> };
+    expect(callArgs.params.status).toBe("Pending");
+  });
+
+  it("fails loud when org_id and project_id are missing and config defaults are unset", async () => {
+    const requestSpy = vi.fn().mockResolvedValue(rawApiResponse);
+    const client = makeClient(requestSpy);
+    const registry = new Registry(
+      makeConfig({ HARNESS_TOOLSETS: "sto", HARNESS_ORG: undefined, HARNESS_PROJECT: undefined }),
+    );
+
+    await expect(
+      registry.dispatch(client, "security_exemption", "list", { status: "Pending" }),
+    ).rejects.toThrow(/requires project scope \(org_id \+ project_id\)/i);
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+
   it("preserves projected display fields under skipCompact (severity, requested_by, …)", async () => {
     const client = makeClient(vi.fn().mockResolvedValue(rawApiResponse));
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "sto" }));

--- a/tests/registry/sto-exemptions.test.ts
+++ b/tests/registry/sto-exemptions.test.ts
@@ -242,21 +242,6 @@ describe("security_exemption list — registry dispatch", () => {
     expect(requestSpy).not.toHaveBeenCalled();
   });
 
-  it("rejects exemption_statuses with a targeted miskey error", async () => {
-    const requestSpy = vi.fn().mockResolvedValue(rawApiResponse);
-    const client = makeClient(requestSpy);
-    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "sto" }));
-
-    await expect(
-      registry.dispatch(client, "security_exemption", "list", {
-        exemption_statuses: ["pending"],
-        org_id: "AI_Devops",
-        project_id: "Sanity",
-      }),
-    ).rejects.toThrow(/use filters\.status for security_exemption/i);
-    expect(requestSpy).not.toHaveBeenCalled();
-  });
-
   it("fails loud when org_id and project_id are missing and config defaults are unset", async () => {
     const requestSpy = vi.fn().mockResolvedValue(rawApiResponse);
     const client = makeClient(requestSpy);

--- a/tests/registry/sto-exemptions.test.ts
+++ b/tests/registry/sto-exemptions.test.ts
@@ -242,19 +242,19 @@ describe("security_exemption list — registry dispatch", () => {
     expect(requestSpy).not.toHaveBeenCalled();
   });
 
-  it("maps exemption_statuses to status before required-filter validation", async () => {
+  it("rejects exemption_statuses with a targeted miskey error", async () => {
     const requestSpy = vi.fn().mockResolvedValue(rawApiResponse);
     const client = makeClient(requestSpy);
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "sto" }));
 
-    await registry.dispatch(client, "security_exemption", "list", {
-      exemption_statuses: ["pending"],
-      org_id: "AI_Devops",
-      project_id: "Sanity",
-    });
-
-    const callArgs = requestSpy.mock.calls[0]![0] as { params: Record<string, unknown> };
-    expect(callArgs.params.status).toBe("Pending");
+    await expect(
+      registry.dispatch(client, "security_exemption", "list", {
+        exemption_statuses: ["pending"],
+        org_id: "AI_Devops",
+        project_id: "Sanity",
+      }),
+    ).rejects.toThrow(/use filters\.status for security_exemption/i);
+    expect(requestSpy).not.toHaveBeenCalled();
   });
 
   it("fails loud when org_id and project_id are missing and config defaults are unset", async () => {


### PR DESCRIPTION
## Summary

- Validate project/org scope before `harness_list` dispatch so missing `org_id`/`project_id` (common when `HARNESS_ORG` / `HARNESS_PROJECT` env defaults are unset in multi-user HTTP mode) returns a clear error instead of STO HTTP 500 → opaque MCP `-32603`.
- Narrow `harness_list` `filters` schema description — stop dumping every filter name from all resource types; point agents to `harness_describe(resource_type=…)` instead.
- Update `security_exemption` describe text to tell agents to pass org/project explicitly when env defaults are unset, and to use `filters.status` (documented on the resource via `listFilterFields` / `harness_describe`).

No per-resource filter alias or miskey shims — wrong keys fail via generic required-filter validation.

## Test plan

- [x] `pnpm test tests/registry/list-filter-utils.test.ts tests/registry/sto-exemptions.test.ts`
- [x] `pnpm typecheck`
- [ ] List pending exemptions with org/project in the tool call — succeeds on first call
- [ ] List without scope in multi-user mode — returns actionable scope error (not `-32603`)