### PR TITLE
Fix v1 pipeline runtime input execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![MCP Toplist](https://mcptoplist.com/badge/glama%2Fharness%2Fmcp-server.svg)](https://mcptoplist.com/server/glama%2Fharness%2Fmcp-server)
 
-An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 242 resource types.
+An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 243 resource types.
 
 ## Why Use This MCP Server
 
@@ -10,7 +10,7 @@ Most MCP servers map one tool per API endpoint. For a platform as broad as Harne
 
 This server is built differently:
 
-- **11 tools, 242 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
+- **11 tools, 243 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
 - **Full platform coverage.** 40 default toolsets spanning CI/CD, GitOps, Feature Flags, Cloud Cost Management, Security Testing, Chaos Engineering, Database DevOps, Internal Developer Portal, Software Supply Chain, Infrastructure as Code Management, Release Management, Governance, Service Overrides, Knowledge Graph, and more. Opt-in Ansible coverage is available when you need inventory and playbook data.
 - **Multi-project workflows out of the box.** Agents discover organizations and projects dynamically — no hardcoded env vars needed. Ask "show failed executions across all projects" and the agent can navigate the full account hierarchy.
 - **35 prompt templates.** Pre-built prompts for common workflows: build & deploy apps end-to-end, debug failed pipelines, review DORA metrics, triage vulnerabilities, optimize cloud costs, audit access control, plan feature flag rollouts, review pull requests, approve pending pipelines, and more.
@@ -870,7 +870,7 @@ Maintainers can refresh the vendored entity snapshots with `pnpm sync-entity-sch
 
 ### Pipeline Run Workflow (Recommended)
 
-Use this sequence to reduce execution-time input errors:
+For v0 pipelines, use this sequence to reduce execution-time input errors:
 
 1. **Discover required runtime inputs**
   - `harness_get(resource_type="runtime_input_template", resource_id="<pipeline_id>")`
@@ -904,6 +904,14 @@ Use this sequence to reduce execution-time input errors:
     ```
 4. **Optional: combine both**
   - Use `input_set_ids` for the base shape and `inputs` for simple overrides.
+
+For v1 pipelines:
+
+1. Fetch `harness_get(resource_type="runtime_input_template_v1", resource_id="<pipeline_id>")`.
+   For Git-backed pipelines, pass `branch_name`, `connector_ref`, and `repo_name` through `params`.
+2. Use each returned `inputs[].details.name` as a top-level key in `harness_execute.inputs`.
+3. Run `harness_execute(resource_type="pipeline_v1", action="run", resource_id="<pipeline_id>", inputs={...})`.
+   The server wraps these values under an `inputs:` YAML root and sends the API's `inputs_yaml` body.
 
 If required fields are unresolved, the tool returns a pre-flight error with expected keys and suggested input sets. You can inspect available shorthand mappings with `harness_describe(resource_type="pipeline")` (`executeActions.run.inputShorthands`).
 
@@ -1205,7 +1213,7 @@ Harness pipelines can be stored in three ways:
 
 ## Resource Types
 
-242 resource types organized across 40 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
+243 resource types organized across 40 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
 
 ### Platform
 
@@ -1230,11 +1238,12 @@ Harness pipelines can be stored in three ways:
 | `pipeline_summary`             |      | x   |        |        |        |                     |
 | `input_set`                    | x    | x   | x      | x      | x      |                     |
 | `runtime_input_template`       |      | x   |        |        |        |                     |
+| `runtime_input_template_v1`    |      | x   |        |        |        |                     |
 | `pipeline_resolved_yaml`       |      | x   |        |        |        |                     |
 | `approval_instance`            | x    |     |        |        |        | `approve`, `reject` |
 
 
-Only one pipeline YAML resource type is loaded at startup. By default `HARNESS_PIPELINE_VERSION=0` exposes `pipeline` and hides `pipeline_v1`; set `HARNESS_PIPELINE_VERSION=1` to expose `pipeline_v1` and hide `pipeline`. In HTTP mode, include `x-harness-pipeline-version: 0` or `1` on the `initialize` request to choose the version for that session.
+Both pipeline YAML resource types are available when the pipelines toolset is enabled. `HARNESS_PIPELINE_VERSION` and the HTTP `x-harness-pipeline-version` initialization header select the default version preference; they do not hide the other version.
 
 ### AI Agents
 
@@ -1929,7 +1938,7 @@ Available toolset names:
                  +--------v---------+
                 |    Registry       |  <-- Declarative resource definitions
                 |  40 Toolsets      |      (data files, not code)
-                |  242 Resource Types|
+                |  243 Resource Types|
                  +--------+---------+
                           |
                  +--------v---------+

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "harness-mcp-server",
   "display_name": "Harness",
-  "version": "3.2.22",
+  "version": "3.2.23",
   "description": "Connect AI agents to Harness for CI/CD, code repositories, pull requests, services, environments, and feature flags.",
   "long_description": "The Harness MCP Server gives MCP-compatible clients access to Harness platform workflows through consolidated tools, resources, and prompts. It supports local stdio usage and can be bundled as a Node-based MCPB extension.",
   "author": {

--- a/mcp-directory/manifest.json
+++ b/mcp-directory/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "harness-mcp-server",
   "display_name": "Harness",
-  "version": "3.2.22",
+  "version": "3.2.23",
   "description": "Connect AI agents to Harness for CI/CD, code repositories, pull requests, services, environments, and feature flags.",
   "long_description": "The Harness MCP Server gives MCP-compatible clients access to Harness platform workflows through consolidated tools, resources, and prompts. It supports local stdio usage and can be bundled as a Node-based MCPB extension.",
   "author": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "harness-mcp-v2",
-  "version": "3.2.22",
+  "version": "3.2.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "harness-mcp-v2",
-      "version": "3.2.22",
+      "version": "3.2.23",
       "dependencies": {
         "@hono/node-server": "^2.0.10",
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-mcp-v2",
-  "version": "3.2.22",
+  "version": "3.2.23",
   "description": "Give AI agents full access to the Harness.io platform — manage pipelines, deployments, cloud costs, chaos engineering, feature flags, SEI, and 125+ resource types through 11 MCP tools",
   "type": "module",
   "main": "build/index.js",

--- a/src/registry/extractors.ts
+++ b/src/registry/extractors.ts
@@ -553,6 +553,34 @@ export const pipelineResolvedYamlExtract = (raw: unknown): unknown => {
 };
 
 /**
+ * Extracts the declared inputs returned by the Harness pipeline v1 inputs API.
+ * V1 values are supplied as one YAML document rooted at `inputs:`.
+ */
+export const runtimeInputV1Extract = (raw: unknown): unknown => {
+  const r = raw as {
+    inputs?: Record<string, unknown>;
+    template_yaml?: string;
+    resolved_yaml?: string;
+    has_input_sets?: boolean;
+    replaced_expressions?: string[];
+    replaced_expressions_per_stage?: Record<string, string[]>;
+    modules?: string[];
+  };
+  return {
+    inputs: r.inputs ?? {},
+    template_yaml: r.template_yaml ?? null,
+    resolved_yaml: r.resolved_yaml ?? null,
+    has_input_sets: r.has_input_sets ?? false,
+    replaced_expressions: r.replaced_expressions ?? [],
+    replaced_expressions_per_stage: r.replaced_expressions_per_stage ?? {},
+    modules: r.modules ?? [],
+    _hint: r.template_yaml
+      ? "This v1 template shows the available ${{ inputs.* }} values. Pass matching key-value pairs through harness_execute(resource_type='pipeline_v1', action='run', inputs={...}); they are sent as one inputs: YAML document."
+      : "This v1 pipeline has no runtime inputs. You can execute it without providing inputs.",
+  };
+};
+
+/**
  * Extracts the dynamic-execution response for
  * POST /v1/orgs/{org}/projects/{project}/pipelines/{pipeline}/execute/dynamic.
  *

--- a/src/registry/extractors.ts
+++ b/src/registry/extractors.ts
@@ -3,7 +3,7 @@
  * Used across all toolset definitions — eliminates per-file duplication.
  */
 import YAML from "yaml";
-import { isRecord } from "../utils/type-guards.js";
+import { asRecord, isRecord } from "../utils/type-guards.js";
 import { parseZipCsv } from "../utils/zip-csv.js";
 import {
   extractVariableInputMetadata,
@@ -553,30 +553,30 @@ export const pipelineResolvedYamlExtract = (raw: unknown): unknown => {
 };
 
 /**
- * Extracts the declared inputs returned by the Harness pipeline v1 inputs API.
- * V1 values are supplied as one YAML document rooted at `inputs:`.
+ * Extracts the declared inputs returned by the Harness pipeline v1 inputs-schema API.
+ * The API may return its public shape directly or inside the standard `data` envelope.
  */
 export const runtimeInputV1Extract = (raw: unknown): unknown => {
-  const r = raw as {
-    inputs?: Record<string, unknown>;
-    template_yaml?: string;
-    resolved_yaml?: string;
-    has_input_sets?: boolean;
-    replaced_expressions?: string[];
-    replaced_expressions_per_stage?: Record<string, string[]>;
-    modules?: string[];
-  };
+  const outer = asRecord(raw);
+  const r = asRecord(outer?.data) ?? outer;
+  const hasInputsField = !!r && Object.prototype.hasOwnProperty.call(r, "inputs");
+  const inputs = hasInputsField && Array.isArray(r?.inputs) ? r.inputs : null;
+
+  let hint: string;
+  if (!hasInputsField) {
+    hint = "The v1 inputs-schema response omitted inputs metadata. Do not assume the pipeline has no runtime inputs.";
+  } else if (!inputs) {
+    hint = "The v1 inputs-schema response contained an invalid inputs field. Expected an array; do not execute until the schema is confirmed.";
+  } else if (inputs.length === 0) {
+    hint = "This v1 pipeline declares no runtime inputs. Execute it without the inputs argument.";
+  } else {
+    hint = "Use each inputs[].details.name as a top-level harness_execute inputs key for pipeline_v1. The server sends those values as one inputs: YAML document.";
+  }
+
   return {
-    inputs: r.inputs ?? {},
-    template_yaml: r.template_yaml ?? null,
-    resolved_yaml: r.resolved_yaml ?? null,
-    has_input_sets: r.has_input_sets ?? false,
-    replaced_expressions: r.replaced_expressions ?? [],
-    replaced_expressions_per_stage: r.replaced_expressions_per_stage ?? {},
-    modules: r.modules ?? [],
-    _hint: r.template_yaml
-      ? "This v1 template shows the available ${{ inputs.* }} values. Pass matching key-value pairs through harness_execute(resource_type='pipeline_v1', action='run', inputs={...}); they are sent as one inputs: YAML document."
-      : "This v1 pipeline has no runtime inputs. You can execute it without providing inputs.",
+    inputs,
+    metadata_available: inputs !== null,
+    _hint: hint,
   };
 };
 

--- a/src/registry/toolsets/pipelines.ts
+++ b/src/registry/toolsets/pipelines.ts
@@ -1,5 +1,5 @@
 import type { ToolsetDefinition, BodySchema, ParamsSchema, PreflightContext } from "../types.js";
-import { ngExtract, pageExtract, passthrough, v1ListExtract, runtimeInputExtract, runtimeInputTemplatePreflight, pipelineResolvedYamlExtract, executionInputsExtract, dynamicExecutionExtract, triggerListExtract } from "../extractors.js";
+import { ngExtract, pageExtract, passthrough, v1ListExtract, runtimeInputExtract, runtimeInputV1Extract, runtimeInputTemplatePreflight, pipelineResolvedYamlExtract, executionInputsExtract, dynamicExecutionExtract, triggerListExtract } from "../extractors.js";
 import { asRecord } from "../../utils/type-guards.js";
 import YAML from "yaml";
 
@@ -372,6 +372,36 @@ function buildV1PipelineBody(input: Record<string, unknown>): Record<string, unk
   return result;
 }
 
+function buildV1RuntimeInputsBody(input: Record<string, unknown>): Record<string, unknown> {
+  const runtimeInputs = input.inputs;
+  if (runtimeInputs === undefined || runtimeInputs === null) return {};
+
+  if (typeof runtimeInputs === "string") {
+    const parsed = YAML.parse(runtimeInputs) as unknown;
+    const parsedRecord = asRecord(parsed);
+    if (!parsedRecord) {
+      throw new Error("pipeline_v1 inputs YAML must contain a mapping");
+    }
+    if (!("inputs" in parsedRecord)) {
+      return { inputs_yaml: YAML.stringify({ inputs: parsedRecord }) };
+    }
+    if (Object.keys(parsedRecord).length !== 1) {
+      throw new Error("pipeline_v1 inputs YAML must contain only the inputs root");
+    }
+    if (!asRecord(parsedRecord.inputs)) {
+      throw new Error("pipeline_v1 inputs YAML root must contain a key-value mapping");
+    }
+    return { inputs_yaml: runtimeInputs };
+  }
+
+  const inputsRecord = asRecord(runtimeInputs);
+  if (!inputsRecord) {
+    throw new Error("pipeline_v1 inputs must be a YAML string or key-value object");
+  }
+
+  return { inputs_yaml: YAML.stringify({ inputs: inputsRecord }) };
+}
+
 // ---------------------------------------------------------------------------
 // V0 Pipeline body schemas
 // ---------------------------------------------------------------------------
@@ -674,6 +704,14 @@ export const pipelinesToolset: ToolsetDefinition = {
       identifierFields: ["pipeline_id"],
       searchAliases: ["v1 pipeline", "agent pipeline", "v1"],
       diagnosticHint: "Use harness_diagnose with pipeline_id or execution_id to analyze failures. V1 pipelines use the same execution engine as v0.",
+      executeHint: "Before executing, fetch harness_get(resource_type='runtime_input_template_v1', resource_id='PIPELINE_ID'). Pass only the named ${{ inputs.* }} values through the top-level inputs argument; the server wraps them under an inputs: YAML root.",
+      relatedResources: [
+        {
+          resourceType: "runtime_input_template_v1",
+          relationship: "runtime-inputs",
+          description: "Discover declared ${{ inputs.* }} values before execute. harness_get(resource_type='runtime_input_template_v1', resource_id=<pipeline_id>).",
+        },
+      ],
       deepLinkTemplate: "/ng/account/{accountId}/all/orgs/{orgIdentifier}/projects/{projectIdentifier}/pipelines/{pipeline}/pipeline-studio",
       operations: {
         list: {
@@ -749,20 +787,12 @@ export const pipelinesToolset: ToolsetDefinition = {
           queryParams: {
             module: "module",
           },
-          bodyBuilder: (input) => {
-            const inputs = input.inputs;
-            if (!inputs) return {};
-            if (typeof inputs === "string") return { inputs_yaml: inputs };
-            // Object inputs — serialize to YAML
-            return { inputs_yaml: YAML.stringify(inputs) };
-          },
+          bodyBuilder: buildV1RuntimeInputsBody,
           responseExtractor: passthrough,
-          actionDescription: "Execute a v1 pipeline. Optionally pass runtime inputs as inputs_yaml (YAML string) or as a key-value object (auto-serialized to YAML).",
+          actionDescription: "Execute a v1 pipeline. First fetch runtime_input_template_v1, then pass named values through the top-level inputs argument. Values are wrapped under an inputs: YAML root and sent as inputs_yaml.",
           bodySchema: {
-            description: "Runtime inputs for v1 pipeline execution. Pass inputs as a YAML string or key-value object.",
-            fields: [
-              { name: "inputs_yaml", type: "string", required: false, description: "YAML-formatted runtime inputs for the pipeline" },
-            ],
+            description: "Do not put v1 runtime inputs under body. Use the top-level harness_execute inputs argument; the MCP server constructs the inputs_yaml API body.",
+            fields: [],
           },
         },
       },
@@ -1273,6 +1303,33 @@ export const pipelinesToolset: ToolsetDefinition = {
           responseExtractor: pipelineResolvedYamlExtract,
           description:
             "Fetch resolved pipeline YAML with templates expanded. Returns stageMetadataMap for patching entity-type activity inputs (deploymentType, environmentRef).",
+        },
+      },
+    },
+    {
+      resourceType: "runtime_input_template_v1",
+      displayName: "Runtime Input Template (V1)",
+      description: "Fetch the declared runtime inputs for a v1 pipeline. Use this before executing pipeline_v1; returned template_yaml shows every ${{ inputs.* }} reference that can be supplied.",
+      toolset: "pipelines",
+      scope: "project",
+      headerBasedScoping: true,
+      identifierFields: ["pipeline_id"],
+      relatedResources: [
+        {
+          resourceType: "pipeline_v1",
+          relationship: "parent",
+          description: "Saved v1 pipeline definition. harness_get(resource_type='pipeline_v1', resource_id=<pipeline_id>).",
+        },
+      ],
+      operations: {
+        get: {
+          method: "POST",
+          path: "/v1/orgs/{org}/projects/{project}/pipelines/{pipeline}/inputs",
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          pathParams: { org_id: "org", project_id: "project", pipeline_id: "pipeline" },
+          bodyBuilder: () => ({ stage_ids: [] }),
+          responseExtractor: runtimeInputV1Extract,
+          description: "Fetch the v1 pipeline input template and resolved pipeline YAML.",
         },
       },
     },

--- a/src/registry/toolsets/pipelines.ts
+++ b/src/registry/toolsets/pipelines.ts
@@ -1,6 +1,7 @@
 import type { ToolsetDefinition, BodySchema, ParamsSchema, PreflightContext } from "../types.js";
 import { ngExtract, pageExtract, passthrough, v1ListExtract, runtimeInputExtract, runtimeInputV1Extract, runtimeInputTemplatePreflight, pipelineResolvedYamlExtract, executionInputsExtract, dynamicExecutionExtract, triggerListExtract } from "../extractors.js";
 import { asRecord } from "../../utils/type-guards.js";
+import { buildV1RuntimeInputsBody } from "../../utils/pipeline-v1-runtime-inputs.js";
 import YAML from "yaml";
 
 function coerceTriggerBodyRecord(body: unknown): Record<string, unknown> {
@@ -105,6 +106,24 @@ const PIPELINE_V1_GET_PARAMS: ParamsSchema = {
     { name: "load_from_fallback_branch", required: false, description: "When true, load from the created non-default branch if the requested branch is empty. Pass via params." },
     { name: "template_applied", required: false, description: "When true, return YAML with templates applied. Pass via params." },
     { name: "validate_async", required: false, description: "When true, validate the pipeline asynchronously. Pass via params." },
+  ],
+};
+
+const PIPELINE_V1_GIT_READ_PARAMS: ParamsSchema = {
+  fields: [
+    { name: "branch", required: false, description: "Git branch alias — maps to branch_name on the wire. Pass via params." },
+    { name: "branch_name", required: false, description: "Git branch — sent as branch_name. Alias of branch. Pass via params." },
+    { name: "repo_name", required: false, description: "Git repository name for Git Experience. Pass via params." },
+    { name: "connector_ref", required: false, description: "Git connector for remote pipelines. Pass via params." },
+  ],
+};
+
+const PIPELINE_V1_EXECUTE_PARAMS: ParamsSchema = {
+  fields: [
+    { name: "module", required: false, description: "Pipeline module, such as CI or CD. Pass via params." },
+    { name: "notify_only_user", required: false, description: "Notify only the user who started the execution. Pass via params." },
+    { name: "notes", required: false, description: "Execution notes. Pass via params." },
+    ...PIPELINE_V1_GIT_READ_PARAMS.fields,
   ],
 };
 
@@ -370,36 +389,6 @@ function buildV1PipelineBody(input: Record<string, unknown>): Record<string, unk
   const gitDetails = collectV1GitDetails(input);
   if (gitDetails) result.git_details = gitDetails;
   return result;
-}
-
-function buildV1RuntimeInputsBody(input: Record<string, unknown>): Record<string, unknown> {
-  const runtimeInputs = input.inputs;
-  if (runtimeInputs === undefined || runtimeInputs === null) return {};
-
-  if (typeof runtimeInputs === "string") {
-    const parsed = YAML.parse(runtimeInputs) as unknown;
-    const parsedRecord = asRecord(parsed);
-    if (!parsedRecord) {
-      throw new Error("pipeline_v1 inputs YAML must contain a mapping");
-    }
-    if (!("inputs" in parsedRecord)) {
-      return { inputs_yaml: YAML.stringify({ inputs: parsedRecord }) };
-    }
-    if (Object.keys(parsedRecord).length !== 1) {
-      throw new Error("pipeline_v1 inputs YAML must contain only the inputs root");
-    }
-    if (!asRecord(parsedRecord.inputs)) {
-      throw new Error("pipeline_v1 inputs YAML root must contain a key-value mapping");
-    }
-    return { inputs_yaml: runtimeInputs };
-  }
-
-  const inputsRecord = asRecord(runtimeInputs);
-  if (!inputsRecord) {
-    throw new Error("pipeline_v1 inputs must be a YAML string or key-value object");
-  }
-
-  return { inputs_yaml: YAML.stringify({ inputs: inputsRecord }) };
 }
 
 // ---------------------------------------------------------------------------
@@ -786,9 +775,16 @@ export const pipelinesToolset: ToolsetDefinition = {
           pathParams: { org_id: "org", project_id: "project", pipeline_id: "pipeline" },
           queryParams: {
             module: "module",
+            notify_only_user: "notify_only_user",
+            notes: "notes",
+            branch: "branch_name",
+            branch_name: "branch_name",
+            connector_ref: "connector_ref",
+            repo_name: "repo_name",
           },
           bodyBuilder: buildV1RuntimeInputsBody,
-          responseExtractor: passthrough,
+          responseExtractor: dynamicExecutionExtract,
+          paramsSchema: PIPELINE_V1_EXECUTE_PARAMS,
           actionDescription: "Execute a v1 pipeline. First fetch runtime_input_template_v1, then pass named values through the top-level inputs argument. Values are wrapped under an inputs: YAML root and sent as inputs_yaml.",
           bodySchema: {
             description: "Do not put v1 runtime inputs under body. Use the top-level harness_execute inputs argument; the MCP server constructs the inputs_yaml API body.",
@@ -1308,8 +1304,8 @@ export const pipelinesToolset: ToolsetDefinition = {
     },
     {
       resourceType: "runtime_input_template_v1",
-      displayName: "Runtime Input Template (V1)",
-      description: "Fetch the declared runtime inputs for a v1 pipeline. Use this before executing pipeline_v1; returned template_yaml shows every ${{ inputs.* }} reference that can be supplied.",
+      displayName: "Runtime Input Schema (V1)",
+      description: "Fetch the declared runtime input schema for a v1 pipeline. Use the returned inputs[].details names and constraints before executing pipeline_v1.",
       toolset: "pipelines",
       scope: "project",
       headerBasedScoping: true,
@@ -1323,13 +1319,19 @@ export const pipelinesToolset: ToolsetDefinition = {
       ],
       operations: {
         get: {
-          method: "POST",
-          path: "/v1/orgs/{org}/projects/{project}/pipelines/{pipeline}/inputs",
+          method: "GET",
+          path: "/v1/orgs/{org}/projects/{project}/pipelines/{pipeline}/inputs-schema",
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           pathParams: { org_id: "org", project_id: "project", pipeline_id: "pipeline" },
-          bodyBuilder: () => ({ stage_ids: [] }),
+          queryParams: {
+            branch: "branch_name",
+            branch_name: "branch_name",
+            connector_ref: "connector_ref",
+            repo_name: "repo_name",
+          },
+          paramsSchema: PIPELINE_V1_GIT_READ_PARAMS,
           responseExtractor: runtimeInputV1Extract,
-          description: "Fetch the v1 pipeline input template and resolved pipeline YAML.",
+          description: "Fetch v1 pipeline input names, types, defaults, allowed values, and dependencies.",
         },
       },
     },

--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -30,6 +30,33 @@ function hasNoInlineRuntimeInputs(inputs: unknown): boolean {
   return !!record && Object.keys(record).length === 0;
 }
 
+function normalizeV1PipelineRunInputs(input: Record<string, unknown>): string | undefined {
+  const body = asRecord(input.body);
+  const candidates: Array<{ name: string; value: unknown }> = [];
+  if (input.inputs !== undefined) candidates.push({ name: "inputs", value: input.inputs });
+  if (body?.inputs !== undefined) candidates.push({ name: "body.inputs", value: body.inputs });
+  if (body?.inputs_yaml !== undefined) candidates.push({ name: "body.inputs_yaml", value: body.inputs_yaml });
+
+  if (candidates.length > 1) {
+    return `Conflicting pipeline_v1 runtime inputs were provided via ${candidates.map(({ name }) => name).join(", ")}. Provide only one source; prefer the top-level inputs argument.`;
+  }
+  if (candidates.length === 0) return undefined;
+
+  const candidate = candidates[0]!;
+  if (candidate.name === "body.inputs_yaml" && typeof candidate.value !== "string") {
+    return "body.inputs_yaml must be a YAML string for pipeline_v1 execution.";
+  }
+  if (
+    typeof candidate.value !== "string"
+    && (!candidate.value || typeof candidate.value !== "object" || Array.isArray(candidate.value))
+  ) {
+    return `${candidate.name} must be a YAML string or key-value object for pipeline_v1 execution.`;
+  }
+
+  input.inputs = candidate.value;
+  return undefined;
+}
+
 /**
  * True when `inputs` is a full pipeline document (`{ pipeline: ... }`) rather
  * than a flat key/value override map. These are merged fragment-wise with a
@@ -153,7 +180,7 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
         org_id: orgIdField(registry.orgId),
         project_id: projectIdField(registry.projectId),
         resource_scope: resourceScopeSchema,
-        inputs: z.union([z.string(), z.record(z.string(), z.unknown())]).optional().describe("Pipeline runtime inputs: key-value pairs like {branch: 'main'} (auto-resolved), or full YAML string. Check runtime_input_template first via harness_get."),
+        inputs: z.union([z.string(), z.record(z.string(), z.unknown())]).optional().describe("Pipeline runtime inputs. For v0 pipeline, check runtime_input_template and pass key-value pairs or full overlay YAML. For pipeline_v1, check runtime_input_template_v1 and pass named values; the server sends them as an inputs: YAML document."),
         input_set_ids: z.array(z.string()).optional().describe("Input set IDs for complex pipelines. List available: harness_list(resource_type='input_set', filters={pipeline_id: '...'})."),
         body: z.record(z.string(), z.unknown()).optional().describe("Additional body payload for the action"),
         params: z.record(z.string(), z.unknown()).optional().describe("Action-specific parameters. Call harness_describe for available fields per resource_type."),
@@ -203,6 +230,10 @@ export function registerExecuteTool(server: McpServer, registry: Registry, clien
         }
 
         const actionSpec = def.executeActions?.[args.action];
+        if (resourceType === "pipeline_v1" && args.action === "run") {
+          const normalizationError = normalizeV1PipelineRunInputs(input);
+          if (normalizationError) return errorResult(normalizationError);
+        }
         const risk = actionSpec?.operationPolicy.risk ?? "low_write";
 
         // Resolve the execute action's path identifier BEFORE any

--- a/src/tools/harness-execute.ts
+++ b/src/tools/harness-execute.ts
@@ -13,6 +13,7 @@ import { asRecord, asString, coerceRecord } from "../utils/type-guards.js";
 import { isFlatKeyValueInputs, isResolvableInputs, flattenInputs, resolveRuntimeInputs, resolveRuntimeInputsWithBaseYaml, type ResolutionResult } from "../utils/runtime-input-resolver.js";
 import { applyInputExpansions } from "../utils/input-expander.js";
 import { materializeInputSetsToRuntimeYaml, mergeRuntimePipelineFragments } from "../utils/materialize-input-sets.js";
+import { normalizeV1PipelineRunInputs } from "../utils/pipeline-v1-runtime-inputs.js";
 import { orgIdField, projectIdField, resourceScopeSchema, resourceTypeSchema } from "./input-schemas.js";
 import { pollExecutionToTerminal, FAILURE_STATUSES, AbortError } from "../utils/poll-execution.js";
 import { sendProgress } from "../utils/progress.js";
@@ -28,33 +29,6 @@ function hasNoInlineRuntimeInputs(inputs: unknown): boolean {
   if (inputs === undefined) return true;
   const record = asRecord(inputs);
   return !!record && Object.keys(record).length === 0;
-}
-
-function normalizeV1PipelineRunInputs(input: Record<string, unknown>): string | undefined {
-  const body = asRecord(input.body);
-  const candidates: Array<{ name: string; value: unknown }> = [];
-  if (input.inputs !== undefined) candidates.push({ name: "inputs", value: input.inputs });
-  if (body?.inputs !== undefined) candidates.push({ name: "body.inputs", value: body.inputs });
-  if (body?.inputs_yaml !== undefined) candidates.push({ name: "body.inputs_yaml", value: body.inputs_yaml });
-
-  if (candidates.length > 1) {
-    return `Conflicting pipeline_v1 runtime inputs were provided via ${candidates.map(({ name }) => name).join(", ")}. Provide only one source; prefer the top-level inputs argument.`;
-  }
-  if (candidates.length === 0) return undefined;
-
-  const candidate = candidates[0]!;
-  if (candidate.name === "body.inputs_yaml" && typeof candidate.value !== "string") {
-    return "body.inputs_yaml must be a YAML string for pipeline_v1 execution.";
-  }
-  if (
-    typeof candidate.value !== "string"
-    && (!candidate.value || typeof candidate.value !== "object" || Array.isArray(candidate.value))
-  ) {
-    return `${candidate.name} must be a YAML string or key-value object for pipeline_v1 execution.`;
-  }
-
-  input.inputs = candidate.value;
-  return undefined;
 }
 
 /**

--- a/src/utils/pipeline-v1-runtime-inputs.ts
+++ b/src/utils/pipeline-v1-runtime-inputs.ts
@@ -1,0 +1,61 @@
+import YAML from "yaml";
+import { asRecord } from "./type-guards.js";
+
+export function normalizeV1PipelineRunInputs(input: Record<string, unknown>): string | undefined {
+  const body = asRecord(input.body);
+  const candidates: Array<{ name: string; value: unknown }> = [];
+  if (input.inputs !== undefined) candidates.push({ name: "inputs", value: input.inputs });
+  if (body?.inputs !== undefined) candidates.push({ name: "body.inputs", value: body.inputs });
+  if (body?.inputs_yaml !== undefined) {
+    candidates.push({ name: "body.inputs_yaml", value: body.inputs_yaml });
+  }
+
+  if (candidates.length > 1) {
+    return `Conflicting pipeline_v1 runtime inputs were provided via ${candidates.map(({ name }) => name).join(", ")}. Provide only one source; prefer the top-level inputs argument.`;
+  }
+  if (candidates.length === 0) return undefined;
+
+  const candidate = candidates[0]!;
+  if (candidate.name === "body.inputs_yaml" && typeof candidate.value !== "string") {
+    return "body.inputs_yaml must be a YAML string for pipeline_v1 execution.";
+  }
+  if (
+    typeof candidate.value !== "string"
+    && (!candidate.value || typeof candidate.value !== "object" || Array.isArray(candidate.value))
+  ) {
+    return `${candidate.name} must be a YAML string or key-value object for pipeline_v1 execution.`;
+  }
+
+  input.inputs = candidate.value;
+  return undefined;
+}
+
+export function buildV1RuntimeInputsBody(input: Record<string, unknown>): Record<string, unknown> {
+  const runtimeInputs = input.inputs;
+  if (runtimeInputs === undefined || runtimeInputs === null) return {};
+
+  if (typeof runtimeInputs === "string") {
+    const parsed = YAML.parse(runtimeInputs) as unknown;
+    const parsedRecord = asRecord(parsed);
+    if (!parsedRecord) {
+      throw new Error("pipeline_v1 inputs YAML must contain a mapping");
+    }
+    if (!("inputs" in parsedRecord)) {
+      return { inputs_yaml: YAML.stringify({ inputs: parsedRecord }) };
+    }
+    if (Object.keys(parsedRecord).length !== 1) {
+      throw new Error("pipeline_v1 inputs YAML must contain only the inputs root");
+    }
+    if (!asRecord(parsedRecord.inputs)) {
+      throw new Error("pipeline_v1 inputs YAML root must contain a key-value mapping");
+    }
+    return { inputs_yaml: runtimeInputs };
+  }
+
+  const inputsRecord = asRecord(runtimeInputs);
+  if (!inputsRecord) {
+    throw new Error("pipeline_v1 inputs must be a YAML string or key-value object");
+  }
+
+  return { inputs_yaml: YAML.stringify({ inputs: inputsRecord }) };
+}

--- a/tests/registry/runtime-input-template.test.ts
+++ b/tests/registry/runtime-input-template.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import type { Config } from "../../src/config.js";
 import type { HarnessClient } from "../../src/client/harness-client.js";
 import { Registry } from "../../src/registry/index.js";
-import { runtimeInputTemplatePreflight } from "../../src/registry/extractors.js";
+import {
+  runtimeInputTemplatePreflight,
+  runtimeInputV1Extract,
+} from "../../src/registry/extractors.js";
 
 function makeConfig(overrides: Partial<Config> = {}): Config {
   return {
@@ -165,6 +168,149 @@ describe("runtime_input_template resource — request shape", () => {
     expect(result).toMatchObject({
       inputSetTemplateYaml: expect.stringContaining("identifier: p"),
     });
+  });
+});
+
+describe("runtimeInputV1Extract — response shape", () => {
+  const branchInput = {
+    details: {
+      name: "branch",
+      type: "string",
+      required: true,
+      allowed_values: ["main", "develop"],
+    },
+    metadata: {
+      dependencies: {
+        required_runtime_inputs: [],
+        required_fixed_values: [],
+      },
+    },
+  };
+
+  it("unwraps a data envelope without changing the inputs schema", () => {
+    expect(runtimeInputV1Extract({ data: { inputs: [branchInput] } })).toEqual({
+      inputs: [branchInput],
+      metadata_available: true,
+      _hint: expect.stringContaining("inputs[].details.name"),
+    });
+  });
+
+  it("accepts the flat public response shape", () => {
+    expect(runtimeInputV1Extract({ inputs: [branchInput] })).toMatchObject({
+      inputs: [branchInput],
+      metadata_available: true,
+    });
+  });
+
+  it("distinguishes an empty input schema from missing metadata", () => {
+    expect(runtimeInputV1Extract({ data: { inputs: [] } })).toEqual({
+      inputs: [],
+      metadata_available: true,
+      _hint: expect.stringContaining("declares no runtime inputs"),
+    });
+    expect(runtimeInputV1Extract({ data: {} })).toEqual({
+      inputs: null,
+      metadata_available: false,
+      _hint: expect.stringContaining("Do not assume"),
+    });
+  });
+
+  it("rejects an invalid inputs field without claiming there are no inputs", () => {
+    expect(runtimeInputV1Extract({ inputs: {} })).toEqual({
+      inputs: null,
+      metadata_available: false,
+      _hint: expect.stringContaining("invalid inputs field"),
+    });
+  });
+});
+
+describe("runtime_input_template_v1 resource — request shape", () => {
+  it("dispatches documented GET inputs-schema with Git Experience params", async () => {
+    const registry = new Registry(makeConfig());
+    const mockRequest = vi.fn().mockResolvedValue({
+      data: {
+        inputs: [
+          {
+            details: { name: "branch", type: "string", required: true },
+          },
+        ],
+      },
+    });
+    const client = makeClient(mockRequest);
+
+    const result = await registry.dispatch(client, "runtime_input_template_v1", "get", {
+      pipeline_id: "my-pipe",
+      org_id: "myorg",
+      project_id: "myproj",
+      branch_name: "feature/runtime-inputs",
+      connector_ref: "account.git",
+      repo_name: "my-repo",
+    });
+
+    expect(result).toMatchObject({
+      inputs: [
+        {
+          details: { name: "branch", type: "string", required: true },
+        },
+      ],
+      metadata_available: true,
+    });
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "GET",
+        path: "/v1/orgs/myorg/projects/myproj/pipelines/my-pipe/inputs-schema",
+        params: expect.objectContaining({
+          branch_name: "feature/runtime-inputs",
+          connector_ref: "account.git",
+          repo_name: "my-repo",
+        }),
+        body: undefined,
+        headerBasedScoping: true,
+      }),
+    );
+  });
+});
+
+describe("pipeline_v1.run — request and response shape", () => {
+  it("forwards Git Experience params and flattens execution details", async () => {
+    const registry = new Registry(makeConfig());
+    const mockRequest = vi.fn().mockResolvedValue({
+      execution_details: {
+        execution_id: "exec-1",
+        status: "RUNNING",
+      },
+    });
+    const client = makeClient(mockRequest);
+
+    const result = await registry.dispatchExecute(client, "pipeline_v1", "run", {
+      pipeline_id: "my-pipe",
+      org_id: "myorg",
+      project_id: "myproj",
+      branch_name: "feature/runtime-inputs",
+      connector_ref: "account.git",
+      repo_name: "my-repo",
+      inputs: { branch: "feature/runtime-inputs" },
+    });
+
+    expect(result).toMatchObject({
+      execution_id: "exec-1",
+      status: "RUNNING",
+    });
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        path: "/v1/orgs/myorg/projects/myproj/pipelines/my-pipe/execute",
+        params: expect.objectContaining({
+          branch_name: "feature/runtime-inputs",
+          connector_ref: "account.git",
+          repo_name: "my-repo",
+        }),
+        body: {
+          inputs_yaml: "inputs:\n  branch: feature/runtime-inputs\n",
+        },
+        headerBasedScoping: true,
+      }),
+    );
   });
 });
 

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -32,7 +32,7 @@ describe("release metadata", () => {
     const rootManifest = readJson("manifest.json");
     const directoryManifest = readJson("mcp-directory/manifest.json");
 
-    expect(packageJson.version).toBe("3.2.22");
+    expect(packageJson.version).toBe("3.2.23");
     expect(rootManifest.version).toBe(packageJson.version);
     expect(directoryManifest.version).toBe(packageJson.version);
   });
@@ -52,9 +52,9 @@ describe("release metadata", () => {
     legacyManifest.server.entry_point = "build/index.js";
     legacyManifest.server.mcp_config.args[0] = "${__dirname}/build/index.js";
 
-    expect(assetNameForVersion("3.2.22")).toBe("harness-mcp-server-3.2.22.mcpb");
+    expect(assetNameForVersion("3.2.23")).toBe("harness-mcp-server-3.2.23.mcpb");
     expect(MCPB_CLI_PACKAGE).toBe("@anthropic-ai/mcpb@2.1.2");
-    expect(normalizeBundleManifest(legacyManifest, "3.2.22").server).toMatchObject({
+    expect(normalizeBundleManifest(legacyManifest, "3.2.23").server).toMatchObject({
       entry_point: "server/index.js",
       mcp_config: { args: ["${__dirname}/server/index.js", "stdio"] },
     });

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -5,6 +5,7 @@
  * Does not test actual API calls — that's covered by registry dispatch tests.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import YAML from "yaml";
 import type { Config } from "../../src/config.js";
 import type { HarnessClient } from "../../src/client/harness-client.js";
 import type { ToolResult } from "../../src/utils/response-formatter.js";
@@ -215,6 +216,40 @@ describe("harness_get", () => {
     expect(result.isError).toBeUndefined();
     const data = parseResult(result) as { identifier: string };
     expect(data.identifier).toBe("my-pipeline");
+  });
+
+  it("fetches and projects the v1 runtime input template", async () => {
+    mockRequest.mockResolvedValueOnce({
+      inputs: {},
+      template_yaml: "pipeline:\n  clone:\n    ref:\n      name: \"${{ inputs.branch }}\"\n",
+      resolved_yaml: "pipeline:\n  id: my-pipeline\n",
+      has_input_sets: false,
+      replaced_expressions: [],
+      replaced_expressions_per_stage: {},
+      modules: ["ci", "pms"],
+    });
+
+    const result = await server.call("harness_get", {
+      resource_type: "runtime_input_template_v1",
+      resource_id: "my-pipeline",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(parseResult(result)).toMatchObject({
+      inputs: {},
+      template_yaml: expect.stringContaining("inputs.branch"),
+      resolved_yaml: expect.stringContaining("my-pipeline"),
+      has_input_sets: false,
+      modules: ["ci", "pms"],
+      _hint: expect.stringContaining("pipeline_v1"),
+    });
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        path: "/v1/orgs/default/projects/test-project/pipelines/my-pipeline/inputs",
+        body: { stage_ids: [] },
+      }),
+    );
   });
 
   it("documents resource_scope in the registered input schema", () => {
@@ -1861,6 +1896,181 @@ describe("harness_execute", () => {
     expect(mockRequest).toHaveBeenCalled();
   });
 
+  it("wraps pipeline_v1 input values under the inputs YAML root", async () => {
+    await server.call("harness_execute", {
+      resource_type: "pipeline_v1",
+      action: "run",
+      resource_id: "my-pipe",
+      inputs: {
+        branch: "feature/my-fix",
+        deploy: { environment: "qa" },
+      },
+    });
+
+    const call = mockRequest.mock.calls[0]![0] as {
+      path: string;
+      body: { inputs_yaml: string };
+    };
+    expect(call.path).toBe("/v1/orgs/default/projects/test-project/pipelines/my-pipe/execute");
+    expect(call.body.inputs_yaml).toContain("inputs:");
+    expect(call.body.inputs_yaml).toContain("branch: feature/my-fix");
+    expect(call.body.inputs_yaml).toContain("environment: qa");
+  });
+
+  it("sends an empty body when pipeline_v1 has no runtime inputs", async () => {
+    await server.call("harness_execute", {
+      resource_type: "pipeline_v1",
+      action: "run",
+      resource_id: "my-pipe",
+    });
+
+    const call = mockRequest.mock.calls[0]![0] as { body: Record<string, unknown> };
+    expect(call.body).toEqual({});
+  });
+
+  it("wraps empty pipeline_v1 input values under an empty inputs mapping", async () => {
+    await server.call("harness_execute", {
+      resource_type: "pipeline_v1",
+      action: "run",
+      resource_id: "my-pipe",
+      inputs: {},
+    });
+
+    const call = mockRequest.mock.calls[0]![0] as { body: { inputs_yaml: string } };
+    expect(YAML.parse(call.body.inputs_yaml)).toEqual({ inputs: {} });
+  });
+
+  it("wraps an unrooted pipeline_v1 YAML string", async () => {
+    await server.call("harness_execute", {
+      resource_type: "pipeline_v1",
+      action: "run",
+      resource_id: "my-pipe",
+      inputs: "branch: feature/my-fix\n",
+    });
+
+    const call = mockRequest.mock.calls[0]![0] as { body: { inputs_yaml: string } };
+    expect(YAML.parse(call.body.inputs_yaml)).toEqual({
+      inputs: { branch: "feature/my-fix" },
+    });
+  });
+
+  it("preserves arrays as named pipeline_v1 input values", async () => {
+    await server.call("harness_execute", {
+      resource_type: "pipeline_v1",
+      action: "run",
+      resource_id: "my-pipe",
+      inputs: { services: ["api", "worker"] },
+    });
+
+    const call = mockRequest.mock.calls[0]![0] as { body: { inputs_yaml: string } };
+    expect(YAML.parse(call.body.inputs_yaml)).toEqual({
+      inputs: { services: ["api", "worker"] },
+    });
+  });
+
+  it("supports a pipeline_v1 runtime input literally named inputs", async () => {
+    await server.call("harness_execute", {
+      resource_type: "pipeline_v1",
+      action: "run",
+      resource_id: "my-pipe",
+      inputs: { inputs: "literal-value" },
+    });
+
+    const call = mockRequest.mock.calls[0]![0] as { body: { inputs_yaml: string } };
+    expect(YAML.parse(call.body.inputs_yaml)).toEqual({
+      inputs: { inputs: "literal-value" },
+    });
+  });
+
+  it("preserves pipeline_v1 YAML that already has an inputs root", async () => {
+    const inputsYaml = "inputs:\n  branch: feature/my-fix\n";
+
+    await server.call("harness_execute", {
+      resource_type: "pipeline_v1",
+      action: "run",
+      resource_id: "my-pipe",
+      inputs: inputsYaml,
+    });
+
+    const call = mockRequest.mock.calls[0]![0] as { body: { inputs_yaml: string } };
+    expect(call.body).toEqual({ inputs_yaml: inputsYaml });
+  });
+
+  it.each([
+    ["invalid YAML", "inputs: [\n"],
+    ["an array root", "- branch\n- environment\n"],
+    ["a non-mapping inputs root", "inputs:\n  - branch\n"],
+    ["additional top-level roots", "inputs:\n  branch: main\nextra: value\n"],
+  ])("rejects pipeline_v1 %s before execution", async (_caseName, inputs) => {
+    const result = await server.call("harness_execute", {
+      resource_type: "pipeline_v1",
+      action: "run",
+      resource_id: "my-pipe",
+      inputs,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it("accepts body.inputs as a pipeline_v1 compatibility alias", async () => {
+    await server.call("harness_execute", {
+      resource_type: "pipeline_v1",
+      action: "run",
+      resource_id: "my-pipe",
+      body: { inputs: { branch: "feature/my-fix" } },
+    });
+
+    const call = mockRequest.mock.calls[0]![0] as { body: { inputs_yaml: string } };
+    expect(call.body.inputs_yaml).toContain("inputs:");
+    expect(call.body.inputs_yaml).toContain("branch: feature/my-fix");
+  });
+
+  it("accepts body.inputs_yaml as a pipeline_v1 compatibility alias", async () => {
+    const inputsYaml = "inputs:\n  branch: feature/my-fix\n";
+
+    await server.call("harness_execute", {
+      resource_type: "pipeline_v1",
+      action: "run",
+      resource_id: "my-pipe",
+      body: { inputs_yaml: inputsYaml },
+    });
+
+    const call = mockRequest.mock.calls[0]![0] as { body: { inputs_yaml: string } };
+    expect(call.body).toEqual({ inputs_yaml: inputsYaml });
+  });
+
+  it("rejects a non-string body.inputs_yaml compatibility alias", async () => {
+    const result = await server.call("harness_execute", {
+      resource_type: "pipeline_v1",
+      action: "run",
+      resource_id: "my-pipe",
+      body: { inputs_yaml: { inputs: { branch: "feature/my-fix" } } },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result)).toMatchObject({
+      error: expect.stringContaining("body.inputs_yaml must be a YAML string"),
+    });
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects conflicting pipeline_v1 input sources before execution", async () => {
+    const result = await server.call("harness_execute", {
+      resource_type: "pipeline_v1",
+      action: "run",
+      resource_id: "my-pipe",
+      inputs: { branch: "feature/a" },
+      body: { inputs_yaml: "inputs:\n  branch: feature/b\n" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result)).toMatchObject({
+      error: expect.stringContaining("Conflicting pipeline_v1 runtime inputs"),
+    });
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
   it("passes pipeline_branch from params as ?pipelineBranchName= query param", async () => {
     await server.call("harness_execute", {
       resource_type: "pipeline",
@@ -3181,6 +3391,29 @@ describe("harness_describe", () => {
     const data = parseResult(result) as { resource_type: string; operations: unknown[] };
     expect(data.resource_type).toBe("pipeline");
     expect(data.operations.length).toBeGreaterThan(0);
+  });
+
+  it("describes the pipeline_v1 runtime input template workflow", async () => {
+    const result = await server.call("harness_describe", { resource_type: "pipeline_v1" });
+
+    expect(result.isError).toBeUndefined();
+    const data = parseResult(result) as {
+      executeHint?: string;
+      relatedResources?: Array<{ resourceType: string }>;
+      executeActions?: Array<{
+        action: string;
+        bodySchema?: { description: string; fields: unknown[] };
+      }>;
+    };
+    expect(data.executeHint).toContain("runtime_input_template_v1");
+    expect(data.relatedResources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ resourceType: "runtime_input_template_v1" }),
+      ]),
+    );
+    const run = data.executeActions?.find((action) => action.action === "run");
+    expect(run?.bodySchema?.description).toContain("top-level harness_execute inputs");
+    expect(run?.bodySchema?.fields).toEqual([]);
   });
 
   it("describes account/org/project scope support for multi-scope resources", async () => {

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -220,34 +220,53 @@ describe("harness_get", () => {
 
   it("fetches and projects the v1 runtime input template", async () => {
     mockRequest.mockResolvedValueOnce({
-      inputs: {},
-      template_yaml: "pipeline:\n  clone:\n    ref:\n      name: \"${{ inputs.branch }}\"\n",
-      resolved_yaml: "pipeline:\n  id: my-pipeline\n",
-      has_input_sets: false,
-      replaced_expressions: [],
-      replaced_expressions_per_stage: {},
-      modules: ["ci", "pms"],
+      data: {
+        inputs: [
+          {
+            details: {
+              name: "branch",
+              type: "string",
+              required: true,
+            },
+          },
+        ],
+      },
     });
 
     const result = await server.call("harness_get", {
       resource_type: "runtime_input_template_v1",
       resource_id: "my-pipeline",
+      params: {
+        branch_name: "feature/my-fix",
+        connector_ref: "account.git",
+        repo_name: "my-repo",
+      },
     });
 
     expect(result.isError).toBeUndefined();
     expect(parseResult(result)).toMatchObject({
-      inputs: {},
-      template_yaml: expect.stringContaining("inputs.branch"),
-      resolved_yaml: expect.stringContaining("my-pipeline"),
-      has_input_sets: false,
-      modules: ["ci", "pms"],
-      _hint: expect.stringContaining("pipeline_v1"),
+      inputs: [
+        {
+          details: {
+            name: "branch",
+            type: "string",
+            required: true,
+          },
+        },
+      ],
+      metadata_available: true,
+      _hint: expect.stringContaining("inputs[].details.name"),
     });
     expect(mockRequest).toHaveBeenCalledWith(
       expect.objectContaining({
-        method: "POST",
-        path: "/v1/orgs/default/projects/test-project/pipelines/my-pipeline/inputs",
-        body: { stage_ids: [] },
+        method: "GET",
+        path: "/v1/orgs/default/projects/test-project/pipelines/my-pipeline/inputs-schema",
+        params: expect.objectContaining({
+          branch_name: "feature/my-fix",
+          connector_ref: "account.git",
+          repo_name: "my-repo",
+        }),
+        headerBasedScoping: true,
       }),
     );
   });
@@ -1897,7 +1916,10 @@ describe("harness_execute", () => {
   });
 
   it("wraps pipeline_v1 input values under the inputs YAML root", async () => {
-    await server.call("harness_execute", {
+    mockRequest.mockResolvedValueOnce({
+      execution_details: { execution_id: "v1-exec", status: "RUNNING" },
+    });
+    const result = await server.call("harness_execute", {
       resource_type: "pipeline_v1",
       action: "run",
       resource_id: "my-pipe",
@@ -1905,13 +1927,28 @@ describe("harness_execute", () => {
         branch: "feature/my-fix",
         deploy: { environment: "qa" },
       },
+      params: {
+        branch_name: "feature/my-fix",
+        connector_ref: "account.git",
+        repo_name: "my-repo",
+      },
     });
 
     const call = mockRequest.mock.calls[0]![0] as {
       path: string;
+      params: Record<string, unknown>;
       body: { inputs_yaml: string };
     };
+    expect(parseResult(result)).toMatchObject({
+      execution_id: "v1-exec",
+      status: "RUNNING",
+    });
     expect(call.path).toBe("/v1/orgs/default/projects/test-project/pipelines/my-pipe/execute");
+    expect(call.params).toMatchObject({
+      branch_name: "feature/my-fix",
+      connector_ref: "account.git",
+      repo_name: "my-repo",
+    });
     expect(call.body.inputs_yaml).toContain("inputs:");
     expect(call.body.inputs_yaml).toContain("branch: feature/my-fix");
     expect(call.body.inputs_yaml).toContain("environment: qa");


### PR DESCRIPTION
## Summary
- add v1 runtime-input template discovery and version-specific execution guidance
- serialize named v1 values under the required `inputs:` YAML root before sending `inputs_yaml`
- validate rooted YAML, preserve compatibility aliases, and cover empty, nested, array, invalid, and conflicting inputs
- bump release metadata to 3.2.23

## Test plan
- [x] `pnpm test` (144 files, 3246 tests)
- [x] `pnpm typecheck`
- [x] `pnpm standards:check`
- [x] `git diff --check`

## Rollout
Consumer dependency bumps should merge only after `harness-mcp-v2@3.2.23` is published and independently available from npm.

Made with [Cursor](https://cursor.com)