### PR TITLE
feat: add IaCM variable set list, get, create, and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1422,13 +1422,16 @@ Template operations use the Harness Template service paths (`/template/api/templ
 
 ### Infrastructure as Code Management (IaCM)
 
-IaCM resources are default-enabled and mostly project-scoped. Start with `iacm_workspace` to find workspace identifiers, then use that `workspace_id` for workspace resources, costs, and activity diffs. The module registry is account-scoped.
+IaCM resources are default-enabled and mostly project-scoped. Start with `iacm_workspace` to find workspace identifiers, then use that `workspace_id` for workspace resources, costs, and activity diffs. Use `iacm_variable_set` for reusable variable sets at account, org, or project scope. The module registry is account-scoped.
 
-`iacm_workspace` create/update return `{ policy_evaluation }` only — follow up with `harness_get` to fetch the workspace. Writes are `medium_write` and require confirmation (elicitation or `confirm: true`).
+`iacm_workspace` create/update return `{ policy_evaluation }` only — follow up with `harness_get` to fetch the workspace. `iacm_variable_set` create/update return the VariableSet resource itself. Writes are `medium_write` and require confirmation (elicitation or `confirm: true`).
+
+Variable-set RBAC (`iac_variableset_*`) is currently Experimental in Harness — access checks always allow until iac-server activates enforcement. MCP still forwards the caller PAT/SAT unchanged.
 
 | Resource Type                   | List | Get | Create | Update | Delete | Execute Actions |
 | ------------------------------- | ---- | --- | ------ | ------ | ------ | --------------- |
 | `iacm_workspace`                | x    | x   | x      | x      |        |                 |
+| `iacm_variable_set`             | x    | x   | x      | x      |        |                 |
 | `iacm_resource`                 | x    |     |        |        |        |                 |
 | `iacm_module`                   | x    | x   |        |        |        |                 |
 | `iacm_workspace_costs`          | x    |     |        |        |        |                 |
@@ -1439,11 +1442,12 @@ Typical workflow:
 1. `harness_list(resource_type="iacm_workspace", org_id="...", project_id="...")` to find the workspace.
 2. `harness_create` / `harness_update` on `iacm_workspace` to create from scratch or a template (`associated_template`), or update an existing workspace — response is `{ policy_evaluation }` only.
 3. `harness_get(resource_type="iacm_workspace", workspace_id="...")` to fetch the created/updated workspace.
-4. `harness_list(resource_type="iacm_resource", org_id="...", project_id="...", workspace_id="...")` to inspect Terraform resources, outputs, and data sources.
-5. `harness_list(resource_type="iacm_workspace_costs", org_id="...", project_id="...", workspace_id="...")` to review per-execution cost entries.
-6. `harness_list(resource_type="iacm_activity_resource_change", org_id="...", project_id="...", activity_id="...", workspace_id="...")` to inspect before/after resource diffs for a plan, apply, or destroy activity.
+4. `harness_list` / `harness_create` / `harness_update` on `iacm_variable_set` (optionally with `resource_scope`) for reusable Terraform/env variable sets — response is the VariableSet resource.
+5. `harness_list(resource_type="iacm_resource", org_id="...", project_id="...", workspace_id="...")` to inspect Terraform resources, outputs, and data sources.
+6. `harness_list(resource_type="iacm_workspace_costs", org_id="...", project_id="...", workspace_id="...")` to review per-execution cost entries.
+7. `harness_list(resource_type="iacm_activity_resource_change", org_id="...", project_id="...", activity_id="...", workspace_id="...")` to inspect before/after resource diffs for a plan, apply, or destroy activity.
 
-IaCM list responses expose `page_count` as the count for the current page only. When `has_more` is true, keep requesting the next 1-based page and sum page counts if you need a total.
+IaCM list responses expose `page_count` as the count for the current page only (except `iacm_variable_set`, which is not paginated). When `has_more` is true, keep requesting the next 1-based page and sum page counts if you need a total.
 
 ### Internal Developer Portal (IDP)
 
@@ -1841,7 +1845,7 @@ Available toolset names:
 | `knowledge-graph`       | kg_queryable_type_summary, kg_grammar, hql_query                                                                                                                                                                                                                                                |
 | `semantic-layer`        | kg_type, kg_related_type                                                                                                                                                                                                                                                                        |
 | `ai-evals`              | eval_dataset, eval_dataset_item, evaluation, eval_run, eval_run_item, eval_run_by_eval, eval_metric, eval_metric_set, eval_metric_set_entry, eval_suite, eval_suite_evaluation, eval_suite_run, eval_target, eval_annotation, eval_analytics, eval_git_settings, eval_registry_item, eval_git_registration, online_eval |
-| `iacm`                  | iacm_workspace, iacm_resource, iacm_module, iacm_workspace_costs, iacm_activity_resource_change                                                                                                                                                                                                 |
+| `iacm`                  | iacm_workspace, iacm_variable_set, iacm_resource, iacm_module, iacm_workspace_costs, iacm_activity_resource_change                                                                                                                                                                              |
 | `ansible` *(opt-in)*    | ansible_inventory, ansible_playbook, ansible_host, ansible_host_activity, ansible_activity                                                                                                                                                                                                      |
 
 

--- a/README.md
+++ b/README.md
@@ -1424,7 +1424,7 @@ Template operations use the Harness Template service paths (`/template/api/templ
 
 IaCM resources are default-enabled and mostly project-scoped. Start with `iacm_workspace` to find workspace identifiers, then use that `workspace_id` for workspace resources, costs, and activity diffs. Use `iacm_variable_set` for reusable variable sets at account, org, or project scope. The module registry is account-scoped.
 
-`iacm_workspace` create/update return `{ policy_evaluation }` only — follow up with `harness_get` to fetch the workspace. `iacm_variable_set` create/update return the VariableSet resource itself. Writes are `medium_write` and require confirmation (elicitation or `confirm: true`).
+`iacm_workspace` create/update return `{ policy_evaluation }` only — follow up with `harness_get` to fetch the workspace. `iacm_variable_set` create/update return the VariableSet resource itself. Variable-set **update is HTTP PUT with full-replacement collections** — always `harness_get` first, then PUT the full desired body (`terraform_variables` / `environment_variables` are required on update; omit/empty clears connectors and variable files). Writes are `medium_write` and require confirmation (elicitation or `confirm: true`).
 
 Variable-set RBAC (`iac_variableset_*`) is currently Experimental in Harness — access checks always allow until iac-server activates enforcement. MCP still forwards the caller PAT/SAT unchanged.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![MCP Toplist](https://mcptoplist.com/badge/glama%2Fharness%2Fmcp-server.svg)](https://mcptoplist.com/server/glama%2Fharness%2Fmcp-server)
 
-An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 223 resource types.
+An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 224 resource types.
 
 ## Why Use This MCP Server
 
@@ -10,7 +10,7 @@ Most MCP servers map one tool per API endpoint. For a platform as broad as Harne
 
 This server is built differently:
 
-- **11 tools, 223 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
+- **11 tools, 224 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
 - **Full platform coverage.** 38 default toolsets spanning CI/CD, GitOps, Feature Flags, Cloud Cost Management, Security Testing, Chaos Engineering, Database DevOps, Internal Developer Portal, Software Supply Chain, Infrastructure as Code Management, Governance, Service Overrides, Knowledge Graph, and more. Opt-in Ansible coverage is available when you need inventory and playbook data.
 - **Multi-project workflows out of the box.** Agents discover organizations and projects dynamically — no hardcoded env vars needed. Ask "show failed executions across all projects" and the agent can navigate the full account hierarchy.
 - **34 prompt templates.** Pre-built prompts for common workflows: build & deploy apps end-to-end, debug failed pipelines, review DORA metrics, triage vulnerabilities, optimize cloud costs, audit access control, plan feature flag rollouts, review pull requests, approve pending pipelines, and more.
@@ -1202,7 +1202,7 @@ Harness pipelines can be stored in three ways:
 
 ## Resource Types
 
-223 resource types organized across 38 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
+224 resource types organized across 38 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
 
 ### Platform
 
@@ -1861,7 +1861,7 @@ Available toolset names:
                  +--------v---------+
                 |    Registry       |  <-- Declarative resource definitions
                 |  38 Toolsets      |      (data files, not code)
-                |  223 Resource Types|
+                |  224 Resource Types|
                  +--------+---------+
                           |
                  +--------v---------+

--- a/src/registry/toolsets/iacm.ts
+++ b/src/registry/toolsets/iacm.ts
@@ -441,51 +441,89 @@ const workspaceUpdateSchema: BodySchema = {
   ],
 };
 
-const variableSetOptionalFields: BodyFieldSpec[] = [
-  { name: "description", type: "string", required: false, description: "Long-form variable set description" },
-  {
-    name: "environment_variables",
-    type: "object",
-    required: false,
-    description: "Environment variable map (key -> { key, value, value_type })",
-  },
-  {
-    name: "terraform_variables",
-    type: "object",
-    required: false,
-    description: "Terraform variable map (key -> { key, value, value_type })",
-  },
+const variableSetOptionalCollections: BodyFieldSpec[] = [
   {
     name: "terraform_variable_files",
     type: "array",
     required: false,
     itemType: "variable-set Terraform variable-file reference",
-    description: "Variable files stored in external repositories",
+    description:
+      "Variable files stored in external repositories. On update this is full-replacement: " +
+      "omit or [] clears existing files. Prefer get-then-put and resend current files to keep them.",
   },
   {
     name: "connectors",
     type: "array",
     required: false,
     itemType: "variable-set connector",
-    description: "Connector references attached to the variable set",
+    description:
+      "Connector references attached to the variable set ({ connector_ref, type }). " +
+      "On update this is full-replacement: omit or [] clears existing connectors. " +
+      "Prefer get-then-put and resend current connectors to keep them.",
   },
 ];
 
 const variableSetCreateSchema: BodySchema = {
-  description: "IaCM variable set definition for create.",
+  description:
+    "IaCM variable set definition for create. Optional maps use key → { key, value, value_type } " +
+    'where value_type is "string" or "secret".',
   fields: [
     { name: "identifier", type: "string", required: true, description: "Unique variable set identifier" },
     { name: "name", type: "string", required: true, description: "Variable set display name" },
-    ...variableSetOptionalFields,
+    { name: "description", type: "string", required: false, description: "Long-form variable set description" },
+    {
+      name: "environment_variables",
+      type: "object",
+      required: false,
+      description:
+        "Environment variable map (key → { key, value, value_type }). " +
+        'Use {} when none are configured. value_type is "string" or "secret".',
+      fields: workspaceVariableValueFields,
+    },
+    {
+      name: "terraform_variables",
+      type: "object",
+      required: false,
+      description:
+        "Terraform variable map (key → { key, value, value_type }). " +
+        'Use {} when none are configured. value_type is "string" or "secret".',
+      fields: workspaceVariableValueFields,
+    },
+    ...variableSetOptionalCollections,
   ],
 };
 
 const variableSetUpdateSchema: BodySchema = {
   description:
-    "IaCM variable set update definition. Identifier comes from the path (variable_set_id / resource_id).",
+    "Complete IaCM variable set update body (HTTP PUT — not a partial patch). " +
+    "Identifier comes from the path (variable_set_id / resource_id). " +
+    "IaCM merges collections by full replacement: omitting terraform_variables, environment_variables, " +
+    "connectors, or terraform_variable_files clears those collections. " +
+    "Always harness_get first, then PUT the full desired state (or {} / [] to clear).",
   fields: [
     { name: "name", type: "string", required: true, description: "Variable set display name" },
-    ...variableSetOptionalFields,
+    { name: "description", type: "string", required: false, description: "Long-form variable set description" },
+    {
+      name: "environment_variables",
+      type: "object",
+      required: true,
+      description:
+        "Complete environment variable map (key → { key, value, value_type }). " +
+        "Required on update so agents cannot accidentally wipe vars by omitting the field — " +
+        'send the current map from harness_get, or {} to clear. value_type is "string" or "secret".',
+      fields: workspaceVariableValueFields,
+    },
+    {
+      name: "terraform_variables",
+      type: "object",
+      required: true,
+      description:
+        "Complete Terraform variable map (key → { key, value, value_type }). " +
+        "Required on update so agents cannot accidentally wipe vars by omitting the field — " +
+        'send the current map from harness_get, or {} to clear. value_type is "string" or "secret".',
+      fields: workspaceVariableValueFields,
+    },
+    ...variableSetOptionalCollections,
   ],
 };
 
@@ -655,6 +693,8 @@ export const iacmToolset: ToolsetDefinition = {
         SCOPE_BEHAVIOR_DOC +
         " Use harness_list/harness_get to discover sets, harness_create to create, and harness_update with variable_set_id to update. " +
         "Create/update return the VariableSet resource (identifier, name, variables, connectors). " +
+        "IMPORTANT: harness_update is HTTP PUT with full-replacement collections — call harness_get first, then PUT the full desired body " +
+        "(omitting terraform_variables / environment_variables / connectors / terraform_variable_files clears them on the server). " +
         "NOTE: IaCM variable-set RBAC permissions (iac_variableset_*) are currently Experimental in Harness — " +
         "deny paths are not enforceable until iac-server activates them; MCP still forwards the caller token unchanged. " +
         "See also: iacm_workspace.variable_sets for attaching sets to a workspace.",
@@ -702,6 +742,7 @@ export const iacmToolset: ToolsetDefinition = {
           description:
             "Create an IaCM variable set. Required body fields: identifier, name. " +
             "Optional: description, environment_variables, terraform_variables, terraform_variable_files, connectors. " +
+            "Variable maps use key → { key, value, value_type } with value_type string|secret. " +
             "Response is the created VariableSet resource. " +
             "MCP forwards the caller token; variable-set RBAC permissions are Experimental until iac-server enforces them.",
         },
@@ -716,7 +757,11 @@ export const iacmToolset: ToolsetDefinition = {
           responseExtractor: variableSetExtract,
           description:
             "Update an IaCM variable set by identifier (variable_set_id / resource_id). " +
-            "Required body field: name. Optional maps/files/connectors replace configured values when provided. " +
+            "HTTP PUT with full-replacement semantics for collections (same behavior as iac-server): " +
+            "required body fields are name, terraform_variables, and environment_variables " +
+            "(send maps from harness_get, or {} to clear). " +
+            "connectors and terraform_variable_files are also full-replacement — omit or [] clears them; " +
+            "prefer get-then-put and resend current values to keep them. " +
             "Response is the updated VariableSet resource. " +
             "MCP forwards the caller token; variable-set RBAC permissions are Experimental until iac-server enforces them.",
         },

--- a/src/registry/toolsets/iacm.ts
+++ b/src/registry/toolsets/iacm.ts
@@ -75,7 +75,8 @@ const variableSetListExtract = (
 };
 
 /**
- * Variable-set get/create/update return the VariableSet resource/save result directly.
+ * Variable-set get/create/update return the VariableSet resource directly
+ * (identifier, name, variables, connectors, …) — not a policy_evaluation envelope.
  */
 const variableSetExtract = (raw: unknown): unknown => raw;
 
@@ -653,6 +654,9 @@ export const iacmToolset: ToolsetDefinition = {
         "Supports account, org, and project scope. " +
         SCOPE_BEHAVIOR_DOC +
         " Use harness_list/harness_get to discover sets, harness_create to create, and harness_update with variable_set_id to update. " +
+        "Create/update return the VariableSet resource (identifier, name, variables, connectors). " +
+        "NOTE: IaCM variable-set RBAC permissions (iac_variableset_*) are currently Experimental in Harness — " +
+        "deny paths are not enforceable until iac-server activates them; MCP still forwards the caller token unchanged. " +
         "See also: iacm_workspace.variable_sets for attaching sets to a workspace.",
       toolset: "iacm",
       scope: "project",
@@ -684,7 +688,7 @@ export const iacmToolset: ToolsetDefinition = {
           responseExtractor: variableSetExtract,
           description:
             "Get a variable set by identifier at the selected account/org/project scope. " +
-            "Pass variable_set_id via params or as resource_id.",
+            "Pass variable_set_id via params or as resource_id. Response is the VariableSet resource.",
         },
         create: {
           method: "POST",
@@ -698,7 +702,8 @@ export const iacmToolset: ToolsetDefinition = {
           description:
             "Create an IaCM variable set. Required body fields: identifier, name. " +
             "Optional: description, environment_variables, terraform_variables, terraform_variable_files, connectors. " +
-            "IaCM enforces permissions and validation.",
+            "Response is the created VariableSet resource. " +
+            "MCP forwards the caller token; variable-set RBAC permissions are Experimental until iac-server enforces them.",
         },
         update: {
           method: "PUT",
@@ -712,7 +717,8 @@ export const iacmToolset: ToolsetDefinition = {
           description:
             "Update an IaCM variable set by identifier (variable_set_id / resource_id). " +
             "Required body field: name. Optional maps/files/connectors replace configured values when provided. " +
-            "IaCM enforces permissions and validation.",
+            "Response is the updated VariableSet resource. " +
+            "MCP forwards the caller token; variable-set RBAC permissions are Experimental until iac-server enforces them.",
         },
       },
     },

--- a/src/registry/toolsets/iacm.ts
+++ b/src/registry/toolsets/iacm.ts
@@ -1,9 +1,12 @@
 import type {
   BodyFieldSpec,
   BodySchema,
+  PathBuilderConfig,
+  ResourceScope,
   ToolsetDefinition,
   PreflightContext,
 } from "../types.js";
+import { SCOPE_BEHAVIOR_DOC } from "../scope-utils.js";
 
 // ─── Response extractors ─────────────────────────────────────────────────────
 
@@ -49,6 +52,32 @@ const workspaceWriteExtract = (raw: unknown): unknown => {
     policy_evaluation: rec.policy_evaluation ?? null,
   };
 };
+
+/**
+ * Variable-set list: API returns `{ items: [...] }` with no pagination params.
+ * Normalize to the shared list shape used by other IaCM resources.
+ */
+const variableSetListExtract = (
+  raw: unknown,
+): { items: unknown[]; page_count: number; has_more: boolean; pagination_note: string } => {
+  const items = Array.isArray(raw)
+    ? raw
+    : raw && typeof raw === "object" && Array.isArray((raw as { items?: unknown[] }).items)
+      ? ((raw as { items: unknown[] }).items)
+      : [];
+  return {
+    items,
+    page_count: items.length,
+    has_more: false,
+    pagination_note:
+      `Returned ${items.length} variable set(s). This endpoint is not paginated — treat page_count as the full result size for the selected scope.`,
+  };
+};
+
+/**
+ * Variable-set get/create/update return the VariableSet resource/save result directly.
+ */
+const variableSetExtract = (raw: unknown): unknown => raw;
 
 /**
  * IACM resources list: API returns a ResourcesResponse with resources, outputs,
@@ -163,6 +192,67 @@ const requireProjectScope = async (ctx: PreflightContext): Promise<void> => {
         "and will fail silently without them.",
     );
   }
+};
+
+/**
+ * Resolve account/org/project path prefix for IaCM variable-set endpoints.
+ * Paths use `/variable-sets` for list and `/variable-set` for get/create/update.
+ */
+const resolveVariableSetScopePrefix = (
+  input: Record<string, unknown>,
+  config: PathBuilderConfig,
+): string => {
+  const requestedScope = input.resource_scope as ResourceScope | undefined;
+  const org = (input.org_id as string | undefined) ?? config.HARNESS_ORG;
+  const project = (input.project_id as string | undefined) ?? config.HARNESS_PROJECT;
+
+  const useProject =
+    requestedScope === "project" ||
+    (!requestedScope && Boolean(org && project));
+  const useOrg =
+    requestedScope === "org" ||
+    useProject ||
+    (!requestedScope && Boolean(org));
+
+  if (requestedScope === "project" && (!org || !project)) {
+    throw new Error(
+      'resource_scope="project" requires org_id and project_id (or HARNESS_ORG / HARNESS_PROJECT defaults).',
+    );
+  }
+  if (requestedScope === "org" && !org) {
+    throw new Error('resource_scope="org" requires org_id (or a HARNESS_ORG default).');
+  }
+
+  if (useProject && org && project) {
+    return `/iacm/api/orgs/${encodeURIComponent(org)}/projects/${encodeURIComponent(project)}`;
+  }
+  if (useOrg && org) {
+    return `/iacm/api/orgs/${encodeURIComponent(org)}`;
+  }
+  return "/iacm/api";
+};
+
+const variableSetListPath = (
+  input: Record<string, unknown>,
+  config: PathBuilderConfig,
+): string => `${resolveVariableSetScopePrefix(input, config)}/variable-sets`;
+
+const variableSetCollectionPath = (
+  input: Record<string, unknown>,
+  config: PathBuilderConfig,
+): string => `${resolveVariableSetScopePrefix(input, config)}/variable-set`;
+
+const variableSetItemPath = (
+  input: Record<string, unknown>,
+  config: PathBuilderConfig,
+): string => {
+  const id = input.variable_set_id as string | undefined;
+  if (!id) {
+    throw new Error(
+      'Missing required field "variable_set_id" for iacm_variable_set. Pass it via params or as resource_id.',
+    );
+  }
+  return `${variableSetCollectionPath(input, config)}/${encodeURIComponent(id)}`;
 };
 
 // ─── Workspace request schemas ───────────────────────────────────────────────
@@ -350,6 +440,54 @@ const workspaceUpdateSchema: BodySchema = {
   ],
 };
 
+const variableSetOptionalFields: BodyFieldSpec[] = [
+  { name: "description", type: "string", required: false, description: "Long-form variable set description" },
+  {
+    name: "environment_variables",
+    type: "object",
+    required: false,
+    description: "Environment variable map (key -> { key, value, value_type })",
+  },
+  {
+    name: "terraform_variables",
+    type: "object",
+    required: false,
+    description: "Terraform variable map (key -> { key, value, value_type })",
+  },
+  {
+    name: "terraform_variable_files",
+    type: "array",
+    required: false,
+    itemType: "variable-set Terraform variable-file reference",
+    description: "Variable files stored in external repositories",
+  },
+  {
+    name: "connectors",
+    type: "array",
+    required: false,
+    itemType: "variable-set connector",
+    description: "Connector references attached to the variable set",
+  },
+];
+
+const variableSetCreateSchema: BodySchema = {
+  description: "IaCM variable set definition for create.",
+  fields: [
+    { name: "identifier", type: "string", required: true, description: "Unique variable set identifier" },
+    { name: "name", type: "string", required: true, description: "Variable set display name" },
+    ...variableSetOptionalFields,
+  ],
+};
+
+const variableSetUpdateSchema: BodySchema = {
+  description:
+    "IaCM variable set update definition. Identifier comes from the path (variable_set_id / resource_id).",
+  fields: [
+    { name: "name", type: "string", required: true, description: "Variable set display name" },
+    ...variableSetOptionalFields,
+  ],
+};
+
 // ─── Toolset definition ─────────────────────────────────────────────────────
 
 export const iacmToolset: ToolsetDefinition = {
@@ -357,12 +495,12 @@ export const iacmToolset: ToolsetDefinition = {
   displayName: "Infrastructure as Code Management (IaCM)",
   description:
     "Harness IaCM (Infrastructure as Code Management) — manage Terraform workspaces " +
-    "(list/get/create/update), inspect provisioned resources and Terraform outputs, " +
-    "browse the module registry, review workspace cost history, and diff resource changes " +
-    "from past plan/apply/destroy activities. " +
-    "Use iacm_workspace to list, get, create, or update workspaces; iacm_resource for Terraform " +
-    "resources and outputs; iacm_module for the module registry; iacm_workspace_costs for cost " +
-    "breakdown; and iacm_activity_resource_change for activity diffs.",
+    "(list/get/create/update), shared variable sets, provisioned resources and Terraform outputs, " +
+    "the module registry, workspace cost history, and resource-change diffs from plan/apply/destroy. " +
+    "Use iacm_workspace to list, get, create, or update workspaces; iacm_variable_set for reusable " +
+    "variable sets (account/org/project); iacm_resource for Terraform resources and outputs; " +
+    "iacm_module for the module registry; iacm_workspace_costs for cost breakdown; " +
+    "and iacm_activity_resource_change for activity diffs.",
   optIn: false,
   resources: [
     // ─── Workspace ─────────────────────────────────────────────────────────
@@ -501,6 +639,80 @@ export const iacmToolset: ToolsetDefinition = {
             "IaCM enforces permissions, validation, and policy evaluation. " +
             "Response is { policy_evaluation } only — not the workspace. Follow up with harness_get " +
             "(resource_type=iacm_workspace, workspace_id=<identifier>) to fetch the updated workspace.",
+        },
+      },
+    },
+
+    // ─── Variable Sets ─────────────────────────────────────────────────────
+    {
+      resourceType: "iacm_variable_set",
+      displayName: "IaCM Variable Set",
+      description:
+        "A reusable IaCM variable set containing Terraform variables, environment variables, " +
+        "variable files, and connector references that can be attached to workspaces. " +
+        "Supports account, org, and project scope. " +
+        SCOPE_BEHAVIOR_DOC +
+        " Use harness_list/harness_get to discover sets, harness_create to create, and harness_update with variable_set_id to update. " +
+        "See also: iacm_workspace.variable_sets for attaching sets to a workspace.",
+      toolset: "iacm",
+      scope: "project",
+      supportedScopes: ["account", "org", "project"],
+      identifierFields: ["variable_set_id"],
+      relatedResources: [
+        {
+          resourceType: "iacm_workspace",
+          relationship: "used by",
+          description: "Workspaces can attach this variable set via their variable_sets field",
+        },
+      ],
+      operations: {
+        list: {
+          method: "GET",
+          path: "/iacm/api/orgs/{org}/projects/{project}/variable-sets",
+          pathBuilder: variableSetListPath,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          responseExtractor: variableSetListExtract,
+          description:
+            "List IaCM variable sets at the selected account/org/project scope. " +
+            "Response fields: items, page_count (full result size — this API is not paginated), has_more=false.",
+        },
+        get: {
+          method: "GET",
+          path: "/iacm/api/orgs/{org}/projects/{project}/variable-set/{variableSetId}",
+          pathBuilder: variableSetItemPath,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          responseExtractor: variableSetExtract,
+          description:
+            "Get a variable set by identifier at the selected account/org/project scope. " +
+            "Pass variable_set_id via params or as resource_id.",
+        },
+        create: {
+          method: "POST",
+          path: "/iacm/api/orgs/{org}/projects/{project}/variable-set",
+          pathBuilder: variableSetCollectionPath,
+          operationPolicy: { risk: "medium_write", retryPolicy: "do_not_retry" },
+          bodyBuilder: (input) => input.body,
+          bodySchema: variableSetCreateSchema,
+          skipScopeBodyInjection: true,
+          responseExtractor: variableSetExtract,
+          description:
+            "Create an IaCM variable set. Required body fields: identifier, name. " +
+            "Optional: description, environment_variables, terraform_variables, terraform_variable_files, connectors. " +
+            "IaCM enforces permissions and validation.",
+        },
+        update: {
+          method: "PUT",
+          path: "/iacm/api/orgs/{org}/projects/{project}/variable-set/{variableSetId}",
+          pathBuilder: variableSetItemPath,
+          operationPolicy: { risk: "medium_write", retryPolicy: "do_not_retry" },
+          bodyBuilder: (input) => input.body,
+          bodySchema: variableSetUpdateSchema,
+          skipScopeBodyInjection: true,
+          responseExtractor: variableSetExtract,
+          description:
+            "Update an IaCM variable set by identifier (variable_set_id / resource_id). " +
+            "Required body field: name. Optional maps/files/connectors replace configured values when provided. " +
+            "IaCM enforces permissions and validation.",
         },
       },
     },

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,6 @@
 # Harness MCP Server — Task Tracking
 
-## IaCM workspace create/update (this PR)
+## IaCM workspace create/update (merged #793)
 - [x] Add create/update tests and implement `iacm_workspace` writes
 - [x] bodySchema + medium_write policy + project-scope preflight
 - [x] Run build, typecheck, standards, docs checks, and full tests
@@ -10,6 +10,18 @@
 - Follow the declarative registry model; no endpoint-specific MCP tools.
 - IaCM APIs own validation, RBAC, persistence, and audit; MCP forwards the caller token.
 - Stacked follow-ups (separate PRs): variable sets → modules → providers.
+
+## IaCM variable set list/get/create/update (this PR)
+- [x] Add `iacm_variable_set` list/get/create/update with multi-scope pathBuilder
+- [x] bodySchema + medium_write policy + skipScopeBodyInjection
+- [ ] Polish tests (wiring, validation, mock-fetch, MCP elicitation) + README
+- [ ] Note Experimental RBAC: `iac_variableset_*` always permitted until iac-server enforces
+- [ ] Open PR stacked on merged workspace (#793)
+
+### Plan
+- Variable sets are multi-scope (account/org/project) via pathBuilder + resource_scope.
+- Create/update return the VariableSet resource (not policy_evaluation).
+- Do not claim deny-path RBAC coverage while permissions are Experimental.
 
 ## Dependency security advisories (2026-08-03)
 - [x] Confirm affected dependency chains and fixed versions for `fast-uri` and `ip-address`

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -16,7 +16,7 @@
 - [x] bodySchema + medium_write policy + skipScopeBodyInjection
 - [x] Polish tests (wiring, validation, mock-fetch, MCP elicitation) + README
 - [x] Note Experimental RBAC: `iac_variableset_*` always permitted until iac-server enforces
-- [ ] Open PR stacked on merged workspace (#793)
+- [x] Open PR stacked on merged workspace (#793) — https://github.com/harness/mcp-server/pull/800
 
 ### Plan
 - Variable sets are multi-scope (account/org/project) via pathBuilder + resource_scope.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -14,8 +14,8 @@
 ## IaCM variable set list/get/create/update (this PR)
 - [x] Add `iacm_variable_set` list/get/create/update with multi-scope pathBuilder
 - [x] bodySchema + medium_write policy + skipScopeBodyInjection
-- [ ] Polish tests (wiring, validation, mock-fetch, MCP elicitation) + README
-- [ ] Note Experimental RBAC: `iac_variableset_*` always permitted until iac-server enforces
+- [x] Polish tests (wiring, validation, mock-fetch, MCP elicitation) + README
+- [x] Note Experimental RBAC: `iac_variableset_*` always permitted until iac-server enforces
 - [ ] Open PR stacked on merged workspace (#793)
 
 ### Plan

--- a/tests/integration/elicitation-flow.test.ts
+++ b/tests/integration/elicitation-flow.test.ts
@@ -424,6 +424,39 @@ describe("Elicitation flow: iacm_workspace medium_write", () => {
     expect(server._elicitInput).not.toHaveBeenCalled();
     expect(mockRequest).toHaveBeenCalledOnce();
   });
+
+  it("elicits confirmation for iacm_variable_set medium_write create", async () => {
+    mockRequest = vi.fn().mockResolvedValue({
+      identifier: "shared-env",
+      name: "Shared Env",
+    });
+    client = {
+      request: mockRequest,
+      account: "test-account",
+    } as unknown as HarnessClient;
+
+    const server = makeMcpServer({ supportsElicitation: true, elicitAction: "accept" });
+    const { registerCreateTool } = await import("../../src/tools/harness-create.js");
+    registerCreateTool(server, registry, client, makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+
+    const result = await server.call("harness_create", {
+      resource_type: "iacm_variable_set",
+      org_id: "default",
+      project_id: "test-project",
+      body: {
+        identifier: "shared-env",
+        name: "Shared Env",
+      },
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(server._elicitInput).toHaveBeenCalledOnce();
+    expect(mockRequest).toHaveBeenCalledOnce();
+    expect(JSON.parse(result.content[0]!.text)).toEqual({
+      identifier: "shared-env",
+      name: "Shared Env",
+    });
+  });
 });
 
 describe("Elicitation ordering: validate before elicit", () => {

--- a/tests/integration/mock-harness-api.test.ts
+++ b/tests/integration/mock-harness-api.test.ts
@@ -539,4 +539,65 @@ describe("Integration: Registry → HarnessClient → fetch", () => {
       expect(fetchSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe("iacm variable set writes", () => {
+    it("create posts JSON body through pathBuilder and returns the VariableSet", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          identifier: "shared-env",
+          name: "Shared Env",
+          terraform_variables: {},
+          environment_variables: {},
+        }),
+      );
+
+      const config = makeConfig({ HARNESS_TOOLSETS: "iacm" });
+      const client = new HarnessClient(config);
+      const registry = new Registry(config);
+      const body = {
+        identifier: "shared-env",
+        name: "Shared Env",
+        terraform_variables: {},
+        environment_variables: {},
+      };
+
+      const result = await registry.dispatch(client, "iacm_variable_set", "create", {
+        org_id: "default",
+        project_id: "test-project",
+        body,
+      });
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [url, options] = fetchSpy.mock.calls[0]!;
+      const urlStr = url instanceof URL ? url.toString() : String(url);
+      const init = options as RequestInit;
+      expect(urlStr).toContain("/iacm/api/orgs/default/projects/test-project/variable-set");
+      expect((init.method ?? "GET").toUpperCase()).toBe("POST");
+      expect(JSON.parse(init.body as string)).toEqual(body);
+      expect(result).toEqual(body);
+    });
+
+    it("update puts by variable_set_id at org scope", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({ identifier: "shared-env", name: "Shared Env Updated" }),
+      );
+
+      const config = makeConfig({ HARNESS_TOOLSETS: "iacm" });
+      const client = new HarnessClient(config);
+      const registry = new Registry(config);
+
+      const result = await registry.dispatch(client, "iacm_variable_set", "update", {
+        resource_scope: "org",
+        org_id: "default",
+        variable_set_id: "shared-env",
+        body: { name: "Shared Env Updated" },
+      });
+
+      const [url, options] = fetchSpy.mock.calls[0]!;
+      const urlStr = url instanceof URL ? url.toString() : String(url);
+      expect(urlStr).toContain("/iacm/api/orgs/default/variable-set/shared-env");
+      expect((options as RequestInit).method?.toUpperCase()).toBe("PUT");
+      expect(result).toEqual({ identifier: "shared-env", name: "Shared Env Updated" });
+    });
+  });
 });

--- a/tests/integration/mock-harness-api.test.ts
+++ b/tests/integration/mock-harness-api.test.ts
@@ -590,13 +590,22 @@ describe("Integration: Registry → HarnessClient → fetch", () => {
         resource_scope: "org",
         org_id: "default",
         variable_set_id: "shared-env",
-        body: { name: "Shared Env Updated" },
+        body: {
+          name: "Shared Env Updated",
+          terraform_variables: {},
+          environment_variables: {},
+        },
       });
 
       const [url, options] = fetchSpy.mock.calls[0]!;
       const urlStr = url instanceof URL ? url.toString() : String(url);
       expect(urlStr).toContain("/iacm/api/orgs/default/variable-set/shared-env");
       expect((options as RequestInit).method?.toUpperCase()).toBe("PUT");
+      expect(JSON.parse((options as RequestInit).body as string)).toEqual({
+        name: "Shared Env Updated",
+        terraform_variables: {},
+        environment_variables: {},
+      });
       expect(result).toEqual({ identifier: "shared-env", name: "Shared Env Updated" });
     });
   });

--- a/tests/registry/iacm.test.ts
+++ b/tests/registry/iacm.test.ts
@@ -278,10 +278,34 @@ describe("iacm_variable_set contract", () => {
     const updateRequired = update.bodySchema!.fields.filter((field) => field.required).map((field) => field.name);
 
     expect(createRequired).toEqual(["identifier", "name"]);
-    expect(updateRequired).toEqual(["name"]);
+    expect(updateRequired).toEqual(["name", "environment_variables", "terraform_variables"]);
     expect(create.description).toMatch(/VariableSet resource/i);
     expect(create.description).toMatch(/Experimental/i);
     expect(update.description).toMatch(/Experimental/i);
+    expect(update.description).toMatch(/full-replacement|get-then-put|harness_get/i);
+    expect(update.bodySchema!.description).toMatch(/not a partial patch|full replacement/i);
+
+    for (const fieldName of ["terraform_variables", "environment_variables"] as const) {
+      const createField = create.bodySchema!.fields.find((field) => field.name === fieldName);
+      const updateField = update.bodySchema!.fields.find((field) => field.name === fieldName);
+      expect(createField).toMatchObject({
+        type: "object",
+        fields: [
+          expect.objectContaining({ name: "key", required: true }),
+          expect.objectContaining({ name: "value", required: true }),
+          expect.objectContaining({ name: "value_type", required: true }),
+        ],
+      });
+      expect(updateField).toMatchObject({
+        type: "object",
+        required: true,
+        fields: [
+          expect.objectContaining({ name: "key", required: true }),
+          expect.objectContaining({ name: "value", required: true }),
+          expect.objectContaining({ name: "value_type", required: true }),
+        ],
+      });
+    }
   });
 
   it("normalizes list responses that already wrap items", () => {
@@ -848,7 +872,11 @@ describe("iacm registry dispatch", () => {
       resource_scope: "org",
       org_id: "default",
       variable_set_id: "shared-env",
-      body: { name: "Shared Env Updated" },
+      body: {
+        name: "Shared Env Updated",
+        terraform_variables: {},
+        environment_variables: {},
+      },
     });
 
     expect(mockRequest.mock.calls[0]![0]).toMatchObject({
@@ -868,7 +896,51 @@ describe("iacm registry dispatch", () => {
     expect(mockRequest.mock.calls[2]![0]).toMatchObject({
       method: "PUT",
       path: "/iacm/api/orgs/default/variable-set/shared-env",
-      body: { name: "Shared Env Updated" },
+      body: {
+        name: "Shared Env Updated",
+        terraform_variables: {},
+        environment_variables: {},
+      },
+    });
+  });
+
+  it("dispatches variable set create and get at account scope", async () => {
+    const mockRequest = vi.fn()
+      .mockResolvedValueOnce({ identifier: "acct-defaults", name: "Account Defaults" })
+      .mockResolvedValueOnce({
+        identifier: "acct-defaults",
+        name: "Account Defaults",
+        terraform_variables: {},
+      });
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+
+    await registry.dispatch(makeClient(mockRequest), "iacm_variable_set", "create", {
+      resource_scope: "account",
+      body: {
+        identifier: "acct-defaults",
+        name: "Account Defaults",
+        terraform_variables: {},
+        environment_variables: {},
+      },
+    });
+    await registry.dispatch(makeClient(mockRequest), "iacm_variable_set", "get", {
+      resource_scope: "account",
+      variable_set_id: "acct-defaults",
+    });
+
+    expect(mockRequest.mock.calls[0]![0]).toMatchObject({
+      method: "POST",
+      path: "/iacm/api/variable-set",
+      body: {
+        identifier: "acct-defaults",
+        name: "Account Defaults",
+        terraform_variables: {},
+        environment_variables: {},
+      },
+    });
+    expect(mockRequest.mock.calls[1]![0]).toMatchObject({
+      method: "GET",
+      path: "/iacm/api/variable-set/acct-defaults",
     });
   });
 
@@ -911,9 +983,28 @@ describe("iacm registry dispatch", () => {
         org_id: "default",
         project_id: "Testim",
         variable_set_id: "shared-env",
-        body: { description: "no name" },
+        body: {
+          description: "no name",
+          terraform_variables: {},
+          environment_variables: {},
+        },
       }),
     ).rejects.toThrow("name");
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects variable set update when variable maps are omitted (prevents silent wipe)", async () => {
+    const mockRequest = vi.fn();
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+
+    await expect(
+      registry.dispatch(makeClient(mockRequest), "iacm_variable_set", "update", {
+        org_id: "default",
+        project_id: "Testim",
+        variable_set_id: "shared-env",
+        body: { name: "Shared Env Updated" },
+      }),
+    ).rejects.toThrow(/terraform_variables|environment_variables/);
     expect(mockRequest).not.toHaveBeenCalled();
   });
 

--- a/tests/registry/iacm.test.ts
+++ b/tests/registry/iacm.test.ts
@@ -264,19 +264,24 @@ describe("iacm_variable_set contract", () => {
         risk: "medium_write",
         retryPolicy: "do_not_retry",
       });
+      expect(getOp("iacm_variable_set", op).skipScopeBodyInjection).toBe(true);
+      expect(getOp("iacm_variable_set", op).bodyBuilder!({ body: { name: "x" } })).toEqual({
+        name: "x",
+      });
     }
   });
 
   it("documents create and update body requirements", () => {
-    const createRequired = getOp("iacm_variable_set", "create")
-      .bodySchema!.fields.filter((field) => field.required)
-      .map((field) => field.name);
-    const updateRequired = getOp("iacm_variable_set", "update")
-      .bodySchema!.fields.filter((field) => field.required)
-      .map((field) => field.name);
+    const create = getOp("iacm_variable_set", "create");
+    const update = getOp("iacm_variable_set", "update");
+    const createRequired = create.bodySchema!.fields.filter((field) => field.required).map((field) => field.name);
+    const updateRequired = update.bodySchema!.fields.filter((field) => field.required).map((field) => field.name);
 
     expect(createRequired).toEqual(["identifier", "name"]);
     expect(updateRequired).toEqual(["name"]);
+    expect(create.description).toMatch(/VariableSet resource/i);
+    expect(create.description).toMatch(/Experimental/i);
+    expect(update.description).toMatch(/Experimental/i);
   });
 
   it("normalizes list responses that already wrap items", () => {
@@ -291,6 +296,28 @@ describe("iacm_variable_set contract", () => {
     ]);
     expect(result.page_count).toBe(2);
     expect(result.has_more).toBe(false);
+  });
+
+  it("normalizes bare array and empty list payloads", () => {
+    const extract = getOp("iacm_variable_set", "list").responseExtractor!;
+    expect(extract([{ identifier: "a" }])).toMatchObject({
+      items: [{ identifier: "a" }],
+      page_count: 1,
+      has_more: false,
+    });
+    expect(extract(null)).toMatchObject({ items: [], page_count: 0, has_more: false });
+  });
+
+  it("passes through get/create/update VariableSet payloads", () => {
+    const payload = {
+      identifier: "shared-env",
+      name: "Shared Env",
+      terraform_variables: {},
+      environment_variables: {},
+    };
+    expect(getOp("iacm_variable_set", "create").responseExtractor!(payload)).toEqual(payload);
+    expect(getOp("iacm_variable_set", "update").responseExtractor!(payload)).toEqual(payload);
+    expect(getOp("iacm_variable_set", "get").responseExtractor!(payload)).toEqual(payload);
   });
 });
 
