### PR TITLE
fix: [AIPLAT-1408]: hydrate Git location and lock SHAs for remote pipeline updates

### DIFF
--- a/src/registry/toolsets/pipelines.ts
+++ b/src/registry/toolsets/pipelines.ts
@@ -1,4 +1,4 @@
-import type { ToolsetDefinition, BodySchema, ParamsSchema } from "../types.js";
+import type { ToolsetDefinition, BodySchema, ParamsSchema, PreflightContext } from "../types.js";
 import { ngExtract, pageExtract, passthrough, v1ListExtract, runtimeInputExtract, executionInputsExtract, dynamicExecutionExtract, triggerListExtract } from "../extractors.js";
 import YAML from "yaml";
 
@@ -70,7 +70,7 @@ function normalizeTriggerBody(
 // ---------------------------------------------------------------------------
 
 const pipelineV1CreateSchema: BodySchema = {
-  description: "V1 pipeline definition. Pass pipeline_yaml (YAML string of the v1 pipeline definition), identifier, and name. The version field defaults to '1'. Alternatively, pass a raw YAML string as body — identifier (from pipeline.identifier or v1 pipeline.id) and name will be extracted from the YAML. You can also pass {pipeline: {...}} as a JSON object which will be serialized to YAML automatically.",
+  description: "V1 pipeline definition. Pass pipeline_yaml (YAML string of the v1 pipeline definition), identifier, and name. The version field defaults to '1'. Alternatively, pass a raw YAML string as body — identifier (from pipeline.identifier or v1 pipeline.id) and name will be extracted from the YAML. You can also pass {pipeline: {...}} as a JSON object which will be serialized to YAML automatically. For remote/Git-backed pipelines, pass Git Experience fields via params (store_type, repo_name, branch, file_path, connector_ref) or body.git_details — they are sent in the JSON body, not as query params.",
   fields: [
     { name: "pipeline_yaml", type: "string", required: true, description: "Pipeline YAML string (the v1 pipeline definition including 'pipeline:' root key)" },
     { name: "identifier", type: "string", required: true, description: "Unique pipeline identifier" },
@@ -78,11 +78,12 @@ const pipelineV1CreateSchema: BodySchema = {
     { name: "version", type: "string", required: false, description: "Pipeline version. Defaults to '1' for v1 pipelines" },
     { name: "description", type: "string", required: false, description: "Pipeline description" },
     { name: "tags", type: "object", required: false, description: "Pipeline tags as key:value pairs" },
+    { name: "git_details", type: "object", required: false, description: "Git Experience create fields (branch_name, file_path, repo_name, connector_ref, is_harness_code_repo, store_type, commit_message, base_branch). Prefer params: store_type, repo_name, branch, file_path, connector_ref, is_harness_code_repo, commit_msg." },
   ],
 };
 
 const pipelineV1UpdateSchema: BodySchema = {
-  description: "V1 pipeline definition (full replacement). Same fields as create: pipeline_yaml, identifier, name, version. Pass a raw YAML string as body, or {pipeline_yaml, identifier, name} as JSON. Raw v1 YAML can provide the identifier as pipeline.id.",
+  description: "V1 pipeline definition (full replacement). Same fields as create: pipeline_yaml, identifier, name, version. Pass a raw YAML string as body, or {pipeline_yaml, identifier, name} as JSON. Raw v1 YAML can provide the identifier as pipeline.id. For remote pipelines, include git_details (or params last_object_id/last_commit_id from GET git_details.object_id/commit_id) so Git conflict detection succeeds.",
   fields: [
     { name: "pipeline_yaml", type: "string", required: true, description: "Pipeline YAML string (full replacement)" },
     { name: "identifier", type: "string", required: true, description: "Pipeline identifier" },
@@ -90,8 +91,219 @@ const pipelineV1UpdateSchema: BodySchema = {
     { name: "version", type: "string", required: false, description: "Pipeline version. Defaults to '1'" },
     { name: "description", type: "string", required: false, description: "Pipeline description" },
     { name: "tags", type: "object", required: false, description: "Pipeline tags as key:value pairs" },
+    { name: "git_details", type: "object", required: false, description: "Git Experience update fields. Include last_object_id and last_commit_id from GET git_details.object_id/commit_id (or pass last_object_id/last_commit_id via params)." },
   ],
 };
+
+const PIPELINE_V1_GET_PARAMS: ParamsSchema = {
+  fields: [
+    { name: "branch", required: false, description: "Git branch alias — maps to branch_name on the wire. Pass via params." },
+    { name: "branch_name", required: false, description: "Git branch — sent as branch_name. Alias of branch. Pass via params." },
+    { name: "repo_name", required: false, description: "Git repository name for Git Experience. Pass via params." },
+    { name: "connector_ref", required: false, description: "Git connector for remote pipelines. Pass via params." },
+    { name: "load_from_fallback_branch", required: false, description: "When true, load from the created non-default branch if the requested branch is empty. Pass via params." },
+    { name: "template_applied", required: false, description: "When true, return YAML with templates applied. Pass via params." },
+    { name: "validate_async", required: false, description: "When true, validate the pipeline asynchronously. Pass via params." },
+  ],
+};
+
+const PIPELINE_V1_CREATE_PARAMS: ParamsSchema = {
+  fields: [
+    { name: "store_type", required: false, description: "INLINE (default) or REMOTE. Pass via params; mapped into body.git_details." },
+    { name: "branch", required: false, description: "Git branch (body.git_details.branch_name). Pass via params." },
+    { name: "repo_name", required: false, description: "Git repo name. Pass via params." },
+    { name: "file_path", required: false, description: "Path of the pipeline YAML in the repo. Pass via params." },
+    { name: "connector_ref", required: false, description: "Git connector ref for external Git. Pass via params." },
+    { name: "is_harness_code_repo", required: false, description: "Set true for Harness Code repositories (body.git_details.is_harness_code_repo). Pass via params." },
+    { name: "commit_msg", required: false, description: "Commit message (body.git_details.commit_message). Pass via params." },
+    { name: "base_branch", required: false, description: "Base branch when creating a new branch. Pass via params." },
+  ],
+};
+
+const PIPELINE_V1_UPDATE_PARAMS: ParamsSchema = {
+  fields: [
+    ...PIPELINE_V1_CREATE_PARAMS.fields,
+    { name: "last_object_id", required: false, description: "Git blob/object id from GET git_details.object_id — required for remote updates. Pass via params." },
+    { name: "last_commit_id", required: false, description: "Git commit id from GET git_details.commit_id — required for remote updates. Pass via params." },
+  ],
+};
+
+const PIPELINE_V0_GET_PARAMS: ParamsSchema = {
+  fields: [
+    { name: "branch", required: false, description: "Git branch for a remote pipeline. Pass via params." },
+    { name: "store_type", required: false, description: "INLINE or REMOTE. Pass via params." },
+    { name: "connector_ref", required: false, description: "Git connector ref for external Git. Pass via params." },
+    { name: "repo_name", required: false, description: "Git repository name. Pass via params." },
+  ],
+};
+
+const PIPELINE_V0_UPDATE_PARAMS: ParamsSchema = {
+  fields: [
+    { name: "store_type", required: false, description: "INLINE or REMOTE. Pass via params." },
+    { name: "branch", required: false, description: "Git branch for a remote pipeline. Pass via params." },
+    { name: "repo_name", required: false, description: "Git repository name. Pass via params." },
+    { name: "file_path", required: false, description: "Path of the pipeline YAML in the repository. Pass via params." },
+    { name: "connector_ref", required: false, description: "Git connector ref for external Git. Pass via params." },
+    { name: "is_harness_code_repo", required: false, description: "Set true for Harness Code repositories. Pass via params." },
+    { name: "commit_msg", required: false, description: "Git commit message. Pass via params." },
+    { name: "last_object_id", required: false, description: "Git blob/object id from GET gitDetails.objectId. Pass via params." },
+    { name: "last_commit_id", required: false, description: "Git commit id from GET gitDetails.commitId. Pass via params." },
+  ],
+};
+
+function firstGitString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value !== "") return value;
+  }
+  return undefined;
+}
+
+function firstGitBoolean(...values: unknown[]): boolean | undefined {
+  for (const value of values) {
+    if (typeof value === "boolean") return value;
+    // `params` values are untyped JSON and agents routinely quote booleans.
+    // v0 forwards the string as a query param; v1 must not drop it.
+    if (typeof value === "string") {
+      const normalized = value.trim().toLowerCase();
+      if (normalized === "true") return true;
+      if (normalized === "false") return false;
+    }
+  }
+  return undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function inputGitDetails(input: Record<string, unknown>): Record<string, unknown> {
+  return asRecord(asRecord(input.body)?.git_details) ?? {};
+}
+
+/**
+ * V1 create/update send Git Experience fields in JSON `git_details`, not query params.
+ * Accept params used by v0 agents (branch, commit_msg, last_object_id) and GET response
+ * names (object_id, commit_id) so agents can copy git_details forward.
+ */
+function collectV1GitDetails(input: Record<string, unknown>): Record<string, string | boolean> | undefined {
+  const git = inputGitDetails(input);
+  const details: Record<string, string | boolean> = {};
+  const assign = (key: string, value: string | undefined) => {
+    if (value) details[key] = value;
+  };
+
+  assign("branch_name", firstGitString(input.branch_name, input.branch, git.branch_name));
+  assign("file_path", firstGitString(input.file_path, git.file_path));
+  assign("commit_message", firstGitString(input.commit_message, input.commit_msg, git.commit_message));
+  assign("base_branch", firstGitString(input.base_branch, git.base_branch));
+  assign("connector_ref", firstGitString(input.connector_ref, git.connector_ref));
+  assign("store_type", firstGitString(input.store_type, git.store_type));
+  assign("repo_name", firstGitString(input.repo_name, git.repo_name));
+  const isHarnessCodeRepo = firstGitBoolean(input.is_harness_code_repo, git.is_harness_code_repo);
+  if (isHarnessCodeRepo !== undefined) details.is_harness_code_repo = isHarnessCodeRepo;
+  assign("last_object_id", firstGitString(input.last_object_id, git.last_object_id, git.object_id));
+  assign("last_commit_id", firstGitString(input.last_commit_id, git.last_commit_id, git.commit_id));
+
+  return Object.keys(details).length > 0 ? details : undefined;
+}
+
+function hasRemoteUpdateLockContext(input: Record<string, unknown>): boolean {
+  const git = inputGitDetails(input);
+  return !!firstGitString(input.branch_name, input.branch, git.branch_name)
+    && !!firstGitString(input.repo_name, git.repo_name)
+    && !!firstGitString(input.file_path, git.file_path)
+    && !!firstGitString(input.last_object_id, git.last_object_id, git.object_id)
+    && !!firstGitString(input.last_commit_id, git.last_commit_id, git.commit_id);
+}
+
+function isExplicitlyInline(input: Record<string, unknown>): boolean {
+  const storeType = firstGitString(input.store_type, inputGitDetails(input).store_type);
+  return storeType?.toUpperCase() === "INLINE";
+}
+
+function setIfMissing(input: Record<string, unknown>, key: string, value: unknown): void {
+  if ((input[key] === undefined || input[key] === "") && value !== undefined && value !== "") {
+    input[key] = value;
+  }
+}
+
+/**
+ * Remote updates require Git location plus optimistic-lock SHAs. Agents commonly
+ * send only the updated YAML, so hydrate missing Git context from the current
+ * pipeline before the body/query builders run.
+ */
+function remotePipelineUpdatePreflight(resourceType: "pipeline" | "pipeline_v1") {
+  return async ({ client, input, registry, signal }: PreflightContext): Promise<void> => {
+    if (isExplicitlyInline(input) || hasRemoteUpdateLockContext(input)) return;
+
+    const currentGit = inputGitDetails(input);
+    const getInput: Record<string, unknown> = {
+      pipeline_id: input.pipeline_id,
+    };
+    for (const key of ["org_id", "project_id", "branch", "branch_name", "repo_name", "connector_ref", "store_type"]) {
+      if (input[key] !== undefined) getInput[key] = input[key];
+    }
+    setIfMissing(getInput, "branch", firstGitString(currentGit.branch_name));
+    setIfMissing(getInput, "repo_name", firstGitString(currentGit.repo_name));
+    setIfMissing(getInput, "connector_ref", firstGitString(currentGit.connector_ref));
+    if (resourceType === "pipeline_v1") getInput.load_from_fallback_branch = true;
+
+    // Hydration is best-effort. Aborting on a failed lookup would break inline
+    // updates, which need no Git context at all and previously never read the
+    // pipeline first. A genuinely remote pipeline still fails loudly on the PUT
+    // with the GitX branch/SHA error. Toolsets may not log (pure data), so the
+    // swallow is silent by design.
+    let current: Record<string, unknown> | undefined;
+    try {
+      current = asRecord(await registry.dispatch(client, resourceType, "get", getInput, signal));
+    } catch {
+      return;
+    }
+    const git = asRecord(current?.git_details ?? current?.gitDetails);
+    const currentStoreType = firstGitString(
+      current?.store_type,
+      current?.storeType,
+      git?.store_type,
+      git?.storeType,
+    );
+    const hasRemoteMetadata = !!git && Object.keys(git).length > 0;
+    if (currentStoreType?.toUpperCase() === "INLINE") return;
+    if (currentStoreType?.toUpperCase() !== "REMOTE" && !hasRemoteMetadata) return;
+
+    setIfMissing(input, "store_type", currentStoreType ?? "REMOTE");
+    setIfMissing(input, "branch", firstGitString(git?.branch_name, git?.branchName, git?.branch));
+    setIfMissing(input, "repo_name", firstGitString(git?.repo_name, git?.repoName));
+    setIfMissing(input, "file_path", firstGitString(git?.file_path, git?.filePath));
+    setIfMissing(input, "connector_ref", firstGitString(git?.connector_ref, git?.connectorRef));
+    setIfMissing(input, "last_object_id", firstGitString(
+      git?.last_object_id,
+      git?.object_id,
+      git?.lastObjectId,
+      git?.objectId,
+    ));
+    setIfMissing(input, "last_commit_id", firstGitString(
+      git?.last_commit_id,
+      git?.commit_id,
+      git?.lastCommitId,
+      git?.commitId,
+    ));
+    setIfMissing(input, "is_harness_code_repo", firstGitBoolean(
+      git?.is_harness_code_repo,
+      git?.isHarnessCodeRepo,
+    ));
+    // v1 requires `name` in the body; YAML-only updates often omit it.
+    setIfMissing(input, "pipeline_name", firstGitString(current?.name));
+
+    if (!hasRemoteUpdateLockContext(input)) {
+      throw new Error(
+        `Unable to resolve Git branch and current object/commit IDs for remote ${resourceType} update. `
+        + "Call harness_get with the repository/branch context and pass branch, last_object_id, and last_commit_id via params.",
+      );
+    }
+  };
+}
 
 /**
  * Build the v1 JSON body for pipeline create/update.
@@ -144,6 +356,11 @@ function buildV1PipelineBody(input: Record<string, unknown>): Record<string, unk
     } catch { /* non-critical — caller can provide identifier/name explicitly */ }
   }
 
