### PR TITLE
fix: route user get through the aggregate API

### DIFF
--- a/docs/testing/user/test_plan.md
+++ b/docs/testing/user/test_plan.md
@@ -35,6 +35,7 @@
 ## Notes
 - User resource is account-scoped — no org/project required for list/get
 - List endpoint is POST-based at `/ng/api/user/aggregate` with body containing searchTerm
+- Get endpoint is GET `/ng/api/user/aggregate/{userId}` (not `/ng/api/user/{userId}`, which returns 405)
 - Invite endpoint at `/ng/api/user/users` accepts emails as array or comma-separated string
 - Invite body supports `emails` (or `email_ids`), `user_groups` (or `user_group_ids`), and `role_bindings`
 - role_bindings is an array of objects with: roleIdentifier, resourceGroupIdentifier, roleScopeLevel, roleName, resourceGroupName, managedRole

--- a/src/registry/toolsets/access-control.ts
+++ b/src/registry/toolsets/access-control.ts
@@ -31,7 +31,7 @@ export const accessControlToolset: ToolsetDefinition = {
         },
         get: {
           method: "GET",
-          path: "/ng/api/user/{userId}",
+          path: "/ng/api/user/aggregate/{userId}",
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           pathParams: { user_id: "userId" },
           responseExtractor: ngExtract,


### PR DESCRIPTION
## Summary
- `harness_get(resource_type="user")` called `GET /ng/api/user/{userId}`, which ng-manager rejects with HTTP 405 (then maps to a generic 500).
- Point `user.get` at `GET /ng/api/user/aggregate/{userId}`, the same endpoint the UI uses and that already returns 200.



