### PR TITLE
feat: add Evidence Vault attestation download URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1605,12 +1605,12 @@ SEI resources are consolidated for token efficiency. Use `metric` or `aspect` pa
 
 ### Evidence Vault
 
-Evidence Vault stores in-toto attestations (SDLC evidences). List supports account/org/project scope via `resource_scope`. Singular free-text filters (pipeline, artifact alone, gitoid) use `search_term`; an additional Name constraint uses `filters.subject_name`; subject content digest uses `filters.subject_digest`. Get looks up by `gitoid_sha256` and requires `org_id`/`project_id` (from the list row). Requires feature flag `SCS_EVIDENCE_VAULT`.
+Evidence Vault stores in-toto attestations (SDLC evidences). List supports account/org/project scope via `resource_scope`. Singular free-text filters (pipeline, artifact alone, gitoid) use `search_term`; an additional Name constraint uses `filters.subject_name`; subject content digest uses `filters.subject_digest`. Get looks up by `gitoid_sha256` and requires `org_id`/`project_id` (from the list row). Download (`harness_execute` action `download`) returns a time-limited `download_url` — always show that link to the user. Requires feature flag `SCS_EVIDENCE_VAULT`.
 
 
 | Resource Type | List | Get | Create | Update | Delete | Execute Actions |
 | ------------- | ---- | --- | ------ | ------ | ------ | --------------- |
-| `attestation` | x    | x   |        |        |        |                 |
+| `attestation` | x    | x   |        |        |        | `download`      |
 
 
 

--- a/src/registry/toolsets/evidence-vault.ts
+++ b/src/registry/toolsets/evidence-vault.ts
@@ -172,6 +172,18 @@ export function attestationDetailsExtract(raw: unknown): Record<string, unknown>
   return out;
 }
 
