### PR TITLE
feat(registry): guard against duplicate canonical resourceType across toolsets

### DIFF
--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -98,6 +98,27 @@ function buildToolsetAliases(allToolsets: ToolsetDefinition[]): Map<string, stri
  * resource's declarative `aliases`. An alias must never shadow a canonical
  * resourceType and must map to exactly one canonical type.
  */
+/**
+ * Guards against two toolsets declaring the same canonical resourceType. Checked
+ * against the full static toolset list (not just the runtime-enabled subset), since
+ * a collision is a property of the source data and must fail regardless of which
+ * HARNESS_TOOLSETS filter a given deployment happens to use.
+ */
+function assertUniqueResourceTypes(allToolsets: ToolsetDefinition[]): void {
+  const owner = new Map<string, string>();
+  for (const toolset of allToolsets) {
+    for (const resource of toolset.resources) {
+      const existing = owner.get(resource.resourceType);
+      if (existing && existing !== toolset.name) {
+        throw new Error(
+          `Duplicate resourceType "${resource.resourceType}" declared in both "${existing}" and "${toolset.name}" toolsets.`,
+        );
+      }
+      owner.set(resource.resourceType, toolset.name);
+    }
+  }
+}
+
 function buildResourceTypeAliases(resourceMap: Map<string, ResourceDefinition>): Map<string, string> {
   const map = new Map<string, string>();
   for (const [canonical, def] of resourceMap) {
@@ -260,6 +281,8 @@ export class Registry {
     this.accountIdResolver = options.accountIdResolver;
     this.auditManager = options.auditManager;
     const allToolsets = [...ALL_TOOLSETS, ...(options.additionalToolsets ?? [])];
+
+    assertUniqueResourceTypes(allToolsets);
 
     // Toolset aliases must be resolved before parsing HARNESS_TOOLSETS so old
     // toolset names in that config still enable the renamed toolset.

--- a/tests/registry/aliases.test.ts
+++ b/tests/registry/aliases.test.ts
@@ -214,4 +214,51 @@ describe("P0 alias layer — load-time collision guards", () => {
     };
     expect(() => registryWith([a, b])).toThrow(/claimed by both/);
   });
+
+  it("throws when two toolsets declare the same canonical resourceType", () => {
+    const a: ToolsetDefinition = {
+      name: "cap_a",
+      displayName: "A",
+      description: "d",
+      resources: [res({ resourceType: "shared_thing", toolset: "cap_a" })],
+    };
+    const b: ToolsetDefinition = {
+      name: "cap_b",
+      displayName: "B",
+      description: "d",
+      resources: [res({ resourceType: "shared_thing", toolset: "cap_b" })],
+    };
+    expect(() => registryWith([a, b])).toThrow(/Duplicate resourceType "shared_thing"/);
+  });
+
+  it("checks canonical-resourceType uniqueness against the full static toolset list, not just the enabled subset", () => {
+    const a: ToolsetDefinition = {
+      name: "cap_a",
+      optIn: true,
+      displayName: "A",
+      description: "d",
+      resources: [res({ resourceType: "shared_thing", toolset: "cap_a" })],
+    };
+    const b: ToolsetDefinition = {
+      name: "cap_b",
+      optIn: true,
+      displayName: "B",
+      description: "d",
+      resources: [res({ resourceType: "shared_thing", toolset: "cap_b" })],
+    };
+    // Neither toolset is enabled by default (optIn), and HARNESS_TOOLSETS selects neither —
+    // the collision must still be caught at construction time.
+    expect(() => registryWith([a, b], { HARNESS_TOOLSETS: "pipelines" })).toThrow(
+      /Duplicate resourceType "shared_thing"/,
+    );
+  });
+});
+
+describe("P0 alias layer — global resourceType uniqueness (production registry)", () => {
+  it("has no two production toolsets declaring the same canonical resourceType", () => {
+    // Constructing the default registry (no additionalToolsets) already runs
+    // assertUniqueResourceTypes against every real toolset; this just documents
+    // the invariant explicitly so a future collision fails with a clear intent.
+    expect(() => new Registry(makeConfig())).not.toThrow();
+  });
 });


### PR DESCRIPTION
## What & why

Stacked on #892. Follow-up from review: the alias layer added in #892 guards alias-vs-canonical shadowing and alias-vs-alias collisions (`buildToolsetAliases`/`buildResourceTypeAliases`), but nothing guarded against two toolsets declaring the same **canonical** `resourceType`. `resourceMap.set(resource.resourceType, resource)` would silently overwrite one definition with no error — the kind of mistake that's easy to introduce during a large manual rename like #892's STO+SCS merge (27 resources renamed into one file).

Adds `assertUniqueResourceTypes`, checked at Registry construction against the full static toolset list (`ALL_TOOLSETS` + `additionalToolsets`), not just the runtime-enabled subset — a collision is a property of the source data and must fail regardless of which `HARNESS_TOOLSETS` filter a given deployment uses.

## Changes

- `src/registry/index.ts` — new `assertUniqueResourceTypes()`, called once in the `Registry` constructor before the alias maps are built.
- `tests/registry/aliases.test.ts` — three new tests: synthetic collision throws, collision is caught even when both colliding toolsets are `optIn`/disabled by `HARNESS_TOOLSETS`, and the real production toolset list is currently collision-free (documents the invariant explicitly).

## Verification

`pnpm typecheck` clean, `pnpm test` → 3322/3322 passing (3319 + 3 new), `pnpm standards:check` → 77/77 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)