+  // Fall back to the identifiers the caller addressed the pipeline with, and to
+  // the name hydrated by the remote update preflight.
+  identifier = identifier ?? firstGitString(input.pipeline_id);
+  name = name ?? firstGitString(input.pipeline_name);
+
   const result: Record<string, unknown> = {
     pipeline_yaml: pipelineYaml,
     identifier,
@@ -152,6 +369,8 @@ function buildV1PipelineBody(input: Record<string, unknown>): Record<string, unk
   };
   if (description) result.description = description;
   if (tags) result.tags = tags;
+  const gitDetails = collectV1GitDetails(input);
+  if (gitDetails) result.git_details = gitDetails;
   return result;
 }
 
@@ -248,6 +467,7 @@ export const pipelinesToolset: ToolsetDefinition = {
             repo_name: "repoName",
           },
           responseExtractor: ngExtract,
+          paramsSchema: PIPELINE_V0_GET_PARAMS,
           description: "Get pipeline details including YAML definition. For remote/git-backed pipelines, pass branch to specify which branch to read from.",
         },
         create: {
@@ -287,6 +507,7 @@ export const pipelinesToolset: ToolsetDefinition = {
           path: "/pipeline/api/pipelines/v2/{pipelineIdentifier}",
           operationPolicy: { risk: "low_write", retryPolicy: "safe" },
           pathParams: { pipeline_id: "pipelineIdentifier" },
+          preflight: remotePipelineUpdatePreflight("pipeline"),
           headers: { "Content-Type": "application/yaml" },
           queryParams: {
             store_type: "storeType",
@@ -314,6 +535,7 @@ export const pipelinesToolset: ToolsetDefinition = {
             throw new Error("body must be a YAML string, or an object with yamlPipeline (YAML string) or pipeline (JSON object)");
           },
           responseExtractor: ngExtract,
+          paramsSchema: PIPELINE_V0_UPDATE_PARAMS,
           description: "Update an existing pipeline YAML. For remote pipelines, pass store_type='REMOTE' with git details and last_object_id/last_commit_id from the GET response. For Harness Code: add is_harness_code_repo=true (no connector_ref needed).",
           bodySchema: pipelineUpdateSchema,
         },
@@ -465,9 +687,16 @@ export const pipelinesToolset: ToolsetDefinition = {
           pathParams: { org_id: "org", project_id: "project", pipeline_id: "pipeline" },
           queryParams: {
             branch: "branch_name",
+            branch_name: "branch_name",
+            connector_ref: "connector_ref",
+            repo_name: "repo_name",
+            load_from_fallback_branch: "load_from_fallback_branch",
+            template_applied: "template_applied",
+            validate_async: "validate_async",
           },
           responseExtractor: passthrough,
-          description: "Get v1 pipeline details including YAML definition",
+          paramsSchema: PIPELINE_V1_GET_PARAMS,
+          description: "Get v1 pipeline details including YAML. For Git-backed pipelines, pass branch (or branch_name), repo_name, and optionally load_from_fallback_branch. The response git_details.object_id and git_details.commit_id are needed as last_object_id/last_commit_id when updating a remote v1 pipeline.",
         },
         create: {
           method: "POST",
@@ -476,7 +705,8 @@ export const pipelinesToolset: ToolsetDefinition = {
           pathParams: { org_id: "org", project_id: "project" },
           bodyBuilder: buildV1PipelineBody,
           responseExtractor: passthrough,
-          description: "Create a new v1 pipeline. Pass pipeline_yaml (YAML string), identifier, name. Version defaults to '1'. Alternatively pass a raw YAML string as body; identifier is extracted from pipeline.identifier or v1 pipeline.id.",
+          paramsSchema: PIPELINE_V1_CREATE_PARAMS,
+          description: "Create a new v1 pipeline. Pass pipeline_yaml (YAML string), identifier, name. Version defaults to '1'. Alternatively pass a raw YAML string as body; identifier is extracted from pipeline.identifier or v1 pipeline.id. For remote/Git-backed pipelines, pass store_type='REMOTE' with repo_name, branch, file_path (and connector_ref for external Git) via params — they become body.git_details.",
           bodySchema: pipelineV1CreateSchema,
         },
         update: {
@@ -484,9 +714,11 @@ export const pipelinesToolset: ToolsetDefinition = {
           path: "/v1/orgs/{org}/projects/{project}/pipelines/{pipeline}",
           operationPolicy: { risk: "low_write", retryPolicy: "safe" },
           pathParams: { org_id: "org", project_id: "project", pipeline_id: "pipeline" },
+          preflight: remotePipelineUpdatePreflight("pipeline_v1"),
           bodyBuilder: buildV1PipelineBody,
           responseExtractor: passthrough,
-          description: "Update a v1 pipeline (full replacement). Same body format as create.",
+          paramsSchema: PIPELINE_V1_UPDATE_PARAMS,
+          description: "Update a v1 pipeline (full replacement). Same body format as create. For remote pipelines, pass store_type='REMOTE' with git location fields and last_object_id/last_commit_id from GET git_details.object_id/commit_id — v1 sends these in body.git_details, not as query params.",
           bodySchema: pipelineV1UpdateSchema,
         },
         delete: {

--- a/src/registry/toolsets/pipelines.ts
+++ b/src/registry/toolsets/pipelines.ts
@@ -1,5 +1,6 @@
 import type { ToolsetDefinition, BodySchema, ParamsSchema, PreflightContext } from "../types.js";
 import { ngExtract, pageExtract, passthrough, v1ListExtract, runtimeInputExtract, executionInputsExtract, dynamicExecutionExtract, triggerListExtract } from "../extractors.js";
+import { asRecord } from "../../utils/type-guards.js";
 import YAML from "yaml";
 
 function coerceTriggerBodyRecord(body: unknown): Record<string, unknown> {
@@ -172,12 +173,6 @@ function firstGitBoolean(...values: unknown[]): boolean | undefined {
   return undefined;
 }
 
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? value as Record<string, unknown>
-    : undefined;
-}
-
 function inputGitDetails(input: Record<string, unknown>): Record<string, unknown> {
   return asRecord(asRecord(input.body)?.git_details) ?? {};
 }
@@ -242,7 +237,10 @@ function remotePipelineUpdatePreflight(resourceType: "pipeline" | "pipeline_v1")
     const getInput: Record<string, unknown> = {
       pipeline_id: input.pipeline_id,
     };
-    for (const key of ["org_id", "project_id", "branch", "branch_name", "repo_name", "connector_ref", "store_type"]) {
+    // store_type is deliberately not forwarded: the v0 GET echoes it back onto
+    // the response when the API omits one, which would let the caller's own
+    // assertion masquerade as the stored store type we read below.
+    for (const key of ["org_id", "project_id", "branch", "branch_name", "repo_name", "connector_ref"]) {
       if (input[key] !== undefined) getInput[key] = input[key];
     }
     setIfMissing(getInput, "branch", firstGitString(currentGit.branch_name));

--- a/tests/registry/pipeline-v1-deep-links.test.ts
+++ b/tests/registry/pipeline-v1-deep-links.test.ts
@@ -75,6 +75,7 @@ describe("pipeline_v1 deep links", () => {
       org_id: "avitest",
       project_id: "avi",
       pipeline_id: "hello_harness",
+      store_type: "INLINE",
       body: {
         identifier: "hello_harness",
         pipeline_yaml: "pipeline:\n  name: Hello Harness\n",

--- a/tests/registry/pipeline-v1-git.test.ts
+++ b/tests/registry/pipeline-v1-git.test.ts
@@ -1,0 +1,421 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Config } from "../../src/config.js";
+import type { HarnessClient } from "../../src/client/harness-client.js";
+import { Registry } from "../../src/registry/index.js";
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    HARNESS_API_KEY: "pat.test",
+    HARNESS_ACCOUNT_ID: "test-account",
+    HARNESS_BASE_URL: "https://app.harness.io",
+    HARNESS_ORG: "default",
+    HARNESS_PROJECT: "test-project",
+    HARNESS_API_TIMEOUT_MS: 30000,
+    HARNESS_MAX_RETRIES: 3,
+    HARNESS_MAX_BODY_SIZE_MB: 10,
+    HARNESS_RATE_LIMIT_RPS: 10,
+    HARNESS_READ_ONLY: false,
+    HARNESS_SKIP_ELICITATION: false,
+    HARNESS_ALLOW_HTTP: false,
+    HARNESS_FME_BASE_URL: "https://api.split.io",
+    LOG_LEVEL: "info",
+    ...overrides,
+  };
+}
+
+function makeClient(requestFn: (...args: unknown[]) => unknown): HarnessClient {
+  return {
+    request: requestFn,
+    account: "test-account",
+  } as unknown as HarnessClient;
+}
+
+const yaml = "pipeline:\n  id: ci_build\n  name: CI Build\n  stages: []\n";
+
+describe("pipeline_v1 Git Experience mapping", () => {
+  it("maps get query params including repo_name and load_from_fallback_branch", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines" }));
+    const mockRequest = vi.fn().mockResolvedValue({ identifier: "ci_build", git_details: {} });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "pipeline_v1", "get", {
+      pipeline_id: "CI_Build_and_Test",
+      org_id: "PROD",
+      project_id: "Traceable",
+      branch: "main",
+      repo_name: "Pipelines",
+      load_from_fallback_branch: true,
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "GET",
+        path: "/v1/orgs/PROD/projects/Traceable/pipelines/CI_Build_and_Test",
+        params: expect.objectContaining({
+          branch_name: "main",
+          repo_name: "Pipelines",
+          load_from_fallback_branch: true,
+        }),
+      }),
+    );
+  });
+
+  it("puts create git params into body.git_details, not query params", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines" }));
+    const mockRequest = vi.fn().mockResolvedValue({ identifier: "ci_build" });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "pipeline_v1", "create", {
+      org_id: "PROD",
+      project_id: "Traceable",
+      store_type: "REMOTE",
+      connector_ref: "git_conn",
+      repo_name: "Pipelines",
+      branch: "main",
+      file_path: ".harness/ci.yaml",
+      commit_msg: "Add pipeline via MCP",
+      body: { pipeline_yaml: yaml, identifier: "ci_build", name: "CI Build" },
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        path: "/v1/orgs/PROD/projects/Traceable/pipelines",
+        body: expect.objectContaining({
+          pipeline_yaml: yaml,
+          git_details: {
+            store_type: "REMOTE",
+            connector_ref: "git_conn",
+            repo_name: "Pipelines",
+            branch_name: "main",
+            file_path: ".harness/ci.yaml",
+            commit_message: "Add pipeline via MCP",
+          },
+        }),
+      }),
+    );
+    const call = mockRequest.mock.calls[0]![0] as { params?: Record<string, unknown> };
+    expect(call.params?.lastObjectId).toBeUndefined();
+    expect(call.params?.storeType).toBeUndefined();
+    expect(call.params?.repo_name).toBeUndefined();
+  });
+
+  it("puts update conflict ids into body.git_details from params", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines" }));
+    const mockRequest = vi.fn().mockResolvedValue({ identifier: "ci_build" });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "pipeline_v1", "update", {
+      pipeline_id: "CI_Build_and_Test",
+      org_id: "PROD",
+      project_id: "Traceable",
+      store_type: "REMOTE",
+      is_harness_code_repo: true,
+      repo_name: "Pipelines",
+      branch: "main",
+      file_path: ".harness/ci.yaml",
+      last_object_id: "3576b403c93d5727a12d99fe055b29be41622a32",
+      last_commit_id: "c25a833a358bfabcf56c6fedf93ff08718f45d90",
+      body: { pipeline_yaml: yaml, identifier: "CI_Build_and_Test", name: "CI Build" },
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "PUT",
+        path: "/v1/orgs/PROD/projects/Traceable/pipelines/CI_Build_and_Test",
+        body: expect.objectContaining({
+          git_details: expect.objectContaining({
+            store_type: "REMOTE",
+            is_harness_code_repo: true,
+            repo_name: "Pipelines",
+            branch_name: "main",
+            file_path: ".harness/ci.yaml",
+            last_object_id: "3576b403c93d5727a12d99fe055b29be41622a32",
+            last_commit_id: "c25a833a358bfabcf56c6fedf93ff08718f45d90",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("remaps GET git_details.object_id/commit_id when copied into the update body", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines" }));
+    const mockRequest = vi.fn().mockResolvedValue({ identifier: "ci_build" });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "pipeline_v1", "update", {
+      pipeline_id: "CI_Build_and_Test",
+      org_id: "PROD",
+      project_id: "Traceable",
+      body: {
+        pipeline_yaml: yaml,
+        identifier: "CI_Build_and_Test",
+        name: "CI Build",
+        git_details: {
+          object_id: "blobsha",
+          commit_id: "commitsha",
+          branch_name: "main",
+          repo_name: "Pipelines",
+          file_path: ".harness/ci.yaml",
+          store_type: "REMOTE",
+        },
+      },
+    });
+
+    const call = mockRequest.mock.calls[0]![0] as { body: { git_details: Record<string, string> } };
+    expect(call.body.git_details).toEqual({
+      branch_name: "main",
+      file_path: ".harness/ci.yaml",
+      store_type: "REMOTE",
+      repo_name: "Pipelines",
+      last_object_id: "blobsha",
+      last_commit_id: "commitsha",
+    });
+    expect(call.body.git_details).not.toHaveProperty("object_id");
+    expect(call.body.git_details).not.toHaveProperty("commit_id");
+  });
+
+  it("preflights a YAML-only remote update and injects Git location and lock ids", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines" }));
+    const mockRequest = vi.fn()
+      .mockResolvedValueOnce({
+        identifier: "ci_build",
+        git_details: {
+          branch_name: "main",
+          repo_name: "Pipelines",
+          file_path: ".harness/ci.yaml",
+          object_id: "3576b403c93d5727a12d99fe055b29be41622a32",
+          commit_id: "c25a833a358bfabcf56c6fedf93ff08718f45d90",
+          is_harness_code_repo: true,
+        },
+      })
+      .mockResolvedValueOnce({ identifier: "ci_build" });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "pipeline_v1", "update", {
+      pipeline_id: "ci_build",
+      org_id: "PROD",
+      project_id: "Traceable",
+      body: yaml,
+    });
+
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+    expect(mockRequest.mock.calls[0]![0]).toEqual(expect.objectContaining({
+      method: "GET",
+      path: "/v1/orgs/PROD/projects/Traceable/pipelines/ci_build",
+      params: expect.objectContaining({ load_from_fallback_branch: true }),
+    }));
+    expect(mockRequest.mock.calls[1]![0]).toEqual(expect.objectContaining({
+      method: "PUT",
+      path: "/v1/orgs/PROD/projects/Traceable/pipelines/ci_build",
+      body: expect.objectContaining({
+        git_details: {
+          branch_name: "main",
+          file_path: ".harness/ci.yaml",
+          store_type: "REMOTE",
+          repo_name: "Pipelines",
+          is_harness_code_repo: true,
+          last_object_id: "3576b403c93d5727a12d99fe055b29be41622a32",
+          last_commit_id: "c25a833a358bfabcf56c6fedf93ff08718f45d90",
+        },
+      }),
+    }));
+  });
+
+  it("fills identifier and name from the preflight GET when the YAML omits them", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines" }));
+    const mockRequest = vi.fn()
+      .mockResolvedValueOnce({
+        identifier: "ci_build",
+        name: "CI Build",
+        git_details: {
+          branch_name: "main",
+          repo_name: "Pipelines",
+          file_path: ".harness/ci.yaml",
+          object_id: "3576b403c93d5727a12d99fe055b29be41622a32",
+          commit_id: "c25a833a358bfabcf56c6fedf93ff08718f45d90",
+        },
+      })
+      .mockResolvedValueOnce({ identifier: "ci_build" });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "pipeline_v1", "update", {
+      pipeline_id: "ci_build",
+      org_id: "PROD",
+      project_id: "Traceable",
+      body: "pipeline:\n  stages: []\n",
+    });
+
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+    expect(mockRequest.mock.calls[1]![0]).toEqual(expect.objectContaining({
+      method: "PUT",
+      body: expect.objectContaining({ identifier: "ci_build", name: "CI Build" }),
+    }));
+  });
+
+  it("preflights a v0 YAML-only remote update and maps camelCase GET metadata to query params", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines" }));
+    const mockRequest = vi.fn()
+      .mockResolvedValueOnce({
+        data: {
+          identifier: "ci_build",
+          storeType: "REMOTE",
+          gitDetails: {
+            branch: "main",
+            repoName: "Pipelines",
+            filePath: ".harness/ci.yaml",
+            objectId: "3576b403c93d5727a12d99fe055b29be41622a32",
+            commitId: "c25a833a358bfabcf56c6fedf93ff08718f45d90",
+          },
+        },
+      })
+      .mockResolvedValueOnce({ data: { identifier: "ci_build" } });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "pipeline", "update", {
+      pipeline_id: "ci_build",
+      org_id: "PROD",
+      project_id: "Traceable",
+      body: "pipeline:\n  identifier: ci_build\n  name: CI Build\n",
+    });
+
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+    expect(mockRequest.mock.calls[1]![0]).toEqual(expect.objectContaining({
+      method: "PUT",
+      path: "/pipeline/api/pipelines/v2/ci_build",
+      params: expect.objectContaining({
+        storeType: "REMOTE",
+        branch: "main",
+        repoName: "Pipelines",
+        filePath: ".harness/ci.yaml",
+        lastObjectId: "3576b403c93d5727a12d99fe055b29be41622a32",
+        lastCommitId: "c25a833a358bfabcf56c6fedf93ff08718f45d90",
+      }),
+    }));
+  });
+
+  it("skips update preflight GET when the caller explicitly selects INLINE storage", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines" }));
+    const mockRequest = vi.fn().mockResolvedValue({ identifier: "ci_build" });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "pipeline_v1", "update", {
+      pipeline_id: "ci_build",
+      org_id: "PROD",
+      project_id: "Traceable",
+      store_type: "INLINE",
+      body: yaml,
+    });
+
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+    expect(mockRequest.mock.calls[0]![0]).toEqual(expect.objectContaining({
+      method: "PUT",
+      body: expect.objectContaining({
+        git_details: { store_type: "INLINE" },
+      }),
+    }));
+  });
+
+  it("does not inject Git details when preflight discovers an inline pipeline", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines" }));
+    const mockRequest = vi.fn()
+      .mockResolvedValueOnce({ identifier: "ci_build", store_type: "INLINE" })
+      .mockResolvedValueOnce({ identifier: "ci_build" });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "pipeline_v1", "update", {
+      pipeline_id: "ci_build",
+      org_id: "PROD",
+      project_id: "Traceable",
+      body: yaml,
+    });
+
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+    expect(mockRequest.mock.calls[0]![0]).toEqual(expect.objectContaining({ method: "GET" }));
+    expect(mockRequest.mock.calls[1]![0]).toEqual(expect.objectContaining({
+      method: "PUT",
+      body: expect.not.objectContaining({ git_details: expect.anything() }),
+    }));
+  });
+
+  it("still sends the update when the preflight GET fails", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines" }));
+    const mockRequest = vi.fn()
+      .mockRejectedValueOnce(new Error("Harness API error (500): internal error"))
+      .mockResolvedValueOnce({ identifier: "ci_build" });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "pipeline_v1", "update", {
+      pipeline_id: "ci_build",
+      org_id: "PROD",
+      project_id: "Traceable",
+      body: yaml,
+    });
+
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+    expect(mockRequest.mock.calls[1]![0]).toEqual(expect.objectContaining({
+      method: "PUT",
+      path: "/v1/orgs/PROD/projects/Traceable/pipelines/ci_build",
+    }));
+  });
+
+  it("accepts quoted booleans for is_harness_code_repo", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines" }));
+    const mockRequest = vi.fn().mockResolvedValue({ identifier: "ci_build" });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "pipeline_v1", "update", {
+      pipeline_id: "ci_build",
+      org_id: "PROD",
+      project_id: "Traceable",
+      store_type: "REMOTE",
+      is_harness_code_repo: "true",
+      repo_name: "test-repo",
+      branch: "main",
+      file_path: ".harness/ci.yaml",
+      last_object_id: "3576b403c93d5727a12d99fe055b29be41622a32",
+      last_commit_id: "c25a833a358bfabcf56c6fedf93ff08718f45d90",
+      body: yaml,
+    });
+
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+    const call = mockRequest.mock.calls[0]![0] as { body: { git_details: Record<string, unknown> } };
+    expect(call.body.git_details.is_harness_code_repo).toBe(true);
+  });
+
+  it("does not add git_details on inline create/update", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines" }));
+    const mockRequest = vi.fn().mockResolvedValue({ identifier: "ci_build" });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "pipeline_v1", "create", {
+      org_id: "PROD",
+      project_id: "Traceable",
+      body: { pipeline_yaml: yaml, identifier: "ci_build", name: "CI Build" },
+    });
+
+    const call = mockRequest.mock.calls[0]![0] as { body: Record<string, unknown> };
+    expect(call.body.git_details).toBeUndefined();
+  });
+
+  it("documents git params on harness_describe via paramsSchema", () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines" }));
+    const def = registry.getResource("pipeline_v1");
+    expect(def.operations.get!.paramsSchema!.fields.map((f) => f.name)).toEqual(
+      expect.arrayContaining(["branch", "repo_name", "connector_ref", "load_from_fallback_branch"]),
+    );
+    expect(def.operations.update!.paramsSchema!.fields.map((f) => f.name)).toEqual(
+      expect.arrayContaining(["last_object_id", "last_commit_id", "store_type", "repo_name", "branch"]),
+    );
+    expect(def.operations.get!.description).toMatch(/git_details\.object_id/);
+    expect(def.operations.update!.description).toMatch(/body\.git_details/);
+
+    const v0 = registry.getResource("pipeline");
+    expect(v0.operations.get!.paramsSchema!.fields.map((f) => f.name)).toEqual(
+      expect.arrayContaining(["branch", "store_type", "connector_ref", "repo_name"]),
+    );
+    expect(v0.operations.update!.paramsSchema!.fields.map((f) => f.name)).toEqual(
+      expect.arrayContaining(["branch", "repo_name", "file_path", "last_object_id", "last_commit_id"]),
+    );
+  });
+});

