### PR TITLE
feat: [CCM-33565]: added support for ccm budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![MCP Toplist](https://mcptoplist.com/badge/glama%2Fharness%2Fmcp-server.svg)](https://mcptoplist.com/server/glama%2Fharness%2Fmcp-server)
 
-An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 220 resource types.
+An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 223 resource types.
 
 ## Why Use This MCP Server
 
@@ -10,7 +10,7 @@ Most MCP servers map one tool per API endpoint. For a platform as broad as Harne
 
 This server is built differently:
 
-- **11 tools, 220 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
+- **11 tools, 223 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
 - **Full platform coverage.** 38 default toolsets spanning CI/CD, GitOps, Feature Flags, Cloud Cost Management, Security Testing, Chaos Engineering, Database DevOps, Internal Developer Portal, Software Supply Chain, Infrastructure as Code Management, Governance, Service Overrides, Knowledge Graph, and more. Opt-in Ansible coverage is available when you need inventory and playbook data.
 - **Multi-project workflows out of the box.** Agents discover organizations and projects dynamically — no hardcoded env vars needed. Ask "show failed executions across all projects" and the agent can navigate the full account hierarchy.
 - **34 prompt templates.** Pre-built prompts for common workflows: build & deploy apps end-to-end, debug failed pipelines, review DORA metrics, triage vulnerabilities, optimize cloud costs, audit access control, plan feature flag rollouts, review pull requests, approve pending pipelines, and more.
@@ -1202,7 +1202,7 @@ Harness pipelines can be stored in three ways:
 
 ## Resource Types
 
-220 resource types organized across 38 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
+223 resource types organized across 38 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
 
 ### Platform
 
@@ -1857,7 +1857,7 @@ Available toolset names:
                  +--------v---------+
                 |    Registry       |  <-- Declarative resource definitions
                 |  38 Toolsets      |      (data files, not code)
-                |  220 Resource Types|
+                |  223 Resource Types|
                  +--------+---------+
                           |
                  +--------v---------+

--- a/src/registry/extractors.ts
+++ b/src/registry/extractors.ts
@@ -12,6 +12,30 @@ export const ngExtract = (raw: unknown): unknown => {
   return r.data ?? raw;
 };
 
+/**
+ * Extractor for CCM budget/budget-group writes (create, update, clone). These
+ * endpoints return the new/affected entity ID as a BARE STRING under `data`:
+ * `{ status: "SUCCESS", data: "<budgetId>" }`. The write tools (harness_create
+ * etc.) declare an object outputSchema, so a bare string fails structured-content
+ * validation. Wrap the id into `{ id, status }` so callers get a usable object.
+ * Falls back to ngExtract behavior for object payloads (e.g. DELETE returning
+ * `{ data: true }` or a full entity).
+ */
+export const ccmBudgetWriteExtract = (raw: unknown): unknown => {
+  if (raw === null || raw === undefined) return raw;
+  const r = raw as { data?: unknown; status?: unknown };
+  if (typeof r.data === "string") {
+    // create/clone return the new entity id (no spaces); delete returns a
+    // human-readable confirmation message (e.g. "Successfully deleted the budget").
+    const key = /\s/.test(r.data) ? "message" : "id";
+    return { [key]: r.data, status: r.status ?? "SUCCESS" };
+  }
+  if (typeof r.data === "boolean" || typeof r.data === "number") {
+    return { result: r.data, status: r.status ?? "SUCCESS" };
+  }
+  return r.data ?? raw;
+};
+
 /** Extract paginated content from NG API responses: `{ data: { content, totalElements|totalItems } }` */
 export const pageExtract = (raw: unknown): { items: unknown[]; total: number } => {
   const r = raw as { data?: { content?: unknown[]; totalElements?: number; totalItems?: number } };
@@ -442,6 +466,106 @@ export const ccmViewsExtract = (raw: unknown): { items: unknown[]; total: number
   return {
     items: r.data?.views ?? [],
     total: r.data?.totalCount ?? 0,
+  };
+};
+
+/**
+ * CCM budget list (POST /ccm/api/budgets/v2/list) — keep the essential budget
+ * health fields and drop noise. Strips alertThresholds (contains emails),
+ * budgetMonthlyBreakdown (mostly zeros), and internal UUIDs.
+ *
+ * Response shape: `{ status, data: { summaries: [...], totalCount: N } }`.
+ * Falls back to the standard paged shape if `summaries` is absent.
+ */
+export const ccmBudgetListCompactExtract = (raw: unknown): { items: unknown[]; total: number } => {
+  const r = raw as { data?: { summaries?: unknown[]; totalCount?: number } };
+  let items: unknown[] = r.data?.summaries ?? [];
+  let total = typeof r.data?.totalCount === "number" ? r.data.totalCount : items.length;
+
+  if (items.length === 0) {
+    const paged = pageExtract(raw);
+    items = paged.items;
+    total = paged.total;
+  }
+
+  const compact = items.map((item) => {
+    if (!isRecord(item)) return item;
+    return {
+      id: item.uuid ?? item.id,
+      name: item.name,
+      perspectiveId: item.perspectiveId,
+      perspectiveName: item.perspectiveName,
+      budgetAmount: item.budgetAmount,
+      actualCost: item.actualCost,
+      forecastCost: item.forecastCost,
+      timeLeft: item.timeLeft,
+      timeUnit: item.timeUnit,
+      period: item.period,
+      type: item.type,
+      growthRate: item.growthRate,
+      actualCostAlerts: item.actualCostAlerts,
+      forecastCostAlerts: item.forecastCostAlerts,
+      budgetGroup: item.budgetGroup,
+      folderId: item.folderId,
+    };
+  });
+
+  return { items: compact, total };
+};
+
+/**
+ * CCM budget variance detail — per-period actual-vs-budgeted time-series.
+ *
+ * Sourced from the REST budget detail (`GET /ccm/api/budgets/{id}`), which
+ * returns a populated `budgetHistory` map keyed by period-start epoch-ms. The
+ * GraphQL `FetchBudgetsGridData` grid resolver returns empty `costData` even
+ * for budgets with history, so we derive the series from budgetHistory instead.
+ *
+ * Each history entry: `{ time, endTime, actualCost, forecastCost, budgeted,
+ * budgetVariance, budgetVariancePercentage }`. We sort ascending by `time` so
+ * the last row is the current (partial) period. Also handles budget GROUPS,
+ * whose detail carries the same shape under `budgetGroupHistory`.
+ *
+ * Response shape: `{ data: { budgetHistory: {ts: {...}}, forecastCost, period,
+ * name, budgetAmount, ... } }` (NG-wrapped).
+ */
+export const ccmBudgetDetailExtract = (raw: unknown): unknown => {
+  const r = raw as {
+    data?: Record<string, unknown>;
+    // GraphQL fallback shape (kept for safety if the resolver ever returns data)
+    errors?: unknown;
+  };
+  const d = isRecord(r?.data) ? r.data : isRecord(raw) ? (raw as Record<string, unknown>) : undefined;
+  if (!d) return raw;
+
+  const history = (d.budgetHistory ?? d.budgetGroupHistory) as
+    | Record<string, unknown>
+    | undefined;
+
+  let costData: unknown[] = [];
+  if (isRecord(history)) {
+    costData = Object.values(history)
+      .filter(isRecord)
+      .map((e) => ({
+        time: e.time,
+        endTime: e.endTime,
+        actualCost: e.actualCost,
+        forecastCost: e.forecastCost,
+        budgeted: e.budgeted,
+        budgetVariance: e.budgetVariance,
+        budgetVariancePercentage: e.budgetVariancePercentage,
+      }))
+      .sort((a, b) => Number(a.time ?? 0) - Number(b.time ?? 0));
+  }
+
+  return {
+    budgetId: d.uuid ?? d.id,
+    name: d.name,
+    period: d.period,
+    budgetAmount: d.budgetAmount ?? d.budgetGroupAmount,
+    forecastCost: d.forecastCost,
+    actualCost: d.actualCost,
+    costData,
   };
 };
 

--- a/src/registry/toolsets/ccm.ts
+++ b/src/registry/toolsets/ccm.ts
@@ -1510,6 +1510,151 @@ For cost time-series data, use harness_get with start_time and end_time.`,
     },
 
     // ------------------------------------------------------------------
+    // 7b. cost_budget — REST CRUD for CCM budgets (/ccm/api/budgets)
+    // ------------------------------------------------------------------
+    {
+      resourceType: "cost_budget",
+      displayName: "Cost Budget",
+      description:
+        "Cloud cost budgets — set spend targets and receive alerts when costs exceed (or are forecasted to exceed) the budget. Use harness_list to see all budgets, harness_get with budget_id for details, harness_create/harness_update to manage them. Use the clone action to copy a budget and bulk_delete to delete several at once.",
+      toolset: "ccm",
+      scope: "account",
+      identifierFields: ["budget_id"],
+      deepLinkTemplate: "/ng/account/{accountId}/ce/budget",
+      listFilterFields: [
+        { name: "budget_sort_type", description: "Sort field", enum: ["BUDGET_AMOUNT", "NAME", "PERSPECTIVE", "ACTUAL_COST", "LAST_MONTH_COST", "FORECAST_COST"] },
+        { name: "sort_order", description: "Sort direction", enum: ["ASCENDING", "DESCENDING"] },
+      ],
+      operations: {
+        list: {
+          method: "GET",
+          path: "/ccm/api/budgets",
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          queryParams: {
+            budget_sort_type: "budgetSortType",
+            sort_order: "sortOrder",
+          },
+          responseExtractor: ngExtract,
+          description: "List all budgets for the account. Optionally sort with budget_sort_type and sort_order.",
+        },
+        get: {
+          method: "GET",
+          path: "/ccm/api/budgets/{budgetId}",
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          pathParams: { budget_id: "budgetId" },
+          responseExtractor: ngExtract,
+          description: "Get budget details by ID",
+        },
+        create: {
+          method: "POST",
+          path: "/ccm/api/budgets",
+          operationPolicy: { risk: "low_write", retryPolicy: "do_not_retry" },
+          injectAccountInBody: "accountId",
+          bodyBuilder: (input) => input.body,
+          bodySchema: {
+            description: "Budget definition. accountId is injected automatically; the budget is created as a NextGen budget. budgetAmount is required for type SPECIFIED_AMOUNT.",
+            fields: [
+              { name: "name", type: "string", required: true, description: "Budget name (1-80 chars)" },
+              { name: "type", type: "string", required: false, description: "How the budget amount is determined: SPECIFIED_AMOUNT (fixed), PREVIOUS_MONTH_SPEND, or PREVIOUS_PERIOD_SPEND. Default SPECIFIED_AMOUNT." },
+              { name: "budgetAmount", type: "number", required: false, description: "Budget amount (required when type is SPECIFIED_AMOUNT)" },
+              { name: "period", type: "string", required: false, description: "Budget period: DAILY | WEEKLY | MONTHLY | QUARTERLY | YEARLY" },
+              { name: "growthRate", type: "number", required: false, description: "Expected growth rate (%) applied per period for PREVIOUS_*_SPEND types" },
+              { name: "startTime", type: "number", required: false, description: "Budget start time (epoch ms)" },
+              { name: "scope", type: "object", required: false, description: "What the budget applies to (polymorphic, discriminated by 'type'). Perspective budget: { type: 'PERSPECTIVE', viewId: string, viewName: string }. Also supports CLUSTER, APPLICATION, COST_BUCKET." },
+              {
+                name: "alertThresholds", type: "array", required: false,
+                description: "Alert thresholds. Each: { percentage: number, basedOn: 'ACTUAL_COST'|'FORECASTED_COST'|'PARTIAL_COST'|'YEARLY_ACTUAL_COST'|'YEARLY_FORECASTED_COST', emailAddresses?: string[], userGroupIds?: string[], slackWebhooks?: string[] }",
+                itemType: "{ percentage: number, basedOn: string, emailAddresses?: string[], userGroupIds?: string[], slackWebhooks?: string[] }",
+              },
+              { name: "emailAddresses", type: "array", required: false, description: "Email addresses to notify (string array)" },
+              { name: "userGroupIds", type: "array", required: false, description: "User group IDs to notify (string array)" },
+              { name: "notifyOnSlack", type: "boolean", required: false, description: "Whether to send alert notifications to Slack" },
+              { name: "folderId", type: "string", required: false, description: "Perspective folder ID the budget belongs to" },
+              { name: "budgetMonthlyBreakdown", type: "object", required: false, description: "Monthly breakdown for yearly budgets: { budgetBreakdown: 'MONTHLY'|'YEARLY', budgetMonthlyAmount?: [{ key, value }] }" },
+              { name: "customAlertMessage", type: "string", required: false, description: "Custom message included in alerts" },
+              { name: "disableCurrencyWarning", type: "boolean", required: false, description: "Suppress currency mismatch warning" },
+            ],
+          },
+          responseExtractor: ngExtract,
+          description: "Create a new budget. The accountId is injected automatically.",
+        },
+        update: {
+          method: "PUT",
+          path: "/ccm/api/budgets/{budgetId}",
+          operationPolicy: { risk: "low_write", retryPolicy: "do_not_retry" },
+          pathParams: { budget_id: "budgetId" },
+          bodyBuilder: (input) => input.body,
+          bodySchema: {
+            description: "Full budget object to replace the existing one. Fetch the budget via harness_get first, modify fields, and send the whole object back. Include alertThresholds only when you intend to update them.",
+            fields: [
+              { name: "uuid", type: "string", required: true, description: "Budget UUID (from harness_get)" },
+              { name: "name", type: "string", required: true, description: "Budget name (1-80 chars)" },
+              { name: "type", type: "string", required: false, description: "SPECIFIED_AMOUNT | PREVIOUS_MONTH_SPEND | PREVIOUS_PERIOD_SPEND" },
+              { name: "budgetAmount", type: "number", required: false, description: "Budget amount (required when type is SPECIFIED_AMOUNT)" },
+              { name: "period", type: "string", required: false, description: "DAILY | WEEKLY | MONTHLY | QUARTERLY | YEARLY" },
+              { name: "growthRate", type: "number", required: false, description: "Expected growth rate (%) per period" },
+              { name: "startTime", type: "number", required: false, description: "Budget start time (epoch ms)" },
+              { name: "scope", type: "object", required: false, description: "What the budget applies to (discriminated by 'type'). Perspective: { type: 'PERSPECTIVE', viewId, viewName }" },
+              {
+                name: "alertThresholds", type: "array", required: false,
+                description: "Alert thresholds. Each: { percentage, basedOn: 'ACTUAL_COST'|'FORECASTED_COST'|..., emailAddresses?, userGroupIds?, slackWebhooks? }",
+                itemType: "{ percentage: number, basedOn: string, emailAddresses?: string[], userGroupIds?: string[], slackWebhooks?: string[] }",
+              },
+              { name: "emailAddresses", type: "array", required: false, description: "Email addresses to notify" },
+              { name: "userGroupIds", type: "array", required: false, description: "User group IDs to notify" },
+              { name: "notifyOnSlack", type: "boolean", required: false, description: "Send alerts to Slack" },
+              { name: "folderId", type: "string", required: false, description: "Perspective folder ID" },
+              { name: "budgetMonthlyBreakdown", type: "object", required: false, description: "Monthly breakdown for yearly budgets" },
+              { name: "customAlertMessage", type: "string", required: false, description: "Custom alert message" },
+              { name: "disableCurrencyWarning", type: "boolean", required: false, description: "Suppress currency mismatch warning" },
+            ],
+          },
+          responseExtractor: ngExtract,
+          description: "Update an existing budget (full replacement)",
+        },
+        delete: {
+          method: "DELETE",
+          path: "/ccm/api/budgets/{budgetId}",
+          operationPolicy: { risk: "destructive", retryPolicy: "do_not_retry" },
+          pathParams: { budget_id: "budgetId" },
+          responseExtractor: ngExtract,
+          description: "Delete a budget by ID",
+        },
+      },
+      executeActions: {
+        clone: {
+          method: "POST",
+          path: "/ccm/api/budgets/{budgetId}",
+          operationPolicy: { risk: "low_write", retryPolicy: "do_not_retry" },
+          pathParams: { budget_id: "budgetId" },
+          queryParams: { clone_name: "cloneName" },
+          bodyBuilder: () => ({}),
+          bodySchema: { description: "No body required. Clone is parameterized via budget_id and clone_name.", fields: [] },
+          responseExtractor: ngExtract,
+          actionDescription: "Clone a budget. Requires budget_id (the source budget) and clone_name (the new budget's name).",
+        },
+        bulk_delete: {
+          method: "POST",
+          path: "/ccm/api/budgets/bulk/delete",
+          operationPolicy: { risk: "destructive", retryPolicy: "do_not_retry" },
+          bodyBuilder: (input) => {
+            const body = (input.body as Record<string, unknown> | undefined) ?? {};
+            const budgetIds = input.budget_ids ?? body.budgetIds;
+            return { budgetIds };
+          },
+          bodySchema: {
+            description: "Delete multiple budgets in one async bulk operation.",
+            fields: [
+              { name: "budgetIds", type: "array", required: true, description: "Array of budget IDs to delete. Alternatively pass budget_ids at the top level." },
+            ],
+          },
+          responseExtractor: ngExtract,
+          actionDescription: "Delete several budgets at once. Pass budgetIds (array of budget IDs) in the body, or budget_ids at the top level.",
+        },
+      },
+    },
+
+    // ------------------------------------------------------------------
     // 7b. cost_recommendation_filter — filter-panel endpoint for recommendation filters
     // ------------------------------------------------------------------
     {

--- a/src/registry/toolsets/ccm.ts
+++ b/src/registry/toolsets/ccm.ts
@@ -1,6 +1,6 @@
 import type { ToolsetDefinition, PreflightContext, ParamsSchema } from "../types.js";
 import type { PathBuilderConfig } from "../types.js";
-import { ngExtract, passthrough, gqlExtract, ccmViewsExtract, anomalyListExtract, ccmBreakdownExtract, ccmTimeseriesExtract, ccmSummaryExtract, ccmRecommendationsExtract, countExtract } from "../extractors.js";
+import { ngExtract, passthrough, gqlExtract, ccmViewsExtract, anomalyListExtract, ccmBreakdownExtract, ccmTimeseriesExtract, ccmSummaryExtract, ccmRecommendationsExtract, countExtract, ccmBudgetListCompactExtract, ccmBudgetDetailExtract, ccmBudgetWriteExtract } from "../extractors.js";
 
 // ---------------------------------------------------------------------------
 // GraphQL queries — ported from the official Go MCP server
@@ -1522,20 +1522,48 @@ For cost time-series data, use harness_get with start_time and end_time.`,
       identifierFields: ["budget_id"],
       deepLinkTemplate: "/ng/account/{accountId}/ce/budget",
       listFilterFields: [
+        { name: "search_term", description: "Search budgets by name" },
+        { name: "perspective_name", description: "Filter by perspective name(s) (comma-separated)" },
         { name: "budget_sort_type", description: "Sort field", enum: ["BUDGET_AMOUNT", "NAME", "PERSPECTIVE", "ACTUAL_COST", "LAST_MONTH_COST", "FORECAST_COST"] },
         { name: "sort_order", description: "Sort direction", enum: ["ASCENDING", "DESCENDING"] },
+        { name: "limit", description: "Result limit (default 20)", type: "number" },
+        { name: "offset", description: "Pagination offset (default 0)", type: "number" },
       ],
       operations: {
         list: {
-          method: "GET",
-          path: "/ccm/api/budgets",
+          method: "POST",
+          path: "/ccm/api/budgets/v2/list",
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           queryParams: {
             budget_sort_type: "budgetSortType",
             sort_order: "sortOrder",
           },
-          responseExtractor: ngExtract,
-          description: "List all budgets for the account. Optionally sort with budget_sort_type and sort_order.",
+          bodyBuilder: (input) => {
+            const body: Record<string, unknown> = {
+              filterType: "CCMBudget",
+              limit: (input.limit as number) ?? (input.size as number) ?? 20,
+              offset: (input.offset as number) ?? 0,
+            };
+
+            const searchKey = (input.search_term ?? input.search_key) as string | undefined;
+            if (typeof searchKey === "string" && searchKey.trim()) {
+              body.searchKey = searchKey.trim();
+            }
+
+            // Accept a comma-separated string or array of perspective names.
+            const rawNames = input.perspective_name;
+            const names = (Array.isArray(rawNames) ? rawNames : typeof rawNames === "string" ? rawNames.split(",") : [])
+              .map((s) => String(s).trim())
+              .filter((s) => s.length > 0);
+            if (names.length > 0) {
+              body.perspectiveNames = names;
+            }
+
+            return body;
+          },
+          responseExtractor: ccmBudgetListCompactExtract,
+          description:
+            "List budgets for the account. Filter by search_term (name) or perspective_name. Returns budget health: actualCost vs budgetAmount, forecastCost, timeLeft, and fired alerts.",
         },
         get: {
           method: "GET",
@@ -1575,7 +1603,7 @@ For cost time-series data, use harness_get with start_time and end_time.`,
               { name: "disableCurrencyWarning", type: "boolean", required: false, description: "Suppress currency mismatch warning" },
             ],
           },
-          responseExtractor: ngExtract,
+          responseExtractor: ccmBudgetWriteExtract,
           description: "Create a new budget. The accountId is injected automatically.",
         },
         update: {
@@ -1609,7 +1637,7 @@ For cost time-series data, use harness_get with start_time and end_time.`,
               { name: "disableCurrencyWarning", type: "boolean", required: false, description: "Suppress currency mismatch warning" },
             ],
           },
-          responseExtractor: ngExtract,
+          responseExtractor: ccmBudgetWriteExtract,
           description: "Update an existing budget (full replacement)",
         },
         delete: {
@@ -1617,7 +1645,7 @@ For cost time-series data, use harness_get with start_time and end_time.`,
           path: "/ccm/api/budgets/{budgetId}",
           operationPolicy: { risk: "destructive", retryPolicy: "do_not_retry" },
           pathParams: { budget_id: "budgetId" },
-          responseExtractor: ngExtract,
+          responseExtractor: ccmBudgetWriteExtract,
           description: "Delete a budget by ID",
         },
       },
@@ -1630,7 +1658,7 @@ For cost time-series data, use harness_get with start_time and end_time.`,
           queryParams: { clone_name: "cloneName" },
           bodyBuilder: () => ({}),
           bodySchema: { description: "No body required. Clone is parameterized via budget_id and clone_name.", fields: [] },
-          responseExtractor: ngExtract,
+          responseExtractor: ccmBudgetWriteExtract,
           actionDescription: "Clone a budget. Requires budget_id (the source budget) and clone_name (the new budget's name).",
         },
         bulk_delete: {
@@ -1648,8 +1676,143 @@ For cost time-series data, use harness_get with start_time and end_time.`,
               { name: "budgetIds", type: "array", required: true, description: "Array of budget IDs to delete. Alternatively pass budget_ids at the top level." },
             ],
           },
-          responseExtractor: ngExtract,
+          responseExtractor: ccmBudgetWriteExtract,
           actionDescription: "Delete several budgets at once. Pass budgetIds (array of budget IDs) in the body, or budget_ids at the top level.",
+        },
+      },
+    },
+
+    // ------------------------------------------------------------------
+    // 7c. cost_budget_variance — read-only per-period actual-vs-budgeted grid
+    // ------------------------------------------------------------------
+    {
+      resourceType: "cost_budget_variance",
+      displayName: "Cost Budget Variance",
+      description:
+        "Read-only time-series detail for a single budget: actual vs budgeted cost per period (month-by-month or yearly) with variance tracking and end-of-period forecast. Use harness_get with budget_id (from cost_budget list) and optional breakdown (MONTHLY or YEARLY) to see how a budget has tracked over time and where it went over.",
+      toolset: "ccm",
+      scope: "account",
+      identifierFields: ["budget_id"],
+      deepLinkTemplate: "/ng/account/{accountId}/ce/budget",
+      operations: {
+        get: {
+          method: "GET",
+          path: "/ccm/api/budgets/{budgetId}",
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          pathParams: { budget_id: "budgetId" },
+          responseExtractor: ccmBudgetDetailExtract,
+          description:
+            "Get a budget's period-by-period variance history (per period: time, actualCost, forecastCost, budgeted, budgetVariance, budgetVariancePercentage), sorted ascending by time — the last row is the current partial period. Pass budget_id from cost_budget list.",
+        },
+      },
+    },
+
+    // ------------------------------------------------------------------
+    // 7d. cost_budget_group — REST CRUD for CCM budget groups (/ccm/api/budgetGroups)
+    // ------------------------------------------------------------------
+    {
+      resourceType: "cost_budget_group",
+      displayName: "Cost Budget Group",
+      description:
+        "Budget groups — roll up multiple child budgets (or nested groups) under a single parent target and cascade alerts. Use harness_list to see all budget groups, harness_get with budget_group_id for details, and harness_create/harness_update/harness_delete to manage them.",
+      toolset: "ccm",
+      scope: "account",
+      identifierFields: ["budget_group_id"],
+      deepLinkTemplate: "/ng/account/{accountId}/ce/budget",
+      listFilterFields: [
+        { name: "budget_sort_type", description: "Sort field", enum: ["BUDGET_AMOUNT", "NAME", "ACTUAL_COST", "LAST_MONTH_COST", "FORECAST_COST"] },
+        { name: "sort_order", description: "Sort direction", enum: ["ASCENDING", "DESCENDING"] },
+      ],
+      operations: {
+        list: {
+          method: "GET",
+          path: "/ccm/api/budgetGroups",
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          queryParams: {
+            budget_sort_type: "budgetSortType",
+            sort_order: "sortOrder",
+          },
+          responseExtractor: ngExtract,
+          description: "List all budget groups for the account. Optionally sort with budget_sort_type and sort_order.",
+        },
+        get: {
+          method: "GET",
+          path: "/ccm/api/budgetGroups/{budgetGroupId}",
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          pathParams: { budget_group_id: "budgetGroupId" },
+          responseExtractor: ngExtract,
+          description: "Get budget group details by ID",
+        },
+        create: {
+          method: "POST",
+          path: "/ccm/api/budgetGroups",
+          operationPolicy: { risk: "low_write", retryPolicy: "do_not_retry" },
+          injectAccountInBody: "accountId",
+          bodyBuilder: (input) => input.body,
+          bodySchema: {
+            description: "Budget group definition. accountId is injected automatically. A group aggregates child budgets (or child groups) referenced by childEntities.",
+            fields: [
+              { name: "name", type: "string", required: true, description: "Budget group name (1-80 chars)" },
+              { name: "budgetGroupAmount", type: "number", required: false, description: "Total amount for the group (usually the sum of child budgets)" },
+              { name: "period", type: "string", required: false, description: "Budget period: DAILY | WEEKLY | MONTHLY | QUARTERLY | YEARLY" },
+              { name: "startTime", type: "number", required: false, description: "Group start time (epoch ms)" },
+              {
+                name: "childEntities", type: "array", required: false,
+                description: "Child budgets (or child groups) aggregated by this group. Each: { id: string (the child budget/group UUID), proportion?: number (percent share when cascadeType=PROPORTIONAL), budgetGroup: boolean (true if the child is itself a budget group, false for a budget) }. NOTE: all children must share the same period AND the same startTime, or the API rejects the request.",
+                itemType: "{ id: string, proportion?: number, budgetGroup: boolean }",
+              },
+              {
+                name: "alertThresholds", type: "array", required: false,
+                description: "Alert thresholds. Each: { percentage: number, basedOn: 'ACTUAL_COST'|'FORECASTED_COST'|..., emailAddresses?: string[], userGroupIds?: string[], slackWebhooks?: string[] }",
+                itemType: "{ percentage: number, basedOn: string, emailAddresses?: string[], userGroupIds?: string[], slackWebhooks?: string[] }",
+              },
+              { name: "cascadeType", type: "string", required: false, description: "How the group amount cascades to children: EQUAL | PROPORTIONAL | NO_CASCADE" },
+              { name: "budgetGroupMonthlyBreakdown", type: "object", required: false, description: "Breakdown config: { budgetBreakdown: 'MONTHLY'|'YEARLY' }" },
+              { name: "parentBudgetGroupId", type: "string", required: false, description: "Parent budget group ID when nesting groups" },
+            ],
+          },
+          responseExtractor: ccmBudgetWriteExtract,
+          description: "Create a new budget group. The accountId is injected automatically. All child budgets/groups must share the same period and startTime.",
+        },
+        update: {
+          method: "PUT",
+          path: "/ccm/api/budgetGroups/{budgetGroupId}",
+          operationPolicy: { risk: "low_write", retryPolicy: "do_not_retry" },
+          pathParams: { budget_group_id: "budgetGroupId" },
+          bodyBuilder: (input) => input.body,
+          bodySchema: {
+            description: "Full budget group object to replace the existing one. Fetch via harness_get first, modify, and send the whole object back.",
+            fields: [
+              { name: "uuid", type: "string", required: true, description: "Budget group UUID (from harness_get)" },
+              { name: "name", type: "string", required: true, description: "Budget group name (1-80 chars)" },
+              { name: "budgetGroupAmount", type: "number", required: false, description: "Total amount for the group" },
+              { name: "period", type: "string", required: false, description: "DAILY | WEEKLY | MONTHLY | QUARTERLY | YEARLY" },
+              { name: "startTime", type: "number", required: false, description: "Group start time (epoch ms)" },
+              {
+                name: "childEntities", type: "array", required: false,
+                description: "Child budgets or groups. Each: { id: string (child UUID), proportion?: number, budgetGroup: boolean (true if child is a group) }",
+                itemType: "{ id: string, proportion?: number, budgetGroup: boolean }",
+              },
+              {
+                name: "alertThresholds", type: "array", required: false,
+                description: "Alert thresholds. Each: { percentage, basedOn, emailAddresses?, userGroupIds?, slackWebhooks? }",
+                itemType: "{ percentage: number, basedOn: string, emailAddresses?: string[], userGroupIds?: string[], slackWebhooks?: string[] }",
+              },
+              { name: "cascadeType", type: "string", required: false, description: "EQUAL | PROPORTIONAL | NO_CASCADE" },
+              { name: "budgetGroupMonthlyBreakdown", type: "object", required: false, description: "Breakdown config: { budgetBreakdown: 'MONTHLY'|'YEARLY' }" },
+              { name: "parentBudgetGroupId", type: "string", required: false, description: "Parent budget group ID when nesting groups" },
+            ],
+          },
+          responseExtractor: ccmBudgetWriteExtract,
+          description: "Update an existing budget group (full replacement). Fetch via harness_get first, modify, and send the whole object back.",
+        },
+        delete: {
+          method: "DELETE",
+          path: "/ccm/api/budgetGroups/{budgetGroupId}",
+          operationPolicy: { risk: "destructive", retryPolicy: "do_not_retry" },
+          pathParams: { budget_group_id: "budgetGroupId" },
+          responseExtractor: ccmBudgetWriteExtract,
+          description: "Delete a budget group by ID",
         },
       },
     },

--- a/src/utils/compact.ts
+++ b/src/utils/compact.ts
@@ -8,7 +8,7 @@ const TIMESTAMP_PATTERN = /(?:At|Ts|Time|Date)$/;
 
 /** Fields to always keep when compacting list items. */
 const IDENTITY_FIELDS = new Set([
-  "identifier", "identity", "name", "displayName", "description", "slug",
+  "id", "uuid", "identifier", "identity", "name", "displayName", "description", "slug",
   "versionLabel", "sha", "title", "message",
 ]);
 

--- a/tests/registry/ccm-budget.test.ts
+++ b/tests/registry/ccm-budget.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for the CCM cost_budget resource registration and bodyBuilders.
+ * Guards the public contract of the budget CRUD + clone + bulk_delete tools.
+ */
+import { describe, it, expect } from "vitest";
+import { ccmToolset } from "../../src/registry/toolsets/ccm.js";
+
+const budget = ccmToolset.resources.find((r) => r.resourceType === "cost_budget");
+
+describe("cost_budget resource", () => {
+  it("is registered in the ccm toolset", () => {
+    expect(budget).toBeDefined();
+    expect(budget!.toolset).toBe("ccm");
+    expect(budget!.scope).toBe("account");
+    expect(budget!.identifierFields).toEqual(["budget_id"]);
+  });
+
+  it("exposes the full CRUD operation set", () => {
+    expect(Object.keys(budget!.operations).sort()).toEqual(
+      ["create", "delete", "get", "list", "update"].sort(),
+    );
+  });
+
+  it("maps list/get/update/delete to the correct paths and methods", () => {
+    expect(budget!.operations.list).toMatchObject({ method: "GET", path: "/ccm/api/budgets" });
+    expect(budget!.operations.get).toMatchObject({ method: "GET", path: "/ccm/api/budgets/{budgetId}" });
+    expect(budget!.operations.create).toMatchObject({ method: "POST", path: "/ccm/api/budgets" });
+    expect(budget!.operations.update).toMatchObject({ method: "PUT", path: "/ccm/api/budgets/{budgetId}" });
+    expect(budget!.operations.delete).toMatchObject({ method: "DELETE", path: "/ccm/api/budgets/{budgetId}" });
+  });
+
+  it("classifies write risk: low_write for create/update, destructive for delete", () => {
+    expect(budget!.operations.create!.operationPolicy.risk).toBe("low_write");
+    expect(budget!.operations.update!.operationPolicy.risk).toBe("low_write");
+    expect(budget!.operations.delete!.operationPolicy.risk).toBe("destructive");
+  });
+
+  it("injects accountId into the create body and passes the user body through", () => {
+    expect(budget!.operations.create!.injectAccountInBody).toBe("accountId");
+    const body = { name: "Q1 Budget", type: "SPECIFIED_AMOUNT", budgetAmount: 1000, period: "MONTHLY" };
+    expect(budget!.operations.create!.bodyBuilder!({ body })).toEqual(body);
+  });
+
+  it("exposes clone and bulk_delete actions", () => {
+    expect(Object.keys(budget!.executeActions!).sort()).toEqual(["bulk_delete", "clone"]);
+    expect(budget!.executeActions!.clone).toMatchObject({
+      method: "POST",
+      path: "/ccm/api/budgets/{budgetId}",
+    });
+    expect(budget!.executeActions!.clone.queryParams).toEqual({ clone_name: "cloneName" });
+    expect(budget!.executeActions!.bulk_delete).toMatchObject({
+      method: "POST",
+      path: "/ccm/api/budgets/bulk/delete",
+    });
+    expect(budget!.executeActions!.bulk_delete.operationPolicy.risk).toBe("destructive");
+  });
+
+  it("bulk_delete wraps budget_ids into { budgetIds } and accepts body.budgetIds", () => {
+    const builder = budget!.executeActions!.bulk_delete.bodyBuilder!;
+    expect(builder({ budget_ids: ["a", "b"] })).toEqual({ budgetIds: ["a", "b"] });
+    expect(builder({ body: { budgetIds: ["c"] } })).toEqual({ budgetIds: ["c"] });
+  });
+});

--- a/tests/registry/ccm-budget.test.ts
+++ b/tests/registry/ccm-budget.test.ts
@@ -4,8 +4,11 @@
  */
 import { describe, it, expect } from "vitest";
 import { ccmToolset } from "../../src/registry/toolsets/ccm.js";
+import { ccmBudgetWriteExtract } from "../../src/registry/extractors.js";
 
 const budget = ccmToolset.resources.find((r) => r.resourceType === "cost_budget");
+const variance = ccmToolset.resources.find((r) => r.resourceType === "cost_budget_variance");
+const budgetGroup = ccmToolset.resources.find((r) => r.resourceType === "cost_budget_group");
 
 describe("cost_budget resource", () => {
   it("is registered in the ccm toolset", () => {
@@ -22,11 +25,32 @@ describe("cost_budget resource", () => {
   });
 
   it("maps list/get/update/delete to the correct paths and methods", () => {
-    expect(budget!.operations.list).toMatchObject({ method: "GET", path: "/ccm/api/budgets" });
+    expect(budget!.operations.list).toMatchObject({ method: "POST", path: "/ccm/api/budgets/v2/list" });
     expect(budget!.operations.get).toMatchObject({ method: "GET", path: "/ccm/api/budgets/{budgetId}" });
     expect(budget!.operations.create).toMatchObject({ method: "POST", path: "/ccm/api/budgets" });
     expect(budget!.operations.update).toMatchObject({ method: "PUT", path: "/ccm/api/budgets/{budgetId}" });
     expect(budget!.operations.delete).toMatchObject({ method: "DELETE", path: "/ccm/api/budgets/{budgetId}" });
+  });
+
+  it("builds the v2 list body: filterType, limit/offset, searchKey, perspectiveNames", () => {
+    const builder = budget!.operations.list!.bodyBuilder!;
+    expect(builder({})).toEqual({ filterType: "CCMBudget", limit: 20, offset: 0 });
+    expect(builder({ search_term: "  Q1  ", limit: 5, offset: 10 })).toEqual({
+      filterType: "CCMBudget",
+      limit: 5,
+      offset: 10,
+      searchKey: "Q1",
+    });
+    // perspective_name accepts comma-separated string or array, trimmed + de-blanked
+    expect(builder({ perspective_name: "Prod, , Staging" })).toEqual({
+      filterType: "CCMBudget",
+      limit: 20,
+      offset: 0,
+      perspectiveNames: ["Prod", "Staging"],
+    });
+    expect(builder({ perspective_name: ["A", "B"] })).toMatchObject({
+      perspectiveNames: ["A", "B"],
+    });
   });
 
   it("classifies write risk: low_write for create/update, destructive for delete", () => {
@@ -59,5 +83,92 @@ describe("cost_budget resource", () => {
     const builder = budget!.executeActions!.bulk_delete.bodyBuilder!;
     expect(builder({ budget_ids: ["a", "b"] })).toEqual({ budgetIds: ["a", "b"] });
     expect(builder({ body: { budgetIds: ["c"] } })).toEqual({ budgetIds: ["c"] });
+  });
+});
+
+describe("ccmBudgetWriteExtract", () => {
+  it("wraps a bare-string id (create/clone return { status, data: '<id>' })", () => {
+    expect(ccmBudgetWriteExtract({ status: "SUCCESS", data: "abc123XYZ" })).toEqual({
+      id: "abc123XYZ",
+      status: "SUCCESS",
+    });
+  });
+
+  it("treats a spaced string as a message (delete returns a confirmation)", () => {
+    expect(ccmBudgetWriteExtract({ status: "SUCCESS", data: "Successfully deleted the budget" })).toEqual({
+      message: "Successfully deleted the budget",
+      status: "SUCCESS",
+    });
+  });
+
+  it("wraps boolean/number data under result", () => {
+    expect(ccmBudgetWriteExtract({ status: "SUCCESS", data: true })).toEqual({ result: true, status: "SUCCESS" });
+  });
+
+  it("passes object data through (full entity payloads)", () => {
+    expect(ccmBudgetWriteExtract({ data: { uuid: "x", name: "n" } })).toEqual({ uuid: "x", name: "n" });
+  });
+
+  it("is wired into budget + budget group writes and actions", () => {
+    expect(budget!.operations.create!.responseExtractor).toBe(ccmBudgetWriteExtract);
+    expect(budget!.operations.update!.responseExtractor).toBe(ccmBudgetWriteExtract);
+    expect(budget!.operations.delete!.responseExtractor).toBe(ccmBudgetWriteExtract);
+    expect(budget!.executeActions!.clone.responseExtractor).toBe(ccmBudgetWriteExtract);
+    expect(budget!.executeActions!.bulk_delete.responseExtractor).toBe(ccmBudgetWriteExtract);
+    expect(budgetGroup!.operations.create!.responseExtractor).toBe(ccmBudgetWriteExtract);
+    expect(budgetGroup!.operations.update!.responseExtractor).toBe(ccmBudgetWriteExtract);
+    expect(budgetGroup!.operations.delete!.responseExtractor).toBe(ccmBudgetWriteExtract);
+  });
+});
+
+describe("cost_budget_variance resource", () => {
+  it("is registered as a read-only resource in the ccm toolset", () => {
+    expect(variance).toBeDefined();
+    expect(variance!.toolset).toBe("ccm");
+    expect(variance!.scope).toBe("account");
+    expect(variance!.identifierFields).toEqual(["budget_id"]);
+    // Read-only: only a get operation, no create/update/delete.
+    expect(Object.keys(variance!.operations)).toEqual(["get"]);
+  });
+
+  it("get reads the REST budget detail and maps budget_id to the path param", () => {
+    // The GraphQL FetchBudgetsGridData grid resolver returns empty costData even
+    // for budgets with history, so variance is sourced from the REST budget
+    // detail's populated budgetHistory map instead.
+    expect(variance!.operations.get).toMatchObject({ method: "GET", path: "/ccm/api/budgets/{budgetId}" });
+    expect(variance!.operations.get!.operationPolicy.risk).toBe("read");
+    expect(variance!.operations.get!.pathParams).toEqual({ budget_id: "budgetId" });
+  });
+});
+
+describe("cost_budget_group resource", () => {
+  it("is registered in the ccm toolset", () => {
+    expect(budgetGroup).toBeDefined();
+    expect(budgetGroup!.toolset).toBe("ccm");
+    expect(budgetGroup!.scope).toBe("account");
+    expect(budgetGroup!.identifierFields).toEqual(["budget_group_id"]);
+  });
+
+  it("exposes the full CRUD operation set", () => {
+    expect(Object.keys(budgetGroup!.operations).sort()).toEqual(
+      ["create", "delete", "get", "list", "update"].sort(),
+    );
+  });
+
+  it("maps operations to the budgetGroups endpoints", () => {
+    expect(budgetGroup!.operations.list).toMatchObject({ method: "GET", path: "/ccm/api/budgetGroups" });
+    expect(budgetGroup!.operations.get).toMatchObject({ method: "GET", path: "/ccm/api/budgetGroups/{budgetGroupId}" });
+    expect(budgetGroup!.operations.create).toMatchObject({ method: "POST", path: "/ccm/api/budgetGroups" });
+    expect(budgetGroup!.operations.update).toMatchObject({ method: "PUT", path: "/ccm/api/budgetGroups/{budgetGroupId}" });
+    expect(budgetGroup!.operations.delete).toMatchObject({ method: "DELETE", path: "/ccm/api/budgetGroups/{budgetGroupId}" });
+  });
+
+  it("classifies write risk and injects accountId on create", () => {
+    expect(budgetGroup!.operations.create!.operationPolicy.risk).toBe("low_write");
+    expect(budgetGroup!.operations.update!.operationPolicy.risk).toBe("low_write");
+    expect(budgetGroup!.operations.delete!.operationPolicy.risk).toBe("destructive");
+    expect(budgetGroup!.operations.create!.injectAccountInBody).toBe("accountId");
+    const body = { name: "Eng Group", budgetGroupAmount: 5000 };
+    expect(budgetGroup!.operations.create!.bodyBuilder!({ body })).toEqual(body);
   });
 });

--- a/tests/registry/scs.test.ts
+++ b/tests/registry/scs.test.ts
@@ -819,12 +819,13 @@ describe("T9-v2: compactItems effectiveness for SCS", () => {
 
     const [compacted] = compactItems([scsArtifact]) as Record<string, unknown>[];
 
-    // Only name and tags survive the generic whitelist
+    // name, tags, and the generic id survive the whitelist
     expect(compacted.name).toBeDefined();
     expect(compacted.tags).toBeDefined();
+    expect(compacted.id).toBeDefined();
 
-    // All these critical SCS fields are dropped
-    expect(compacted.id).toBeUndefined();
+    // But these SCS-specific fields are still dropped — which is why SCS uses
+    // scsCleanExtract to bypass compaction entirely (see test above).
     expect(compacted.digest).toBeUndefined();
     expect(compacted.url).toBeUndefined();
     expect(compacted.components_count).toBeUndefined();


### PR DESCRIPTION
## Description
<!-- What does this PR do? -->
Adds support for all related CCM Budget operations (Including budget groups)

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [x] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
If this PR adds or changes Harness API coverage:
- [x] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [x] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [x] `operationPolicy` on every new/changed endpoint
- [x] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [x] `identifierFields` and `scope` declared on new resources
- [x] No `console.log()` in `src/` (stdio JSON-RPC safety)
