### PR TITLE
fix: resolve agent openInHarness URL from uid/id

### DIFF
--- a/src/registry/extractors.ts
+++ b/src/registry/extractors.ts
@@ -71,6 +71,56 @@ export const countExtract = (raw: unknown): { count: number; _error?: string } =
 /** Pass-through extractor — returns raw response unchanged. Used for APIs that don't wrap in `data`. */
 export const passthrough = (raw: unknown): unknown => raw;
 
+/**
+ * Agent APIs return `id` (the UID), not `identifier`. Alias so deep links can
+ * resolve `{agentIdentifier}`. Handles:
+ * - create/get entity `{ id }`
+ * - NG/gateway envelope `{ data: { id } }`
+ * - list as a raw array or `{ data: [...] }` (normalized to `{ items, total }`)
+ */
+export const agentExtract = (raw: unknown): unknown => {
+  if (raw === null || raw === undefined) return raw;
+  const unwrapped = unwrapAgentPayload(raw);
+  if (Array.isArray(unwrapped)) {
+    const items = unwrapped.map(aliasAgentItem);
+    return { items, total: items.length };
+  }
+  if (!isRecord(unwrapped)) return unwrapped;
+  aliasAgentIdentifier(unwrapped);
+  for (const key of ["items", "data", "content"] as const) {
+    const arr = unwrapped[key];
+    if (Array.isArray(arr)) {
+      unwrapped[key] = arr.map(aliasAgentItem);
+    }
+  }
+  return unwrapped;
+};
+
+function unwrapAgentPayload(raw: unknown): unknown {
+  if (!isRecord(raw) || !("data" in raw)) return raw;
+  const data = raw.data;
+  if (Array.isArray(data)) return data;
+  if (isRecord(data) && looksLikeAgent(data)) return data;
+  return raw;
+}
+
+function looksLikeAgent(record: Record<string, unknown>): boolean {
+  return record.id != null || record.uid != null || record.identifier != null || typeof record.name === "string";
+}
+
+function aliasAgentIdentifier(record: Record<string, unknown>): void {
+  if (record.identifier != null && record.identifier !== "") return;
+  const id = record.id ?? record.uid;
+  if (id != null && id !== "") {
+    record.identifier = id;
+  }
+}
+
+function aliasAgentItem(item: unknown): unknown {
+  if (isRecord(item)) aliasAgentIdentifier(item);
+  return item;
+}
+
 /** Offset-paginated list (OffsetPaginatedResult): { entities, totalCount } */
 export const offsetListExtract = (raw: unknown): { items: unknown[]; total: number } => {
   const r = raw as { entities?: unknown[]; totalCount?: number };

--- a/src/registry/extractors.ts
+++ b/src/registry/extractors.ts
@@ -86,13 +86,7 @@ export const agentExtract = (raw: unknown): unknown => {
     return { items, total: items.length };
   }
   if (!isRecord(unwrapped)) return unwrapped;
-  aliasAgentIdentifier(unwrapped);
-  for (const key of ["items", "data", "content"] as const) {
-    const arr = unwrapped[key];
-    if (Array.isArray(arr)) {
-      unwrapped[key] = arr.map(aliasAgentItem);
-    }
-  }
+  aliasAgentRecord(unwrapped);
   return unwrapped;
 };
 
