### PR TITLE
chore: bump version to 3.2.18

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "harness-mcp-server",
   "display_name": "Harness",
-  "version": "3.2.17",
+  "version": "3.2.18",
   "description": "Connect AI agents to Harness for CI/CD, code repositories, pull requests, services, environments, and feature flags.",
   "long_description": "The Harness MCP Server gives MCP-compatible clients access to Harness platform workflows through consolidated tools, resources, and prompts. It supports local stdio usage and can be bundled as a Node-based MCPB extension.",
   "author": {

--- a/mcp-directory/manifest.json
+++ b/mcp-directory/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "harness-mcp-server",
   "display_name": "Harness",
-  "version": "3.2.17",
+  "version": "3.2.18",
   "description": "Connect AI agents to Harness for CI/CD, code repositories, pull requests, services, environments, and feature flags.",
   "long_description": "The Harness MCP Server gives MCP-compatible clients access to Harness platform workflows through consolidated tools, resources, and prompts. It supports local stdio usage and can be bundled as a Node-based MCPB extension.",
   "author": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "harness-mcp-v2",
-  "version": "3.2.17",
+  "version": "3.2.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "harness-mcp-v2",
-      "version": "3.2.17",
+      "version": "3.2.18",
       "dependencies": {
         "@hono/node-server": "^2.0.10",
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-mcp-v2",
-  "version": "3.2.17",
+  "version": "3.2.18",
   "description": "Give AI agents full access to the Harness.io platform — manage pipelines, deployments, cloud costs, chaos engineering, feature flags, SEI, and 125+ resource types through 11 MCP tools",
   "type": "module",
   "main": "build/index.js",

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -24,7 +24,7 @@ describe("release metadata", () => {
     const rootManifest = readJson("manifest.json");
     const directoryManifest = readJson("mcp-directory/manifest.json");
 
-    expect(packageJson.version).toBe("3.2.17");
+    expect(packageJson.version).toBe("3.2.18");
     expect(rootManifest.version).toBe(packageJson.version);
     expect(directoryManifest.version).toBe(packageJson.version);
   });


### PR DESCRIPTION
## Summary
- Bump package and bundle metadata from \`3.2.17\` to \`3.2.18\` for the next release.
- Keep \`package.json\`, root \`manifest.json\`, \`mcp-directory/manifest.json\`, \`npm-shrinkwrap.json\`, and the release-metadata test expectation in sync.

## Test plan
- [x] \`pnpm exec vitest run tests/release-metadata.test.ts\` (3 passed)
- [x] \`pnpm typecheck\`
- [ ] CI PR checks