### PR TITLE
chore: bump version to 3.2.21

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "harness-mcp-server",
   "display_name": "Harness",
-  "version": "3.2.20",
+  "version": "3.2.21",
   "description": "Connect AI agents to Harness for CI/CD, code repositories, pull requests, services, environments, and feature flags.",
   "long_description": "The Harness MCP Server gives MCP-compatible clients access to Harness platform workflows through consolidated tools, resources, and prompts. It supports local stdio usage and can be bundled as a Node-based MCPB extension.",
   "author": {

--- a/mcp-directory/manifest.json
+++ b/mcp-directory/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "harness-mcp-server",
   "display_name": "Harness",
-  "version": "3.2.20",
+  "version": "3.2.21",
   "description": "Connect AI agents to Harness for CI/CD, code repositories, pull requests, services, environments, and feature flags.",
   "long_description": "The Harness MCP Server gives MCP-compatible clients access to Harness platform workflows through consolidated tools, resources, and prompts. It supports local stdio usage and can be bundled as a Node-based MCPB extension.",
   "author": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "harness-mcp-v2",
-  "version": "3.2.20",
+  "version": "3.2.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "harness-mcp-v2",
-      "version": "3.2.20",
+      "version": "3.2.21",
       "dependencies": {
         "@hono/node-server": "^2.0.10",
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-mcp-v2",
-  "version": "3.2.20",
+  "version": "3.2.21",
   "description": "Give AI agents full access to the Harness.io platform — manage pipelines, deployments, cloud costs, chaos engineering, feature flags, SEI, and 125+ resource types through 11 MCP tools",
   "type": "module",
   "main": "build/index.js",

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,15 @@
 # Lessons Learned
 
+## Generated Docs Checks Must Run After Build Completes
+- **Issue**: Running `pnpm build` and `pnpm docs:check` concurrently lets the docs checker read a partially rewritten `build/`, producing false resource-count and operation-table drift even when README is current.
+- **Fix**: Complete `pnpm build` first, then run `pnpm docs:check` or `pnpm docs:generate` sequentially. A sequential regenerate after the false failure reported README already up to date.
+- **Rule**: Never parallelize build with commands that consume `build/`; fresh-build ordering is a correctness requirement, not only a CI convention.
+
+## Full Vitest Runs Should Not Compete With Overlapping Suites
+- **Issue**: Running `pnpm test` concurrently with `pnpm standards:check` caused the timing-sensitive semantic-search manager test to exceed its 5-second timeout even though the same full suite passed immediately when run alone.
+- **Fix**: Run the full Vitest suite by itself; use parallelism for independent non-Vitest checks instead of launching overlapping test pools.
+- **Rule**: Treat a timeout under concurrent local test load as resource contention until an isolated rerun reproduces it, and report both results.
+
 ## Production Shrinkwraps Need a Production Staging Manifest
 - **Issue**: `npm-shrinkwrap.json` intentionally captures the production dependency tree and npm-native mirrors of the repository's pnpm security overrides. Running `npm ci --omit=dev` against that shrinkwrap and the full development `package.json` still makes npm validate missing dev dependencies and ignore `pnpm.overrides`, so MCPB staging fails even though the release shrinkwrap check is healthy.
 - **Fix**: Generate a minimal staging `package.json` with runtime dependencies, optional dependencies, and transitive pnpm overrides mirrored into npm's `overrides`, then run `npm ci` against the checked-in shrinkwrap.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -513,6 +513,25 @@ Feature is **opt-in** (`include_visual` defaults to false) and the `visual_*` re
 - Ninth follow-up review fix: URL-only `harness_update`/`harness_delete` calls now resolve the primary ID from the parsed URL, edited optional Zod fields keep `.describe()` last, and File Store `file_usage` rejects values outside `MANIFEST_FILE`, `CONFIG`, or `SCRIPT` before dispatch.
 - Ninth follow-up verification passed: `pnpm typecheck`, `pnpm exec vitest run tests/registry/file-store-multipart.test.ts tests/tools/tool-handlers.test.ts tests/utils/url-parser.test.ts`, `pnpm build`, `pnpm docs:check`, `git diff --check`, and `pnpm test`.
 
+## Version Bump 3.2.21 (2026-08-24)
+
+- [x] Update package and MCPB manifest versions to 3.2.21.
+- [x] Update npm shrinkwrap root metadata and release metadata expectations.
+- [x] Run focused release checks, typecheck, build, and diff validation.
+- [x] Commit, push, and open a new PR against main.
+
+### Plan
+
+- Keep this a metadata-only patch release bump from current `origin/main`.
+- Synchronize `package.json`, both root version fields in `npm-shrinkwrap.json`, `manifest.json`, `mcp-directory/manifest.json`, and the pinned expectations in `tests/release-metadata.test.ts`.
+- Stage and publish only the version-bump files plus this task record.
+
+### Review
+
+- Updated all six release metadata surfaces from 3.2.20 to 3.2.21 without dependency or runtime changes.
+- Verification passed: 10 focused release tests, typecheck, build, sequential docs check, shrinkwrap check, standards (77 tests), and the isolated full suite (137 files / 3,143 tests).
+- An initial concurrent full-suite run had one semantic-search timeout; the isolated rerun passed, confirming local test-pool contention rather than a version-bump regression.
+
 ## PR 172 Conflict Resolution (2026-06-04)
 - [x] Inspect PR status and identify conflicted documentation files
 - [x] Merge current `origin/main` into PR branch

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -32,7 +32,7 @@ describe("release metadata", () => {
     const rootManifest = readJson("manifest.json");
     const directoryManifest = readJson("mcp-directory/manifest.json");
 
-    expect(packageJson.version).toBe("3.2.20");
+    expect(packageJson.version).toBe("3.2.21");
     expect(rootManifest.version).toBe(packageJson.version);
     expect(directoryManifest.version).toBe(packageJson.version);
   });
@@ -52,9 +52,9 @@ describe("release metadata", () => {
     legacyManifest.server.entry_point = "build/index.js";
     legacyManifest.server.mcp_config.args[0] = "${__dirname}/build/index.js";
 
-    expect(assetNameForVersion("3.2.20")).toBe("harness-mcp-server-3.2.20.mcpb");
+    expect(assetNameForVersion("3.2.21")).toBe("harness-mcp-server-3.2.21.mcpb");
     expect(MCPB_CLI_PACKAGE).toBe("@anthropic-ai/mcpb@2.1.2");
-    expect(normalizeBundleManifest(legacyManifest, "3.2.20").server).toMatchObject({
+    expect(normalizeBundleManifest(legacyManifest, "3.2.21").server).toMatchObject({
       entry_point: "server/index.js",
       mcp_config: { args: ["${__dirname}/server/index.js", "stdio"] },
     });


### PR DESCRIPTION
## Summary

- bump package and MCPB manifests to 3.2.21
- synchronize npm shrinkwrap root metadata
- update release metadata regression expectations

No dependency or runtime changes.

## Verification

- pnpm exec vitest run tests/release-metadata.test.ts tests/release-workflow.test.ts
- pnpm typecheck
- pnpm build
- pnpm docs:check
- pnpm npm-shrinkwrap:check
- pnpm standards:check
- pnpm test (137 files, 3143 tests)