### PR TITLE
feat: add IaCM workspace create and update operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1424,9 +1424,11 @@ Template operations use the Harness Template service paths (`/template/api/templ
 
 IaCM resources are default-enabled and mostly project-scoped. Start with `iacm_workspace` to find workspace identifiers, then use that `workspace_id` for workspace resources, costs, and activity diffs. The module registry is account-scoped.
 
+`iacm_workspace` create/update return `{ policy_evaluation }` only — follow up with `harness_get` to fetch the workspace. Writes are `medium_write` and require confirmation (elicitation or `confirm: true`).
+
 | Resource Type                   | List | Get | Create | Update | Delete | Execute Actions |
 | ------------------------------- | ---- | --- | ------ | ------ | ------ | --------------- |
-| `iacm_workspace`                | x    | x   |        |        |        |                 |
+| `iacm_workspace`                | x    | x   | x      | x      |        |                 |
 | `iacm_resource`                 | x    |     |        |        |        |                 |
 | `iacm_module`                   | x    | x   |        |        |        |                 |
 | `iacm_workspace_costs`          | x    |     |        |        |        |                 |
@@ -1435,9 +1437,11 @@ IaCM resources are default-enabled and mostly project-scoped. Start with `iacm_w
 Typical workflow:
 
 1. `harness_list(resource_type="iacm_workspace", org_id="...", project_id="...")` to find the workspace.
-2. `harness_list(resource_type="iacm_resource", org_id="...", project_id="...", workspace_id="...")` to inspect Terraform resources, outputs, and data sources.
-3. `harness_list(resource_type="iacm_workspace_costs", org_id="...", project_id="...", workspace_id="...")` to review per-execution cost entries.
-4. `harness_list(resource_type="iacm_activity_resource_change", org_id="...", project_id="...", activity_id="...", workspace_id="...")` to inspect before/after resource diffs for a plan, apply, or destroy activity.
+2. `harness_create` / `harness_update` on `iacm_workspace` to create from scratch or a template (`associated_template`), or update an existing workspace — response is `{ policy_evaluation }` only.
+3. `harness_get(resource_type="iacm_workspace", workspace_id="...")` to fetch the created/updated workspace.
+4. `harness_list(resource_type="iacm_resource", org_id="...", project_id="...", workspace_id="...")` to inspect Terraform resources, outputs, and data sources.
+5. `harness_list(resource_type="iacm_workspace_costs", org_id="...", project_id="...", workspace_id="...")` to review per-execution cost entries.
+6. `harness_list(resource_type="iacm_activity_resource_change", org_id="...", project_id="...", activity_id="...", workspace_id="...")` to inspect before/after resource diffs for a plan, apply, or destroy activity.
 
 IaCM list responses expose `page_count` as the count for the current page only. When `has_more` is true, keep requesting the next 1-based page and sum page counts if you need a total.
 

--- a/src/registry/toolsets/iacm.ts
+++ b/src/registry/toolsets/iacm.ts
@@ -36,10 +36,19 @@ const workspaceListExtract = (
 const workspaceGetExtract = (raw: unknown): unknown => raw;
 
 /**
- * Workspace create/update return the IaCM policy evaluation result directly.
- * Keep that public contract intact rather than wrapping it in an NG envelope.
+ * Workspace create/update return `{ policy_evaluation? }` only — not the workspace.
+ * Project that stable shape so agents don't treat the write response as workspace
+ * metadata; follow up with harness_get for the workspace itself.
  */
-const workspaceWriteExtract = (raw: unknown): unknown => raw;
+const workspaceWriteExtract = (raw: unknown): unknown => {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return {};
+  }
+  const rec = raw as Record<string, unknown>;
+  return {
+    policy_evaluation: rec.policy_evaluation ?? null,
+  };
+};
 
 /**
  * IACM resources list: API returns a ResourcesResponse with resources, outputs,
@@ -176,7 +185,9 @@ const workspaceOptionalFields: BodyFieldSpec[] = [
     name: "provisioner_configuration",
     type: "object",
     required: false,
-    description: "Provisioner-specific configuration as a string-to-string map",
+    description:
+      "Provisioner-specific configuration as a string-to-string map " +
+      "(IaCM wire type is map[string]string; OpenAPI may show string due to a custom goa type).",
   },
   { name: "terragrunt_provider", type: "boolean", required: false, description: "Whether the workspace uses Terragrunt" },
   { name: "terragrunt_version", type: "string", required: false, description: "Terragrunt version" },
@@ -205,7 +216,9 @@ const workspaceOptionalFields: BodyFieldSpec[] = [
     type: "array",
     required: false,
     itemType: "string",
-    description: "Git sparse-checkout path patterns",
+    description:
+      "Git sparse-checkout path patterns as a JSON string array " +
+      "(IaCM wire type is string[]; OpenAPI may show string due to a custom goa type).",
   },
   {
     name: "cost_estimation_enabled",
@@ -343,12 +356,13 @@ export const iacmToolset: ToolsetDefinition = {
   name: "iacm",
   displayName: "Infrastructure as Code Management (IaCM)",
   description:
-    "Harness IaCM (Infrastructure as Code Management) — manage Terraform workspaces, " +
-    "inspect provisioned resources and Terraform outputs, browse the module registry, " +
-    "review workspace cost history, and diff resource changes from past plan/apply/destroy activities. " +
-    "Use iacm_workspace to list and get workspaces, iacm_resource for Terraform resources and outputs, " +
-    "iacm_module for the module registry, iacm_workspace_costs for cost breakdown, " +
-    "and iacm_activity_resource_change for activity diffs.",
+    "Harness IaCM (Infrastructure as Code Management) — manage Terraform workspaces " +
+    "(list/get/create/update), inspect provisioned resources and Terraform outputs, " +
+    "browse the module registry, review workspace cost history, and diff resource changes " +
+    "from past plan/apply/destroy activities. " +
+    "Use iacm_workspace to list, get, create, or update workspaces; iacm_resource for Terraform " +
+    "resources and outputs; iacm_module for the module registry; iacm_workspace_costs for cost " +
+    "breakdown; and iacm_activity_resource_change for activity diffs.",
   optIn: false,
   resources: [
     // ─── Workspace ─────────────────────────────────────────────────────────
@@ -463,7 +477,9 @@ export const iacmToolset: ToolsetDefinition = {
           responseExtractor: workspaceWriteExtract,
           description:
             "Create an IaCM workspace. Supply the full required workspace body; to create from a template, " +
-            "also provide associated_template with template_id and version. IaCM enforces permissions, validation, and policy evaluation.",
+            "also provide associated_template with template_id and version. IaCM enforces permissions, validation, and policy evaluation. " +
+            "Response is { policy_evaluation } only — not the workspace. Follow up with harness_get " +
+            "(resource_type=iacm_workspace, workspace_id=<identifier>) to fetch the created workspace.",
         },
         update: {
           method: "PUT",
@@ -482,7 +498,9 @@ export const iacmToolset: ToolsetDefinition = {
           description:
             "Update an IaCM workspace by identifier. This endpoint uses full-replacement semantics for core fields: " +
             "include name, provider_connector, provisioner, terraform_variables, and environment_variables. " +
-            "IaCM enforces permissions, validation, and policy evaluation.",
+            "IaCM enforces permissions, validation, and policy evaluation. " +
+            "Response is { policy_evaluation } only — not the workspace. Follow up with harness_get " +
+            "(resource_type=iacm_workspace, workspace_id=<identifier>) to fetch the updated workspace.",
         },
       },
     },

--- a/src/registry/toolsets/iacm.ts
+++ b/src/registry/toolsets/iacm.ts
@@ -1,4 +1,9 @@
-import type { ToolsetDefinition, PreflightContext } from "../types.js";
+import type {
+  BodyFieldSpec,
+  BodySchema,
+  ToolsetDefinition,
+  PreflightContext,
+} from "../types.js";
 
 // ─── Response extractors ─────────────────────────────────────────────────────
 
@@ -29,6 +34,12 @@ const workspaceListExtract = (
  * IACM workspace get: API returns a single workspace object directly.
  */
 const workspaceGetExtract = (raw: unknown): unknown => raw;
+
+/**
+ * Workspace create/update return the IaCM policy evaluation result directly.
+ * Keep that public contract intact rather than wrapping it in an NG envelope.
+ */
+const workspaceWriteExtract = (raw: unknown): unknown => raw;
 
 /**
  * IACM resources list: API returns a ResourcesResponse with resources, outputs,
@@ -145,6 +156,187 @@ const requireProjectScope = async (ctx: PreflightContext): Promise<void> => {
   }
 };
 
+// ─── Workspace request schemas ───────────────────────────────────────────────
+
+const workspaceVariableValueFields: BodyFieldSpec[] = [
+  { name: "key", type: "string", required: true, description: "Variable key (must match the map entry key)" },
+  { name: "value", type: "string", required: true, description: "Variable value, or secret reference when value_type is secret" },
+  {
+    name: "value_type",
+    type: "string",
+    required: true,
+    description: "Variable value type: string or secret",
+  },
+];
+
+const workspaceOptionalFields: BodyFieldSpec[] = [
+  { name: "description", type: "string", required: false, description: "Long-form workspace description" },
+  { name: "provisioner_version", type: "string", required: false, description: "Provisioner version; defaults to latest" },
+  {
+    name: "provisioner_configuration",
+    type: "object",
+    required: false,
+    description: "Provisioner-specific configuration as a string-to-string map",
+  },
+  { name: "terragrunt_provider", type: "boolean", required: false, description: "Whether the workspace uses Terragrunt" },
+  { name: "terragrunt_version", type: "string", required: false, description: "Terragrunt version" },
+  { name: "run_all", type: "boolean", required: false, description: "Run all Terragrunt modules" },
+  {
+    name: "repository",
+    type: "string",
+    required: false,
+    description:
+      "Infrastructure repository name. Required by IaCM when repository_connector is empty " +
+      '(API returns "repository name can\'t be empty").',
+  },
+  { name: "repository_branch", type: "string", required: false, description: "Repository branch" },
+  { name: "repository_commit", type: "string", required: false, description: "Repository commit or tag" },
+  { name: "repository_sha", type: "string", required: false, description: "Repository commit SHA" },
+  { name: "repository_connector", type: "string", required: false, description: "Harness connector for the infrastructure repository" },
+  { name: "repository_path", type: "string", required: false, description: "Path to the infrastructure code within the repository" },
+  {
+    name: "repository_submodules",
+    type: "string",
+    required: false,
+    description: "Submodule checkout mode: false, true, or recursive",
+  },
+  {
+    name: "sparse_checkout",
+    type: "array",
+    required: false,
+    itemType: "string",
+    description: "Git sparse-checkout path patterns",
+  },
+  {
+    name: "cost_estimation_enabled",
+    type: "boolean",
+    required: false,
+    description: "Enable cost-estimation operations for the workspace",
+  },
+  {
+    name: "terraform_variable_files",
+    type: "array",
+    required: false,
+    itemType: "workspace Terraform variable-file reference",
+    description: "Variable files stored in repositories other than the workspace repository",
+  },
+  { name: "budget", type: "number", required: false, description: "Workspace budget" },
+  {
+    name: "default_pipelines",
+    type: "object",
+    required: false,
+    description: "Operation-to-default-pipeline map with optional workspace overrides",
+  },
+  {
+    name: "variable_sets",
+    type: "array",
+    required: false,
+    itemType: "string",
+    description: "Identifiers of variable sets attached to the workspace",
+  },
+  { name: "tags", type: "object", required: false, description: "String key-value tags" },
+  {
+    name: "provider_connectors",
+    type: "array",
+    required: false,
+    itemType: "workspace provider connector",
+    description: "Additional provider connector definitions",
+  },
+  {
+    name: "prune_sensitive_data",
+    type: "boolean",
+    required: false,
+    description: "Prune sensitive data from workspace output",
+  },
+  {
+    name: "ccm_cost_enabled",
+    type: "boolean",
+    required: false,
+    description: "Enable CCM cost integration for the workspace",
+  },
+];
+
+const workspaceCreateSchema: BodySchema = {
+  description:
+    "IaCM workspace definition. Create from a template by also supplying associated_template.",
+  fields: [
+    { name: "identifier", type: "string", required: true, description: "Unique workspace identifier" },
+    { name: "name", type: "string", required: true, description: "Workspace display name" },
+    {
+      name: "provider_connector",
+      type: "string",
+      required: true,
+      description: "Harness connector reference for the infrastructure provider",
+    },
+    { name: "provisioner", type: "string", required: true, description: "Provisioner such as terraform, opentofu, terragrunt, or awscdk" },
+    {
+      name: "terraform_variables",
+      type: "object",
+      required: true,
+      description:
+        "Map of Terraform variables (key → { key, value, value_type }). " +
+        'Use {} when none are required. value_type is "string" or "secret".',
+      fields: workspaceVariableValueFields,
+    },
+    {
+      name: "environment_variables",
+      type: "object",
+      required: true,
+      description:
+        "Map of environment variables (key → { key, value, value_type }). " +
+        'Use {} when none are required. value_type is "string" or "secret".',
+      fields: workspaceVariableValueFields,
+    },
+    {
+      name: "associated_template",
+      type: "object",
+      required: false,
+      description: "Optional workspace template reference",
+      fields: [
+        { name: "template_id", type: "string", required: true, description: "Template identifier" },
+        { name: "version", type: "string", required: true, description: "Template version" },
+      ],
+    },
+    ...workspaceOptionalFields,
+  ],
+};
+
+const workspaceUpdateSchema: BodySchema = {
+  description:
+    "Complete IaCM workspace update definition. Send the full workspace body (not a partial patch). " +
+    "Include repository (and related git fields) when updating a git-backed workspace — " +
+    "IaCM rejects an empty repository when repository_connector is empty.",
+  fields: [
+    { name: "name", type: "string", required: true, description: "Workspace display name" },
+    {
+      name: "provider_connector",
+      type: "string",
+      required: true,
+      description: "Harness connector reference for the infrastructure provider",
+    },
+    { name: "provisioner", type: "string", required: true, description: "Provisioner such as terraform, opentofu, terragrunt, or awscdk" },
+    {
+      name: "terraform_variables",
+      type: "object",
+      required: true,
+      description:
+        "Complete Terraform variable map (key → { key, value, value_type }). " +
+        'Use {} when none are configured. value_type is "string" or "secret".',
+      fields: workspaceVariableValueFields,
+    },
+    {
+      name: "environment_variables",
+      type: "object",
+      required: true,
+      description:
+        "Complete environment variable map (key → { key, value, value_type }). " +
+        'Use {} when none are configured. value_type is "string" or "secret".',
+      fields: workspaceVariableValueFields,
+    },
+    ...workspaceOptionalFields,
+  ],
+};
+
 // ─── Toolset definition ─────────────────────────────────────────────────────
 
 export const iacmToolset: ToolsetDefinition = {
@@ -171,7 +363,8 @@ export const iacmToolset: ToolsetDefinition = {
         "The response includes has_more (true = more pages exist) and page_count (items on THIS page only). " +
         "IMPORTANT: page_count is NOT the total number of workspaces. " +
         "To find the true total or list all workspaces, keep calling with page+1 until has_more=false, then sum the page_counts. " +
-        "Use harness_get with workspace_id to fetch full details of a single workspace. " +
+        "Use harness_get with workspace_id to fetch full details, harness_create to create from scratch or a template, " +
+        "and harness_update with workspace_id to update an existing workspace. " +
         "See also: iacm_resource for Terraform resources, iacm_workspace_costs for cost breakdown.",
       toolset: "iacm",
       scope: "project",
@@ -257,6 +450,39 @@ export const iacmToolset: ToolsetDefinition = {
           description:
             "Get full metadata for a specific IaCM workspace by its identifier. " +
             "Returns id, identifier, name, status, last_run, variables, cost_summary, and project_id.",
+        },
+        create: {
+          method: "POST",
+          path: "/iacm/api/orgs/{org}/projects/{project}/workspaces",
+          pathParams: { org_id: "org", project_id: "project" },
+          preflight: requireProjectScope,
+          operationPolicy: { risk: "medium_write", retryPolicy: "do_not_retry" },
+          bodyBuilder: (input) => input.body,
+          bodySchema: workspaceCreateSchema,
+          skipScopeBodyInjection: true,
+          responseExtractor: workspaceWriteExtract,
+          description:
+            "Create an IaCM workspace. Supply the full required workspace body; to create from a template, " +
+            "also provide associated_template with template_id and version. IaCM enforces permissions, validation, and policy evaluation.",
+        },
+        update: {
+          method: "PUT",
+          path: "/iacm/api/orgs/{org}/projects/{project}/workspaces/{workspaceId}",
+          pathParams: {
+            org_id: "org",
+            project_id: "project",
+            workspace_id: "workspaceId",
+          },
+          preflight: requireProjectScope,
+          operationPolicy: { risk: "medium_write", retryPolicy: "do_not_retry" },
+          bodyBuilder: (input) => input.body,
+          bodySchema: workspaceUpdateSchema,
+          skipScopeBodyInjection: true,
+          responseExtractor: workspaceWriteExtract,
+          description:
+            "Update an IaCM workspace by identifier. This endpoint uses full-replacement semantics for core fields: " +
+            "include name, provider_connector, provisioner, terraform_variables, and environment_variables. " +
+            "IaCM enforces permissions, validation, and policy evaluation.",
         },
       },
     },

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,16 @@
 # Harness MCP Server — Task Tracking
 
+## IaCM workspace create/update (this PR)
+- [x] Add create/update tests and implement `iacm_workspace` writes
+- [x] bodySchema + medium_write policy + project-scope preflight
+- [x] Run build, typecheck, standards, docs checks, and full tests
+- [x] QA RBAC smoke for workspaces (view/none/edit)
+
+### Plan
+- Follow the declarative registry model; no endpoint-specific MCP tools.
+- IaCM APIs own validation, RBAC, persistence, and audit; MCP forwards the caller token.
+- Stacked follow-ups (separate PRs): variable sets → modules → providers.
+
 ## Dependency security advisories (2026-08-03)
 - [x] Confirm affected dependency chains and fixed versions for `fast-uri` and `ip-address`
 - [x] Update pnpm overrides and regenerate both dependency lockfiles

--- a/tests/integration/elicitation-flow.test.ts
+++ b/tests/integration/elicitation-flow.test.ts
@@ -13,7 +13,7 @@ import type { Config } from "../../src/config.js";
 import type { HarnessClient } from "../../src/client/harness-client.js";
 import type { ToolResult } from "../../src/utils/response-formatter.js";
 
-function makeConfig(): Config {
+function makeConfig(overrides: Partial<Config> = {}): Config {
   return {
     HARNESS_API_KEY: "pat.test.abc.xyz",
     HARNESS_ACCOUNT_ID: "test-account",
@@ -23,6 +23,7 @@ function makeConfig(): Config {
     HARNESS_API_TIMEOUT_MS: 30000,
     HARNESS_MAX_RETRIES: 3,
     LOG_LEVEL: "info",
+    ...overrides,
   };
 }
 
@@ -82,7 +83,7 @@ describe("Elicitation flow: harness_create", () => {
   let client: HarnessClient;
 
   beforeEach(() => {
-    registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines" } as any));
+    registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines" }));
     client = makeClient();
   });
 
@@ -320,6 +321,108 @@ describe("Elicitation flow: harness_update", () => {
 
     expect(result.isError).toBeUndefined();
     expect(server._elicitInput).not.toHaveBeenCalled();
+  });
+});
+
+describe("Elicitation flow: iacm_workspace medium_write", () => {
+  const workspaceBody = {
+    identifier: "payments-prod",
+    name: "Payments Production",
+    provider_connector: "account.aws",
+    provisioner: "terraform",
+    terraform_variables: {},
+    environment_variables: {},
+  };
+
+  let registry: Registry;
+  let mockRequest: ReturnType<typeof vi.fn>;
+  let client: HarnessClient;
+
+  beforeEach(() => {
+    registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+    mockRequest = vi.fn().mockResolvedValue({ policy_evaluation: { status: "success" } });
+    client = {
+      request: mockRequest,
+      account: "test-account",
+    } as unknown as HarnessClient;
+  });
+
+  it("elicits confirmation for medium_write create and proceeds on accept", async () => {
+    const server = makeMcpServer({ supportsElicitation: true, elicitAction: "accept" });
+    const { registerCreateTool } = await import("../../src/tools/harness-create.js");
+    registerCreateTool(server, registry, client, makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+
+    const result = await server.call("harness_create", {
+      resource_type: "iacm_workspace",
+      org_id: "default",
+      project_id: "test-project",
+      body: workspaceBody,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(server._elicitInput).toHaveBeenCalledOnce();
+    expect(mockRequest).toHaveBeenCalledOnce();
+    expect(JSON.parse(result.content[0]!.text)).toEqual({
+      policy_evaluation: { status: "success" },
+    });
+  });
+
+  it("blocks medium_write create when user declines confirmation", async () => {
+    const server = makeMcpServer({ supportsElicitation: true, elicitAction: "decline" });
+    const { registerCreateTool } = await import("../../src/tools/harness-create.js");
+    registerCreateTool(server, registry, client, makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+
+    const result = await server.call("harness_create", {
+      resource_type: "iacm_workspace",
+      org_id: "default",
+      project_id: "test-project",
+      body: workspaceBody,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(server._elicitInput).toHaveBeenCalledOnce();
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it("elicits confirmation for medium_write update and proceeds on accept", async () => {
+    const server = makeMcpServer({ supportsElicitation: true, elicitAction: "accept" });
+    const { registerUpdateTool } = await import("../../src/tools/harness-update.js");
+    registerUpdateTool(server, registry, client, makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+    const updateBody = { ...workspaceBody };
+    delete (updateBody as { identifier?: string }).identifier;
+
+    const result = await server.call("harness_update", {
+      resource_type: "iacm_workspace",
+      resource_id: "payments-prod",
+      org_id: "default",
+      project_id: "test-project",
+      body: updateBody,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(server._elicitInput).toHaveBeenCalledOnce();
+    expect(mockRequest).toHaveBeenCalledOnce();
+    expect(JSON.parse(result.content[0]!.text)).toEqual({
+      policy_evaluation: { status: "success" },
+    });
+  });
+
+  it("allows medium_write create with confirm: true when elicitation is unavailable", async () => {
+    const server = makeMcpServer({ supportsElicitation: false });
+    const { registerCreateTool } = await import("../../src/tools/harness-create.js");
+    registerCreateTool(server, registry, client, makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+
+    const result = await server.call("harness_create", {
+      resource_type: "iacm_workspace",
+      org_id: "default",
+      project_id: "test-project",
+      body: workspaceBody,
+      confirm: true,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(server._elicitInput).not.toHaveBeenCalled();
+    expect(mockRequest).toHaveBeenCalledOnce();
   });
 });
 

--- a/tests/integration/mock-harness-api.test.ts
+++ b/tests/integration/mock-harness-api.test.ts
@@ -434,4 +434,109 @@ describe("Integration: Registry → HarnessClient → fetch", () => {
       expect(getResult).toBeDefined();
     });
   });
+
+  describe("iacm workspace writes", () => {
+    const workspaceBody = {
+      identifier: "payments-prod",
+      name: "Payments Production",
+      provider_connector: "account.aws",
+      provisioner: "terraform",
+      terraform_variables: {},
+      environment_variables: {},
+    };
+
+    it("create posts JSON body to IaCM path and projects policy_evaluation", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          policy_evaluation: { status: "success" },
+          identifier: "payments-prod",
+          extra: "dropped",
+        }),
+      );
+
+      const config = makeConfig({ HARNESS_TOOLSETS: "iacm" });
+      const client = new HarnessClient(config);
+      const registry = new Registry(config);
+
+      const result = await registry.dispatch(client, "iacm_workspace", "create", {
+        org_id: "default",
+        project_id: "test-project",
+        body: workspaceBody,
+      });
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [url, options] = fetchSpy.mock.calls[0]!;
+      const urlStr = url instanceof URL ? url.toString() : String(url);
+      const init = options as RequestInit;
+      const headers = init.headers as Record<string, string>;
+
+      expect(urlStr).toContain("/iacm/api/orgs/default/projects/test-project/workspaces");
+      expect(urlStr).toContain("accountIdentifier=testaccount");
+      expect((init.method ?? "GET").toUpperCase()).toBe("POST");
+      expect(headers["x-api-key"]).toBe("pat.testaccount.tokenid.secret");
+      expect(headers["Content-Type"]).toBe("application/json");
+      const sentBody = JSON.parse(init.body as string);
+      expect(sentBody).toEqual(workspaceBody);
+      expect(sentBody).not.toHaveProperty("orgIdentifier");
+      expect(sentBody).not.toHaveProperty("projectIdentifier");
+      expect(result).toEqual({ policy_evaluation: { status: "success" } });
+    });
+
+    it("update puts JSON body by workspace identifier and projects policy_evaluation", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          policy_evaluation: { status: "success" },
+          name: "Payments Production",
+        }),
+      );
+
+      const config = makeConfig({ HARNESS_TOOLSETS: "iacm" });
+      const client = new HarnessClient(config);
+      const registry = new Registry(config);
+      const updateBody = {
+        name: "Payments Production",
+        provider_connector: "account.aws",
+        provisioner: "terraform",
+        terraform_variables: {},
+        environment_variables: {},
+      };
+
+      const result = await registry.dispatch(client, "iacm_workspace", "update", {
+        org_id: "default",
+        project_id: "test-project",
+        workspace_id: "payments-prod",
+        body: updateBody,
+      });
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [url, options] = fetchSpy.mock.calls[0]!;
+      const urlStr = url instanceof URL ? url.toString() : String(url);
+      const init = options as RequestInit;
+
+      expect(urlStr).toContain(
+        "/iacm/api/orgs/default/projects/test-project/workspaces/payments-prod",
+      );
+      expect((init.method ?? "GET").toUpperCase()).toBe("PUT");
+      expect(JSON.parse(init.body as string)).toEqual(updateBody);
+      expect(result).toEqual({ policy_evaluation: { status: "success" } });
+    });
+
+    it("rejects invalid create bodies before calling fetch", async () => {
+      const config = makeConfig({ HARNESS_TOOLSETS: "iacm" });
+      const client = new HarnessClient(config);
+      const registry = new Registry(config);
+      const invalidBody = { ...workspaceBody };
+      delete (invalidBody as { provider_connector?: string }).provider_connector;
+
+      await expect(
+        registry.dispatch(client, "iacm_workspace", "create", {
+          org_id: "default",
+          project_id: "test-project",
+          body: invalidBody,
+        }),
+      ).rejects.toThrow("provider_connector");
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/registry/iacm.test.ts
+++ b/tests/registry/iacm.test.ts
@@ -131,6 +131,10 @@ describe("iacm_workspace write contract", () => {
       risk: "medium_write",
       retryPolicy: "do_not_retry",
     });
+    expect(create.description).toContain("policy_evaluation");
+    expect(create.description).toContain("harness_get");
+    expect(update.description).toContain("policy_evaluation");
+    expect(update.description).toContain("harness_get");
   });
 
   it("documents the API-required create body and optional template association", () => {
@@ -466,7 +470,10 @@ describe("iacm registry dispatch", () => {
   };
 
   it("dispatches workspace create with the IaCM body unchanged", async () => {
-    const response = { policy_evaluation: { status: "success" } };
+    const response = {
+      policy_evaluation: { status: "success" },
+      extra_server_field: "should-be-dropped",
+    };
     const mockRequest = vi.fn().mockResolvedValue(response);
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
 
@@ -484,11 +491,14 @@ describe("iacm registry dispatch", () => {
     expect(request.method).toBe("POST");
     expect(request.path).toBe("/iacm/api/orgs/default/projects/Testim/workspaces");
     expect(request.body).toEqual(workspaceBody);
-    expect(result).toEqual(response);
+    expect(result).toEqual({ policy_evaluation: { status: "success" } });
   });
 
   it("dispatches workspace update by workspace identifier", async () => {
-    const response = { policy_evaluation: { status: "success" } };
+    const response = {
+      policy_evaluation: { status: "success" },
+      extra_server_field: "should-be-dropped",
+    };
     const mockRequest = vi.fn().mockResolvedValue(response);
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
     const updateBody = { ...workspaceBody };
@@ -511,7 +521,7 @@ describe("iacm registry dispatch", () => {
       "/iacm/api/orgs/default/projects/Testim/workspaces/payments-prod",
     );
     expect(request.body).toEqual(updateBody);
-    expect(result).toEqual(response);
+    expect(result).toEqual({ policy_evaluation: { status: "success" } });
   });
 
   it("rejects workspace create when an API-required field is missing", async () => {

--- a/tests/registry/iacm.test.ts
+++ b/tests/registry/iacm.test.ts
@@ -44,7 +44,7 @@ function findResource(type: string): ResourceDefinition {
   return res;
 }
 
-function getOp(type: string, op: "list" | "get"): EndpointSpec {
+function getOp(type: string, op: "list" | "get" | "create" | "update"): EndpointSpec {
   const res = findResource(type);
   const spec = res.operations[op];
   if (!spec) throw new Error(`Operation "${op}" not found on "${type}"`);
@@ -93,9 +93,98 @@ describe("iacmToolset structure", () => {
           spec.operationPolicy,
           `${resource.resourceType}.${opName} is missing operationPolicy`,
         ).toBeDefined();
-        expect(spec.operationPolicy!.risk).toBe("read");
+        expect(spec.operationPolicy!.risk).toBe(
+          opName === "create" || opName === "update" ? "medium_write" : "read",
+        );
       }
     }
+  });
+});
+
+// ─── Workspace write contract ───────────────────────────────────────────────
+
+describe("iacm_workspace write contract", () => {
+  it("registers project-scoped create and update operations", () => {
+    const create = getOp("iacm_workspace", "create");
+    const update = getOp("iacm_workspace", "update");
+
+    expect(create.method).toBe("POST");
+    expect(create.path).toBe("/iacm/api/orgs/{org}/projects/{project}/workspaces");
+    expect(create.pathParams).toEqual({ org_id: "org", project_id: "project" });
+    expect(create.preflight).toBeDefined();
+    expect(create.operationPolicy).toEqual({
+      risk: "medium_write",
+      retryPolicy: "do_not_retry",
+    });
+
+    expect(update.method).toBe("PUT");
+    expect(update.path).toBe(
+      "/iacm/api/orgs/{org}/projects/{project}/workspaces/{workspaceId}",
+    );
+    expect(update.pathParams).toEqual({
+      org_id: "org",
+      project_id: "project",
+      workspace_id: "workspaceId",
+    });
+    expect(update.preflight).toBeDefined();
+    expect(update.operationPolicy).toEqual({
+      risk: "medium_write",
+      retryPolicy: "do_not_retry",
+    });
+  });
+
+  it("documents the API-required create body and optional template association", () => {
+    const fields = getOp("iacm_workspace", "create").bodySchema!.fields;
+    const required = fields.filter((field) => field.required).map((field) => field.name);
+
+    expect(required).toEqual([
+      "identifier",
+      "name",
+      "provider_connector",
+      "provisioner",
+      "terraform_variables",
+      "environment_variables",
+    ]);
+    expect(fields.find((field) => field.name === "associated_template")).toMatchObject({
+      type: "object",
+      required: false,
+      fields: [
+        expect.objectContaining({ name: "template_id", required: true }),
+        expect.objectContaining({ name: "version", required: true }),
+      ],
+    });
+    expect(fields.find((field) => field.name === "provisioner_configuration")).toMatchObject({
+      type: "object",
+      required: false,
+    });
+    expect(fields.find((field) => field.name === "sparse_checkout")).toMatchObject({
+      type: "array",
+      itemType: "string",
+      required: false,
+    });
+    expect(fields.find((field) => field.name === "terraform_variables")).toMatchObject({
+      type: "object",
+      required: true,
+      fields: [
+        expect.objectContaining({ name: "key", required: true }),
+        expect.objectContaining({ name: "value", required: true }),
+        expect.objectContaining({ name: "value_type", required: true }),
+      ],
+    });
+  });
+
+  it("documents the API-required update body", () => {
+    const fields = getOp("iacm_workspace", "update").bodySchema!.fields;
+    const required = fields.filter((field) => field.required).map((field) => field.name);
+
+    expect(required).toEqual([
+      "name",
+      "provider_connector",
+      "provisioner",
+      "terraform_variables",
+      "environment_variables",
+    ]);
+    expect(fields.some((field) => field.name === "identifier")).toBe(false);
   });
 });
 
@@ -367,6 +456,80 @@ describe("endpoint paths", () => {
 // ─── Registry dispatch integration ───────────────────────────────────────────
 
 describe("iacm registry dispatch", () => {
+  const workspaceBody = {
+    identifier: "payments-prod",
+    name: "Payments Production",
+    provider_connector: "account.aws",
+    provisioner: "terraform",
+    terraform_variables: {},
+    environment_variables: {},
+  };
+
+  it("dispatches workspace create with the IaCM body unchanged", async () => {
+    const response = { policy_evaluation: { status: "success" } };
+    const mockRequest = vi.fn().mockResolvedValue(response);
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+
+    const result = await registry.dispatch(makeClient(mockRequest), "iacm_workspace", "create", {
+      org_id: "default",
+      project_id: "Testim",
+      body: workspaceBody,
+    });
+
+    const request = mockRequest.mock.calls[0]![0] as {
+      method: string;
+      path: string;
+      body: Record<string, unknown>;
+    };
+    expect(request.method).toBe("POST");
+    expect(request.path).toBe("/iacm/api/orgs/default/projects/Testim/workspaces");
+    expect(request.body).toEqual(workspaceBody);
+    expect(result).toEqual(response);
+  });
+
+  it("dispatches workspace update by workspace identifier", async () => {
+    const response = { policy_evaluation: { status: "success" } };
+    const mockRequest = vi.fn().mockResolvedValue(response);
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+    const updateBody = { ...workspaceBody };
+    delete (updateBody as Partial<typeof workspaceBody>).identifier;
+
+    const result = await registry.dispatch(makeClient(mockRequest), "iacm_workspace", "update", {
+      org_id: "default",
+      project_id: "Testim",
+      workspace_id: "payments-prod",
+      body: updateBody,
+    });
+
+    const request = mockRequest.mock.calls[0]![0] as {
+      method: string;
+      path: string;
+      body: Record<string, unknown>;
+    };
+    expect(request.method).toBe("PUT");
+    expect(request.path).toBe(
+      "/iacm/api/orgs/default/projects/Testim/workspaces/payments-prod",
+    );
+    expect(request.body).toEqual(updateBody);
+    expect(result).toEqual(response);
+  });
+
+  it("rejects workspace create when an API-required field is missing", async () => {
+    const mockRequest = vi.fn();
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+    const invalidBody = { ...workspaceBody };
+    delete (invalidBody as Partial<typeof workspaceBody>).provider_connector;
+
+    await expect(
+      registry.dispatch(makeClient(mockRequest), "iacm_workspace", "create", {
+        org_id: "default",
+        project_id: "Testim",
+        body: invalidBody,
+      }),
+    ).rejects.toThrow("provider_connector");
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
   it("dispatches iacm_module get using the numeric id from harness_get resource_id mapping", async () => {
     const mockRequest = vi.fn().mockResolvedValue({ id: 4640, name: "vpc" });
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));

--- a/tests/registry/iacm.test.ts
+++ b/tests/registry/iacm.test.ts
@@ -107,6 +107,7 @@ describe("iacm_workspace write contract", () => {
   it("registers project-scoped create and update operations", () => {
     const create = getOp("iacm_workspace", "create");
     const update = getOp("iacm_workspace", "update");
+    const list = getOp("iacm_workspace", "list");
 
     expect(create.method).toBe("POST");
     expect(create.path).toBe("/iacm/api/orgs/{org}/projects/{project}/workspaces");
@@ -135,12 +136,29 @@ describe("iacm_workspace write contract", () => {
     expect(create.description).toContain("harness_get");
     expect(update.description).toContain("policy_evaluation");
     expect(update.description).toContain("harness_get");
+    // Create/update share the same project-scope preflight as list.
+    expect(create.preflight).toBe(list.preflight);
+    expect(update.preflight).toBe(list.preflight);
+  });
+
+  it("create/update use skipScopeBodyInjection and identity bodyBuilder", () => {
+    for (const op of ["create", "update"] as const) {
+      const spec = getOp("iacm_workspace", op);
+      expect(spec.skipScopeBodyInjection).toBe(true);
+      expect(spec.bodyBuilder).toBeDefined();
+      expect(spec.bodyBuilder!({ body: { name: "x", provisioner: "terraform" } })).toEqual({
+        name: "x",
+        provisioner: "terraform",
+      });
+    }
   });
 
   it("documents the API-required create body and optional template association", () => {
-    const fields = getOp("iacm_workspace", "create").bodySchema!.fields;
+    const create = getOp("iacm_workspace", "create");
+    const fields = create.bodySchema!.fields;
     const required = fields.filter((field) => field.required).map((field) => field.name);
 
+    expect(create.bodySchema!.description).toMatch(/workspace definition|associated_template/i);
     expect(required).toEqual([
       "identifier",
       "name",
@@ -160,11 +178,13 @@ describe("iacm_workspace write contract", () => {
     expect(fields.find((field) => field.name === "provisioner_configuration")).toMatchObject({
       type: "object",
       required: false,
+      description: expect.stringMatching(/map\[string\]string|string-to-string map/i),
     });
     expect(fields.find((field) => field.name === "sparse_checkout")).toMatchObject({
       type: "array",
       itemType: "string",
       required: false,
+      description: expect.stringMatching(/string array|string\[\]/i),
     });
     expect(fields.find((field) => field.name === "terraform_variables")).toMatchObject({
       type: "object",
@@ -178,9 +198,11 @@ describe("iacm_workspace write contract", () => {
   });
 
   it("documents the API-required update body", () => {
-    const fields = getOp("iacm_workspace", "update").bodySchema!.fields;
+    const update = getOp("iacm_workspace", "update");
+    const fields = update.bodySchema!.fields;
     const required = fields.filter((field) => field.required).map((field) => field.name);
 
+    expect(update.bodySchema!.description).toMatch(/full workspace body|not a partial patch/i);
     expect(required).toEqual([
       "name",
       "provider_connector",
@@ -189,6 +211,37 @@ describe("iacm_workspace write contract", () => {
       "environment_variables",
     ]);
     expect(fields.some((field) => field.name === "identifier")).toBe(false);
+  });
+});
+
+// ─── Response extractor: workspaceWriteExtract ───────────────────────────────
+
+describe("workspaceWriteExtract", () => {
+  function extract(raw: unknown) {
+    return getOp("iacm_workspace", "create").responseExtractor!(raw);
+  }
+
+  it.each([
+    [null, {}],
+    [undefined, {}],
+    ["string", {}],
+    [42, {}],
+    [[], {}],
+    [{ policy_evaluation: { status: "success" } }, { policy_evaluation: { status: "success" } }],
+    [{ policy_evaluation: null, workspace: { id: "x" } }, { policy_evaluation: null }],
+    [{}, { policy_evaluation: null }],
+    [
+      { policy_evaluation: { status: "failed" }, id: "ws-1", identifier: "ws-1" },
+      { policy_evaluation: { status: "failed" } },
+    ],
+  ])("projects create/update response %j", (raw, expected) => {
+    expect(extract(raw)).toEqual(expected);
+  });
+
+  it("update uses the same extractor as create", () => {
+    expect(getOp("iacm_workspace", "update").responseExtractor).toBe(
+      getOp("iacm_workspace", "create").responseExtractor,
+    );
   });
 });
 
@@ -280,6 +333,11 @@ describe("requireProjectScope preflight", () => {
       const spec = getOp(type, "list");
       expect(spec.preflight, `${type}.list is missing preflight`).toBeDefined();
     }
+  });
+
+  it("is present on iacm_workspace create and update", () => {
+    expect(getOp("iacm_workspace", "create").preflight).toBe(preflight);
+    expect(getOp("iacm_workspace", "update").preflight).toBe(preflight);
   });
 
   it("is NOT present on account-scoped iacm_module list", () => {
@@ -538,6 +596,101 @@ describe("iacm registry dispatch", () => {
       }),
     ).rejects.toThrow("provider_connector");
     expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects workspace update when an API-required field is missing", async () => {
+    const mockRequest = vi.fn();
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+    const invalidBody = { ...workspaceBody };
+    delete (invalidBody as Partial<typeof workspaceBody>).identifier;
+    delete (invalidBody as Partial<typeof workspaceBody>).name;
+
+    await expect(
+      registry.dispatch(makeClient(mockRequest), "iacm_workspace", "update", {
+        org_id: "default",
+        project_id: "Testim",
+        workspace_id: "payments-prod",
+        body: invalidBody,
+      }),
+    ).rejects.toThrow("name");
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it("dispatches template-based workspace create with associated_template", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({
+      policy_evaluation: { status: "success" },
+    });
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+    const templateBody = {
+      ...workspaceBody,
+      associated_template: { template_id: "ws-template", version: "1" },
+    };
+
+    const result = await registry.dispatch(makeClient(mockRequest), "iacm_workspace", "create", {
+      org_id: "default",
+      project_id: "Testim",
+      body: templateBody,
+    });
+
+    const request = mockRequest.mock.calls[0]![0] as {
+      method: string;
+      path: string;
+      body: Record<string, unknown>;
+    };
+    expect(request.method).toBe("POST");
+    expect(request.path).toBe("/iacm/api/orgs/default/projects/Testim/workspaces");
+    expect(request.body).toEqual(templateBody);
+    expect(request.body).not.toHaveProperty("orgIdentifier");
+    expect(request.body).not.toHaveProperty("projectIdentifier");
+    expect(result).toEqual({ policy_evaluation: { status: "success" } });
+  });
+
+  it("blocks workspace create when project scope is missing", async () => {
+    const mockRequest = vi.fn();
+    const registry = new Registry(
+      makeConfig({ HARNESS_TOOLSETS: "iacm", HARNESS_ORG: "", HARNESS_PROJECT: undefined }),
+    );
+
+    await expect(
+      registry.dispatch(makeClient(mockRequest), "iacm_workspace", "create", {
+        body: workspaceBody,
+      }),
+    ).rejects.toThrow(/org_id|project_id|IaCM/);
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it("blocks workspace update when project scope is missing", async () => {
+    const mockRequest = vi.fn();
+    const registry = new Registry(
+      makeConfig({ HARNESS_TOOLSETS: "iacm", HARNESS_ORG: "", HARNESS_PROJECT: undefined }),
+    );
+    const updateBody = { ...workspaceBody };
+    delete (updateBody as Partial<typeof workspaceBody>).identifier;
+
+    await expect(
+      registry.dispatch(makeClient(mockRequest), "iacm_workspace", "update", {
+        workspace_id: "payments-prod",
+        body: updateBody,
+      }),
+    ).rejects.toThrow(/org_id|project_id|IaCM/);
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it("does not inject org/project identifiers into workspace write bodies", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ policy_evaluation: { status: "success" } });
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+
+    await registry.dispatch(makeClient(mockRequest), "iacm_workspace", "create", {
+      org_id: "default",
+      project_id: "Testim",
+      body: workspaceBody,
+    });
+
+    const request = mockRequest.mock.calls[0]![0] as { body: Record<string, unknown> };
+    expect(request.body).toEqual(workspaceBody);
+    expect(request.body).not.toHaveProperty("orgIdentifier");
+    expect(request.body).not.toHaveProperty("projectIdentifier");
+    expect(request.body).not.toHaveProperty("accountIdentifier");
   });
 
   it("dispatches iacm_module get using the numeric id from harness_get resource_id mapping", async () => {

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -879,6 +879,101 @@ describe("harness_create", () => {
   });
 });
 
+describe("iacm_workspace create/update via MCP tools", () => {
+  const workspaceBody = {
+    identifier: "payments-prod",
+    name: "Payments Production",
+    provider_connector: "account.aws",
+    provisioner: "terraform",
+    terraform_variables: {},
+    environment_variables: {},
+  };
+
+  it("harness_create dispatches iacm_workspace and returns projected policy_evaluation", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+    const mockRequest = vi.fn().mockResolvedValue({
+      policy_evaluation: { status: "success" },
+      identifier: "payments-prod",
+    });
+    const client = makeClient(mockRequest);
+    const server = makeMcpServer("accept");
+    const { registerCreateTool } = await import("../../src/tools/harness-create.js");
+    registerCreateTool(server, registry, client, makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+
+    const result = await server.call("harness_create", {
+      resource_type: "iacm_workspace",
+      org_id: "default",
+      project_id: "test-project",
+      body: workspaceBody,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(parseResult(result)).toEqual({ policy_evaluation: { status: "success" } });
+    const callArgs = mockRequest.mock.calls[0]![0] as {
+      method: string;
+      path: string;
+      body: Record<string, unknown>;
+    };
+    expect(callArgs.method).toBe("POST");
+    expect(callArgs.path).toBe("/iacm/api/orgs/default/projects/test-project/workspaces");
+    expect(callArgs.body).toEqual(workspaceBody);
+  });
+
+  it("harness_update maps resource_id to workspace_id and projects policy_evaluation", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+    const mockRequest = vi.fn().mockResolvedValue({
+      policy_evaluation: { status: "success" },
+      name: "Payments Production",
+    });
+    const client = makeClient(mockRequest);
+    const server = makeMcpServer("accept");
+    const { registerUpdateTool } = await import("../../src/tools/harness-update.js");
+    registerUpdateTool(server, registry, client, makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+    const updateBody = { ...workspaceBody };
+    delete (updateBody as { identifier?: string }).identifier;
+
+    const result = await server.call("harness_update", {
+      resource_type: "iacm_workspace",
+      resource_id: "payments-prod",
+      org_id: "default",
+      project_id: "test-project",
+      body: updateBody,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(parseResult(result)).toEqual({ policy_evaluation: { status: "success" } });
+    const callArgs = mockRequest.mock.calls[0]![0] as {
+      method: string;
+      path: string;
+      body: Record<string, unknown>;
+    };
+    expect(callArgs.method).toBe("PUT");
+    expect(callArgs.path).toBe(
+      "/iacm/api/orgs/default/projects/test-project/workspaces/payments-prod",
+    );
+    expect(callArgs.body).toEqual(updateBody);
+  });
+
+  it("harness_create declines medium_write iacm_workspace without calling the API", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+    const mockRequest = vi.fn();
+    const client = makeClient(mockRequest);
+    const declineServer = makeMcpServer("decline");
+    const { registerCreateTool } = await import("../../src/tools/harness-create.js");
+    registerCreateTool(declineServer, registry, client, makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+
+    const result = await declineServer.call("harness_create", {
+      resource_type: "iacm_workspace",
+      org_id: "default",
+      project_id: "test-project",
+      body: workspaceBody,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+});
+
 describe("harness_update", () => {
   let server: ReturnType<typeof makeMcpServer>;
   let registry: Registry;


### PR DESCRIPTION
## Summary
- Adds `create` and `update` on MCP resource `iacm_workspace` (scratch + template create via `associated_template`, update via `PUT .../workspaces/{identifier}`).
- Includes `bodySchema`, `medium_write` operation policy, and unit tests in `tests/registry/iacm.test.ts`.
- First of four stacked PRs (workspace → variable set → module → provider).

## Test plan
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm standards:check`
- [x] `pnpm docs:check`
- [x] `pnpm test` (full suite on stack tip)
- [x] QA RBAC smoke: view/none/edit SATs — deny path proven

## Review follow-ups
- Write response projected to `{ policy_evaluation }` only; create/update descriptions tell agents to `harness_get` for the workspace.
- `sparse_checkout` / `provisioner_configuration` kept as array / object to match IaCM wire types (`StringArray` / `StringStringMap`); OpenAPI shows `string` due to goa custom-type encoding.