@@ -105,14 +99,31 @@ function unwrapAgentPayload(raw: unknown): unknown {
 }
 
 function looksLikeAgent(record: Record<string, unknown>): boolean {
-  return record.id != null || record.uid != null || record.identifier != null || typeof record.name === "string";
+  return isScalarId(record.id) || isScalarId(record.uid) || isScalarId(record.identifier) || typeof record.name === "string";
+}
+
+function isScalarId(value: unknown): value is string | number {
+  return (typeof value === "string" && value !== "") || typeof value === "number";
+}
+
+/** Alias id/uid onto identifier. Walk nested data/items/content objects, not only arrays. */
+function aliasAgentRecord(record: Record<string, unknown>): void {
+  aliasAgentIdentifier(record);
+  for (const key of ["items", "data", "content"] as const) {
+    const val = record[key];
+    if (Array.isArray(val)) {
+      record[key] = val.map(aliasAgentItem);
+    } else if (isRecord(val)) {
+      aliasAgentRecord(val);
+    }
+  }
 }
 
 function aliasAgentIdentifier(record: Record<string, unknown>): void {
-  if (record.identifier != null && record.identifier !== "") return;
+  if (typeof record.identifier === "string" && record.identifier !== "") return;
   const id = record.id ?? record.uid;
-  if (id != null && id !== "") {
-    record.identifier = id;
+  if (isScalarId(id)) {
+    record.identifier = String(id);
   }
 }
 

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -6,7 +6,7 @@ import type { ResourceDefinition, ToolsetDefinition, ToolsetName, OperationName,
 import type { AuditManager } from "../audit/manager.js";
 import type { AuditContext, AuditEvent, AuditOutcome } from "../audit/types.js";
 import { createLogger } from "../utils/logger.js";
-import { buildDeepLink, appendStoreType } from "../utils/deep-links.js";
+import { buildDeepLink, appendStoreType, appendAgentTypeQuery } from "../utils/deep-links.js";
 import { isFormDataBody } from "../utils/type-guards.js";
 import { canonicalizeListFilterEnums } from "./enum-utils.js";
 import { assertListScopeResolved } from "./list-filter-utils.js";
@@ -1007,6 +1007,9 @@ export class Registry {
             baseLinkParams,
           );
           link = appendStoreType(link, resultRecord);
+          if (def.resourceType === "agent") {
+            link = appendAgentTypeQuery(link, resultRecord);
+          }
           resultRecord.openInHarness = link;
         } catch {
           // Deep link construction failed — non-critical
@@ -1101,6 +1104,9 @@ export class Registry {
               itemLinkParams,
             );
             itemLink = appendStoreType(itemLink, itemRecord);
+            if (def.resourceType === "agent") {
+              itemLink = appendAgentTypeQuery(itemLink, itemRecord);
+            }
             itemRecord.openInHarness = itemLink;
           } catch {
             // Per-item deep link failed — non-critical, skip

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -7,7 +7,7 @@ import type { AuditManager } from "../audit/manager.js";
 import type { AuditContext, AuditEvent, AuditOutcome } from "../audit/types.js";
 import { createLogger } from "../utils/logger.js";
 import { buildDeepLink, appendStoreType } from "../utils/deep-links.js";
-import { isFormDataBody } from "../utils/type-guards.js";
+import { isFormDataBody, isRecord } from "../utils/type-guards.js";
 import { canonicalizeListFilterEnums } from "./enum-utils.js";
 import { assertListScopeResolved } from "./list-filter-utils.js";
 
@@ -947,9 +947,13 @@ export class Registry {
       for (const field of def.identifierFields) {
         const pathParamName = spec.pathParams?.[field] ?? getPathParam?.[field] ?? field;
         let value = input[field];
+        // Create bodies often carry the id as uid/identifier rather than agent_id.
+        if (!value && isRecord(input.body)) {
+          value = input.body[field] ?? input.body[pathParamName] ?? input.body.uid ?? input.body.identifier ?? input.body.id;
+        }
         if (!value && resultRecord) {
-          // Check top-level first
-          value = resultRecord[pathParamName] ?? resultRecord.identifier;
+          // Check top-level first. Agent create/get return `id` (the UID), not `identifier`.
+          value = resultRecord[pathParamName] ?? resultRecord.identifier ?? resultRecord.id ?? resultRecord.uid;
           if (!value) {
             // Look for identifier in any nested object that has an 'identifier' field
             // This handles wrapped responses like {service: {identifier: "..."}}, {environment: {...}}, etc.
@@ -1039,6 +1043,10 @@ export class Registry {
                 itemLinkParams[pathParamName] = String(rawValue);
               } else if (itemRecord.identifier !== undefined && typeof itemRecord.identifier !== "object") {
                 itemLinkParams[pathParamName] = String(itemRecord.identifier);
+              } else if (itemRecord.id !== undefined && typeof itemRecord.id !== "object") {
+                itemLinkParams[pathParamName] = String(itemRecord.id);
+              } else if (itemRecord.uid !== undefined && typeof itemRecord.uid !== "object") {
+                itemLinkParams[pathParamName] = String(itemRecord.uid);
               } else if (itemRecord.name !== undefined && typeof itemRecord.name !== "object") {
                 itemLinkParams[pathParamName] = String(itemRecord.name);
               } else {

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -7,7 +7,7 @@ import type { AuditManager } from "../audit/manager.js";
 import type { AuditContext, AuditEvent, AuditOutcome } from "../audit/types.js";
 import { createLogger } from "../utils/logger.js";
 import { buildDeepLink, appendStoreType } from "../utils/deep-links.js";
-import { isFormDataBody, isRecord } from "../utils/type-guards.js";
+import { isFormDataBody } from "../utils/type-guards.js";
 import { canonicalizeListFilterEnums } from "./enum-utils.js";
 import { assertListScopeResolved } from "./list-filter-utils.js";
 
@@ -947,13 +947,9 @@ export class Registry {
       for (const field of def.identifierFields) {
         const pathParamName = spec.pathParams?.[field] ?? getPathParam?.[field] ?? field;
         let value = input[field];
-        // Create bodies often carry the id as uid/identifier rather than agent_id.
-        if (!value && isRecord(input.body)) {
-          value = input.body[field] ?? input.body[pathParamName] ?? input.body.uid ?? input.body.identifier ?? input.body.id;
-        }
         if (!value && resultRecord) {
-          // Check top-level first. Agent create/get return `id` (the UID), not `identifier`.
-          value = resultRecord[pathParamName] ?? resultRecord.identifier ?? resultRecord.id ?? resultRecord.uid;
+          // Check top-level first
+          value = resultRecord[pathParamName] ?? resultRecord.identifier;
           if (!value) {
             // Look for identifier in any nested object that has an 'identifier' field
             // This handles wrapped responses like {service: {identifier: "..."}}, {environment: {...}}, etc.
@@ -1043,10 +1039,6 @@ export class Registry {
                 itemLinkParams[pathParamName] = String(rawValue);
               } else if (itemRecord.identifier !== undefined && typeof itemRecord.identifier !== "object") {
                 itemLinkParams[pathParamName] = String(itemRecord.identifier);
-              } else if (itemRecord.id !== undefined && typeof itemRecord.id !== "object") {
-                itemLinkParams[pathParamName] = String(itemRecord.id);
-              } else if (itemRecord.uid !== undefined && typeof itemRecord.uid !== "object") {
-                itemLinkParams[pathParamName] = String(itemRecord.uid);
               } else if (itemRecord.name !== undefined && typeof itemRecord.name !== "object") {
                 itemLinkParams[pathParamName] = String(itemRecord.name);
               } else {

--- a/src/registry/toolsets/agents.ts
+++ b/src/registry/toolsets/agents.ts
@@ -1,5 +1,5 @@
 import type { ToolsetDefinition, BodySchema } from "../types.js";
-import { isRecord } from "../../utils/type-guards.js";
+import { agentExtract, passthrough } from "../extractors.js";
 
 /**
  * Generate a UID from an agent name by converting to lowercase and replacing
@@ -10,36 +10,6 @@ function generateAgentUid(name: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "_")
     .replace(/^_+|_+$/g, ""); // trim leading/trailing underscores
-}
-
-/** Agent APIs return `id` (the UID), not `identifier`. Alias so deep links can resolve {agentIdentifier}. */
-function aliasAgentIdentifier(record: Record<string, unknown>): void {
-  if (record.identifier != null && record.identifier !== "") return;
-  const id = record.id ?? record.uid;
-  if (id != null && id !== "") {
-    record.identifier = id;
-  }
-}
-
-function agentExtract(raw: unknown): unknown {
-  if (raw === null || raw === undefined) return raw;
-  if (Array.isArray(raw)) {
-    for (const item of raw) {
-      if (isRecord(item)) aliasAgentIdentifier(item);
-    }
-    return raw;
-  }
-  if (!isRecord(raw)) return raw;
-  aliasAgentIdentifier(raw);
-  for (const key of ["items", "data", "content"] as const) {
-    const arr = raw[key];
-    if (Array.isArray(arr)) {
-      for (const item of arr) {
-        if (isRecord(item)) aliasAgentIdentifier(item);
-      }
-    }
-  }
-  return raw;
 }
 
 const agentCreateSchema: BodySchema = {
@@ -137,7 +107,7 @@ export const agentsToolset: ToolsetDefinition = {
           path: "/gateway/agents/api/v1/agents/{agentIdentifier}",
           operationPolicy: { risk: "destructive", retryPolicy: "do_not_retry" },
           pathParams: { agent_id: "agentIdentifier" },
-          responseExtractor: agentExtract,
+          responseExtractor: passthrough,
           description: "Delete a custom agent (soft delete - sets status to 'deleted'). Only custom agents can be deleted.",
         },
       },

--- a/src/registry/toolsets/agents.ts
+++ b/src/registry/toolsets/agents.ts
@@ -1,5 +1,5 @@
 import type { ToolsetDefinition, BodySchema } from "../types.js";
-import { passthrough } from "../extractors.js";
+import { isRecord } from "../../utils/type-guards.js";
 
 /**
  * Generate a UID from an agent name by converting to lowercase and replacing
@@ -10,6 +10,36 @@ function generateAgentUid(name: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "_")
     .replace(/^_+|_+$/g, ""); // trim leading/trailing underscores
+}
+
+/** Agent APIs return `id` (the UID), not `identifier`. Alias so deep links can resolve {agentIdentifier}. */
+function aliasAgentIdentifier(record: Record<string, unknown>): void {
+  if (record.identifier != null && record.identifier !== "") return;
+  const id = record.id ?? record.uid;
+  if (id != null && id !== "") {
+    record.identifier = id;
+  }
+}
+
+function agentExtract(raw: unknown): unknown {
+  if (raw === null || raw === undefined) return raw;
+  if (Array.isArray(raw)) {
+    for (const item of raw) {
+      if (isRecord(item)) aliasAgentIdentifier(item);
+    }
+    return raw;
+  }
+  if (!isRecord(raw)) return raw;
+  aliasAgentIdentifier(raw);
+  for (const key of ["items", "data", "content"] as const) {
+    const arr = raw[key];
+    if (Array.isArray(arr)) {
+      for (const item of arr) {
+        if (isRecord(item)) aliasAgentIdentifier(item);
+      }
+    }
+  }
+  return raw;
 }
 
 const agentCreateSchema: BodySchema = {
@@ -54,7 +84,7 @@ export const agentsToolset: ToolsetDefinition = {
           method: "GET",
           path: "/gateway/agents/api/v1/agents",
           operationPolicy: { risk: "read", retryPolicy: "safe" },
-          responseExtractor: passthrough,
+          responseExtractor: agentExtract,
           description: "List all agents (system and custom) scoped to the account/org/project context",
         },
         get: {
@@ -62,7 +92,7 @@ export const agentsToolset: ToolsetDefinition = {
           path: "/gateway/agents/api/v1/agents/{agentIdentifier}",
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           pathParams: { agent_id: "agentIdentifier" },
-          responseExtractor: passthrough,
+          responseExtractor: agentExtract,
           description: "Get agent details including YAML spec, role, status, timestamps, wiki, and logo",
         },
         create: {
@@ -84,7 +114,7 @@ export const agentsToolset: ToolsetDefinition = {
 
             return body;
           },
-          responseExtractor: passthrough,
+          responseExtractor: agentExtract,
           description: "Create a new custom agent with YAML specification. System agents cannot be created via API. The uid field is required and must be unique within the scope.",
           bodySchema: agentCreateSchema,
         },
@@ -98,7 +128,7 @@ export const agentsToolset: ToolsetDefinition = {
             if (!body) throw new Error("body is required for agent update");
             return body;
           },
-          responseExtractor: passthrough,
+          responseExtractor: agentExtract,
           description: "Update a custom agent. All fields are optional. Only custom agents can be updated (role='custom').",
           bodySchema: agentUpdateSchema,
         },
@@ -107,7 +137,7 @@ export const agentsToolset: ToolsetDefinition = {
           path: "/gateway/agents/api/v1/agents/{agentIdentifier}",
           operationPolicy: { risk: "destructive", retryPolicy: "do_not_retry" },
           pathParams: { agent_id: "agentIdentifier" },
-          responseExtractor: passthrough,
+          responseExtractor: agentExtract,
           description: "Delete a custom agent (soft delete - sets status to 'deleted'). Only custom agents can be deleted.",
         },
       },

--- a/src/registry/toolsets/agents.ts
+++ b/src/registry/toolsets/agents.ts
@@ -48,7 +48,7 @@ export const agentsToolset: ToolsetDefinition = {
       scope: "project",
       scopeOptional: false,
       identifierFields: ["agent_id"],
-      deepLinkTemplate: "/ng/account/{accountId}/all/ai-agents/orgs/{orgIdentifier}/projects/{projectIdentifier}/agents/{agentIdentifier}?type=custom",
+      deepLinkTemplate: "/ng/account/{accountId}/all/ai-agents/orgs/{orgIdentifier}/projects/{projectIdentifier}/agents/{agentIdentifier}",
       operations: {
         list: {
           method: "GET",

--- a/src/registry/toolsets/agents.ts
+++ b/src/registry/toolsets/agents.ts
@@ -48,7 +48,7 @@ export const agentsToolset: ToolsetDefinition = {
       scope: "project",
       scopeOptional: false,
       identifierFields: ["agent_id"],
-      deepLinkTemplate: "/ng/account/{accountId}/all/orgs/{orgIdentifier}/projects/{projectIdentifier}/agents/{agentIdentifier}/details",
+      deepLinkTemplate: "/ng/account/{accountId}/all/ai-agents/orgs/{orgIdentifier}/projects/{projectIdentifier}/agents/{agentIdentifier}?type=custom",
       operations: {
         list: {
           method: "GET",

--- a/src/utils/deep-links.ts
+++ b/src/utils/deep-links.ts
@@ -37,3 +37,16 @@ export function appendStoreType(link: string, record: Record<string, unknown>): 
   }
   return link;
 }
+
+/**
+ * Agent details URLs use ?type=custom|system. List/get include both roles;
+ * only append when the extracted record has a known role.
+ */
+export function appendAgentTypeQuery(link: string, record: Record<string, unknown>): string {
+  const role = record.role;
+  if (role !== "custom" && role !== "system") {
+    return link;
+  }
+  const separator = link.includes("?") ? "&" : "?";
+  return `${link}${separator}type=${encodeURIComponent(role)}`;
+}

--- a/tests/registry/agent-deep-links.test.ts
+++ b/tests/registry/agent-deep-links.test.ts
@@ -7,6 +7,11 @@
  *
  * Correct UI 2.0 path (same layout as the worker-agents list):
  * /ng/account/{accountId}/all/ai-agents/orgs/{org}/projects/{project}/agents/{id}
+ *
+ * Create with only `id`/`uid` (no `agent_id` on input) is what would have caught
+ * the original bug. List also has no `agent_id`; items must not include `name`
+ * or the registry would fill the placeholder from name without the extractor.
+ * Get already has `agent_id` on input — it only asserts the new path string.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { HarnessClient } from "../../src/client/harness-client.js";
@@ -36,6 +41,12 @@ function mockFetchResponse(body: unknown, status = 200): Response {
 const EXPECTED_LINK =
   "https://app.harness.io/ng/account/testaccount/all/ai-agents/orgs/default/projects/aiTeam/agents/pipeline_lister_agent?type=custom";
 
+const createBody = {
+  uid: "pipeline_lister_agent",
+  name: "Pipeline Lister Agent",
+  spec: "agent:\n  name: Pipeline Lister Agent\n",
+};
+
 describe("agent deep links", () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
 
@@ -48,24 +59,13 @@ describe("agent deep links", () => {
   });
 
   it("resolves {agentIdentifier} from a create response that only returns `id`", async () => {
-    fetchSpy.mockResolvedValueOnce(
-      mockFetchResponse({
-        id: "pipeline_lister_agent",
-        name: "Pipeline Lister Agent",
-        role: "custom",
-        status: "active",
-      }),
-    );
+    fetchSpy.mockResolvedValueOnce(mockFetchResponse({ id: "pipeline_lister_agent" }));
 
     const registry = new Registry(makeConfig());
     const result = (await registry.dispatch(new HarnessClient(makeConfig()), "agent", "create", {
       org_id: "default",
       project_id: "aiTeam",
-      body: {
-        uid: "pipeline_lister_agent",
-        name: "Pipeline Lister Agent",
-        spec: "agent:\n  name: Pipeline Lister Agent\n",
-      },
+      body: createBody,
     })) as Record<string, unknown>;
 
     expect(result.openInHarness).toBe(EXPECTED_LINK);
@@ -73,40 +73,13 @@ describe("agent deep links", () => {
   });
 
   it("resolves {agentIdentifier} from a create response that only returns `uid`", async () => {
-    fetchSpy.mockResolvedValueOnce(
-      mockFetchResponse({
-        uid: "pipeline_lister_agent",
-        name: "Pipeline Lister Agent",
-      }),
-    );
+    fetchSpy.mockResolvedValueOnce(mockFetchResponse({ uid: "pipeline_lister_agent" }));
 
     const registry = new Registry(makeConfig());
     const result = (await registry.dispatch(new HarnessClient(makeConfig()), "agent", "create", {
       org_id: "default",
       project_id: "aiTeam",
-      body: {
-        uid: "pipeline_lister_agent",
-        name: "Pipeline Lister Agent",
-        spec: "agent:\n  name: Pipeline Lister Agent\n",
-      },
-    })) as Record<string, unknown>;
-
-    expect(result.openInHarness).toBe(EXPECTED_LINK);
-  });
-
-  it("resolves {agentIdentifier} on get from response id", async () => {
-    fetchSpy.mockResolvedValueOnce(
-      mockFetchResponse({
-        id: "pipeline_lister_agent",
-        name: "Pipeline Lister Agent",
-      }),
-    );
-
-    const registry = new Registry(makeConfig());
-    const result = (await registry.dispatch(new HarnessClient(makeConfig()), "agent", "get", {
-      org_id: "default",
-      project_id: "aiTeam",
-      agent_id: "pipeline_lister_agent",
+      body: createBody,
     })) as Record<string, unknown>;
 
     expect(result.openInHarness).toBe(EXPECTED_LINK);
@@ -116,7 +89,7 @@ describe("agent deep links", () => {
     fetchSpy.mockResolvedValueOnce(
       mockFetchResponse({
         status: "SUCCESS",
-        data: { id: "pipeline_lister_agent", name: "Pipeline Lister Agent" },
+        data: { id: "pipeline_lister_agent" },
       }),
     );
 
@@ -124,22 +97,33 @@ describe("agent deep links", () => {
     const result = (await registry.dispatch(new HarnessClient(makeConfig()), "agent", "create", {
       org_id: "default",
       project_id: "aiTeam",
-      body: {
-        uid: "pipeline_lister_agent",
-        name: "Pipeline Lister Agent",
-        spec: "agent:\n  name: Pipeline Lister Agent\n",
-      },
+      body: createBody,
     })) as Record<string, unknown>;
 
     expect(result.openInHarness).toBe(EXPECTED_LINK);
     expect(result.identifier).toBe("pipeline_lister_agent");
   });
 
-  it("attaches per-item openInHarness on list arrays", async () => {
+  it("resolves {agentIdentifier} from list items that only have `id`", async () => {
+    fetchSpy.mockResolvedValueOnce(mockFetchResponse([{ id: "pipeline_lister_agent" }]));
+
+    const registry = new Registry(makeConfig());
+    const result = (await registry.dispatch(new HarnessClient(makeConfig()), "agent", "list", {
+      org_id: "default",
+      project_id: "aiTeam",
+    })) as { items: Array<Record<string, unknown>> };
+
+    expect(result.items[0]!.openInHarness).toBe(EXPECTED_LINK);
+    expect(result.items[0]!.identifier).toBe("pipeline_lister_agent");
+    expect(String(result.items[0]!.openInHarness)).not.toContain("{agentIdentifier}");
+  });
+
+  it("resolves {agentIdentifier} from a { data: [{ id }] } list envelope", async () => {
     fetchSpy.mockResolvedValueOnce(
-      mockFetchResponse([
-        { id: "pipeline_lister_agent", name: "Pipeline Lister Agent" },
-      ]),
+      mockFetchResponse({
+        status: "SUCCESS",
+        data: [{ id: "pipeline_lister_agent" }],
+      }),
     );
 
     const registry = new Registry(makeConfig());
@@ -150,5 +134,18 @@ describe("agent deep links", () => {
 
     expect(result.items[0]!.openInHarness).toBe(EXPECTED_LINK);
     expect(result.items[0]!.identifier).toBe("pipeline_lister_agent");
+  });
+
+  it("uses the UI 2.0 ai-agents path on get (agent_id is already on the input)", async () => {
+    fetchSpy.mockResolvedValueOnce(mockFetchResponse({ id: "pipeline_lister_agent" }));
+
+    const registry = new Registry(makeConfig());
+    const result = (await registry.dispatch(new HarnessClient(makeConfig()), "agent", "get", {
+      org_id: "default",
+      project_id: "aiTeam",
+      agent_id: "pipeline_lister_agent",
+    })) as Record<string, unknown>;
+
+    expect(result.openInHarness).toBe(EXPECTED_LINK);
   });
 });

--- a/tests/registry/agent-deep-links.test.ts
+++ b/tests/registry/agent-deep-links.test.ts
@@ -111,4 +111,44 @@ describe("agent deep links", () => {
 
     expect(result.openInHarness).toBe(EXPECTED_LINK);
   });
+
+  it("resolves {agentIdentifier} from a { data: { id } } create envelope", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      mockFetchResponse({
+        status: "SUCCESS",
+        data: { id: "pipeline_lister_agent", name: "Pipeline Lister Agent" },
+      }),
+    );
+
+    const registry = new Registry(makeConfig());
+    const result = (await registry.dispatch(new HarnessClient(makeConfig()), "agent", "create", {
+      org_id: "default",
+      project_id: "aiTeam",
+      body: {
+        uid: "pipeline_lister_agent",
+        name: "Pipeline Lister Agent",
+        spec: "agent:\n  name: Pipeline Lister Agent\n",
+      },
+    })) as Record<string, unknown>;
+
+    expect(result.openInHarness).toBe(EXPECTED_LINK);
+    expect(result.identifier).toBe("pipeline_lister_agent");
+  });
+
+  it("attaches per-item openInHarness on list arrays", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      mockFetchResponse([
+        { id: "pipeline_lister_agent", name: "Pipeline Lister Agent" },
+      ]),
+    );
+
+    const registry = new Registry(makeConfig());
+    const result = (await registry.dispatch(new HarnessClient(makeConfig()), "agent", "list", {
+      org_id: "default",
+      project_id: "aiTeam",
+    })) as { items: Array<Record<string, unknown>> };
+
+    expect(result.items[0]!.openInHarness).toBe(EXPECTED_LINK);
+    expect(result.items[0]!.identifier).toBe("pipeline_lister_agent");
+  });
 });

--- a/tests/registry/agent-deep-links.test.ts
+++ b/tests/registry/agent-deep-links.test.ts
@@ -72,8 +72,13 @@ describe("agent deep links", () => {
     expect(String(result.openInHarness)).not.toContain("{agentIdentifier}");
   });
 
-  it("resolves {agentIdentifier} from body.uid when the response has no id", async () => {
-    fetchSpy.mockResolvedValueOnce(mockFetchResponse({ name: "Pipeline Lister Agent" }));
+  it("resolves {agentIdentifier} from a create response that only returns `uid`", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      mockFetchResponse({
+        uid: "pipeline_lister_agent",
+        name: "Pipeline Lister Agent",
+      }),
+    );
 
     const registry = new Registry(makeConfig());
     const result = (await registry.dispatch(new HarnessClient(makeConfig()), "agent", "create", {

--- a/tests/registry/agent-deep-links.test.ts
+++ b/tests/registry/agent-deep-links.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Deep links for AI agents must carry the agent UID.
+ *
+ * Regression: the template used {agentIdentifier} while create/get responses
+ * only return `id` (the UID), so openInHarness kept the placeholder
+ * (".../agents/{agentIdentifier}/details"). Chat navigated to that URL as-is.
+ *
+ * Correct UI 2.0 path (same layout as the worker-agents list):
+ * /ng/account/{accountId}/all/ai-agents/orgs/{org}/projects/{project}/agents/{id}
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { HarnessClient } from "../../src/client/harness-client.js";
+import { Registry } from "../../src/registry/index.js";
+import type { Config } from "../../src/config.js";
+
+function makeConfig(): Config {
+  return {
+    HARNESS_API_KEY: "pat.testaccount.tokenid.secret",
+    HARNESS_ACCOUNT_ID: "testaccount",
+    HARNESS_BASE_URL: "https://app.harness.io",
+    HARNESS_ORG: "",
+    HARNESS_PROJECT: "",
+    HARNESS_API_TIMEOUT_MS: 5000,
+    HARNESS_MAX_RETRIES: 0,
+    LOG_LEVEL: "error",
+  } as Config;
+}
+
+function mockFetchResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const EXPECTED_LINK =
+  "https://app.harness.io/ng/account/testaccount/all/ai-agents/orgs/default/projects/aiTeam/agents/pipeline_lister_agent?type=custom";
+
+describe("agent deep links", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("resolves {agentIdentifier} from a create response that only returns `id`", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      mockFetchResponse({
+        id: "pipeline_lister_agent",
+        name: "Pipeline Lister Agent",
+        role: "custom",
+        status: "active",
+      }),
+    );
+
+    const registry = new Registry(makeConfig());
+    const result = (await registry.dispatch(new HarnessClient(makeConfig()), "agent", "create", {
+      org_id: "default",
+      project_id: "aiTeam",
+      body: {
+        uid: "pipeline_lister_agent",
+        name: "Pipeline Lister Agent",
+        spec: "agent:\n  name: Pipeline Lister Agent\n",
+      },
+    })) as Record<string, unknown>;
+
+    expect(result.openInHarness).toBe(EXPECTED_LINK);
+    expect(String(result.openInHarness)).not.toContain("{agentIdentifier}");
+  });
+
+  it("resolves {agentIdentifier} from body.uid when the response has no id", async () => {
+    fetchSpy.mockResolvedValueOnce(mockFetchResponse({ name: "Pipeline Lister Agent" }));
+
+    const registry = new Registry(makeConfig());
+    const result = (await registry.dispatch(new HarnessClient(makeConfig()), "agent", "create", {
+      org_id: "default",
+      project_id: "aiTeam",
+      body: {
+        uid: "pipeline_lister_agent",
+        name: "Pipeline Lister Agent",
+        spec: "agent:\n  name: Pipeline Lister Agent\n",
+      },
+    })) as Record<string, unknown>;
+
+    expect(result.openInHarness).toBe(EXPECTED_LINK);
+  });
+
+  it("resolves {agentIdentifier} on get from response id", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      mockFetchResponse({
+        id: "pipeline_lister_agent",
+        name: "Pipeline Lister Agent",
+      }),
+    );
+
+    const registry = new Registry(makeConfig());
+    const result = (await registry.dispatch(new HarnessClient(makeConfig()), "agent", "get", {
+      org_id: "default",
+      project_id: "aiTeam",
+      agent_id: "pipeline_lister_agent",
+    })) as Record<string, unknown>;
+
+    expect(result.openInHarness).toBe(EXPECTED_LINK);
+  });
+});

--- a/tests/registry/agent-deep-links.test.ts
+++ b/tests/registry/agent-deep-links.test.ts
@@ -38,8 +38,10 @@ function mockFetchResponse(body: unknown, status = 200): Response {
   });
 }
 
-const EXPECTED_LINK =
-  "https://app.harness.io/ng/account/testaccount/all/ai-agents/orgs/default/projects/aiTeam/agents/pipeline_lister_agent?type=custom";
+const EXPECTED_PATH =
+  "https://app.harness.io/ng/account/testaccount/all/ai-agents/orgs/default/projects/aiTeam/agents/pipeline_lister_agent";
+const EXPECTED_CUSTOM_LINK = `${EXPECTED_PATH}?type=custom`;
+const EXPECTED_SYSTEM_LINK = `${EXPECTED_PATH}?type=system`;
 
 const createBody = {
   uid: "pipeline_lister_agent",
@@ -68,7 +70,7 @@ describe("agent deep links", () => {
       body: createBody,
     })) as Record<string, unknown>;
 
-    expect(result.openInHarness).toBe(EXPECTED_LINK);
+    expect(result.openInHarness).toBe(EXPECTED_PATH);
     expect(String(result.openInHarness)).not.toContain("{agentIdentifier}");
   });
 
@@ -82,7 +84,7 @@ describe("agent deep links", () => {
       body: createBody,
     })) as Record<string, unknown>;
 
-    expect(result.openInHarness).toBe(EXPECTED_LINK);
+    expect(result.openInHarness).toBe(EXPECTED_PATH);
   });
 
   it("resolves {agentIdentifier} from a { data: { id } } create envelope", async () => {
@@ -100,7 +102,7 @@ describe("agent deep links", () => {
       body: createBody,
     })) as Record<string, unknown>;
 
-    expect(result.openInHarness).toBe(EXPECTED_LINK);
+    expect(result.openInHarness).toBe(EXPECTED_PATH);
     expect(result.identifier).toBe("pipeline_lister_agent");
   });
 
@@ -113,7 +115,7 @@ describe("agent deep links", () => {
       project_id: "aiTeam",
     })) as { items: Array<Record<string, unknown>> };
 
-    expect(result.items[0]!.openInHarness).toBe(EXPECTED_LINK);
+    expect(result.items[0]!.openInHarness).toBe(EXPECTED_PATH);
     expect(result.items[0]!.identifier).toBe("pipeline_lister_agent");
     expect(String(result.items[0]!.openInHarness)).not.toContain("{agentIdentifier}");
   });
@@ -132,7 +134,7 @@ describe("agent deep links", () => {
       project_id: "aiTeam",
     })) as { items: Array<Record<string, unknown>> };
 
-    expect(result.items[0]!.openInHarness).toBe(EXPECTED_LINK);
+    expect(result.items[0]!.openInHarness).toBe(EXPECTED_PATH);
     expect(result.items[0]!.identifier).toBe("pipeline_lister_agent");
   });
 
@@ -146,6 +148,54 @@ describe("agent deep links", () => {
       agent_id: "pipeline_lister_agent",
     })) as Record<string, unknown>;
 
-    expect(result.openInHarness).toBe(EXPECTED_LINK);
+    expect(result.openInHarness).toBe(EXPECTED_PATH);
+  });
+
+  it("appends ?type=custom when create/get role is custom", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      mockFetchResponse({ id: "pipeline_lister_agent", role: "custom" }),
+    );
+
+    const registry = new Registry(makeConfig());
+    const result = (await registry.dispatch(new HarnessClient(makeConfig()), "agent", "create", {
+      org_id: "default",
+      project_id: "aiTeam",
+      body: createBody,
+    })) as Record<string, unknown>;
+
+    expect(result.openInHarness).toBe(EXPECTED_CUSTOM_LINK);
+  });
+
+  it("appends ?type=system for list items with role system", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      mockFetchResponse([{ id: "pipeline_lister_agent", role: "system" }]),
+    );
+
+    const registry = new Registry(makeConfig());
+    const result = (await registry.dispatch(new HarnessClient(makeConfig()), "agent", "list", {
+      org_id: "default",
+      project_id: "aiTeam",
+    })) as { items: Array<Record<string, unknown>> };
+
+    expect(result.items[0]!.openInHarness).toBe(EXPECTED_SYSTEM_LINK);
+  });
+
+  it("resolves {agentIdentifier} from a { data: { id } } get envelope", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      mockFetchResponse({
+        status: "SUCCESS",
+        data: { id: "pipeline_lister_agent", role: "custom" },
+      }),
+    );
+
+    const registry = new Registry(makeConfig());
+    const result = (await registry.dispatch(new HarnessClient(makeConfig()), "agent", "get", {
+      org_id: "default",
+      project_id: "aiTeam",
+      agent_id: "pipeline_lister_agent",
+    })) as Record<string, unknown>;
+
+    expect(result.openInHarness).toBe(EXPECTED_CUSTOM_LINK);
+    expect(result.identifier).toBe("pipeline_lister_agent");
   });
 });

