### PR TITLE
fix: wrapped scs_chain_of_custody as structured content to fix schema validation error in mcp clients

### DIFF
--- a/src/registry/toolsets/scs.ts
+++ b/src/registry/toolsets/scs.ts
@@ -176,6 +176,21 @@ const componentRemediationExtract = (raw: unknown): unknown => {
 };
 
 /**
+ * Chain of custody get returns a top-level JSON array. MCP harness_get declares an
+ * output schema that requires structuredContent (objects only) — wrap as { items, total }.
+ */
+export function chainOfCustodyExtract(raw: unknown): Record<string, unknown> {
+  const cleaned = scsCleanExtract(raw);
+  if (Array.isArray(cleaned)) {
+    return { items: cleaned, total: cleaned.length };
+  }
+  if (cleaned !== null && typeof cleaned === "object") {
+    return cleaned as Record<string, unknown>;
+  }
+  return { items: [], total: 0 };
+}
+
+/**
  * Custom extractor for scs_project_security_overview.
  * The agent tends to calculate percentages and invent total component counts
  * that are not present in the API response.
@@ -683,7 +698,7 @@ export const scsToolset: ToolsetDefinition = {
           path: `${SCS}/v2/orgs/{org}/projects/{project}/artifacts/{artifact}/chain-of-custody`,
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           pathParams: { org_id: "org", project_id: "project", artifact_id: "artifact" },
-          responseExtractor: scsCleanExtract,
+          responseExtractor: chainOfCustodyExtract,
           description: "Get chain of custody events for an artifact",
         },
       },

--- a/tests/registry/scs.test.ts
+++ b/tests/registry/scs.test.ts
@@ -283,6 +283,22 @@ describe("T11-v2: ID retention hints in descriptions", () => {
     expect(res.description).toContain("SBOM");
   });
 
+  it("scs_chain_of_custody get wraps arrays for MCP structuredContent", async () => {
+    const { chainOfCustodyExtract } = await import("../../src/registry/toolsets/scs.js");
+    const raw = [
+      { orchestration: { id: "orch-1" }, type: "SBOM", empty: null },
+      { orchestration: { id: "orch-2" }, type: "SLSA", name: "" },
+    ];
+    expect(chainOfCustodyExtract(raw)).toEqual({
+      items: [
+        { orchestration: { id: "orch-1" }, type: "SBOM" },
+        { orchestration: { id: "orch-2" }, type: "SLSA" },
+      ],
+      total: 2,
+    });
+    expect(findResource("scs_chain_of_custody").operations.get?.responseExtractor).toBe(chainOfCustodyExtract);
+  });
+
   it("scs_artifact_component description mentions retaining purl", () => {
     const res = findResource("scs_artifact_component");
     expect(res.description).toContain("purl");


### PR DESCRIPTION
## Description
- `harness_get(resource_type=scs_chain_of_custody)` was failing Cursor output validation: the SCS API returns a bare JSON array, and MCP `structuredContent` requires an object
- Add `chainOfCustodyExtract` in the SCS toolset: run `scsCleanExtract`, then wrap arrays as `{ items, total }`
- No changes to `harness_get` / shared response formatters
- Error
```
resource_type
scs_chain_of_custody
params
{ "artifact_id": "<id>" }
MCP error -32602: Output validation error: Tool harness_get has an output schema but no structured content was provided
```

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [x] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
If this PR adds or changes Harness API coverage:
- [x] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [x] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [x] `operationPolicy` on every new/changed endpoint
- [x] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [x] `identifierFields` and `scope` declared on new resources
- [x] No `console.log()` in `src/` (stdio JSON-RPC safety)