+/** Presigned download URL — surface download_url to the user; do not fetch the blob. */
+export function attestationDownloadExtract(raw: unknown): Record<string, unknown> {
+  if (!isRecord(raw)) return {};
+  const out: Record<string, unknown> = {};
+  if (asString(raw.download_url)) out.download_url = raw.download_url;
+  if (asNumber(raw.expires_at) !== undefined) out.expires_at = raw.expires_at;
+  out._display_hint =
+    "ALWAYS show download_url as a clickable download link to the user. "
+    + "Do not omit it or only summarize. The URL expires at expires_at (epoch ms).";
+  return out;
+}
+
 export const evidenceVaultToolset: ToolsetDefinition = {
   name: "evidence-vault",
   displayName: "Evidence Vault",
@@ -184,11 +196,13 @@ export const evidenceVaultToolset: ToolsetDefinition = {
       displayName: "Attestation",
       description:
         "Evidence Vault attestation (in-toto evidence). "
-        + "List: always show gitoid_sha256 in tables; retain gitoid_sha256 + org + project for get. "
+        + "List: always show gitoid_sha256 in tables; retain gitoid_sha256 + org + project for get/download. "
         + "Get: harness_get(resource_id=<gitoid_sha256>, org_id, project_id) — lookup by gitoid only. "
+        + "Download: harness_execute(action='download', resource_id=<gitoid_sha256>, org_id, project_id) — "
+        + "returns a time-limited download_url; ALWAYS show that URL as a clickable link to the user. "
         + "Singular free-text (pipeline, artifact alone, gitoid) → search_term; additional Name → filters.subject_name; "
         + "subject digest → filters.subject_digest (not gitoid). Use item `description` to explain a single attestation. "
-        + "Default list scope is account; get requires org_id and project_id. Requires SCS_EVIDENCE_VAULT.",
+        + "Default list scope is account; get/download require org_id and project_id. Requires SCS_EVIDENCE_VAULT.",
       searchAliases: [
         "evidence vault",
         "attestation",
@@ -251,6 +265,23 @@ export const evidenceVaultToolset: ToolsetDefinition = {
           defaultQueryParams: { identifier_type: "gitoid_sha256" },
           responseExtractor: attestationDetailsExtract,
           description: "Get attestation details by gitoid_sha256",
+        },
+      },
+      executeActions: {
+        download: {
+          method: "GET",
+          path: `${SCS}/v2/orgs/{org}/projects/{project}/attestations/download-attestation/{digest}`,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          pathParams: {
+            org_id: "org",
+            project_id: "project",
+            gitoid_sha256: "digest",
+          },
+          responseExtractor: attestationDownloadExtract,
+          actionDescription:
+            "Get a time-limited pre-signed URL for the DSSE attestation blob. "
+            + "ALWAYS show download_url as a clickable link to the user; do not omit it or only summarize.",
+          bodySchema: { description: "No body", fields: [] },
         },
       },
     },

--- a/tests/registry/evidence-vault.test.ts
+++ b/tests/registry/evidence-vault.test.ts
@@ -4,6 +4,7 @@ import {
   buildAttestationListBody,
   attestationListExtract,
   attestationDetailsExtract,
+  attestationDownloadExtract,
 } from "../../src/registry/toolsets/evidence-vault.js";
 import { Registry } from "../../src/registry/index.js";
 import type { Config } from "../../src/config.js";
@@ -55,6 +56,12 @@ function getGetOp(): EndpointSpec {
   return spec;
 }
 
+function getDownloadOp(): EndpointSpec {
+  const spec = findResource("attestation").executeActions?.download;
+  if (!spec) throw new Error("download execute action missing on attestation");
+  return spec;
+}
+
 describe("evidence-vault toolset", () => {
   it("registers attestation list against /ssca-manager/v2/attestations", () => {
     expect(evidenceVaultToolset.name).toBe("evidence-vault");
@@ -89,6 +96,20 @@ describe("evidence-vault toolset", () => {
     });
     expect(get.defaultQueryParams).toEqual({ identifier_type: "gitoid_sha256" });
     expect(get.operationPolicy).toEqual({ risk: "read", retryPolicy: "safe" });
+  });
+
+  it("registers attestation download execute action against download-attestation path", () => {
+    const download = getDownloadOp();
+    expect(download.method).toBe("GET");
+    expect(download.path).toBe(
+      "/ssca-manager/v2/orgs/{org}/projects/{project}/attestations/download-attestation/{digest}",
+    );
+    expect(download.pathParams).toEqual({
+      org_id: "org",
+      project_id: "project",
+      gitoid_sha256: "digest",
+    });
+    expect(download.operationPolicy).toEqual({ risk: "read", retryPolicy: "safe" });
   });
 
   it("loads into Registry by default", () => {
@@ -369,5 +390,75 @@ describe("attestation get dispatch", () => {
     await expect(
       registry.dispatch(makeClient(), "attestation", "get", { gitoid_sha256: "gid123" }),
     ).rejects.toThrow(/org_id/);
+  });
+});
+
+describe("attestationDownloadExtract", () => {
+  it("keeps download_url and expires_at with display hint", () => {
+    const result = attestationDownloadExtract({
+      download_url: "https://s3.example/presigned?X=1",
+      expires_at: 1700003600000,
+      extra: "drop-me",
+    });
+    expect(result).toEqual({
+      download_url: "https://s3.example/presigned?X=1",
+      expires_at: 1700003600000,
+      _display_hint: expect.stringMatching(/download_url/),
+    });
+    expect(result).not.toHaveProperty("extra");
+  });
+});
+
+describe("attestation download dispatch", () => {
+  it("GETs download-attestation path with gitoid as digest", async () => {
+    const request = vi.fn().mockResolvedValue({
+      download_url: "https://s3.example/presigned",
+      expires_at: 1700003600000,
+    });
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "evidence-vault" }));
+    const result = await registry.dispatchExecute(makeClient(request), "attestation", "download", {
+      org_id: "SSCA",
+      project_id: "Sanity",
+      gitoid_sha256: "gid123",
+    });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    const opts = request.mock.calls[0]![0] as {
+      method: string;
+      path: string;
+    };
+    expect(opts.method).toBe("GET");
+    expect(opts.path).toBe(
+      "/ssca-manager/v2/orgs/SSCA/projects/Sanity/attestations/download-attestation/gid123",
+    );
+    expect(result).toMatchObject({
+      download_url: "https://s3.example/presigned",
+      expires_at: 1700003600000,
+      _display_hint: expect.stringMatching(/download_url/),
+    });
+  });
+
+  it("requires org_id and project_id for download", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "evidence-vault" }));
+    await expect(
+      registry.dispatchExecute(makeClient(), "attestation", "download", { gitoid_sha256: "gid123" }),
+    ).rejects.toThrow(/org_id/);
+  });
+
+  it("allows download under HARNESS_READ_ONLY (risk read)", async () => {
+    const request = vi.fn().mockResolvedValue({
+      download_url: "https://s3.example/presigned",
+      expires_at: 1700003600000,
+    });
+    const registry = new Registry(
+      makeConfig({ HARNESS_TOOLSETS: "evidence-vault", HARNESS_READ_ONLY: true }),
+    );
+    await expect(
+      registry.dispatchExecute(makeClient(request), "attestation", "download", {
+        org_id: "SSCA",
+        project_id: "Sanity",
+        gitoid_sha256: "gid123",
+      }),
+    ).resolves.toMatchObject({ download_url: "https://s3.example/presigned" });
   });
 });


### PR DESCRIPTION
## Description
- Add `harness_execute` action `download` on Evidence Vault `attestation` via `GET /ssca-manager/v2/orgs/{org}/projects/{project}/attestations/download-attestation/{digest}`
- Lookup by `gitoid_sha256` (same identifier as get); requires `org_id`/`project_id` from the list row
- Returns a time-limited `download_url` + `expires_at` (MCP does not fetch the blob); agents/clients must show the URL as a download link to the user

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [x] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
If this PR adds or changes Harness API coverage:
- [x] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [x] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [x] `operationPolicy` on every new/changed endpoint
- [x] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [x] `identifierFields` and `scope` declared on new resources
- [x] No `console.log()` in `src/` (stdio JSON-RPC safety)