--- a/tests/registry/extractors-agent.test.ts
+++ b/tests/registry/extractors-agent.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { agentExtract } from "../../src/registry/extractors.js";
+
+describe("agentExtract", () => {
+  it("aliases id onto identifier for a bare create/get entity", () => {
+    expect(agentExtract({ id: "ca_new", name: "New" })).toEqual({
+      id: "ca_new",
+      name: "New",
+      identifier: "ca_new",
+    });
+  });
+
+  it("aliases uid onto identifier when id is absent", () => {
+    expect(agentExtract({ uid: "ca_new", name: "New" })).toEqual({
+      uid: "ca_new",
+      name: "New",
+      identifier: "ca_new",
+    });
+  });
+
+  it("unwraps { data: { id } } create/get envelope and aliases identifier", () => {
+    expect(
+      agentExtract({
+        status: "SUCCESS",
+        data: { id: "ca_new", name: "New" },
+      }),
+    ).toEqual({
+      id: "ca_new",
+      name: "New",
+      identifier: "ca_new",
+    });
+  });
+
+  it("does not overwrite an existing identifier", () => {
+    expect(agentExtract({ id: "internal", identifier: "canonical" })).toEqual({
+      id: "internal",
+      identifier: "canonical",
+    });
+  });
+
+  it("normalizes a raw list array to { items, total } with aliased identifiers", () => {
+    expect(
+      agentExtract([
+        { id: "a1", name: "One" },
+        { uid: "a2", name: "Two" },
+      ]),
+    ).toEqual({
+      items: [
+        { id: "a1", name: "One", identifier: "a1" },
+        { uid: "a2", name: "Two", identifier: "a2" },
+      ],
+      total: 2,
+    });
+  });
+
+  it("normalizes { data: [...] } list envelope to { items, total }", () => {
+    expect(
+      agentExtract({
+        status: "SUCCESS",
+        data: [{ id: "a1", name: "One" }],
+      }),
+    ).toEqual({
+      items: [{ id: "a1", name: "One", identifier: "a1" }],
+      total: 1,
+    });
+  });
+
+  it("aliases items already wrapped as { items }", () => {
+    expect(agentExtract({ items: [{ id: "a1" }], total: 1 })).toEqual({
+      items: [{ id: "a1", identifier: "a1" }],
+      total: 1,
+    });
+  });
+
+  it("leaves delete-style { data: true } alone", () => {
+    expect(agentExtract({ data: true })).toEqual({ data: true });
+  });
+});