@@ -859,5 +886,47 @@ describe("iacm registry dispatch", () => {
       method: "GET",
       path: "/iacm/api/orgs/default/projects/Testim/variable-set/shared-env",
     });
+  });
+
+  it("rejects variable set create when identifier is missing", async () => {
+    const mockRequest = vi.fn();
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+
+    await expect(
+      registry.dispatch(makeClient(mockRequest), "iacm_variable_set", "create", {
+        org_id: "default",
+        project_id: "Testim",
+        body: { name: "Missing Identifier" },
+      }),
+    ).rejects.toThrow("identifier");
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects variable set update when name is missing", async () => {
+    const mockRequest = vi.fn();
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+
+    await expect(
+      registry.dispatch(makeClient(mockRequest), "iacm_variable_set", "update", {
+        org_id: "default",
+        project_id: "Testim",
+        variable_set_id: "shared-env",
+        body: { description: "no name" },
+      }),
+    ).rejects.toThrow("name");
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it("requires variable_set_id for get/update path building", async () => {
+    const mockRequest = vi.fn();
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+
+    await expect(
+      registry.dispatch(makeClient(mockRequest), "iacm_variable_set", "get", {
+        org_id: "default",
+        project_id: "Testim",
+      }),
+    ).rejects.toThrow("variable_set_id");
+    expect(mockRequest).not.toHaveBeenCalled();
   });
 });