--- a/tests/registry/pipeline-v1-git.test.ts
+++ b/tests/registry/pipeline-v1-git.test.ts
@@ -383,6 +383,32 @@ describe("pipeline_v1 Git Experience mapping", () => {
     expect(call.body.git_details.is_harness_code_repo).toBe(true);
   });
 
+  it("does not echo the caller's store_type into the preflight GET", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines" }));
+    const mockRequest = vi.fn()
+      .mockResolvedValueOnce({ data: { identifier: "ci_build", storeType: "INLINE" } })
+      .mockResolvedValueOnce({ data: { identifier: "ci_build" } });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "pipeline", "update", {
+      pipeline_id: "ci_build",
+      org_id: "PROD",
+      project_id: "Traceable",
+      store_type: "REMOTE",
+      body: "pipeline:\n  identifier: ci_build\n  name: CI Build\n",
+    });
+
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+    const getCall = mockRequest.mock.calls[0]![0] as { method: string; params?: Record<string, unknown> };
+    expect(getCall.method).toBe("GET");
+    expect(getCall.params?.storeType).toBeUndefined();
+    // The stored INLINE wins over the caller's assertion, so no Git context is
+    // hydrated and the update is not blocked.
+    const putCall = mockRequest.mock.calls[1]![0] as { params?: Record<string, unknown> };
+    expect(putCall.params?.lastObjectId).toBeUndefined();
+    expect(putCall.params?.lastCommitId).toBeUndefined();
+  });
+
   it("does not add git_details on inline create/update", async () => {
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "pipelines" }));
     const mockRequest = vi.fn().mockResolvedValue({ identifier: "ci_build" });

