### PR TITLE
Add GenAI perspective group_by mappings and cost_timeseries compactItem

### DIFF
--- a/src/registry/toolsets/ccm.ts
+++ b/src/registry/toolsets/ccm.ts
@@ -151,16 +151,6 @@ const VALID_TIME_FILTERS = [
   "LAST_6_MONTHS", "LAST_12_MONTHS",
 ] as const;
 
-const VALID_GROUP_BY_FIELDS = [
-  "region", "awsUsageaccountid", "awsServicecode", "awsBillingEntity",
-  "awsInstancetype", "awsLineItemType", "awspayeraccountid", "awsUsageType",
-  "cloudProvider", "none", "product",
-  // GenAI / AI (identifier "AI") — drill-down dimensions for the DEFAULT "GenAI"
-  // perspective (providers: Anthropic, Cursor, Devin, OpenAI).
-  "genAIModel", "genAIProvider", "genAIUsageType", "genAIPrincipal",
-  "genAIPrincipalId", "genAISubAccountId", "genAISubProvider",
-] as const;
-
 const OUTPUT_FIELDS: Record<string, Record<string, string>> = {
   region:              { fieldId: "region",              fieldName: "Region",         identifier: "COMMON", identifierName: "Common" },
   awsUsageaccountid:   { fieldId: "awsUsageaccountid",   fieldName: "Account",        identifier: "AWS",    identifierName: "AWS" },
@@ -177,6 +167,8 @@ const OUTPUT_FIELDS: Record<string, Record<string, string>> = {
   // perspective UI (Model, Provider, Token Type, Principal, …). Without these
   // entries buildGroupBy() falls through to LABEL_V2 and returns a single
   // "No <field>" bucket, since the raw string isn't a real label key.
+  // Drill-down dimensions for the DEFAULT "GenAI" perspective (providers:
+  // Anthropic, Cursor, Devin, OpenAI).
   genAIModel:          { fieldId: "genAIModel",          fieldName: "Model",          identifier: "AI",     identifierName: "AI" },
   genAIProvider:       { fieldId: "genAIProvider",       fieldName: "Provider",       identifier: "AI",     identifierName: "AI" },
   genAIUsageType:      { fieldId: "genAIUsageType",      fieldName: "Token Type",     identifier: "AI",     identifierName: "AI" },
@@ -185,6 +177,9 @@ const OUTPUT_FIELDS: Record<string, Record<string, string>> = {
   genAISubAccountId:   { fieldId: "genAISubAccountId",   fieldName: "Sub Account ID", identifier: "AI",     identifierName: "AI" },
   genAISubProvider:    { fieldId: "genAISubProvider",    fieldName: "Sub Provider",   identifier: "AI",     identifierName: "AI" },
 };
+
+/** Public predefined group_by list — derived from OUTPUT_FIELDS so descriptions can't drift from wire mappings. */
+const VALID_GROUP_BY_FIELDS = Object.keys(OUTPUT_FIELDS);
 
 /**
  * Build the startTime AFTER/BEFORE timeFilter pair from an explicit epoch-ms

--- a/src/registry/toolsets/ccm.ts
+++ b/src/registry/toolsets/ccm.ts
@@ -360,6 +360,37 @@ function buildPreferences(): Record<string, unknown> {
 }
 
 // ---------------------------------------------------------------------------
+// Compact a perspectiveTimeSeriesStats data point. Each stat is
+// { time, values: [{ key: { id, name, type }, value }] }. None of these
+// fields match the generic compaction whitelist, so without a resource-specific
+// compactItem the whole stat is stripped to `{}` (see harness-list compact pass).
+// Keep `time` and a slimmed `values` array; drop __typename noise.
+// ---------------------------------------------------------------------------
+
+function compactTimeseriesStat(item: Record<string, unknown>): Record<string, unknown> {
+  const slim: Record<string, unknown> = {};
+  if (typeof item.time === "number") slim.time = item.time;
+  if (Array.isArray(item.values)) {
+    slim.values = item.values.map((entry) => {
+      if (entry === null || typeof entry !== "object" || Array.isArray(entry)) return entry;
+      const e = entry as Record<string, unknown>;
+      const out: Record<string, unknown> = {};
+      if (e.key !== null && typeof e.key === "object" && !Array.isArray(e.key)) {
+        const k = e.key as Record<string, unknown>;
+        const keyOut: Record<string, unknown> = {};
+        if (k.id !== undefined) keyOut.id = k.id;
+        if (k.name !== undefined) keyOut.name = k.name;
+        if (k.type !== undefined) keyOut.type = k.type;
+        out.key = keyOut;
+      }
+      if (e.value !== undefined) out.value = e.value;
+      return out;
+    });
+  }
+  return slim;
+}
+
+// ---------------------------------------------------------------------------
 // GraphQL endpoint path helper
 // ---------------------------------------------------------------------------
 
@@ -900,6 +931,7 @@ Optional: time_filter (${VALID_TIME_FILTERS.join(", ")}), time_resolution (DAY, 
       toolset: "ccm",
       scope: "account",
       identifierFields: ["perspective_id"],
+      compactItem: compactTimeseriesStat,
       listFilterFields: [
         { name: "group_by", description: "Group results by field. Use predefined fields (region, product, etc.) OR any label key name (env, team, app, etc.)" },
         { name: "time_filter", description: "Time range filter", enum: [...VALID_TIME_FILTERS] },

--- a/src/registry/toolsets/ccm.ts
+++ b/src/registry/toolsets/ccm.ts
@@ -155,6 +155,10 @@ const VALID_GROUP_BY_FIELDS = [
   "region", "awsUsageaccountid", "awsServicecode", "awsBillingEntity",
   "awsInstancetype", "awsLineItemType", "awspayeraccountid", "awsUsageType",
   "cloudProvider", "none", "product",
+  // GenAI / AI (identifier "AI") — drill-down dimensions for the DEFAULT "GenAI"
+  // perspective (providers: Anthropic, Cursor, Devin, OpenAI).
+  "genAIModel", "genAIProvider", "genAIUsageType", "genAIPrincipal",
+  "genAIPrincipalId", "genAISubAccountId", "genAISubProvider",
 ] as const;
 
 const OUTPUT_FIELDS: Record<string, Record<string, string>> = {
@@ -169,6 +173,17 @@ const OUTPUT_FIELDS: Record<string, Record<string, string>> = {
   cloudProvider:       { fieldId: "cloudProvider",        fieldName: "Cloud Provider", identifier: "COMMON", identifierName: "Common" },
   none:                { fieldId: "none",                 fieldName: "None",           identifier: "COMMON", identifierName: "Common" },
   product:             { fieldId: "product",              fieldName: "Product",        identifier: "COMMON", identifierName: "Common" },
+  // GenAI / AI dimensions — identifier "AI". fieldName values match the CCM
+  // perspective UI (Model, Provider, Token Type, Principal, …). Without these
+  // entries buildGroupBy() falls through to LABEL_V2 and returns a single
+  // "No <field>" bucket, since the raw string isn't a real label key.
+  genAIModel:          { fieldId: "genAIModel",          fieldName: "Model",          identifier: "AI",     identifierName: "AI" },
+  genAIProvider:       { fieldId: "genAIProvider",       fieldName: "Provider",       identifier: "AI",     identifierName: "AI" },
+  genAIUsageType:      { fieldId: "genAIUsageType",      fieldName: "Token Type",     identifier: "AI",     identifierName: "AI" },
+  genAIPrincipal:      { fieldId: "genAIPrincipal",      fieldName: "Principal",      identifier: "AI",     identifierName: "AI" },
+  genAIPrincipalId:    { fieldId: "genAIPrincipalId",    fieldName: "Principal Id",   identifier: "AI",     identifierName: "AI" },
+  genAISubAccountId:   { fieldId: "genAISubAccountId",   fieldName: "Sub Account ID", identifier: "AI",     identifierName: "AI" },
+  genAISubProvider:    { fieldId: "genAISubProvider",    fieldName: "Sub Provider",   identifier: "AI",     identifierName: "AI" },
 };
 
 /**

--- a/src/utils/compact.ts
+++ b/src/utils/compact.ts
@@ -8,7 +8,7 @@ const TIMESTAMP_PATTERN = /(?:At|Ts|Time|Date)$/;
 
 /** Fields to always keep when compacting list items. */
 const IDENTITY_FIELDS = new Set([
-  "identifier", "identity", "name", "displayName", "description", "slug",
+  "id", "uuid", "identifier", "identity", "name", "displayName", "description", "slug",
   "versionLabel", "sha", "title", "message",
 ]);
 

--- a/tests/registry/ccm-extractors.test.ts
+++ b/tests/registry/ccm-extractors.test.ts
@@ -11,6 +11,29 @@ import {
   ccmRecommendationsExtract,
   countExtract,
 } from "../../src/registry/extractors.js";
+import { Registry } from "../../src/registry/index.js";
+import { compactItems } from "../../src/utils/compact.js";
+import type { Config } from "../../src/config.js";
+
+function makeCcmConfig(): Config {
+  return {
+    HARNESS_API_KEY: "pat.test",
+    HARNESS_ACCOUNT_ID: "test-account",
+    HARNESS_BASE_URL: "https://app.harness.io",
+    HARNESS_ORG: "default",
+    HARNESS_PROJECT: "test-project",
+    HARNESS_API_TIMEOUT_MS: 30000,
+    HARNESS_MAX_RETRIES: 3,
+    HARNESS_MAX_BODY_SIZE_MB: 10,
+    HARNESS_RATE_LIMIT_RPS: 10,
+    HARNESS_READ_ONLY: false,
+    HARNESS_SKIP_ELICITATION: false,
+    HARNESS_ALLOW_HTTP: false,
+    HARNESS_FME_BASE_URL: "https://api.split.io",
+    LOG_LEVEL: "info",
+    HARNESS_TOOLSETS: "ccm",
+  } as Config;
+}
 
 describe("countExtract", () => {
   it("extracts numeric data from NG envelope", () => {
@@ -121,5 +144,48 @@ describe("ccmRecommendationsExtract", () => {
 
   it("returns empty items and undefined stats when data is missing", () => {
     expect(ccmRecommendationsExtract({})).toEqual({ items: [], stats: undefined });
+  });
+});
+
+describe("cost_timeseries compactItem", () => {
+  // A perspectiveTimeSeriesStats data point: { time, values: [{ key: {id,name,type}, value }] }.
+  // None of these keys match the generic compaction whitelist, so without a
+  // resource-specific compactItem each stat is stripped to `{}` (regression:
+  // the AI cost chart returned [{},{},...]).
+  const stat = {
+    time: 1783468800000,
+    values: [
+      { key: { id: "ANTHROPIC", name: "Anthropic", type: "", __typename: "Ref" }, value: 696.18, __typename: "DataPoint" },
+    ],
+    __typename: "TimeSeriesDataPoints",
+  };
+
+  it("cost_timeseries resource exposes a compactItem function", () => {
+    const registry = new Registry(makeCcmConfig());
+    const resource = registry.getResource("cost_timeseries");
+    expect(typeof resource.compactItem).toBe("function");
+  });
+
+  it("preserves time and values (with slimmed keys) instead of stripping to {}", () => {
+    const registry = new Registry(makeCcmConfig());
+    const compactFn = registry.getResource("cost_timeseries").compactItem;
+    const [compacted] = compactItems([stat], compactFn) as Record<string, unknown>[];
+    expect(compacted).toEqual({
+      time: 1783468800000,
+      values: [{ key: { id: "ANTHROPIC", name: "Anthropic", type: "" }, value: 696.18 }],
+    });
+  });
+
+  it("would be stripped to {} without the compactItem (documents why it's needed)", () => {
+    const [stripped] = compactItems([stat]) as Record<string, unknown>[];
+    expect(stripped).toEqual({});
+  });
+
+  it("tolerates malformed stats without throwing", () => {
+    const registry = new Registry(makeCcmConfig());
+    const compactFn = registry.getResource("cost_timeseries").compactItem!;
+    expect(compactFn({})).toEqual({});
+    expect(compactFn({ time: 1, values: "not-an-array" })).toEqual({ time: 1 });
+    expect(compactFn({ values: [null, 42, { value: 5 }] })).toEqual({ values: [null, 42, { value: 5 }] });
   });
 });

--- a/tests/registry/ccm-time-filters.test.ts
+++ b/tests/registry/ccm-time-filters.test.ts
@@ -278,16 +278,18 @@ describe("CCM group_by mapping — GenAI (identifier 'AI') and label fallback", 
   let mockRequest: ReturnType<typeof vi.fn>;
   let client: HarnessClient;
 
-  const MOCK_RESPONSE = { data: { perspectiveGrid: { data: [] }, perspectiveTotalCount: 0 } };
+  const BREAKDOWN_RESPONSE = { data: { perspectiveGrid: { data: [] }, perspectiveTotalCount: 0 } };
+  const TIMESERIES_RESPONSE = { data: { perspectiveTimeSeriesStats: { stats: [] } } };
 
   beforeEach(() => {
     registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ccm" }));
-    mockRequest = vi.fn().mockResolvedValue(MOCK_RESPONSE);
+    mockRequest = vi.fn().mockResolvedValue(BREAKDOWN_RESPONSE);
     client = makeClient(mockRequest);
   });
 
   /** Pull the single entityGroupBy field object out of a cost_breakdown request. */
-  async function entityGroupBy(groupBy: string): Promise<Record<string, string>> {
+  async function breakdownEntityGroupBy(groupBy: string): Promise<Record<string, string>> {
+    mockRequest.mockResolvedValue(BREAKDOWN_RESPONSE);
     await registry.dispatch(client, "cost_breakdown", "list", {
       perspective_id: "test-perspective",
       time_filter: "LAST_30_DAYS",
@@ -296,6 +298,43 @@ describe("CCM group_by mapping — GenAI (identifier 'AI') and label fallback", 
     const call = mockRequest.mock.calls[0][0] as Record<string, unknown>;
     const body = call.body as { variables: { groupBy: Array<{ entityGroupBy: Record<string, string> }> } };
     return body.variables.groupBy[0].entityGroupBy;
+  }
+
+  /**
+   * cost_timeseries groupBy is [timeTruncGroupBy, entityGroupBy[0]] — assert the
+   * entity half of that chart-path shape so GenAI → AI can't regress independently
+   * of the breakdown path.
+   */
+  async function timeseriesGroupBy(
+    groupBy: string,
+  ): Promise<{
+    timeTrunc: { resolution: string };
+    entity: Record<string, string>;
+  }> {
+    mockRequest.mockResolvedValue(TIMESERIES_RESPONSE);
+    await registry.dispatch(client, "cost_timeseries", "list", {
+      perspective_id: "test-perspective",
+      time_filter: "LAST_30_DAYS",
+      time_resolution: "DAY",
+      group_by: groupBy,
+    });
+    const call = mockRequest.mock.calls[0][0] as Record<string, unknown>;
+    const body = call.body as {
+      variables: {
+        groupBy: Array<
+          | { timeTruncGroupBy: { resolution: string } }
+          | { entityGroupBy: Record<string, string> }
+        >;
+      };
+    };
+    expect(body.variables.groupBy).toHaveLength(2);
+    const [first, second] = body.variables.groupBy;
+    expect(first).toHaveProperty("timeTruncGroupBy");
+    expect(second).toHaveProperty("entityGroupBy");
+    return {
+      timeTrunc: (first as { timeTruncGroupBy: { resolution: string } }).timeTruncGroupBy,
+      entity: (second as { entityGroupBy: Record<string, string> }).entityGroupBy,
+    };
   }
 
   // Each genAI fieldId must resolve to identifier "AI" with the CCM UI fieldName —
@@ -311,14 +350,20 @@ describe("CCM group_by mapping — GenAI (identifier 'AI') and label fallback", 
   ];
 
   for (const [fieldId, fieldName] of GENAI_CASES) {
-    it(`${fieldId} → entityGroupBy identifier 'AI' (fieldName '${fieldName}')`, async () => {
-      const gb = await entityGroupBy(fieldId);
+    it(`cost_breakdown: ${fieldId} → entityGroupBy identifier 'AI' (fieldName '${fieldName}')`, async () => {
+      const gb = await breakdownEntityGroupBy(fieldId);
       expect(gb).toEqual({ fieldId, fieldName, identifier: "AI", identifierName: "AI" });
+    });
+
+    it(`cost_timeseries: ${fieldId} → [timeTrunc, entityGroupBy] with identifier 'AI'`, async () => {
+      const { timeTrunc, entity } = await timeseriesGroupBy(fieldId);
+      expect(timeTrunc).toEqual({ resolution: "DAY" });
+      expect(entity).toEqual({ fieldId, fieldName, identifier: "AI", identifierName: "AI" });
     });
   }
 
   it("unknown field still falls through to the LABEL_V2 label-key mapping", async () => {
-    const gb = await entityGroupBy("team");
+    const gb = await breakdownEntityGroupBy("team");
     expect(gb).toEqual({
       fieldId: "labels.value",
       fieldName: "team",

--- a/tests/registry/ccm-time-filters.test.ts
+++ b/tests/registry/ccm-time-filters.test.ts
@@ -272,3 +272,58 @@ describe("CCM custom time window — start_time/end_time override across perspec
     expect(before).toBe(Date.UTC(2026, 3, 30, 23, 59, 59, 999));
   });
 });
+
+describe("CCM group_by mapping — GenAI (identifier 'AI') and label fallback", () => {
+  let registry: Registry;
+  let mockRequest: ReturnType<typeof vi.fn>;
+  let client: HarnessClient;
+
+  const MOCK_RESPONSE = { data: { perspectiveGrid: { data: [] }, perspectiveTotalCount: 0 } };
+
+  beforeEach(() => {
+    registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "ccm" }));
+    mockRequest = vi.fn().mockResolvedValue(MOCK_RESPONSE);
+    client = makeClient(mockRequest);
+  });
+
+  /** Pull the single entityGroupBy field object out of a cost_breakdown request. */
+  async function entityGroupBy(groupBy: string): Promise<Record<string, string>> {
+    await registry.dispatch(client, "cost_breakdown", "list", {
+      perspective_id: "test-perspective",
+      time_filter: "LAST_30_DAYS",
+      group_by: groupBy,
+    });
+    const call = mockRequest.mock.calls[0][0] as Record<string, unknown>;
+    const body = call.body as { variables: { groupBy: Array<{ entityGroupBy: Record<string, string> }> } };
+    return body.variables.groupBy[0].entityGroupBy;
+  }
+
+  // Each genAI fieldId must resolve to identifier "AI" with the CCM UI fieldName —
+  // NOT the LABEL_V2 fallback that caused the "No <field>" single-bucket bug.
+  const GENAI_CASES: Array<[string, string]> = [
+    ["genAIModel", "Model"],
+    ["genAIProvider", "Provider"],
+    ["genAIUsageType", "Token Type"],
+    ["genAIPrincipal", "Principal"],
+    ["genAIPrincipalId", "Principal Id"],
+    ["genAISubAccountId", "Sub Account ID"],
+    ["genAISubProvider", "Sub Provider"],
+  ];
+
+  for (const [fieldId, fieldName] of GENAI_CASES) {
+    it(`${fieldId} → entityGroupBy identifier 'AI' (fieldName '${fieldName}')`, async () => {
+      const gb = await entityGroupBy(fieldId);
+      expect(gb).toEqual({ fieldId, fieldName, identifier: "AI", identifierName: "AI" });
+    });
+  }
+
+  it("unknown field still falls through to the LABEL_V2 label-key mapping", async () => {
+    const gb = await entityGroupBy("team");
+    expect(gb).toEqual({
+      fieldId: "labels.value",
+      fieldName: "team",
+      identifier: "LABEL_V2",
+      identifierName: "Label V2",
+    });
+  });
+});

--- a/tests/registry/scs.test.ts
+++ b/tests/registry/scs.test.ts
@@ -803,12 +803,13 @@ describe("T9-v2: compactItems effectiveness for SCS", () => {
 
     const [compacted] = compactItems([scsArtifact]) as Record<string, unknown>[];
 
-    // Only name and tags survive the generic whitelist
+    // name, tags, and the resource's own id survive the generic whitelist.
+    // (id is now retained so drill-down resources can key off it.)
     expect(compacted.name).toBeDefined();
     expect(compacted.tags).toBeDefined();
+    expect(compacted.id).toBe("6799da3b");
 
-    // All these critical SCS fields are dropped
-    expect(compacted.id).toBeUndefined();
+
     expect(compacted.digest).toBeUndefined();
     expect(compacted.url).toBeUndefined();
     expect(compacted.components_count).toBeUndefined();

--- a/tests/utils/compact.test.ts
+++ b/tests/utils/compact.test.ts
@@ -66,6 +66,15 @@ describe("compactItems", () => {
     expect(result[0]).toEqual({ pipelineIdentifier: "p1", projectId: "proj", env_id: "env1" });
   });
 
+  it("keeps bare id and uuid (the resource's own identifier)", () => {
+    // Regression: the IDENTIFIER_PATTERN /(?:Identifier|Id|_id)$/ matches folderId
+    // but NOT lowercase "id"/"uuid". Cost perspectives return their perspective_id
+    // as `id`; stripping it left the agent unable to call cost_breakdown.
+    const items = [{ id: "k0H5ygr7SriAlJNMgAapqg", uuid: "abc-123", name: "GenAI Cost", folderId: "F1" }];
+    const result = compactItems(items) as Record<string, unknown>[];
+    expect(result[0]).toEqual({ id: "k0H5ygr7SriAlJNMgAapqg", uuid: "abc-123", name: "GenAI Cost", folderId: "F1" });
+  });
+
   it("strips verbose metadata fields", () => {
     const items = [{
       identifier: "p1",


### PR DESCRIPTION
## Description

- Map GenAI perspective `group_by` fields (`genAIModel`, `genAIProvider`, etc.) to CCM identifier `"AI"` with UI `fieldName`s, so cost breakdown/timeseries charts don't fall through to the LABEL_V2 `"No <field>"` single-bucket bug
- Add a `compactItem` override for `cost_timeseries` so chart series keep the fields agents need
- Keep a regression test that bare `id`/`uuid` are retained by `compactItems` (whitelist itself already landed on main via #790 — this PR does not change `IDENTITY_FIELDS`)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [x] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
If this PR adds or changes Harness API coverage:
- [ ] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [ ] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [ ] `operationPolicy` on every new/changed endpoint
- [ ] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [ ] `identifierFields` and `scope` declared on new resources
- [ ] No `console.log()` in `src/` (stdio JSON-RPC safety)