### PR TITLE
fix: [AIPLAT-1344]: Surface NG error details in API failures

### DIFF
--- a/src/client/harness-client.ts
+++ b/src/client/harness-client.ts
@@ -107,12 +107,40 @@ const ERROR_FIELD_ENRICHMENTS: Array<{ pathPrefix: string; field: string }> = [
   { pathPrefix: "/loadTest/", field: "description" },
 ];
 
+const MAX_ERROR_DETAIL_CHARS = 400;
+
+/** Extra NG fields (`details`, `detailedMessage`, `responseMessages`) not already in `message`. */
+function collectErrorDetail(parsed: Record<string, unknown>, message: string): string | undefined {
+  const seen = new Set([message.trim()]);
+  const extras: string[] = [];
+  const add = (value: unknown): void => {
+    if (typeof value !== "string") return;
+    const text = value.trim();
+    if (!text || seen.has(text)) return;
+    seen.add(text);
+    extras.push(text);
+  };
+
+  add(parsed.details);
+  add(parsed.detailedMessage);
+  for (const entry of Array.isArray(parsed.responseMessages) ? parsed.responseMessages : []) {
+    if (entry && typeof entry === "object") add((entry as Record<string, unknown>).message);
+  }
+
+  if (extras.length === 0) return undefined;
+  const detail = extras.join("; ");
+  return detail.length > MAX_ERROR_DETAIL_CHARS
+    ? `${detail.slice(0, MAX_ERROR_DETAIL_CHARS)}…`
+    : detail;
+}
+
 function enrichErrorMessage(
   rawMessage: string,
   parsed: Record<string, unknown>,
   path: string,
 ): string {
-  let message = rawMessage;
+  const detail = collectErrorDetail(parsed, rawMessage);
+  let message = detail ? `${rawMessage} — ${detail}` : rawMessage;
   for (const { pathPrefix, field } of ERROR_FIELD_ENRICHMENTS) {
     const value = parsed[field];
     if (path.startsWith(pathPrefix) && typeof value === "string" && value) {

--- a/tests/client/harness-client.test.ts
+++ b/tests/client/harness-client.test.ts
@@ -561,6 +561,114 @@ describe("HarnessClient", () => {
       });
     });
 
+    it("surfaces `details` when NG collapses the cause into the JSON-processing error", async () => {
+      fetchSpy.mockResolvedValue(new Response(
+        JSON.stringify({
+          code: 400,
+          message: "Unable to process JSON",
+          details: "No spec should be provided with the inherit from delegate type",
+        }),
+        { status: 400 },
+      ));
+      const client = new HarnessClient(makeConfig({ HARNESS_MAX_RETRIES: 0 }));
+
+      await expect(client.request({ path: "/ng/api/connectors" })).rejects.toMatchObject({
+        message:
+          "Unable to process JSON — No spec should be provided with the inherit from delegate type",
+        statusCode: 400,
+      });
+    });
+
+    it("leaves the message alone when responseMessages only repeat it", async () => {
+      const message =
+        "Invalid request: Delegate Selector cannot be null for inherit from delegate credential type";
+      fetchSpy.mockResolvedValue(new Response(
+        JSON.stringify({
+          status: "ERROR",
+          code: "INVALID_REQUEST",
+          message,
+          correlationId: "df70c78c-0d47-422a-bd96-faeb9825bc3c",
+          detailedMessage: null,
+          responseMessages: [
+            {
+              code: "INVALID_REQUEST",
+              level: "ERROR",
+              message,
+              exception: null,
+              failureTypes: [],
+              failureSubTypes: [],
+              additionalInfo: {},
+            },
+          ],
+          metadata: null,
+        }),
+        { status: 400 },
+      ));
+      const client = new HarnessClient(makeConfig({ HARNESS_MAX_RETRIES: 0 }));
+
+      await expect(client.request({ path: "/ng/api/connectors" })).rejects.toMatchObject({
+        message,
+        harnessCode: "INVALID_REQUEST",
+        correlationId: "df70c78c-0d47-422a-bd96-faeb9825bc3c",
+      });
+    });
+
+    it("surfaces detailedMessage and responseMessages that add new information", async () => {
+      fetchSpy.mockResolvedValue(new Response(
+        JSON.stringify({
+          message: "Invalid request",
+          detailedMessage: "Field 'spec.credential' is required",
+          responseMessages: [
+            { message: "Invalid request" },
+            { message: "Connector type K8sCluster requires a credential block" },
+          ],
+        }),
+        { status: 400 },
+      ));
+      const client = new HarnessClient(makeConfig({ HARNESS_MAX_RETRIES: 0 }));
+
+      await expect(client.request({ path: "/ng/api/connectors" })).rejects.toMatchObject({
+        message:
+          "Invalid request — Field 'spec.credential' is required; " +
+          "Connector type K8sCluster requires a credential block",
+      });
+    });
+
+    it("truncates oversized upstream detail", async () => {
+      fetchSpy.mockResolvedValue(new Response(
+        JSON.stringify({ message: "Unable to process JSON", details: "x".repeat(900) }),
+        { status: 400 },
+      ));
+      const client = new HarnessClient(makeConfig({ HARNESS_MAX_RETRIES: 0 }));
+
+      try {
+        await client.request({ path: "/ng/api/connectors" });
+        expect.fail("should have thrown");
+      } catch (err) {
+        const { message } = err as HarnessApiError;
+        expect(message).toBe(`Unable to process JSON — ${"x".repeat(400)}…`);
+      }
+    });
+
+    it("surfaces `details` on requestStream errors", async () => {
+      fetchSpy.mockResolvedValue(new Response(
+        JSON.stringify({
+          code: 400,
+          message: "Unable to process JSON",
+          details: "No spec should be provided with the inherit from delegate type",
+        }),
+        { status: 400 },
+      ));
+      const client = new HarnessClient(makeConfig({ HARNESS_MAX_RETRIES: 0 }));
+
+      await expect(
+        client.requestStream({ method: "POST", path: "/ng/api/connectors" }),
+      ).rejects.toMatchObject({
+        message:
+          "Unable to process JSON — No spec should be provided with the inherit from delegate type",
+      });
+    });
+
     it("appends chaos description on requestStream errors", async () => {
       fetchSpy.mockResolvedValue(new Response(
         JSON.stringify({


### PR DESCRIPTION
## Description

NG error bodies often put the real cause in `details`, `detailedMessage`, or `responseMessages` while `message` is only a generic string such as `Unable to process JSON`. Agents then cannot tell what to fix.

This change appends those extra fields onto `HarnessApiError.message` when they add new information, de-duplicates repeats, and truncates oversized detail. The same enrichment applies to `request` and `requestStream`.

Verified against QA `POST /ng/api/connectors` with a K8s `InheritFromDelegate` body that still carries `credential.spec`. NG returns 400; nothing is created.

### Request

```http
POST /ng/api/connectors?accountIdentifier=<account>
{
  "connector": {
    "name": "mcp_err_probe_spec",
    "identifier": "mcp_err_probe_spec",
    "type": "K8sCluster",
    "spec": {
      "credential": {
        "type": "InheritFromDelegate",
        "spec": {}
      },
      "delegateSelectors": ["any-delegate"]
    }
  }
}
```

### NG response

```json
{
  "code": 400,
  "message": "Unable to process JSON",
  "details": "No spec should be provided with the inherit from delegate type"
}
```

### Before

```text
Unable to process JSON
```

### After

```text
Unable to process JSON — No spec should be provided with the inherit from delegate type
```

correlationId and other envelope fields stay on HarnessApiError and are not copied into message. If responseMessages only repeats message, the string is unchanged.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Documentation
* [ ] Other

## Checklist

* [x] `pnpm test` passes
* [x] `pnpm typecheck` passes
* [x] `pnpm build` passes
* [x] `pnpm standards:check` passes (architecture guardrails — see [[docs/coding-standards.md](https://chatgpt.com/c/docs/coding-standards.md)](docs/coding-standards.md))
* [ ] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)

If this PR adds or changes Harness API coverage:

* [ ] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
* [ ] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
* [ ] `operationPolicy` on every new/changed endpoint
* [ ] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
* [ ] `identifierFields` and `scope` declared on new resources
* [ ] No `console.log()` in `src/` (stdio JSON-RPC safety)

N/A — client error parsing only; no registry/toolset changes.