--- a/tests/registry/extractors-agent.test.ts
+++ b/tests/registry/extractors-agent.test.ts
@@ -75,4 +75,25 @@ describe("agentExtract", () => {
   it("leaves delete-style { data: true } alone", () => {
     expect(agentExtract({ data: true })).toEqual({ data: true });
   });
+
+  it("aliases nested object envelopes (items/data/content as objects, not arrays)", () => {
+    expect(agentExtract({ items: { id: "nested" } })).toEqual({
+      items: { id: "nested", identifier: "nested" },
+    });
+    expect(agentExtract({ content: { uid: "from-uid" } })).toEqual({
+      content: { uid: "from-uid", identifier: "from-uid" },
+    });
+  });
+
+  it("aliases numeric id onto identifier as a string", () => {
+    expect(agentExtract({ id: 42 })).toEqual({ id: 42, identifier: "42" });
+  });
+
+  it("does not alias object id or uid onto identifier", () => {
+    const objectId = { oid: "pipeline_lister_agent" };
+    expect(agentExtract({ id: objectId, name: "New" })).toEqual({
+      id: objectId,
+      name: "New",
+    });
+  });
 });

--- a/tests/utils/deep-links.test.ts
+++ b/tests/utils/deep-links.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildDeepLink } from "../../src/utils/deep-links.js";
+import { appendAgentTypeQuery, buildDeepLink } from "../../src/utils/deep-links.js";
 
 describe("buildDeepLink", () => {
   const baseUrl = "https://app.harness.io";
@@ -42,5 +42,19 @@ describe("buildDeepLink", () => {
   it("handles empty params", () => {
     const url = buildDeepLink(baseUrl, accountId, "/ng/account/{accountId}/home", {});
     expect(url).toBe("https://app.harness.io/ng/account/abc123/home");
+  });
+});
+
+describe("appendAgentTypeQuery", () => {
+  const link = "https://app.harness.io/ng/account/a/all/ai-agents/orgs/o/projects/p/agents/x";
+
+  it("appends type=custom or type=system from role", () => {
+    expect(appendAgentTypeQuery(link, { role: "custom" })).toBe(`${link}?type=custom`);
+    expect(appendAgentTypeQuery(link, { role: "system" })).toBe(`${link}?type=system`);
+  });
+
+  it("does not append type when role is missing or unknown", () => {
+    expect(appendAgentTypeQuery(link, {})).toBe(link);
+    expect(appendAgentTypeQuery(link, { role: "other" })).toBe(link);
   });
 });


### PR DESCRIPTION
Agent create/get return id (the UID), not identifier, so the deep-link template left {agentIdentifier} in the URL. Substitute id/uid and use the UI 2.0 ai-agents path.

## Description
<!-- What does this PR do? -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [x] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
If this PR adds or changes Harness API coverage:
- [ ] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [ ] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [ ] `operationPolicy` on every new/changed endpoint
- [ ] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [ ] `identifierFields` and `scope` declared on new resources
- [ ] No `console.log()` in `src/` (stdio JSON-RPC safety)
