### PR TITLE
fix: added new endpointspec to fix sbom download for scs toolset

### DIFF
--- a/src/registry/toolsets/scs.ts
+++ b/src/registry/toolsets/scs.ts
@@ -1,6 +1,7 @@
 import type { ToolsetDefinition, FilterFieldSpec, ParamsSchema } from "../types.js";
 import { scsCleanExtract, scsListExtract } from "../extractors.js";
 import { HarnessApiError } from "../../utils/errors.js";
+import { isRecord, asString, asNumber } from "../../utils/type-guards.js";
 
 function filterFieldsToParamsSchema(fields: FilterFieldSpec[]): ParamsSchema {
   return {
@@ -320,6 +321,18 @@ function ensureArray(val: unknown): unknown[] | undefined {
  * Endpoints use /v1/ (most) or /v2/ (chain of custody).
  */
 const SCS = "/ssca-manager";
+
+/** Presigned SBOM download URL — surface download_url to the user; do not fetch the blob. */
+export function sbomDownloadExtract(raw: unknown): Record<string, unknown> {
+  if (!isRecord(raw)) return {};
+  const out: Record<string, unknown> = {};
+  if (asString(raw.download_url)) out.download_url = raw.download_url;
+  if (asNumber(raw.expires_at) !== undefined) out.expires_at = raw.expires_at;
+  out._display_hint =
+    "ALWAYS show download_url as a clickable download link to the user. "
+    + "Do not omit it or only summarize. The URL expires at expires_at (epoch ms).";
+  return out;
+}
 
 export const scsToolset: ToolsetDefinition = {
   name: "scs",
@@ -1486,9 +1499,15 @@ export const scsToolset: ToolsetDefinition = {
     {
       resourceType: "scs_sbom",
       displayName: "SBOM",
-      description: "Software Bill of Materials download. Requires an orchestration ID (from artifact chain of custody). "
-        + "Use this to download the full SBOM for an artifact build.",
-      diagnosticHint: "If you get a 404: verify orchestration_id is correct. Get orchestration IDs from harness_get(resource_type='scs_chain_of_custody', artifact_id='...').",
+      description: "Software Bill of Materials download via a time-limited pre-signed URL. "
+        + "Requires an orchestration ID from artifact chain of custody: "
+        + "harness_get(resource_type='scs_chain_of_custody', artifact_id='...') then "
+        + "harness_get(resource_type='scs_sbom', orchestration_id=...). "
+        + "Returns download_url + expires_at — ALWAYS show download_url as a clickable download link to the user; "
+        + "do not fetch or dump the SBOM blob into the conversation.",
+      diagnosticHint: "If you get a 404: verify orchestration_id is correct. "
+        + "Get orchestration IDs from harness_get(resource_type='scs_chain_of_custody', artifact_id='...'). "
+        + "Confirm the orchestration run produced an SBOM.",
       searchAliases: ["sbom", "software bill of materials", "bom", "sbom download"],
       relatedResources: [
         { resourceType: "scs_chain_of_custody", relationship: "parent", description: "Get orchestration_id needed for SBOM download" },
@@ -1500,11 +1519,12 @@ export const scsToolset: ToolsetDefinition = {
         get: {
           method: "GET",
           // Note: this endpoint uses singular org/project (no 's') — API inconsistency
-          path: `${SCS}/v1/org/{org}/project/{project}/orchestration/{orchestrationId}/sbom-download`,
+          path: `${SCS}/v1/org/{org}/project/{project}/orchestration/{orchestrationId}/download-sbom`,
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           pathParams: { org_id: "org", project_id: "project", orchestration_id: "orchestrationId" },
-          responseExtractor: scsCleanExtract,
-          description: "Get SBOM download URL for an orchestration run",
+          responseExtractor: sbomDownloadExtract,
+          description: "Get a time-limited pre-signed URL for the SBOM object. "
+            + "ALWAYS show download_url as a clickable link to the user; do not omit it or only summarize.",
         },
       },
     },

--- a/tests/registry/scs.test.ts
+++ b/tests/registry/scs.test.ts
@@ -10,7 +10,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { scsCleanExtract, scsListExtract } from "../../src/registry/extractors.js";
 import { compactItems } from "../../src/utils/compact.js";
-import { scsToolset, normalizePurl } from "../../src/registry/toolsets/scs.js";
+import { scsToolset, normalizePurl, sbomDownloadExtract } from "../../src/registry/toolsets/scs.js";
 import { HarnessApiError } from "../../src/utils/errors.js";
 import { Registry } from "../../src/registry/index.js";
 import type { Config } from "../../src/config.js";
@@ -2297,5 +2297,89 @@ describe("scs_auto_pr_config path and scope", () => {
     expect(call.path).toContain("/v1/ssca-config/auto-pr-config");
     // Scope travels as query params under the configured names.
     expect(call.params).toMatchObject({ org_id: "myOrg", project_id: "myProj" });
+  });
+});
+
+describe("sbomDownloadExtract", () => {
+  it("keeps download_url and expires_at with display hint", () => {
+    const result = sbomDownloadExtract({
+      download_url: "https://s3.example/presigned?X=1",
+      expires_at: 1700003600000,
+      extra: "drop-me",
+    });
+    expect(result).toEqual({
+      download_url: "https://s3.example/presigned?X=1",
+      expires_at: 1700003600000,
+      _display_hint: expect.stringMatching(/download_url/),
+    });
+    expect(result).not.toHaveProperty("extra");
+  });
+
+  it("returns empty object for non-object input", () => {
+    expect(sbomDownloadExtract(null)).toEqual({});
+  });
+});
+
+describe("scs_sbom download dispatch", () => {
+  it("GETs download-sbom path with orchestration_id", async () => {
+    const request = vi.fn().mockResolvedValue({
+      download_url: "https://s3.example/presigned",
+      expires_at: 1700003600000,
+    });
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "scs" }));
+    const result = await registry.dispatch(makeClient(request), "scs_sbom", "get", {
+      org_id: "SSCA",
+      project_id: "Sanity",
+      orchestration_id: "orch-123",
+    });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    const opts = request.mock.calls[0]![0] as {
+      method: string;
+      path: string;
+    };
+    expect(opts.method).toBe("GET");
+    expect(opts.path).toBe(
+      "/ssca-manager/v1/org/SSCA/project/Sanity/orchestration/orch-123/download-sbom",
+    );
+    expect(opts.path).not.toContain("sbom-download");
+    expect(result).toMatchObject({
+      download_url: "https://s3.example/presigned",
+      expires_at: 1700003600000,
+      _display_hint: expect.stringMatching(/download_url/),
+    });
+  });
+
+  it("scs_sbom get uses sbomDownloadExtract and keeps CoC as parent for orchestration_id", () => {
+    const res = findResource("scs_sbom");
+    expect(res.operations.get?.path).toContain("/download-sbom");
+    expect(res.operations.get?.responseExtractor?.name).toBe("sbomDownloadExtract");
+    expect(res.description).toMatch(/scs_chain_of_custody/);
+    expect(res.diagnosticHint).toMatch(/scs_chain_of_custody/);
+    expect(res.relatedResources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          resourceType: "scs_chain_of_custody",
+          relationship: "parent",
+        }),
+      ]),
+    );
+  });
+
+  it("allows scs_sbom get under HARNESS_READ_ONLY (risk read)", async () => {
+    const request = vi.fn().mockResolvedValue({
+      download_url: "https://s3.example/presigned",
+      expires_at: 1700003600000,
+    });
+    const registry = new Registry(
+      makeConfig({ HARNESS_TOOLSETS: "scs", HARNESS_READ_ONLY: true }),
+    );
+    await expect(
+      registry.dispatch(makeClient(request), "scs_sbom", "get", {
+        org_id: "SSCA",
+        project_id: "Sanity",
+        orchestration_id: "orch-123",
+      }),
+    ).resolves.toMatchObject({ download_url: "https://s3.example/presigned" });
   });
 });


### PR DESCRIPTION
## Description
- Fix `scs_sbom` get to call `getSbomDownloadUrl` (`.../orchestration/{id}/download-sbom`) instead of the old inline SBOM endpoint (`.../sbom-download`).
- Return a time-limited `download_url` + `expires_at` with an agent display hint.
- Leave chain-of-custody → `orchestration_id` discovery unchanged.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [x] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
If this PR adds or changes Harness API coverage:
- [x] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [x] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [x] `operationPolicy` on every new/changed endpoint
- [x] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [x] `identifierFields` and `scope` declared on new resources
- [x] No `console.log()` in `src/` (stdio JSON-RPC safety)
