### PR TITLE
Consolidate related activity projection

### DIFF
--- a/src/registry/toolsets/alerts.ts
+++ b/src/registry/toolsets/alerts.ts
@@ -2,6 +2,7 @@ import type { ToolsetDefinition, BodySchema } from "../types.js";
 import { buildBodyNormalized } from "../../utils/body-normalizer.js";
 import { offsetListExtract } from "../extractors.js";
 import { MC_SCOPE } from "./scopes.js";
+import { projectRelatedActivity } from "./related-activities.js";
 import { isRecord } from "../../utils/type-guards.js";
 
 /**
@@ -28,7 +29,8 @@ const LIST_DESCRIPTION_MAX = 400;
  * compactor. Emits a stable, documented shape and drops backend
  * envelope/debug/meta. `verbose` controls whether the heavy keyEvents array
  * is projected in full (detail view) or replaced with a count (list), and
- * whether description is kept in full or truncated.
+ * whether description is kept in full or truncated. Related activities are
+ * already small enough to emit in full in both views.
  */
 function projectAlert(raw: Record<string, unknown>, verbose: boolean): Record<string, unknown> {
   const slim: Record<string, unknown> = {};
@@ -57,6 +59,9 @@ function projectAlert(raw: Record<string, unknown>, verbose: boolean): Record<st
   }
   if (Array.isArray(raw.keyEvents)) {
     slim.keyEvents = verbose ? raw.keyEvents.map(projectKeyEvent) : raw.keyEvents.length;
+  }
+  if (Array.isArray(raw.relatedActivities) && raw.relatedActivities.length > 0) {
+    slim.relatedActivities = raw.relatedActivities.map(projectRelatedActivity);
   }
   return slim;
 }

--- a/src/registry/toolsets/deploys.ts
+++ b/src/registry/toolsets/deploys.ts
@@ -1,16 +1,20 @@
 import type { ToolsetDefinition } from "../types.js";
 import { offsetListExtract } from "../extractors.js";
 import { MC_SCOPE } from "./scopes.js";