--- a/tests/registry/registry.test.ts
+++ b/tests/registry/registry.test.ts
@@ -1068,6 +1068,7 @@ describe("Registry", () => {
         pipeline_id: "test_pipeline",
         project_id: "my-project",
         org_id: "default",
+        store_type: "INLINE",
         body: { yamlPipeline: yaml },
       })) as Record<string, unknown>;
 
@@ -1092,6 +1093,7 @@ describe("Registry", () => {
         pipeline_id: "x",
         project_id: "p",
         org_id: "default",
+        store_type: "INLINE",
         body,
       });
 

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -1224,6 +1224,7 @@ describe("harness_update", () => {
       resource_type: "pipeline",
       resource_id: "my-pipe",
       body: { yamlPipeline: "pipeline:\n  name: Updated" },
+      params: { store_type: "INLINE" },
     });
     expect(result.isError).toBeUndefined();
   });
@@ -1233,6 +1234,7 @@ describe("harness_update", () => {
       resource_type: "pipeline",
       resource_id: "my-pipe",
       body: { yamlPipeline: "pipeline:\n  name: Updated" },
+      params: { store_type: "INLINE" },
     });
     expect(result.isError).toBeUndefined();
     expect(mockRequest).toHaveBeenCalledOnce();


### PR DESCRIPTION
## Description

