### PR TITLE
fix: use working v1 pipeline inputs endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -909,7 +909,7 @@ For v1 pipelines:
 
 1. Fetch `harness_get(resource_type="runtime_input_template_v1", resource_id="<pipeline_id>")`.
    For Git-backed pipelines, pass `branch_name`, `connector_ref`, and `repo_name` through `params`.
-2. Use each returned `inputs[].details.name` as a top-level key in `harness_execute.inputs`.
+2. Read `template_yaml` and `resolved_yaml` for declared `${{ inputs.* }}` values and defaults.
 3. Run `harness_execute(resource_type="pipeline_v1", action="run", resource_id="<pipeline_id>", inputs={...})`.
    The server wraps these values under an `inputs:` YAML root and sends the API's `inputs_yaml` body.
 

--- a/src/registry/extractors.ts
+++ b/src/registry/extractors.ts
@@ -553,30 +553,32 @@ export const pipelineResolvedYamlExtract = (raw: unknown): unknown => {
 };
 
 /**
- * Extracts the declared inputs returned by the Harness pipeline v1 inputs-schema API.
+ * Extracts the declared inputs returned by the Harness pipeline v1 inputs API.
+ * V1 values are supplied as one YAML document rooted at `inputs:`.
  * The API may return its public shape directly or inside the standard `data` envelope.
  */
 export const runtimeInputV1Extract = (raw: unknown): unknown => {
   const outer = asRecord(raw);
-  const r = asRecord(outer?.data) ?? outer;
-  const hasInputsField = !!r && Object.prototype.hasOwnProperty.call(r, "inputs");
-  const inputs = hasInputsField && Array.isArray(r?.inputs) ? r.inputs : null;
-
-  let hint: string;
-  if (!hasInputsField) {
-    hint = "The v1 inputs-schema response omitted inputs metadata. Do not assume the pipeline has no runtime inputs.";
-  } else if (!inputs) {
-    hint = "The v1 inputs-schema response contained an invalid inputs field. Expected an array; do not execute until the schema is confirmed.";
-  } else if (inputs.length === 0) {
-    hint = "This v1 pipeline declares no runtime inputs. Execute it without the inputs argument.";
-  } else {
-    hint = "Use each inputs[].details.name as a top-level harness_execute inputs key for pipeline_v1. The server sends those values as one inputs: YAML document.";
-  }
-
+  const r = (asRecord(outer?.data) ?? outer) as {
+    inputs?: Record<string, unknown>;
+    template_yaml?: string;
+    resolved_yaml?: string;
+    has_input_sets?: boolean;
+    replaced_expressions?: string[];
+    replaced_expressions_per_stage?: Record<string, string[]>;
+    modules?: string[];
+  };
   return {
-    inputs,
-    metadata_available: inputs !== null,
-    _hint: hint,
+    inputs: r.inputs ?? {},
+    template_yaml: r.template_yaml ?? null,
+    resolved_yaml: r.resolved_yaml ?? null,
+    has_input_sets: r.has_input_sets ?? false,
+    replaced_expressions: r.replaced_expressions ?? [],
+    replaced_expressions_per_stage: r.replaced_expressions_per_stage ?? {},
+    modules: r.modules ?? [],
+    _hint: r.template_yaml
+      ? "This v1 template shows the available ${{ inputs.* }} values. Pass matching key-value pairs through harness_execute(resource_type='pipeline_v1', action='run', inputs={...}); they are sent as one inputs: YAML document."
+      : "This v1 pipeline has no runtime inputs. You can execute it without providing inputs.",
   };
 };
 