--- a/tests/registry/iacm.test.ts
+++ b/tests/registry/iacm.test.ts
@@ -62,14 +62,15 @@ describe("iacmToolset structure", () => {
     expect(iacmToolset.optIn).toBe(false);
   });
 
-  it("registers all 5 resource types", () => {
+  it("registers all 6 resource types", () => {
     const types = iacmToolset.resources.map((r) => r.resourceType);
     expect(types).toContain("iacm_workspace");
     expect(types).toContain("iacm_resource");
     expect(types).toContain("iacm_module");
     expect(types).toContain("iacm_workspace_costs");
     expect(types).toContain("iacm_activity_resource_change");
-    expect(types).toHaveLength(5);
+    expect(types).toContain("iacm_variable_set");
+    expect(types).toHaveLength(6);
   });
 
   it("iacm_module is account-scoped", () => {
@@ -78,6 +79,12 @@ describe("iacmToolset structure", () => {
 
   it("iacm_module list has pageOneIndexed=true", () => {
     expect(getOp("iacm_module", "list").pageOneIndexed).toBe(true);
+  });
+
+  it("iacm_variable_set supports account, org, and project scopes", () => {
+    const resource = findResource("iacm_variable_set");
+    expect(resource.scope).toBe("project");
+    expect(resource.supportedScopes).toEqual(["account", "org", "project"]);
   });
 
   it("iacm_workspace, iacm_resource, iacm_workspace_costs, iacm_activity_resource_change are project-scoped", () => {
@@ -245,6 +252,48 @@ describe("workspaceWriteExtract", () => {
   });
 });
 
+// ─── Variable set contract ───────────────────────────────────────────────────
+
+describe("iacm_variable_set contract", () => {
+  it("registers list/get/create/update with medium_write writes", () => {
+    for (const op of ["list", "get"] as const) {
+      expect(getOp("iacm_variable_set", op).operationPolicy.risk).toBe("read");
+    }
+    for (const op of ["create", "update"] as const) {
+      expect(getOp("iacm_variable_set", op).operationPolicy).toEqual({
+        risk: "medium_write",
+        retryPolicy: "do_not_retry",
+      });
+    }
+  });
+
+  it("documents create and update body requirements", () => {
+    const createRequired = getOp("iacm_variable_set", "create")
+      .bodySchema!.fields.filter((field) => field.required)
+      .map((field) => field.name);
+    const updateRequired = getOp("iacm_variable_set", "update")
+      .bodySchema!.fields.filter((field) => field.required)
+      .map((field) => field.name);
+
+    expect(createRequired).toEqual(["identifier", "name"]);
+    expect(updateRequired).toEqual(["name"]);
+  });
+
+  it("normalizes list responses that already wrap items", () => {
+    const extract = getOp("iacm_variable_set", "list").responseExtractor!;
+    const result = extract({
+      items: [{ identifier: "shared-env" }, { identifier: "prod-tf" }],
+    }) as Record<string, unknown>;
+
+    expect(result.items).toEqual([
+      { identifier: "shared-env" },
+      { identifier: "prod-tf" },
+    ]);
+    expect(result.page_count).toBe(2);
+    expect(result.has_more).toBe(false);
+  });
+});
+
 // ─── Registry default-on behaviour ───────────────────────────────────────────
 
 describe("iacm default-on with Registry", () => {
@@ -260,6 +309,7 @@ describe("iacm default-on with Registry", () => {
     expect(registry.getAllResourceTypes()).toContain("iacm_module");
     expect(registry.getAllResourceTypes()).toContain("iacm_workspace_costs");
     expect(registry.getAllResourceTypes()).toContain("iacm_activity_resource_change");
+    expect(registry.getAllResourceTypes()).toContain("iacm_variable_set");
   });
 
   it("IS present when enabled with +iacm modifier", () => {
@@ -745,5 +795,69 @@ describe("iacm registry dispatch", () => {
     const request = mockRequest.mock.calls[0]![0] as { path: string; params: Record<string, unknown> };
     expect(request.path).toBe("/iacm/api/orgs/default/projects/Testim/activities/exec-123/resource-changes");
     expect(request.params.workspace).toBe("ws-1");
+  });
+
+  it("dispatches variable set list/create/update across scopes", async () => {
+    const mockRequest = vi.fn()
+      .mockResolvedValueOnce({ items: [{ identifier: "shared-env" }] })
+      .mockResolvedValueOnce({ identifier: "shared-env", name: "Shared Env" })
+      .mockResolvedValueOnce({ identifier: "shared-env", name: "Shared Env Updated" });
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+
+    await registry.dispatch(makeClient(mockRequest), "iacm_variable_set", "list", {
+      resource_scope: "account",
+    });
+    await registry.dispatch(makeClient(mockRequest), "iacm_variable_set", "create", {
+      org_id: "default",
+      project_id: "Testim",
+      body: {
+        identifier: "shared-env",
+        name: "Shared Env",
+        terraform_variables: {},
+        environment_variables: {},
+      },
+    });
+    await registry.dispatch(makeClient(mockRequest), "iacm_variable_set", "update", {
+      resource_scope: "org",
+      org_id: "default",
+      variable_set_id: "shared-env",
+      body: { name: "Shared Env Updated" },
+    });
+
+    expect(mockRequest.mock.calls[0]![0]).toMatchObject({
+      method: "GET",
+      path: "/iacm/api/variable-sets",
+    });
+    expect(mockRequest.mock.calls[1]![0]).toMatchObject({
+      method: "POST",
+      path: "/iacm/api/orgs/default/projects/Testim/variable-set",
+      body: {
+        identifier: "shared-env",
+        name: "Shared Env",
+        terraform_variables: {},
+        environment_variables: {},
+      },
+    });
+    expect(mockRequest.mock.calls[2]![0]).toMatchObject({
+      method: "PUT",
+      path: "/iacm/api/orgs/default/variable-set/shared-env",
+      body: { name: "Shared Env Updated" },
+    });
+  });
+
+  it("dispatches variable set get at project scope by identifier", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ identifier: "shared-env" });
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+
+    await registry.dispatch(makeClient(mockRequest), "iacm_variable_set", "get", {
+      org_id: "default",
+      project_id: "Testim",
+      variable_set_id: "shared-env",
+    });
+
+    expect(mockRequest.mock.calls[0]![0]).toMatchObject({
+      method: "GET",
+      path: "/iacm/api/orgs/default/projects/Testim/variable-set/shared-env",
+    });
   });
 });

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -1021,7 +1021,11 @@ describe("iacm_variable_set create/update via MCP tools", () => {
       resource_id: "shared-env",
       org_id: "default",
       project_id: "test-project",
-      body: { name: "Shared Env Updated" },
+      body: {
+        name: "Shared Env Updated",
+        terraform_variables: {},
+        environment_variables: {},
+      },
     });
 
     expect(result.isError).toBeUndefined();
@@ -1029,11 +1033,16 @@ describe("iacm_variable_set create/update via MCP tools", () => {
       identifier: "shared-env",
       name: "Shared Env Updated",
     });
-    const callArgs = mockRequest.mock.calls[0]![0] as { method: string; path: string };
+    const callArgs = mockRequest.mock.calls[0]![0] as { method: string; path: string; body: unknown };
     expect(callArgs.method).toBe("PUT");
     expect(callArgs.path).toBe(
       "/iacm/api/orgs/default/projects/test-project/variable-set/shared-env",
     );
+    expect(callArgs.body).toEqual({
+      name: "Shared Env Updated",
+      terraform_variables: {},
+      environment_variables: {},
+    });
   });
 });
 

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -974,6 +974,69 @@ describe("iacm_workspace create/update via MCP tools", () => {
   });
 });
 
