### PR TITLE
feat: [AIPLAT-1334]: Point infrastructure openInHarness at environment Infrastructure section

### DIFF
--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -961,6 +961,8 @@ export class Registry {
           if (key === "accountId" || baseLinkParams[key]) continue;
           if (resultRecord[key] !== undefined) {
             baseLinkParams[key] = String(resultRecord[key]);
+          } else if (params[key] !== undefined && params[key] !== "") {
+            baseLinkParams[key] = String(params[key]);
           }
         }
       }

--- a/src/registry/toolsets/infrastructure.ts
+++ b/src/registry/toolsets/infrastructure.ts
@@ -1,6 +1,31 @@
 import type { ToolsetDefinition } from "../types.js";
 import { buildBodyNormalized } from "../../utils/body-normalizer.js";
 import { ngExtract, pageExtract } from "../extractors.js";
+import { isRecord } from "../../utils/type-guards.js";
+
+/** Copy environmentRef onto environmentIdentifier so the deep-link template can resolve {environmentIdentifier}. */
+function aliasEnvironmentIdentifier(record: Record<string, unknown>): void {
+  if (typeof record.environmentIdentifier === "string" && record.environmentIdentifier) return;
+  const nested = isRecord(record.infrastructure) ? record.infrastructure : undefined;
+  const ref = record.environmentRef ?? nested?.environmentRef;
+  if (typeof ref === "string" && ref) {
+    record.environmentIdentifier = ref;
+  }
+}
+
+const infrastructureExtract = (raw: unknown): unknown => {
+  const data = ngExtract(raw);
+  if (isRecord(data)) aliasEnvironmentIdentifier(data);
+  return data;
+};
+
+const infrastructurePageExtract = (raw: unknown): { items: unknown[]; total: number } => {
+  const page = pageExtract(raw);
+  for (const item of page.items) {
+    if (isRecord(item)) aliasEnvironmentIdentifier(item);
+  }
+  return page;
+};
 
 /**
  * Infra create/update body shaping (same unwrap/strip pattern as service/env), plus
@@ -49,7 +74,7 @@ export const infrastructureToolset: ToolsetDefinition = {
         { name: "sort", description: "Field to sort by (e.g. name, identifier)" },
         { name: "order", description: "Sort order", enum: ["asc", "desc"] },
       ],
-      deepLinkTemplate: "/ng/account/{accountId}/all/orgs/{orgIdentifier}/projects/{projectIdentifier}/environments",
+      deepLinkTemplate: "/ng/account/{accountId}/all/orgs/{orgIdentifier}/projects/{projectIdentifier}/settings/environments/{environmentIdentifier}/details?sectionId=INFRASTRUCTURE",
       operations: {
         list: {
           method: "GET",
@@ -64,7 +89,7 @@ export const infrastructureToolset: ToolsetDefinition = {
             page: "page",
             size: "size",
           },
-          responseExtractor: pageExtract,
+          responseExtractor: infrastructurePageExtract,
           description: "List infrastructure definitions",
         },
         get: {
@@ -73,7 +98,7 @@ export const infrastructureToolset: ToolsetDefinition = {
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           pathParams: { infrastructure_id: "infraIdentifier" },
           queryParams: { environment_id: "environmentIdentifier" },
-          responseExtractor: ngExtract,
+          responseExtractor: infrastructureExtract,
           description: "Get infrastructure definition details",
         },
         create: {
@@ -101,7 +126,7 @@ export const infrastructureToolset: ToolsetDefinition = {
               },
             ],
           },
-          responseExtractor: ngExtract,
+          responseExtractor: infrastructureExtract,
           description: "Create infrastructure definition",
         },
         update: {
@@ -126,7 +151,7 @@ export const infrastructureToolset: ToolsetDefinition = {
               },
             ],
           },
-          responseExtractor: ngExtract,
+          responseExtractor: infrastructureExtract,
           description: "Update infrastructure definition",
         },
         delete: {

--- a/tests/registry/infrastructure.test.ts
+++ b/tests/registry/infrastructure.test.ts
@@ -2,9 +2,15 @@
  * Infrastructure toolset wiring — ensure create/update bodyBuilders synthesize
  * non-empty yaml (NG contract) and pick up tool-level org_id/project_id before
  * yaml synthesis so scope fields appear inside body.yaml.
+ *
+ * Deep links open the environment details Infrastructure section
+ * (`?sectionId=INFRASTRUCTURE`), not a standalone infra settings page.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { infrastructureToolset } from "../../src/registry/toolsets/infrastructure.js";
+import { Registry } from "../../src/registry/index.js";
+import type { Config } from "../../src/config.js";
+import type { HarnessClient } from "../../src/client/harness-client.js";
 
 const infra = infrastructureToolset.resources.find((r) => r.resourceType === "infrastructure");
 if (!infra) throw new Error("infrastructure resource missing from toolset");
@@ -84,5 +90,117 @@ describe("infrastructure update bodyBuilder", () => {
     expect(typeof result.yaml).toBe("string");
     expect(result.yaml as string).toContain("identifier: k8s_staging_infra");
     expect(result.yaml as string).toContain("orgIdentifier: default");
+  });
+});
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    HARNESS_API_KEY: "pat.test",
+    HARNESS_ACCOUNT_ID: "test-account",
+    HARNESS_BASE_URL: "https://app.harness.io",
+    HARNESS_ORG: "default",
+    HARNESS_PROJECT: "avi",
+    HARNESS_API_TIMEOUT_MS: 30000,
+    HARNESS_MAX_RETRIES: 3,
+    HARNESS_MAX_BODY_SIZE_MB: 10,
+    HARNESS_RATE_LIMIT_RPS: 10,
+    HARNESS_READ_ONLY: false,
+    HARNESS_SKIP_ELICITATION: false,
+    HARNESS_ALLOW_HTTP: false,
+    HARNESS_FME_BASE_URL: "https://api.split.io",
+    LOG_LEVEL: "info",
+    ...overrides,
+  };
+}
+
+function makeClient(requestFn?: (...args: unknown[]) => unknown): HarnessClient {
+  return {
+    request: requestFn ?? vi.fn().mockResolvedValue({}),
+    account: "test-account",
+  } as unknown as HarnessClient;
+}
+
+const INFRA_DEEP_LINK =
+  "https://app.harness.io/ng/account/test-account/all/orgs/default/projects/avi/settings/environments/preprod/details?sectionId=INFRASTRUCTURE";
+
+describe("infrastructure deep links", () => {
+  let registry: Registry;
+
+  beforeEach(() => {
+    registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "infrastructure" }));
+  });
+
+  it("list: openInHarness is environment details with the Infrastructure section", async () => {
+    const client = makeClient(
+      vi.fn().mockResolvedValue({
+        data: {
+          content: [
+            {
+              identifier: "k8s",
+              name: "k8s",
+              environmentRef: "preprod",
+              orgIdentifier: "default",
+              projectIdentifier: "avi",
+            },
+          ],
+          totalElements: 1,
+        },
+      }),
+    );
+    const result = (await registry.dispatch(client, "infrastructure", "list", {
+      org_id: "default",
+      project_id: "avi",
+      environment_id: "preprod",
+    })) as { items: Array<Record<string, unknown>> };
+
+    expect(result.items[0]!.openInHarness).toBe(INFRA_DEEP_LINK);
+  });
+
+  it("get: openInHarness uses environmentRef from the response", async () => {
+    const client = makeClient(
+      vi.fn().mockResolvedValue({
+        data: {
+          identifier: "k8s",
+          name: "k8s",
+          environmentRef: "preprod",
+          orgIdentifier: "default",
+          projectIdentifier: "avi",
+        },
+      }),
+    );
+    const result = (await registry.dispatch(client, "infrastructure", "get", {
+      infrastructure_id: "k8s",
+      org_id: "default",
+      project_id: "avi",
+      environment_id: "preprod",
+    })) as Record<string, unknown>;
+
+    expect(result.openInHarness).toBe(INFRA_DEEP_LINK);
+  });
+
+  it("create: openInHarness uses environmentRef when environment_id is not a query param", async () => {
+    const client = makeClient(
+      vi.fn().mockResolvedValue({
+        data: {
+          identifier: "k8s",
+          name: "k8s",
+          environmentRef: "preprod",
+          orgIdentifier: "default",
+          projectIdentifier: "avi",
+        },
+      }),
+    );
+    const result = (await registry.dispatch(client, "infrastructure", "create", {
+      org_id: "default",
+      project_id: "avi",
+      body: {
+        identifier: "k8s",
+        name: "k8s",
+        type: "KubernetesDirect",
+        environmentRef: "preprod",
+      },
+    })) as Record<string, unknown>;
+
+    expect(result.openInHarness).toBe(INFRA_DEEP_LINK);
   });
 });


### PR DESCRIPTION
## Description

Summary

Infrastructure definitions are edited on environment details (?sectionId=INFRASTRUCTURE), not a standalone /environments or /settings/infrastructures page.
Update the infra deepLinkTemplate to /settings/environments/{environmentIdentifier}/details?sectionId=INFRASTRUCTURE.
Fill {environmentIdentifier} from the list/get environment_id query param, or from environmentRef on create/update, so the placeholder is not left in the URL.
Why (the gap)

Old template linked to the environments list, so Open in Harness was wrong.
The new template needs the parent env id. That id lives on the request more often than on the response. The shared deep-link resolver did not read leftover placeholders from query params.
Safety

No API path, method, or body-builder changes.
Shared fallback only applies when a {token} is still unset after the response is applied.
Infra extractor only adds environmentIdentifier; it does not strip fields.


<!-- What does this PR do? -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [x] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
If this PR adds or changes Harness API coverage:
- [ ] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [ ] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [ ] `operationPolicy` on every new/changed endpoint
- [ ] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [ ] `identifierFields` and `scope` declared on new resources
- [ ] No `console.log()` in `src/` (stdio JSON-RPC safety)