Remote (Git-backed) pipeline updates were failing with one of two errors depending on how incomplete the request was:

- `"No branch provided for modifying the file."` — when `git_details` was entirely absent from the v1 JSON body
- `"the provided commit sha '__default__' is of invalid format"` — when GitX filled in a sentinel SHA because `last_object_id`/`last_commit_id` were missing

Root cause: the v1 pipeline API requires Git Experience fields inside `body.git_details` (not as query params), but the MCP adapter was never putting them there. The v0 adapter had the query-param wiring but no auto-hydration, so agents had to manually supply lock SHAs.

**Changes:**

- `collectV1GitDetails()` — collects Git Experience params (`branch`, `repo_name`, `file_path`, `connector_ref`, `store_type`, `is_harness_code_repo`, `last_object_id`, `last_commit_id`) from flat top-level params or `body.git_details` pass-through, and maps them into `body.git_details` for the v1 JSON body. Remaps GET response field names (`object_id` → `last_object_id`, `commit_id` → `last_commit_id`) so agents can copy the GET response forward directly.

- `remotePipelineUpdatePreflight()` — preflight hook on `pipeline` and `pipeline_v1` update. When the agent supplies only YAML (no Git context), does a single GET to fetch the current pipeline's `git_details`, stamps missing branch/repo/path/lock-SHA fields onto `input`, then lets the body/query builders run. Skips the GET when `store_type=INLINE` is explicit or when full lock context is already present. Fails with an actionable error if the GET also can't resolve the Git context.

