### PR TITLE
Add Harness CI example pipeline for react/react

### DIFF
--- a/examples/react-cicd/README.md
+++ b/examples/react-cicd/README.md
@@ -1,0 +1,58 @@
+# React CI/CD for Harness
+
+Harness pipeline generated from [react/react](https://github.com/react/react) (cloned at commit on disk under `/tmp/react-clone/react`).
+
+## What was detected
+
+| Signal | Value |
+|--------|-------|
+| Package manager | Yarn 1.22.22 (`packageManager` + workspaces) |
+| Node | `v20.19.0` (`.nvmrc`) |
+| Lint | `yarn prettier-check`, `node ./scripts/tasks/eslint`, `./scripts/ci/check_license.sh` |
+| Test | `yarn test` via custom Jest CLI (`scripts/jest/jest-cli.js`) |
+| Build | `yarn build --r=<channel> --ci` (Rollup release channels) |
+| Upstream CI | `.github/workflows/runtime_build_and_test.yml`, `shared_lint.yml` |
+| Deploy target | None (library) — CD stage is optional npm publish behind approval |
+
+## Files
+
+- `react_ci_pipeline.yaml` — Harness **v0** CI pipeline (Lint → Test → Build → Validate → Approve → Publish)
+- `react_ci_trigger.yaml` — GitHub push + PR webhook trigger stubs
+
+## Before you import
+
+Replace every `<+input>` with your values:
+
+1. `orgIdentifier` / `projectIdentifier`
+2. Codebase `connectorRef` (GitHub connector that can clone `react/react`)
+3. Approval `userGroups`
+4. Trigger `connectorRef`
+
+Create a Harness text secret named `NPM_TOKEN` if you enable the Publish stage.
+
+## Import options
+
+**Pipeline Studio (YAML)**  
+Continuous Integration → Pipelines → Create Pipeline → YAML → paste `react_ci_pipeline.yaml`.
+
+**MCP** (when authenticated):
+
+```text
+harness_create
+  resource_type: pipeline
+  org_id: <org>
+  project_id: <project>
+  body: { yamlPipeline: "<contents of react_ci_pipeline.yaml>" }
+```
+
+## Notes vs upstream GitHub Actions
+
+Upstream shards builds across 25 workers × 2 channels and runs a much larger Jest matrix (www-classic/modern, Flow host configs, etc.). This Harness pipeline covers the **core** path:
+
+- Shared lint jobs
+- Stable + experimental Jest envs
+- Full `yarn build` per release channel (not worker-sharded)
+- Flags + inline Fizz runtime checks
+- Optional publish gate on `main` / `releases/*`
+
+Harness Cloud supplies a current Node toolchain; pin to 20.19.x in the install step if your cloud image differs.

--- a/examples/react-cicd/react_ci_pipeline.yaml
+++ b/examples/react-cicd/react_ci_pipeline.yaml
@@ -1,0 +1,378 @@
+pipeline:
+  name: React CI
+  identifier: react_ci
+  projectIdentifier: <+input>
+  orgIdentifier: <+input>
+  tags:
+    framework: react
+    language: javascript
+    package_manager: yarn
+  description: >-
+    CI pipeline for https://github.com/react/react — mirrors upstream lint,
+    test matrix, and build jobs from runtime_build_and_test / shared_lint.
+  properties:
+    ci:
+      codebase:
+        connectorRef: <+input>
+        repoName: react/react
+        build: <+input>
+  variables:
+    - name: NODE_VERSION
+      type: String
+      value: "20.19.0"
+    - name: TZ
+      type: String
+      value: America/Los_Angeles
+  stages:
+    - stage:
+        name: Lint
+        identifier: lint
+        description: Prettier, ESLint, and license checks (shared_lint.yml)
+        type: CI
+        spec:
+          cloneCodebase: true
+          caching:
+            enabled: true
+            paths:
+              - node_modules
+              - "**/node_modules"
+          platform:
+            os: Linux
+            arch: Amd64
+          runtime:
+            type: Cloud
+            spec: {}
+          execution:
+            steps:
+              - step:
+                  type: Run
+                  name: Install Dependencies
+                  identifier: install_deps
+                  timeout: 20m
+                  spec:
+                    shell: Sh
+                    envVariables:
+                      TZ: <+pipeline.variables.TZ>
+                    command: |-
+                      node --version
+                      corepack enable || true
+                      yarn --version
+                      yarn install --frozen-lockfile
+              - parallel:
+                  - step:
+                      type: Run
+                      name: Prettier Check
+                      identifier: prettier_check
+                      timeout: 15m
+                      spec:
+                        shell: Sh
+                        envVariables:
+                          TZ: <+pipeline.variables.TZ>
+                        command: yarn prettier-check
+                  - step:
+                      type: Run
+                      name: ESLint
+                      identifier: eslint
+                      timeout: 20m
+                      spec:
+                        shell: Sh
+                        envVariables:
+                          TZ: <+pipeline.variables.TZ>
+                        command: node ./scripts/tasks/eslint
+                  - step:
+                      type: Run
+                      name: License Check
+                      identifier: license_check
+                      timeout: 10m
+                      spec:
+                        shell: Sh
+                        envVariables:
+                          TZ: <+pipeline.variables.TZ>
+                        command: ./scripts/ci/check_license.sh
+        failureStrategies:
+          - onFailure:
+              errors:
+                - AllErrors
+              action:
+                type: MarkAsFailure
+
+    - stage:
+        name: Test
+        identifier: test
+        description: >-
+          Jest unit tests across stable/experimental release channels
+          (subset of runtime_build_and_test.yml test matrix)
+        type: CI
+        spec:
+          cloneCodebase: true
+          caching:
+            enabled: true
+            paths:
+              - node_modules
+              - "**/node_modules"
+              - compiler/node_modules
+          platform:
+            os: Linux
+            arch: Amd64
+          runtime:
+            type: Cloud
+            spec: {}
+          execution:
+            steps:
+              - step:
+                  type: Run
+                  name: Install Runtime and Compiler
+                  identifier: install_runtime_compiler
+                  timeout: 25m
+                  spec:
+                    shell: Sh
+                    envVariables:
+                      TZ: <+pipeline.variables.TZ>
+                    command: |-
+                      yarn install --frozen-lockfile
+                      yarn --cwd compiler install --frozen-lockfile
+              - step:
+                  type: Run
+                  name: Jest Tests
+                  identifier: jest_tests
+                  timeout: 45m
+                  spec:
+                    shell: Sh
+                    envVariables:
+                      TZ: <+pipeline.variables.TZ>
+                      CI: "true"
+                    command: |-
+                      yarn test -r=<+stage.matrix.release_channel> --env=<+stage.matrix.env> --ci --shard=1/1
+        strategy:
+          matrix:
+            release_channel:
+              - stable
+              - experimental
+            env:
+              - development
+              - production
+          maxConcurrency: 2
+        failureStrategies:
+          - onFailure:
+              errors:
+                - AllErrors
+              action:
+                type: MarkAsFailure
+
+    - stage:
+        name: Build
+        identifier: build
+        description: Rollup release build for stable and experimental channels
+        type: CI
+        spec:
+          cloneCodebase: true
+          caching:
+            enabled: true
+            paths:
+              - node_modules
+              - "**/node_modules"
+              - compiler/node_modules
+          platform:
+            os: Linux
+            arch: Amd64
+          runtime:
+            type: Cloud
+            spec: {}
+          execution:
+            steps:
+              - step:
+                  type: Run
+                  name: Install Build Toolchain
+                  identifier: install_build_toolchain
+                  timeout: 25m
+                  spec:
+                    shell: Sh
+                    envVariables:
+                      TZ: <+pipeline.variables.TZ>
+                    command: |-
+                      yarn install --frozen-lockfile
+                      yarn --cwd compiler install --frozen-lockfile
+              - step:
+                  type: Run
+                  name: Build Release Channel
+                  identifier: build_release_channel
+                  timeout: 60m
+                  spec:
+                    shell: Sh
+                    envVariables:
+                      TZ: <+pipeline.variables.TZ>
+                      CI: harness
+                      RELEASE_CHANNEL: <+stage.matrix.release_channel>
+                    command: |-
+                      rm -rf build
+                      yarn build --r=<+stage.matrix.release_channel> --ci
+                      yarn lint-build
+                      ls -la build || true
+        strategy:
+          matrix:
+            release_channel:
+              - stable
+              - experimental
+          maxConcurrency: 2
+        failureStrategies:
+          - onFailure:
+              errors:
+                - AllErrors
+              action:
+                type: MarkAsFailure
+
+    - stage:
+        name: Validate
+        identifier: validate
+        description: Feature-flag and generated Fizz runtime consistency checks
+        type: CI
+        spec:
+          cloneCodebase: true
+          caching:
+            enabled: true
+            paths:
+              - node_modules
+              - "**/node_modules"
+          platform:
+            os: Linux
+            arch: Amd64
+          runtime:
+            type: Cloud
+            spec: {}
+          execution:
+            steps:
+              - step:
+                  type: Run
+                  name: Install Dependencies
+                  identifier: install_validate_deps
+                  timeout: 20m
+                  spec:
+                    shell: Sh
+                    envVariables:
+                      TZ: <+pipeline.variables.TZ>
+                    command: yarn install --frozen-lockfile
+              - parallel:
+                  - step:
+                      type: Run
+                      name: Feature Flags Check
+                      identifier: flags_check
+                      timeout: 15m
+                      spec:
+                        shell: Sh
+                        envVariables:
+                          TZ: <+pipeline.variables.TZ>
+                        command: yarn flags
+                  - step:
+                      type: Run
+                      name: Inline Fizz Runtime Check
+                      identifier: fizz_runtime_check
+                      timeout: 15m
+                      spec:
+                        shell: Sh
+                        envVariables:
+                          TZ: <+pipeline.variables.TZ>
+                        command: |-
+                          yarn generate-inline-fizz-runtime
+                          git diff --exit-code || (
+                            echo "Fizz runtime is out of date. Run yarn generate-inline-fizz-runtime and commit."
+                            exit 1
+                          )
+        failureStrategies:
+          - onFailure:
+              errors:
+                - AllErrors
+              action:
+                type: MarkAsFailure
+
+    - stage:
+        name: Publish Approval
+        identifier: publish_approval
+        description: Manual gate before npm publish (main / release branches only)
+        type: Approval
+        when:
+          pipelineStatus: Success
+          condition: <+pipeline.properties.ci.codebase.build.spec.branch> == "main" || <+pipeline.properties.ci.codebase.build.spec.branch> =~ "releases/.*"
+        spec:
+          execution:
+            steps:
+              - step:
+                  type: HarnessApproval
+                  name: Approve npm Publish
+                  identifier: approve_npm_publish
+                  timeout: 1d
+                  spec:
+                    approvalMessage: >-
+                      Approve publishing React packages built by this pipeline?
+                      Confirm release channel and version before continuing.
+                    includePipelineExecutionHistory: true
+                    approvers:
+                      userGroups:
+                        - <+input>
+                      minimumCount: 1
+                      disallowPipelineExecutor: true
+                    isAutoRejectEnabled: false
+                    approverInputs: []
+
+    - stage:
+        name: Publish
+        identifier: publish
+        description: Optional prerelease publish (requires NPM_TOKEN secret)
+        type: CI
+        when:
+          pipelineStatus: Success
+          condition: <+pipeline.properties.ci.codebase.build.spec.branch> == "main" || <+pipeline.properties.ci.codebase.build.spec.branch> =~ "releases/.*"
+        spec:
+          cloneCodebase: true
+          caching:
+            enabled: true
+            paths:
+              - node_modules
+              - "**/node_modules"
+              - compiler/node_modules
+          platform:
+            os: Linux
+            arch: Amd64
+          runtime:
+            type: Cloud
+            spec: {}
+          execution:
+            steps:
+              - step:
+                  type: Run
+                  name: Install and Build Stable
+                  identifier: install_and_build_stable
+                  timeout: 60m
+                  spec:
+                    shell: Sh
+                    envVariables:
+                      TZ: <+pipeline.variables.TZ>
+                      CI: harness
+                      RELEASE_CHANNEL: stable
+                    command: |-
+                      yarn install --frozen-lockfile
+                      yarn --cwd compiler install --frozen-lockfile
+                      rm -rf build
+                      yarn build --r=stable --ci
+              - step:
+                  type: Run
+                  name: Publish Prereleases
+                  identifier: publish_prereleases
+                  timeout: 30m
+                  spec:
+                    shell: Sh
+                    envVariables:
+                      TZ: <+pipeline.variables.TZ>
+                      NPM_TOKEN: <+secrets.getValue("NPM_TOKEN")>
+                    command: |-
+                      if [ -z "${NPM_TOKEN}" ]; then
+                        echo "NPM_TOKEN secret is not set; skipping publish."
+                        exit 1
+                      fi
+                      echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+                      yarn publish-prereleases
+        failureStrategies:
+          - onFailure:
+              errors:
+                - AllErrors
+              action:
+                type: MarkAsFailure

--- a/examples/react-cicd/react_ci_trigger.yaml
+++ b/examples/react-cicd/react_ci_trigger.yaml
@@ -1,0 +1,74 @@
+trigger:
+  name: React CI on Push and PR
+  identifier: react_ci_push_pr
+  enabled: true
+  description: Runs React CI on pushes to main/releases and on pull requests
+  tags: {}
+  orgIdentifier: <+input>
+  projectIdentifier: <+input>
+  pipelineIdentifier: react_ci
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: Push
+        spec:
+          connectorRef: <+input>
+          autoAbortPreviousExecutions: true
+          payloadConditions:
+            - key: targetBranch
+              operator: In
+              value: main, releases/.*
+          headerConditions: []
+          jexlCondition: ""
+          repoName: react/react
+          actions: []
+  inputYaml: |
+    pipeline:
+      identifier: react_ci
+      properties:
+        ci:
+          codebase:
+            build:
+              type: branch
+              spec:
+                branch: <+trigger.branch>
+---
+# Second trigger definition for pull requests (import separately or merge in UI)
+trigger:
+  name: React CI on Pull Request
+  identifier: react_ci_pull_request
+  enabled: true
+  description: Runs React CI when a PR is opened or updated
+  tags: {}
+  orgIdentifier: <+input>
+  projectIdentifier: <+input>
+  pipelineIdentifier: react_ci
+  source:
+    type: Webhook
+    spec:
+      type: Github
+      spec:
+        type: PullRequest
+        spec:
+          connectorRef: <+input>
+          autoAbortPreviousExecutions: true
+          payloadConditions: []
+          headerConditions: []
+          jexlCondition: ""
+          repoName: react/react
+          actions:
+            - Open
+            - Reopen
+            - Synchronize
+  inputYaml: |
+    pipeline:
+      identifier: react_ci
+      properties:
+        ci:
+          codebase:
+            build:
+              type: PR
+              spec:
+                number: <+trigger.prNumber>

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,6 +4,7 @@
 - [x] Clone https://github.com/react/react
 - [x] Analyze Yarn/Node scripts and GitHub Actions CI
 - [x] Generate Harness v0 CI pipeline + trigger stubs under `examples/react-cicd/`
+- [x] Commit example under `examples/react-cicd/` and open PR
 - [ ] Create pipeline in a Harness account (needs MCP auth + org/project)
 
 ### Plan

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,20 @@
 # Harness MCP Server — Task Tracking
 
+## React CI/CD pipeline example (this session)
+- [x] Clone https://github.com/react/react
+- [x] Analyze Yarn/Node scripts and GitHub Actions CI
+- [x] Generate Harness v0 CI pipeline + trigger stubs under `examples/react-cicd/`
+- [ ] Create pipeline in a Harness account (needs MCP auth + org/project)
+
+### Plan
+- Deliver importable Harness YAML based on upstream `shared_lint` / `runtime_build_and_test`.
+- Keep CD as optional npm publish behind approval (library has no container deploy target).
+
+### Review
+- Files: `examples/react-cicd/react_ci_pipeline.yaml`, `react_ci_trigger.yaml`, `README.md`.
+- Stages: Lint → Test (matrix) → Build (matrix) → Validate → Approve → Publish.
+
+
 ## OPA policy multi-scope (this session)
 - [x] Add `supportedScopes: ["account", "org", "project"]` + description hints for `policy` and `policy_set`
 - [x] Extend governance tests for supportedScopes and `resource_scope` query-param dispatch


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cloned [react/react](https://github.com/react/react) and generated an importable Harness **v0** CI/CD pipeline based on its Yarn workspaces setup and upstream GitHub Actions (`shared_lint.yml`, `runtime_build_and_test.yml`).

### Deliverables (`examples/react-cicd/`)

- `react_ci_pipeline.yaml` — Lint → Test (matrix) → Build (matrix) → Validate → Approve → Publish
- `react_ci_trigger.yaml` — GitHub push + PR webhook trigger stubs
- `README.md` — detection notes and import instructions

### Detected stack

- Node `v20.19.0`, Yarn `1.22.22`
- Commands: `prettier-check`, ESLint, license check, `yarn test -r=…`, `yarn build --r=… --ci`, flags / Fizz checks
- CD: optional npm prerelease publish behind approval (library has no container deploy target)

### Not done in this PR

- Pipeline was **not** created in a live Harness account — Harness MCP needs authentication plus `org_id` / `project_id`. Provide those to import via UI or `harness_create`.

## Test plan

- [ ] Paste `react_ci_pipeline.yaml` into Pipeline Studio YAML and resolve `<+input>` fields
- [ ] Confirm GitHub connector can clone `react/react`
- [ ] Run Lint stage on a sample branch
- [ ] Optionally enable Publish with `NPM_TOKEN` secret and approval user group

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df499683-7df4-4990-8b7b-82844ad38f89?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df499683-7df4-4990-8b7b-82844ad38f89&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