+describe("iacm_variable_set create/update via MCP tools", () => {
+  const variableSetBody = {
+    identifier: "shared-env",
+    name: "Shared Env",
+    terraform_variables: {},
+    environment_variables: {},
+  };
+
+  it("harness_create returns the VariableSet resource for iacm_variable_set", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+    const mockRequest = vi.fn().mockResolvedValue(variableSetBody);
+    const client = makeClient(mockRequest);
+    const server = makeMcpServer("accept");
+    const { registerCreateTool } = await import("../../src/tools/harness-create.js");
+    registerCreateTool(server, registry, client, makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+
+    const result = await server.call("harness_create", {
+      resource_type: "iacm_variable_set",
+      org_id: "default",
+      project_id: "test-project",
+      body: variableSetBody,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(parseResult(result)).toEqual(variableSetBody);
+    const callArgs = mockRequest.mock.calls[0]![0] as { method: string; path: string; body: unknown };
+    expect(callArgs.method).toBe("POST");
+    expect(callArgs.path).toBe("/iacm/api/orgs/default/projects/test-project/variable-set");
+    expect(callArgs.body).toEqual(variableSetBody);
+  });
+
+  it("harness_update maps resource_id to variable_set_id", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+    const mockRequest = vi.fn().mockResolvedValue({
+      identifier: "shared-env",
+      name: "Shared Env Updated",
+    });
+    const client = makeClient(mockRequest);
+    const server = makeMcpServer("accept");
+    const { registerUpdateTool } = await import("../../src/tools/harness-update.js");
+    registerUpdateTool(server, registry, client, makeConfig({ HARNESS_TOOLSETS: "iacm" }));
+
+    const result = await server.call("harness_update", {
+      resource_type: "iacm_variable_set",
+      resource_id: "shared-env",
+      org_id: "default",
+      project_id: "test-project",
+      body: { name: "Shared Env Updated" },
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(parseResult(result)).toEqual({
+      identifier: "shared-env",
+      name: "Shared Env Updated",
+    });
+    const callArgs = mockRequest.mock.calls[0]![0] as { method: string; path: string };
+    expect(callArgs.method).toBe("PUT");
+    expect(callArgs.path).toBe(
+      "/iacm/api/orgs/default/projects/test-project/variable-set/shared-env",
+    );
+  });
+});
+
 describe("harness_update", () => {
   let server: ReturnType<typeof makeMcpServer>;
   let registry: Registry;


### PR DESCRIPTION
## Summary
- Add multi-scope `iacm_variable_set` (account/org/project) with list/get/create/update against existing IaCM APIs
- Create/update return the VariableSet resource (not a `policy_evaluation` envelope); writes are `medium_write` with confirmation
- Document that `iac_variableset_*` RBAC permissions are still **Experimental** in Harness — deny paths are not enforceable until iac-server activates them; MCP continues to forward the caller PAT/SAT unchanged
- Stacked on merged workspace support (#793)

## Test plan
- [x] Unit: variable-set contract, list extract, create/update validation, multi-scope pathBuilder dispatch
- [x] Mock-fetch integration for create/update URL + body
- [x] MCP `harness_create` / `harness_update` + medium_write elicitation
- [x] README resource table + Experimental RBAC note
- [ ] Optional live smoke with SATs (expect allow on view/none/edit while Experimental)


Made with [Cursor](https://cursor.com)