### PR TITLE
fix: [FME-17982]: forward title on feature flag archive/unarchive

### DIFF
--- a/src/registry/toolsets/feature-flags.ts
+++ b/src/registry/toolsets/feature-flags.ts
@@ -57,7 +57,7 @@ const fmeFeatureFlagKillRestoreReallocateSchema: BodySchema = {
 };
 
 const fmeFeatureFlagArchiveSchema: BodySchema = {
-  description: "Optional comment and/or title recorded with the action. Both fields are accepted in legacy (workspace_id) and Harness-native (org_id+project_id) mode.",
+  description: "Optional comment and/or title recorded with the action.",
   fields: [
     { name: "comment", type: "string", required: false, description: "Optional comment explaining the change" },
     { name: "title", type: "string", required: false, description: "Optional short title for the change" },

--- a/src/registry/toolsets/feature-flags.ts
+++ b/src/registry/toolsets/feature-flags.ts
@@ -57,9 +57,10 @@ const fmeFeatureFlagKillRestoreReallocateSchema: BodySchema = {
 };
 
 const fmeFeatureFlagArchiveSchema: BodySchema = {
-  description: "Optional comment recorded with the action.",
+  description: "Optional comment and/or title recorded with the action. Both fields are accepted in legacy (workspace_id) and Harness-native (org_id+project_id) mode.",
   fields: [
     { name: "comment", type: "string", required: false, description: "Optional comment explaining the change" },
+    { name: "title", type: "string", required: false, description: "Optional short title for the change" },
   ],
 };
 
@@ -550,11 +551,14 @@ export const featureFlagsToolset: ToolsetDefinition = {
           pathParams: { workspace_id: "wsId", feature_flag_name: "featureFlagName" },
           bodyBuilder: (input) => {
             const body = (input.body as Record<string, unknown> | undefined) ?? {};
-            return body.comment !== undefined ? { comment: body.comment } : {};
+            return {
+              ...(body.comment !== undefined ? { comment: body.comment } : {}),
+              ...(body.title !== undefined ? { title: body.title } : {}),
+            };
           },
           responseExtractor: fmeActionExtract,
           actionDescription:
-            "Archive a feature flag. Requires feature_flag_name, plus workspace_id (legacy) or org_id+project_id (Harness-native). Subject to OPA policy checks (409 on failure). Optional comment recorded with the change.",
+            "Archive a feature flag. Requires feature_flag_name, plus workspace_id (legacy) or org_id+project_id (Harness-native). Subject to OPA policy checks (409 on failure). Optional comment/title recorded with the change.",
           bodySchema: fmeFeatureFlagArchiveSchema,
         },
         unarchive: {
@@ -576,11 +580,14 @@ export const featureFlagsToolset: ToolsetDefinition = {
           pathParams: { workspace_id: "wsId", feature_flag_name: "featureFlagName" },
           bodyBuilder: (input) => {
             const body = (input.body as Record<string, unknown> | undefined) ?? {};
-            return body.comment !== undefined ? { comment: body.comment } : {};
+            return {
+              ...(body.comment !== undefined ? { comment: body.comment } : {}),
+              ...(body.title !== undefined ? { title: body.title } : {}),
+            };
           },
           responseExtractor: fmeActionExtract,
           actionDescription:
-            "Unarchive a previously archived feature flag. Requires feature_flag_name, plus workspace_id (legacy) or org_id+project_id (Harness-native). Returns 409 if the flag has dependent objects. Optional comment recorded with the change.",
+            "Unarchive a previously archived feature flag. Requires feature_flag_name, plus workspace_id (legacy) or org_id+project_id (Harness-native). Returns 409 if the flag has dependent objects. Optional comment/title recorded with the change.",
           bodySchema: fmeFeatureFlagArchiveSchema,
         },
       },

--- a/tests/registry/feature-flags.test.ts
+++ b/tests/registry/feature-flags.test.ts
@@ -430,7 +430,7 @@ describe("fme_feature_flag kill/restore/reallocate/archive/unarchive dual-mode",
     });
   });
 
-  it("new mode: archive routes to the Harness-native feature-flags path and drops title (unsupported by v4)", async () => {
+  it("new mode: archive routes to the Harness-native feature-flags path and forwards comment/title", async () => {
     const mockRequest = vi.fn().mockResolvedValue({});
     const client = makeClient(mockRequest);
 
@@ -438,7 +438,7 @@ describe("fme_feature_flag kill/restore/reallocate/archive/unarchive dual-mode",
       org_id: "o1",
       project_id: "p1",
       feature_flag_name: "my_flag",
-      body: { comment: "no longer needed", title: "ignored" },
+      body: { comment: "no longer needed", title: "cleanup" },
     });
 
     const req = firstRequest(mockRequest);
@@ -449,7 +449,7 @@ describe("fme_feature_flag kill/restore/reallocate/archive/unarchive dual-mode",
       organization_identifier: "o1",
       project_identifier: "p1",
     });
-    expect(req.body).toEqual({ comment: "no longer needed" });
+    expect(req.body).toEqual({ comment: "no longer needed", title: "cleanup" });
   });
 
   it("new mode: unarchive routes to the Harness-native feature-flags path", async () => {
@@ -468,7 +468,7 @@ describe("fme_feature_flag kill/restore/reallocate/archive/unarchive dual-mode",
     expect(req.body).toEqual({});
   });
 
-  it("legacy mode: archive still posts to the Split.io path and forwards comment (title unsupported)", async () => {
+  it("legacy mode: archive still posts to the Split.io path and forwards comment/title", async () => {
     const mockRequest = vi.fn().mockResolvedValue({});
     const client = makeClient(mockRequest);
 
@@ -481,7 +481,7 @@ describe("fme_feature_flag kill/restore/reallocate/archive/unarchive dual-mode",
     const req = firstRequest(mockRequest);
     expect(req.method).toBe("POST");
     expect(req.path).toBe("/internal/api/v2/splits/ws/ws1/my_flag/archive");
-    expect(req.body).toEqual({ comment: "no longer needed" });
+    expect(req.body).toEqual({ comment: "no longer needed", title: "cleanup" });
   });
 });
 


### PR DESCRIPTION
## Summary
- The archive/unarchive body schema only exposed `comment`, so MCP callers had no way to supply a `title` even though the underlying legacy Split.io API already accepts it and the v4 Harness-native API is being updated to accept it too (see Main FME-17982).
- Mirrors the comment/title-forwarding pattern already used for kill/restore/reallocate (introduced in #806).

## Test plan
- [x] Updated existing archive/unarchive tests in `tests/registry/feature-flags.test.ts` to assert title is now forwarded (legacy and Harness-native)
- [x] Verified locally (see Verification section below)

## Verification
`pnpm test` (3017 passing), `pnpm standards:check` (77 passing), `pnpm docs:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)