### PR TITLE
feat: [AIPLAT-1210]: resolve pipeline_v1 openInHarness placeholder in deep links

### DIFF
--- a/src/registry/toolsets/pipelines.ts
+++ b/src/registry/toolsets/pipelines.ts
@@ -442,7 +442,7 @@ export const pipelinesToolset: ToolsetDefinition = {
       identifierFields: ["pipeline_id"],
       searchAliases: ["v1 pipeline", "agent pipeline", "v1"],
       diagnosticHint: "Use harness_diagnose with pipeline_id or execution_id to analyze failures. V1 pipelines use the same execution engine as v0.",
-      deepLinkTemplate: "/ng/account/{accountId}/all/orgs/{orgIdentifier}/projects/{projectIdentifier}/pipelines/{pipelineIdentifier}/pipeline-studio",
+      deepLinkTemplate: "/ng/account/{accountId}/all/orgs/{orgIdentifier}/projects/{projectIdentifier}/pipelines/{pipeline}/pipeline-studio",
       operations: {
         list: {
           method: "GET",

--- a/tests/registry/pipeline-v1-deep-links.test.ts
+++ b/tests/registry/pipeline-v1-deep-links.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Deep links for v1 pipelines must carry the pipeline identifier.
+ *
+ * Regression: the template asked for {pipelineIdentifier} while v1 paths name the
+ * param {pipeline}, so openInHarness came back with the placeholder intact
+ * (".../pipelines/{pipelineIdentifier}/pipeline-studio"). ml-infra forwards that
+ * URL verbatim in its entity_mutation event, which broke the chat redirect.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { HarnessClient } from "../../src/client/harness-client.js";
+import { Registry } from "../../src/registry/index.js";
+import type { Config } from "../../src/config.js";
+
+function makeV1Config(): Config {
+  return {
+    HARNESS_API_KEY: "pat.testaccount.tokenid.secret",
+    HARNESS_ACCOUNT_ID: "testaccount",
+    HARNESS_BASE_URL: "https://app.harness.io",
+    HARNESS_ORG: "",
+    HARNESS_PROJECT: "",
+    HARNESS_API_TIMEOUT_MS: 5000,
+    HARNESS_MAX_RETRIES: 0,
+    LOG_LEVEL: "error",
+    HARNESS_PIPELINE_VERSION: "1",
+  } as Config;
+}
+
+function mockFetchResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("pipeline_v1 deep links", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("resolves the identifier from a create response that only returns `identifier`", async () => {
+    // PipelineCreateResponseBody carries no name or pipelineIdentifier field.
+    fetchSpy.mockResolvedValueOnce(
+      mockFetchResponse({ identifier: "hello_harness", governance_metadata: {} }),
+    );
+
+    const config = makeV1Config();
+    const registry = new Registry(config);
+    const result = (await registry.dispatch(new HarnessClient(config), "pipeline_v1", "create", {
+      org_id: "avitest",
+      project_id: "avi",
+      body: {
+        identifier: "hello_harness",
+        name: "Hello Harness",
+        pipeline_yaml: "pipeline:\n  name: Hello Harness\n",
+      },
+    })) as Record<string, unknown>;
+
+    expect(result.openInHarness).toBe(
+      "https://app.harness.io/ng/account/testaccount/all/orgs/avitest/projects/avi/pipelines/hello_harness/pipeline-studio",
+    );
+  });
+
+  it("resolves the identifier on update, where it comes from the input", async () => {
+    fetchSpy.mockResolvedValueOnce(mockFetchResponse({ identifier: "hello_harness" }));
+
+    const config = makeV1Config();
+    const registry = new Registry(config);
+    const result = (await registry.dispatch(new HarnessClient(config), "pipeline_v1", "update", {
+      org_id: "avitest",
+      project_id: "avi",
+      pipeline_id: "hello_harness",
+      body: {
+        identifier: "hello_harness",
+        pipeline_yaml: "pipeline:\n  name: Hello Harness\n",
+      },
+    })) as Record<string, unknown>;
+
+    expect(result.openInHarness).toBe(
+      "https://app.harness.io/ng/account/testaccount/all/orgs/avitest/projects/avi/pipelines/hello_harness/pipeline-studio",
+    );
+  });
+});


### PR DESCRIPTION


## Description

## Summary
- Align `pipeline_v1` `deepLinkTemplate` with its path param name (`{pipeline}` instead of `{pipelineIdentifier}`).
- Prevents `openInHarness` / `entity_mutation` URLs like `.../pipelines/{pipelineIdentifier}/pipeline-studio` after V1 create/update.
- Adds a regression test covering V1 create (response only has `identifier`) and update.
## Context
Deep-link substitution is exact-key based. V1 maps `pipeline_id → pipeline`, so the old `{pipelineIdentifier}` token was never filled. Chat’s `entity_mutation` event forwards that URL as-is; the assistant message often looked fine because the model rewrote the link.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [x] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
If this PR adds or changes Harness API coverage:
- [ ] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [ ] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [ ] `operationPolicy` on every new/changed endpoint
- [ ] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [ ] `identifierFields` and `scope` declared on new resources
- [ ] No `console.log()` in `src/` (stdio JSON-RPC safety)