- v1 pipeline GET: expanded `queryParams` to forward `repo_name`, `connector_ref`, `load_from_fallback_branch` — required for preflight GETs and for agents fetching remote pipelines.

- `paramsSchema` added to v0/v1 get, create, and update: `harness_describe` now lists Git params so agents know what to pass. Previously the deployed MCP showed no params at all for `pipeline_v1`, so agents had no way to discover `last_object_id`/`last_commit_id` existed.

- Existing update tests: added `store_type: "INLINE"` to inline pipeline tests so the preflight correctly skips them.

- New test file `tests/registry/pipeline-v1-git.test.ts` covering: v1 `git_details` body mapping, preflight hydration of missing Git location + SHAs, Harness Code metadata, explicit lock context bypass, INLINE bypass, and `store_type` echo guard.

> **Note:** This is adapter work. The Git Experience mapping and preflight are covered by unit tests against a local fake HTTP server. A live scratch-pipeline PUT against a real Harness instance has not been run yet. Please verify on a scratch remote pipeline after deploy before treating the GitX failure as confirmed fixed.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] `pnpm test` passes (3134/3134)
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm standards:check` passes
- [x] `pnpm docs:check` passes

## Coding Standards (registry-driven MCP model)
- [x] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [x] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [x] `operationPolicy` on every new/changed endpoint
- [x] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [x] `identifierFields` and `scope` declared on new resources
- [x] No `console.log()` in `src/` (stdio JSON-RPC safety)