+import { projectRelatedActivity } from "./related-activities.js";
 import { isRecord } from "../../utils/type-guards.js";
 
 /**
- * Compact a deploy list item. The deploy API returns an always-empty `title`,
- * an always-null `status`, and a multi-KB `summary` changelog — the generic
- * key whitelist would keep the first two (useless) and drop the genuinely
- * identifying fields (`id`, `buildVersions`, `deployTimestamp`). This keeps the
- * identity an agent actually needs while dropping the noise:
+ * Compact a deploy list item. The deploy API returns an always-empty `title`
+ * and a multi-KB `summary` changelog — the generic key whitelist would keep the
+ * empty title (useless) and drop the genuinely identifying fields (`id`,
+ * `buildVersions`, `deployTimestamp`). This keeps the identity an agent
+ * actually needs while dropping the noise:
  *   - `summary` truncated to its first line (the "### Change Log for X" header)
  *   - `services` derived from buildVersions (service + version only)
+ *   - related activities projected the same way as in the detail view
+ * `status` is kept when the API supplies one: correlating a deploy to an
+ * incident hinges on whether it succeeded, so it must survive compaction.
  * Full summary/buildVersions remain available via compact:false or harness_get.
  */
 function compactDeploy(item: Record<string, unknown>): Record<string, unknown> {
@@ -20,6 +24,7 @@ function compactDeploy(item: Record<string, unknown>): Record<string, unknown> {
   if (typeof item.summary === "string" && item.summary.length > 0) {
     slim.summary = item.summary.split("\n", 1)[0];
   }
+  if (item.status !== null && item.status !== undefined) slim.status = item.status;
   if (Array.isArray(item.environments)) slim.environments = item.environments;
   if (Array.isArray(item.buildVersions)) {
     slim.services = item.buildVersions.map((bv) => {
@@ -29,15 +34,19 @@ function compactDeploy(item: Record<string, unknown>): Record<string, unknown> {
   }
   if (typeof item.deployTimestamp === "number") slim.deployTimestamp = item.deployTimestamp;
   if (typeof item.webLink === "string") slim.webLink = item.webLink;
+  if (Array.isArray(item.relatedActivities) && item.relatedActivities.length > 0) {
+    slim.relatedActivities = item.relatedActivities.map(projectRelatedActivity);
+  }
   return slim;
 }
 
 /**
  * Extract deploy detail response for GET /deploys/{deployId}.
  * Projects a stable, documented shape (id, projectId, title, summary, status,
- * environments, buildVersions, deployTimestamp, webLink) and strips backend
- * envelope/debug/meta fields. Unlike the list compactor, this keeps the full
- * summary and all buildVersions subfields since this is the detail view.
+ * environments, buildVersions, deployTimestamp, webLink, relatedActivities)
+ * and strips backend envelope/debug/meta fields. Unlike the list compactor,
+ * this keeps the full summary and all buildVersions subfields since this is the
+ * detail view.
  */
 function deployGetExtract(raw: unknown): unknown {
   if (!isRecord(raw)) return raw;
@@ -63,6 +72,9 @@ function deployGetExtract(raw: unknown): unknown {
   }
   if (typeof raw.deployTimestamp === "number") slim.deployTimestamp = raw.deployTimestamp;
   if (typeof raw.webLink === "string") slim.webLink = raw.webLink;
+  if (Array.isArray(raw.relatedActivities) && raw.relatedActivities.length > 0) {
+    slim.relatedActivities = raw.relatedActivities.map(projectRelatedActivity);
+  }
   return slim;
 }
 

--- a/src/registry/toolsets/incidents.ts
+++ b/src/registry/toolsets/incidents.ts
@@ -2,6 +2,7 @@ import type { ToolsetDefinition, BodySchema } from "../types.js";
 import { buildBodyNormalized } from "../../utils/body-normalizer.js";
 import { offsetListExtract } from "../extractors.js";
 import { MC_SCOPE } from "./scopes.js";
+import { projectRelatedActivity } from "./related-activities.js";
 import { isRecord } from "../../utils/type-guards.js";
 
 /**
@@ -42,7 +43,8 @@ const LIST_SUMMARY_MAX = 400;
  * compactor. Emits a stable, documented shape and drops backend
  * envelope/debug/meta. `verbose` controls whether the heavy event/theory
  * arrays are projected in full (detail view) or replaced with counts (list),
- * and whether summary is kept in full or truncated.
+ * and whether summary is kept in full or truncated. Related activities are
+ * already small enough to emit in full in both views.
  */
 function projectIncident(raw: Record<string, unknown>, verbose: boolean): Record<string, unknown> {
   const slim: Record<string, unknown> = {};
@@ -83,7 +85,7 @@ function projectIncident(raw: Record<string, unknown>, verbose: boolean): Record
       : raw.rootCauseTheories.length;
   }
   if (Array.isArray(raw.relatedActivities) && raw.relatedActivities.length > 0) {
-    slim.relatedActivities = raw.relatedActivities;
+    slim.relatedActivities = raw.relatedActivities.map(projectRelatedActivity);
   }
   return slim;
 }

--- a/src/registry/toolsets/related-activities.ts
+++ b/src/registry/toolsets/related-activities.ts
@@ -1,0 +1,33 @@
+import { isRecord } from "../../utils/type-guards.js";
+
+/**
+ * Project a single related-activity entry to the four fields an agent can act
+ * on, identically in the list and detail views.
+ *
+ * Shared by every Mission Control toolset that surfaces `relatedActivities`
+ * (incidents, alerts, deploys): the backend returns the same RelatedActivity
+ * DTO on all of them, and an edge means the same thing whichever end you
+ * fetched it from, so the projection is defined once here.
+ *
+ *   - `name` is the relationship verb; without it a link is meaningless, since
+ *     "causes", "duplicates", and "is correlated with" are not interchangeable.
+ *   - `templateTypeName` is the resource_type to pass to harness_get to follow
+ *     the link. It cannot be inferred from the prettyId prefix — alerts arrive
+ *     as both ALRTHET-* and PAGE_ALERT_<project>-* — so it belongs in the
+ *     compact view too, at ~20 bytes per edge. It is omitted rather than
+ *     emitted as null when the backend does not classify the edge.
+ *
+ * The backend's `globalId` is dropped: no endpoint accepts it as a lookup key
+ * (GET rejects a UUID with "Activity pretty IDs must consist of a
+ * hyphen-separated activity template short ID and activity number"), so it is
+ * a UUID per edge that no caller can act on.
+ */
+export function projectRelatedActivity(a: unknown): unknown {
+  if (!isRecord(a)) return a;
+  const out: Record<string, unknown> = {};
+  if (typeof a.prettyId === "string") out.prettyId = a.prettyId;
+  if (typeof a.templateTypeName === "string") out.templateTypeName = a.templateTypeName;
+  if (typeof a.title === "string") out.title = a.title;
+  if (typeof a.name === "string") out.name = a.name;
+  return out;
+}

--- a/src/registry/toolsets/related-activities.ts
+++ b/src/registry/toolsets/related-activities.ts
@@ -1,8 +1,22 @@
 import { isRecord } from "../../utils/type-guards.js";
 
 /**
- * Project a single related-activity entry to the four fields an agent can act
- * on, identically in the list and detail views.
+ * Backend `templateTypeName` values mapped to the registry resource_type that
+ * fetches them. The backend enum is INCIDENT | ALERT | DEPLOY | CHANGE, or null
+ * when it cannot classify the linked activity's template. `CHANGE` has no
+ * registered resource type here, so it is deliberately absent: an edge with no
+ * mapping is emitted without a resource_type rather than with one that
+ * harness_get would reject.
+ */
+const RESOURCE_TYPE_BY_TEMPLATE_TYPE: Record<string, string> = {
+  INCIDENT: "incident",
+  ALERT: "alert",
+  DEPLOY: "deploy",
+};
+
+/**
+ * Project a single related-activity entry to the fields an agent can act on,
+ * identically in the list and detail views.
  *
  * Shared by every Mission Control toolset that surfaces `relatedActivities`
  * (incidents, alerts, deploys): the backend returns the same RelatedActivity
@@ -11,11 +25,16 @@ import { isRecord } from "../../utils/type-guards.js";
  *
  *   - `name` is the relationship verb; without it a link is meaningless, since
  *     "causes", "duplicates", and "is correlated with" are not interchangeable.
- *   - `templateTypeName` is the resource_type to pass to harness_get to follow
- *     the link. It cannot be inferred from the prettyId prefix — alerts arrive
- *     as both ALRTHET-* and PAGE_ALERT_<project>-* — so it belongs in the
- *     compact view too, at ~20 bytes per edge. It is omitted rather than
- *     emitted as null when the backend does not classify the edge.
+ *   - `resource_type` is the value to pass to harness_get to follow the link,
+ *     translated from the backend's uppercase `templateTypeName` enum. The raw
+ *     enum is not forwarded because it is not a registered resource_type. The
+ *     type cannot be inferred from the prettyId prefix — alerts arrive as both
+ *     ALRTHET-* and PAGE_ALERT_<project>-* — so it belongs in the compact view
+ *     too, at ~20 bytes per edge. An edge the backend does not classify, or
+ *     classifies as a type this server cannot fetch, is emitted without it.
+ *   - `title` is omitted when empty: the backend substitutes the prettyId for a
+ *     null title but passes an empty string straight through, and deploy
+ *     activities always have one.
  *
  * The backend's `globalId` is dropped: no endpoint accepts it as a lookup key
  * (GET rejects a UUID with "Activity pretty IDs must consist of a
@@ -26,8 +45,11 @@ export function projectRelatedActivity(a: unknown): unknown {
   if (!isRecord(a)) return a;
   const out: Record<string, unknown> = {};
   if (typeof a.prettyId === "string") out.prettyId = a.prettyId;
-  if (typeof a.templateTypeName === "string") out.templateTypeName = a.templateTypeName;
-  if (typeof a.title === "string") out.title = a.title;
+  if (typeof a.templateTypeName === "string") {
+    const resourceType = RESOURCE_TYPE_BY_TEMPLATE_TYPE[a.templateTypeName];
+    if (resourceType !== undefined) out.resource_type = resourceType;
+  }
+  if (typeof a.title === "string" && a.title.length > 0) out.title = a.title;
   if (typeof a.name === "string") out.name = a.name;
   return out;
 }

--- a/tests/coding-standards/architecture.test.ts
+++ b/tests/coding-standards/architecture.test.ts
@@ -54,6 +54,7 @@ const ALLOWED_HARNESS_HANDLER_FILES = new Set([
 /** Toolset helper modules — not required to export a ToolsetDefinition. */
 const TOOLSET_HELPER_FILES = new Set([
   "src/registry/toolsets/chaos-descriptions.ts",
+  "src/registry/toolsets/related-activities.ts",
   "src/registry/toolsets/scopes.ts",
 ]);
 

--- a/tests/tools/alerts.test.ts
+++ b/tests/tools/alerts.test.ts
@@ -193,6 +193,37 @@ describe("alert — harness_list", () => {
     expect(item).not.toHaveProperty("__internalMeta");
   });
 
+  it("keeps the linked type and relationship verb in list view, dropping globalId", async () => {
+    mockRequest.mockResolvedValueOnce({
+      entities: [{
+        prettyId: "ALERT-1",
+        relatedActivities: [{
+          name: "relates to",
+          templateTypeName: "INCIDENT",
+          prettyId: "INC-7",
+          globalId: "global-abc",
+          title: "Checkout latency",
+        }],
+      }],
+      totalCount: 1,
+    });
+    const result = await server.call("harness_list", { resource_type: "alert" });
+    const data = parseResult(result) as { items: Array<Record<string, unknown>> };
+    expect(data.items[0]!.relatedActivities).toEqual([
+      { prettyId: "INC-7", templateTypeName: "INCIDENT", title: "Checkout latency", name: "relates to" },
+    ]);
+  });
+
+  it("omits relatedActivities when the alert has none", async () => {
+    mockRequest.mockResolvedValueOnce({
+      entities: [{ prettyId: "ALERT-1", relatedActivities: [] }],
+      totalCount: 1,
+    });
+    const result = await server.call("harness_list", { resource_type: "alert" });
+    const data = parseResult(result) as { items: Array<Record<string, unknown>> };
+    expect(data.items[0]!).not.toHaveProperty("relatedActivities");
+  });
+
   it("keeps a short description verbatim in list view", async () => {
     mockRequest.mockResolvedValueOnce({
       entities: [{ prettyId: "ALERT-1", description: "short" }],
@@ -268,6 +299,28 @@ describe("alert — harness_get", () => {
     expect(data.keyEvents).toEqual([{ timestamp: 1, status: "TRIGGERED", details: "looking" }]);
     expect(data).not.toHaveProperty("__internalMeta");
     expect(data).not.toHaveProperty("correlationId");
+  });
+
+  it("projects related activities the same way as the list view", async () => {
+    mockRequest.mockResolvedValueOnce({
+      prettyId: "ALERT-42",
+      relatedActivities: [{
+        name: "relates to",
+        templateTypeName: "INCIDENT",
+        prettyId: "INC-7",
+        globalId: "global-abc",
+        title: "Checkout latency",
+        __internalMeta: { trace: "abc" },
+      }],
+    });
+    const result = await server.call("harness_get", { resource_type: "alert", resource_id: "ALERT-42" });
+    const data = parseResult(result) as Record<string, unknown>;
+    expect(data.relatedActivities).toEqual([{
+      prettyId: "INC-7",
+      templateTypeName: "INCIDENT",
+      title: "Checkout latency",
+      name: "relates to",
+    }]);
   });
 
   it("keeps the full description in the detail view", async () => {

--- a/tests/tools/alerts.test.ts
+++ b/tests/tools/alerts.test.ts
@@ -210,7 +210,7 @@ describe("alert — harness_list", () => {
     const result = await server.call("harness_list", { resource_type: "alert" });
     const data = parseResult(result) as { items: Array<Record<string, unknown>> };
     expect(data.items[0]!.relatedActivities).toEqual([
-      { prettyId: "INC-7", templateTypeName: "INCIDENT", title: "Checkout latency", name: "relates to" },
+      { prettyId: "INC-7", resource_type: "incident", title: "Checkout latency", name: "relates to" },
     ]);
   });
 
@@ -317,7 +317,7 @@ describe("alert — harness_get", () => {
     const data = parseResult(result) as Record<string, unknown>;
     expect(data.relatedActivities).toEqual([{
       prettyId: "INC-7",
-      templateTypeName: "INCIDENT",
+      resource_type: "incident",
       title: "Checkout latency",
       name: "relates to",
     }]);

--- a/tests/tools/deploys.test.ts
+++ b/tests/tools/deploys.test.ts
@@ -138,6 +138,47 @@ describe("deploy — harness_list", () => {
     expect(item).not.toHaveProperty("buildVersions");
   });
 
+  it("keeps the linked type and relationship verb in list view, dropping globalId", async () => {
+    mockRequest.mockResolvedValueOnce({
+      entities: [{
+        id: "DEPL-1",
+        relatedActivities: [{
+          name: "relates to",
+          templateTypeName: "INCIDENT",
+          prettyId: "INC-7",
+          globalId: "global-abc",
+          title: "Checkout latency",
+        }],
+      }],
+      totalCount: 1,
+    });
+    const result = await server.call("harness_list", { resource_type: "deploy" });
+    const data = parseResult(result) as { items: Array<Record<string, unknown>> };
+    expect(data.items[0]!.relatedActivities).toEqual([
+      { prettyId: "INC-7", templateTypeName: "INCIDENT", title: "Checkout latency", name: "relates to" },
+    ]);
+  });
+
+  it("keeps status in compact output when the API supplies one", async () => {
+    mockRequest.mockResolvedValueOnce({
+      entities: [{ id: "DEPL-1", status: "SUCCESS" }],
+      totalCount: 1,
+    });
+    const result = await server.call("harness_list", { resource_type: "deploy" });
+    const data = parseResult(result) as { items: Record<string, unknown>[] };
+    expect(data.items[0]!.status).toBe("SUCCESS");
+  });
+
+  it("omits relatedActivities when the deploy has none", async () => {
+    mockRequest.mockResolvedValueOnce({
+      entities: [{ id: "DEPL-1", relatedActivities: [] }],
+      totalCount: 1,
+    });
+    const result = await server.call("harness_list", { resource_type: "deploy" });
+    const data = parseResult(result) as { items: Array<Record<string, unknown>> };
+    expect(data.items[0]!).not.toHaveProperty("relatedActivities");
+  });
+
   it("compact:false leaves raw fields intact", async () => {
     mockRequest.mockResolvedValueOnce({
       entities: [{ id: "DEPL-1", status: null, buildVersions: [{ service: "x", version: "1" }] }],
@@ -230,5 +271,27 @@ describe("deploy — harness_get", () => {
     expect(data.webLink).toContain("DEPLU65-8065");
     // Backend debug field stripped
     expect(data).not.toHaveProperty("someBackendDebugField");
+  });
+
+  it("projects related activities the same way as the list view", async () => {
+    mockRequest.mockResolvedValueOnce({
+      id: "DEPL-24",
+      relatedActivities: [{
+        name: "relates to",
+        templateTypeName: "INCIDENT",
+        prettyId: "INC-7",
+        globalId: "global-abc",
+        title: "Checkout latency",
+        __internalMeta: { trace: "abc" },
+      }],
+    });
+    const result = await server.call("harness_get", { resource_type: "deploy", resource_id: "DEPL-24" });
+    const data = parseResult(result) as Record<string, unknown>;
+    expect(data.relatedActivities).toEqual([{
+      prettyId: "INC-7",
+      templateTypeName: "INCIDENT",
+      title: "Checkout latency",
+      name: "relates to",
+    }]);
   });
 });

--- a/tests/tools/deploys.test.ts
+++ b/tests/tools/deploys.test.ts
@@ -155,7 +155,7 @@ describe("deploy — harness_list", () => {
     const result = await server.call("harness_list", { resource_type: "deploy" });
     const data = parseResult(result) as { items: Array<Record<string, unknown>> };
     expect(data.items[0]!.relatedActivities).toEqual([
-      { prettyId: "INC-7", templateTypeName: "INCIDENT", title: "Checkout latency", name: "relates to" },
+      { prettyId: "INC-7", resource_type: "incident", title: "Checkout latency", name: "relates to" },
     ]);
   });
 
@@ -289,7 +289,7 @@ describe("deploy — harness_get", () => {
     const data = parseResult(result) as Record<string, unknown>;
     expect(data.relatedActivities).toEqual([{
       prettyId: "INC-7",
-      templateTypeName: "INCIDENT",
+      resource_type: "incident",
       title: "Checkout latency",
       name: "relates to",
     }]);

--- a/tests/tools/incidents.test.ts
+++ b/tests/tools/incidents.test.ts
@@ -206,14 +206,36 @@ describe("incident — harness_list", () => {
     const result = await server.call("harness_list", { resource_type: "incident" });
     const data = parseResult(result) as { items: Array<Record<string, unknown>> };
     expect(data.items[0]!.relatedActivities).toEqual([
-      { prettyId: "ALERT-9", templateTypeName: "ALERT", title: "CPU spike", name: "relates to" },
+      { prettyId: "ALERT-9", resource_type: "alert", title: "CPU spike", name: "relates to" },
     ]);
   });
 
-  // A null templateTypeName must not surface as `templateTypeName: null` — the
+  it("translates a DEPLOY edge to the deploy resource_type", async () => {
+    mockRequest.mockResolvedValueOnce({
+      entities: [{
+        prettyId: "INC-1",
+        relatedActivities: [{
+          name: "is caused by",
+          templateTypeName: "DEPLOY",
+          prettyId: "DEPLIR1-56",
+          globalId: "global-abc",
+          title: "release 1.2.3",
+        }],
+      }],
+      totalCount: 1,
+    });
+    const result = await server.call("harness_list", { resource_type: "incident" });
+    const data = parseResult(result) as { items: Array<Record<string, unknown>> };
+    expect(data.items[0]!.relatedActivities).toEqual([
+      { prettyId: "DEPLIR1-56", resource_type: "deploy", title: "release 1.2.3", name: "is caused by" },
+    ]);
+  });
+
+  // A null templateTypeName must not surface as `resource_type: null` — the
   // field is the caller's routing key, so an unclassified edge should read as
-  // absent rather than as a type that is explicitly nothing.
-  it("omits templateTypeName when the backend leaves it null", async () => {
+  // absent rather than as a type that is explicitly nothing. An empty title is
+  // dropped for the same reason: it is noise, not a title.
+  it("omits resource_type and an empty title when the backend leaves them blank", async () => {
     mockRequest.mockResolvedValueOnce({
       entities: [{
         prettyId: "INC-1",
@@ -230,7 +252,30 @@ describe("incident — harness_list", () => {
     const result = await server.call("harness_list", { resource_type: "incident" });
     const data = parseResult(result) as { items: Array<Record<string, unknown>> };
     expect(data.items[0]!.relatedActivities).toEqual([
-      { prettyId: "DEPLIR1-56", title: "", name: "is caused by" },
+      { prettyId: "DEPLIR1-56", name: "is caused by" },
+    ]);
+  });
+
+  // CHANGE is a real backend templateTypeName with no registered resource type,
+  // so the edge must not claim a resource_type harness_get would reject.
+  it("omits resource_type for a CHANGE edge this server cannot fetch", async () => {
+    mockRequest.mockResolvedValueOnce({
+      entities: [{
+        prettyId: "INC-1",
+        relatedActivities: [{
+          name: "relates to",
+          templateTypeName: "CHANGE",
+          prettyId: "CHG-3",
+          globalId: "global-abc",
+          title: "Feature flag flip",
+        }],
+      }],
+      totalCount: 1,
+    });
+    const result = await server.call("harness_list", { resource_type: "incident" });
+    const data = parseResult(result) as { items: Array<Record<string, unknown>> };
+    expect(data.items[0]!.relatedActivities).toEqual([
+      { prettyId: "CHG-3", title: "Feature flag flip", name: "relates to" },
     ]);
   });
 
@@ -311,7 +356,7 @@ describe("incident — harness_get", () => {
     const data = parseResult(result) as Record<string, unknown>;
     expect(data.relatedActivities).toEqual([{
       prettyId: "ALERT-9",
-      templateTypeName: "ALERT",
+      resource_type: "alert",
       title: "CPU spike",
       name: "relates to",
     }]);

--- a/tests/tools/incidents.test.ts
+++ b/tests/tools/incidents.test.ts
@@ -188,6 +188,61 @@ describe("incident — harness_list", () => {
     expect(summary).toContain("harness_get");
     expect(summary.startsWith("x".repeat(400))).toBe(true);
   });
+
+  it("keeps the linked type and relationship verb in list view, dropping globalId", async () => {
+    mockRequest.mockResolvedValueOnce({
+      entities: [{
+        prettyId: "INC-1",
+        relatedActivities: [{
+          name: "relates to",
+          templateTypeName: "ALERT",
+          prettyId: "ALERT-9",
+          globalId: "global-abc",
+          title: "CPU spike",
+        }],
+      }],
+      totalCount: 1,
+    });
+    const result = await server.call("harness_list", { resource_type: "incident" });
+    const data = parseResult(result) as { items: Array<Record<string, unknown>> };
+    expect(data.items[0]!.relatedActivities).toEqual([
+      { prettyId: "ALERT-9", templateTypeName: "ALERT", title: "CPU spike", name: "relates to" },
+    ]);
+  });
+
+  // A null templateTypeName must not surface as `templateTypeName: null` — the
+  // field is the caller's routing key, so an unclassified edge should read as
+  // absent rather than as a type that is explicitly nothing.
+  it("omits templateTypeName when the backend leaves it null", async () => {
+    mockRequest.mockResolvedValueOnce({
+      entities: [{
+        prettyId: "INC-1",
+        relatedActivities: [{
+          name: "is caused by",
+          templateTypeName: null,
+          prettyId: "DEPLIR1-56",
+          globalId: "global-abc",
+          title: "",
+        }],
+      }],
+      totalCount: 1,
+    });
+    const result = await server.call("harness_list", { resource_type: "incident" });
+    const data = parseResult(result) as { items: Array<Record<string, unknown>> };
+    expect(data.items[0]!.relatedActivities).toEqual([
+      { prettyId: "DEPLIR1-56", title: "", name: "is caused by" },
+    ]);
+  });
+
+  it("omits relatedActivities when the incident has none", async () => {
+    mockRequest.mockResolvedValueOnce({
+      entities: [{ prettyId: "INC-1", relatedActivities: [] }],
+      totalCount: 1,
+    });
+    const result = await server.call("harness_list", { resource_type: "incident" });
+    const data = parseResult(result) as { items: Array<Record<string, unknown>> };
+    expect(data.items[0]!).not.toHaveProperty("relatedActivities");
+  });
 });
 
 describe("incident — harness_get", () => {
@@ -238,6 +293,28 @@ describe("incident — harness_get", () => {
     // Backend envelope/meta must not leak across the tool boundary
     expect(data).not.toHaveProperty("__internalMeta");
     expect(data).not.toHaveProperty("correlationId");
+  });
+
+  it("projects related activities the same way as the list view", async () => {
+    mockRequest.mockResolvedValueOnce({
+      prettyId: "INC-42",
+      relatedActivities: [{
+        name: "relates to",
+        templateTypeName: "ALERT",
+        prettyId: "ALERT-9",
+        globalId: "global-abc",
+        title: "CPU spike",
+        __internalMeta: { trace: "abc" },
+      }],
+    });
+    const result = await server.call("harness_get", { resource_type: "incident", resource_id: "INC-42" });
+    const data = parseResult(result) as Record<string, unknown>;
+    expect(data.relatedActivities).toEqual([{
+      prettyId: "ALERT-9",
+      templateTypeName: "ALERT",
+      title: "CPU spike",
+      name: "relates to",
+    }]);
   });
 
   it("keeps the full summary in the detail view", async () => {


### PR DESCRIPTION
## Description
This adds better support for handling related activities between incidents, alerts and deploys.

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [x] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
If this PR adds or changes Harness API coverage:
- [ ] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [ ] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [ ] `operationPolicy` on every new/changed endpoint
- [ ] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [ ] `identifierFields` and `scope` declared on new resources
- [ ] No `console.log()` in `src/` (stdio JSON-RPC safety)