--- a/src/registry/toolsets/pipelines.ts
+++ b/src/registry/toolsets/pipelines.ts
@@ -1304,8 +1304,8 @@ export const pipelinesToolset: ToolsetDefinition = {
     },
     {
       resourceType: "runtime_input_template_v1",
-      displayName: "Runtime Input Schema (V1)",
-      description: "Fetch the declared runtime input schema for a v1 pipeline. Use the returned inputs[].details names and constraints before executing pipeline_v1.",
+      displayName: "Runtime Input Template (V1)",
+      description: "Fetch the declared runtime inputs for a v1 pipeline. Use this before executing pipeline_v1; returned template_yaml and resolved_yaml show every ${{ inputs.* }} reference that can be supplied.",
       toolset: "pipelines",
       scope: "project",
       headerBasedScoping: true,
@@ -1319,8 +1319,8 @@ export const pipelinesToolset: ToolsetDefinition = {
       ],
       operations: {
         get: {
-          method: "GET",
-          path: "/v1/orgs/{org}/projects/{project}/pipelines/{pipeline}/inputs-schema",
+          method: "POST",
+          path: "/v1/orgs/{org}/projects/{project}/pipelines/{pipeline}/inputs",
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           pathParams: { org_id: "org", project_id: "project", pipeline_id: "pipeline" },
           queryParams: {
@@ -1329,9 +1329,10 @@ export const pipelinesToolset: ToolsetDefinition = {
             connector_ref: "connector_ref",
             repo_name: "repo_name",
           },
+          bodyBuilder: () => ({ stage_ids: [] }),
           paramsSchema: PIPELINE_V1_GIT_READ_PARAMS,
           responseExtractor: runtimeInputV1Extract,
-          description: "Fetch v1 pipeline input names, types, defaults, allowed values, and dependencies.",
+          description: "Fetch the v1 pipeline input template and resolved pipeline YAML.",
         },
       },
     },

--- a/tests/registry/runtime-input-template.test.ts
+++ b/tests/registry/runtime-input-template.test.ts
@@ -172,69 +172,60 @@ describe("runtime_input_template resource — request shape", () => {
 });
 
 describe("runtimeInputV1Extract — response shape", () => {
-  const branchInput = {
-    details: {
-      name: "branch",
-      type: "string",
-      required: true,
-      allowed_values: ["main", "develop"],
-    },
-    metadata: {
-      dependencies: {
-        required_runtime_inputs: [],
-        required_fixed_values: [],
-      },
-    },
+  const uiResponse = {
+    inputs: {},
+    template_yaml: "pipeline:\n  clone:\n    ref:\n      name: \"${{ inputs.branch }}\"\n",
+    resolved_yaml: "pipeline:\n  inputs:\n    branch:\n      type: string\n      default: main\n",
+    has_input_sets: false,
+    replaced_expressions: [],
+    replaced_expressions_per_stage: {},
+    modules: ["ci", "pms"],
   };
 
-  it("unwraps a data envelope without changing the inputs schema", () => {
-    expect(runtimeInputV1Extract({ data: { inputs: [branchInput] } })).toEqual({
-      inputs: [branchInput],
-      metadata_available: true,
-      _hint: expect.stringContaining("inputs[].details.name"),
+  it("unwraps a data envelope without changing the template fields", () => {
+    expect(runtimeInputV1Extract({ data: uiResponse })).toEqual({
+      inputs: {},
+      template_yaml: uiResponse.template_yaml,
+      resolved_yaml: uiResponse.resolved_yaml,
+      has_input_sets: false,
+      replaced_expressions: [],
+      replaced_expressions_per_stage: {},
+      modules: ["ci", "pms"],
+      _hint: expect.stringContaining("${{ inputs.* }}"),
     });
   });
 
   it("accepts the flat public response shape", () => {
-    expect(runtimeInputV1Extract({ inputs: [branchInput] })).toMatchObject({
-      inputs: [branchInput],
-      metadata_available: true,
+    expect(runtimeInputV1Extract(uiResponse)).toMatchObject({
+      template_yaml: uiResponse.template_yaml,
+      resolved_yaml: uiResponse.resolved_yaml,
+      modules: ["ci", "pms"],
     });
   });
 
-  it("distinguishes an empty input schema from missing metadata", () => {
-    expect(runtimeInputV1Extract({ data: { inputs: [] } })).toEqual({
-      inputs: [],
-      metadata_available: true,
-      _hint: expect.stringContaining("declares no runtime inputs"),
-    });
-    expect(runtimeInputV1Extract({ data: {} })).toEqual({
-      inputs: null,
-      metadata_available: false,
-      _hint: expect.stringContaining("Do not assume"),
-    });
-  });
-
-  it("rejects an invalid inputs field without claiming there are no inputs", () => {
-    expect(runtimeInputV1Extract({ inputs: {} })).toEqual({
-      inputs: null,
-      metadata_available: false,
-      _hint: expect.stringContaining("invalid inputs field"),
+  it("returns a no-inputs hint when template_yaml is absent", () => {
+    expect(runtimeInputV1Extract({ inputs: {}, has_input_sets: false })).toEqual({
+      inputs: {},
+      template_yaml: null,
+      resolved_yaml: null,
+      has_input_sets: false,
+      replaced_expressions: [],
+      replaced_expressions_per_stage: {},
+      modules: [],
+      _hint: expect.stringContaining("no runtime inputs"),
     });
   });
 });
 
 describe("runtime_input_template_v1 resource — request shape", () => {
-  it("dispatches documented GET inputs-schema with Git Experience params", async () => {
+  it("dispatches UI POST /inputs with stage_ids and Git Experience params", async () => {
     const registry = new Registry(makeConfig());
     const mockRequest = vi.fn().mockResolvedValue({
-      data: {
-        inputs: [
-          {
-            details: { name: "branch", type: "string", required: true },
-          },
-        ],
-      },
+      inputs: {},
+      template_yaml: "pipeline:\n  clone:\n    ref:\n      name: \"${{ inputs.branch }}\"\n",
+      resolved_yaml: "pipeline:\n  inputs:\n    branch:\n      type: string\n",
+      has_input_sets: false,
+      modules: ["ci"],
     });
     const client = makeClient(mockRequest);
 
@@ -248,23 +239,20 @@ describe("runtime_input_template_v1 resource — request shape", () => {
     });
 
     expect(result).toMatchObject({
-      inputs: [
-        {
-          details: { name: "branch", type: "string", required: true },
-        },
-      ],
-      metadata_available: true,
+      template_yaml: expect.stringContaining("${{ inputs.branch }}"),
+      resolved_yaml: expect.stringContaining("branch:"),
+      modules: ["ci"],
     });
     expect(mockRequest).toHaveBeenCalledWith(
       expect.objectContaining({
-        method: "GET",
-        path: "/v1/orgs/myorg/projects/myproj/pipelines/my-pipe/inputs-schema",
+        method: "POST",
+        path: "/v1/orgs/myorg/projects/myproj/pipelines/my-pipe/inputs",
         params: expect.objectContaining({
           branch_name: "feature/runtime-inputs",
           connector_ref: "account.git",
           repo_name: "my-repo",
         }),
-        body: undefined,
+        body: { stage_ids: [] },
         headerBasedScoping: true,
       }),
     );

--- a/tests/tools/tool-handlers.test.ts
+++ b/tests/tools/tool-handlers.test.ts
@@ -220,17 +220,11 @@ describe("harness_get", () => {
 
   it("fetches and projects the v1 runtime input template", async () => {
     mockRequest.mockResolvedValueOnce({
-      data: {
-        inputs: [
-          {
-            details: {
-              name: "branch",
-              type: "string",
-              required: true,
-            },
-          },
-        ],
-      },
+      inputs: {},
+      template_yaml: "pipeline:\n  clone:\n    ref:\n      name: \"${{ inputs.branch }}\"\n",
+      resolved_yaml: "pipeline:\n  inputs:\n    branch:\n      type: string\n      default: main\n",
+      has_input_sets: false,
+      modules: ["ci"],
     });
 
     const result = await server.call("harness_get", {
@@ -245,27 +239,21 @@ describe("harness_get", () => {
 
     expect(result.isError).toBeUndefined();
     expect(parseResult(result)).toMatchObject({
-      inputs: [
-        {
-          details: {
-            name: "branch",
-            type: "string",
-            required: true,
-          },
-        },
-      ],
-      metadata_available: true,
-      _hint: expect.stringContaining("inputs[].details.name"),
+      template_yaml: expect.stringContaining("${{ inputs.branch }}"),
+      resolved_yaml: expect.stringContaining("branch:"),
+      modules: ["ci"],
+      _hint: expect.stringContaining("${{ inputs.* }}"),
     });
     expect(mockRequest).toHaveBeenCalledWith(
       expect.objectContaining({
-        method: "GET",
-        path: "/v1/orgs/default/projects/test-project/pipelines/my-pipeline/inputs-schema",
+        method: "POST",
+        path: "/v1/orgs/default/projects/test-project/pipelines/my-pipeline/inputs",
         params: expect.objectContaining({
           branch_name: "feature/my-fix",
           connector_ref: "account.git",
           repo_name: "my-repo",
         }),
+        body: { stage_ids: [] },
         headerBasedScoping: true,
       }),
     );


### PR DESCRIPTION
## Summary
- Restore v1 runtime-input discovery to the UI-backed `POST /inputs` endpoint with `{ stage_ids: [] }`.
- Preserve Git Experience query parameters and project the returned template and resolved YAML for agents.
- Keep the existing v1 execution input wrapping and response normalization unchanged.

## Test plan
- [x] Run `pnpm typecheck`.
- [x] Run the focused runtime-input and tool-handler tests (189 tests).
- [x] Run the full test suite (3,251 tests) before rebasing the follow-up onto current `main`.
- [x] Verify locally that `/inputs` returns the declared `branch` input and that execution sends it under `inputs_yaml`.

Made with [Cursor](https://cursor.com)