### PR TITLE
Fix container image build and HTTP runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,44 @@ jobs:
           HARNESS_TOOLSETS: ${{ matrix.toolsets }}
           HARNESS_READ_ONLY: ${{ matrix.read_only }}
 
+  container-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v4
+      - name: Build container image without publishing
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          push: false
+          tags: harness-mcp-server:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Smoke test HTTP reachability and auth
+        run: |
+          container_id="$(docker run --detach \
+            --publish 3000:3000 \
+            --env HARNESS_MCP_MODE=multi-user \
+            --env HARNESS_MCP_AUTH_TOKEN=ci-smoke-token \
+            harness-mcp-server:ci)"
+          trap 'docker logs "$container_id"; docker rm --force "$container_id"' EXIT
+
+          for attempt in $(seq 1 30); do
+            if curl --fail --silent --show-error http://127.0.0.1:3000/health; then
+              break
+            fi
+            if [ "$attempt" -eq 30 ]; then
+              echo "Container health endpoint did not become ready" >&2
+              exit 1
+            fi
+            sleep 1
+          done
+
+          status="$(curl --silent --output /dev/null --write-out '%{http_code}' \
+            --request POST http://127.0.0.1:3000/mcp)"
+          test "$status" = "401"
+
   npm-consumer-adm-zip:
     runs-on: ubuntu-latest
     needs: build-and-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,25 @@
-# Stage 1 — build
-FROM node:22-alpine AS build
+# syntax=docker/dockerfile:1
+
+ARG NODE_IMAGE=node:22-bookworm-slim
+
+# Shared runtime — ONNX Runtime's Node binding needs glibc and libgomp.
+FROM ${NODE_IMAGE} AS base
 WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates libgomp1 \
+  && rm -rf /var/lib/apt/lists/*
 
 # Enable pnpm via corepack
 RUN corepack enable && corepack prepare pnpm@10.18.2 --activate
 
+# Stage 1 — build
+FROM base AS build
+
 # Install dependencies (layer cache: only re-run when lockfile changes)
 COPY package.json pnpm-lock.yaml ./
+# package.json postinstall imports both files, so they must exist before install.
+COPY scripts/ensure-secure-adm-zip.mjs scripts/adm-zip-security-lib.mjs scripts/
 RUN pnpm install --frozen-lockfile
 
 # Copy source and compile
@@ -20,28 +33,28 @@ ENV HARNESS_HF_CACHE_DIR=/app/.cache/hf
 RUN node scripts/preload-hf-model.mjs /app/.cache/hf
 
 # Stage 2 — production
-FROM node:22-alpine AS production
-WORKDIR /app
+FROM base AS production
 
-RUN corepack enable && corepack prepare pnpm@10.18.2 --activate
+ENV NODE_ENV=production \
+    HOST=0.0.0.0 \
+    PORT=3000 \
+    HARNESS_HF_CACHE_DIR=/app/.cache/hf
 
 # Install production dependencies only
 COPY package.json pnpm-lock.yaml ./
+COPY scripts/ensure-secure-adm-zip.mjs scripts/adm-zip-security-lib.mjs scripts/
 RUN pnpm install --frozen-lockfile --prod
 
 # Copy compiled output and pre-downloaded model cache from build stage
-COPY --from=build /app/build build/
-COPY --from=build /app/.cache/hf /app/.cache/hf
+COPY --from=build --chown=node:node /app/build build/
+COPY --from=build --chown=node:node /app/.cache/hf /app/.cache/hf
 
-ENV HARNESS_HF_CACHE_DIR=/app/.cache/hf
-
-# Non-root user for security
-RUN addgroup -S mcp && adduser -S mcp -G mcp
-USER mcp
+# The official Node image provides a fixed non-root node user (uid/gid 1000).
+USER node
 
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget -qO- http://localhost:3000/health || exit 1
+  CMD ["node", "-e", "const port=process.env.PORT||'3000';fetch(`http://127.0.0.1:${port}/health`).then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
 
 ENTRYPOINT ["node", "build/index.js", "http"]

--- a/README.md
+++ b/README.md
@@ -502,10 +502,13 @@ pnpm docker:run
 docker run --rm -p 3000:3000 \
   -e HARNESS_API_KEY=pat.xxx.xxx.xxx \
   -e HARNESS_ACCOUNT_ID=your-account-id \
+  -e HARNESS_MCP_AUTH_TOKEN=replace-with-a-long-random-token \
   harness-mcp-server
 ```
 
 The container runs in HTTP mode on port 3000 by default with a built-in health check.
+It binds to the container network, so set `HARNESS_MCP_AUTH_TOKEN` in `.env` or the
+container environment and send that value as `Authorization: Bearer <token>` on MCP requests.
 
 ### Kubernetes
 

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -7,6 +7,8 @@ metadata:
     app.kubernetes.io/name: harness-mcp-server
 type: Opaque
 stringData:
-  # Replace with your actual Harness credentials before applying
+  # Replace with your actual Harness credentials and an independent MCP
+  # transport bearer token before applying.
   HARNESS_API_KEY: "pat.REPLACE_ME.REPLACE_ME.REPLACE_ME"
   HARNESS_ACCOUNT_ID: "REPLACE_ME"
+  HARNESS_MCP_AUTH_TOKEN: "REPLACE_WITH_A_LONG_RANDOM_TOKEN"

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,10 @@
 # Lessons Learned
 
+## HTTP Transport Tests Need Localhost Socket Access
+- **Issue**: Running the full suite in the restricted sandbox made HTTP transport tests fail with `listen EPERM: operation not permitted 127.0.0.1`, while all non-socket tests passed.
+- **Fix**: Rerun the same suite with localhost socket access before treating route, auth, host-validation, or rate-limit failures as product regressions.
+- **Rule**: A cluster of HTTP test failures sharing `listen EPERM` is an environment failure; report both runs and require a clean socket-enabled rerun for the functional verdict.
+
 ## Generated Docs Checks Must Run After Build Completes
 - **Issue**: Running `pnpm build` and `pnpm docs:check` concurrently lets the docs checker read a partially rewritten `build/`, producing false resource-count and operation-table drift even when README is current.
 - **Fix**: Complete `pnpm build` first, then run `pnpm docs:check` or `pnpm docs:generate` sequentially. A sequential regenerate after the false failure reported README already up to date.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,27 @@
 # Harness MCP Server — Task Tracking
 
+## Docker image build/runtime alignment (2026-09-04)
+- [x] Copy required postinstall security scripts before dependency installation in both stages
+- [x] Use a glibc-based Node image for the native ONNX search dependency
+- [x] Make HTTP mode reachable through the container network while retaining the auth requirement
+- [x] Align the health check with the configurable runtime port and non-root user
+- [x] Add a CI image build and health smoke test so Dockerfile drift fails pull requests
+- [ ] Run repository validation, push the branch, open a PR, and verify its checks
+
+### Plan
+- Preserve the existing multi-stage build, frozen pnpm lockfile, and preloaded local-search model.
+- Keep credentials out of the image; remote deployments must inject `HARNESS_MCP_AUTH_TOKEN`
+  and either single-user Harness credentials or multi-user session credentials at runtime.
+- Validate the container on GitHub's Linux builder because no local Docker-compatible daemon is
+  available, and do not push an image as part of this corrective PR.
+
+### Review
+- Local validation passed: dependency install/postinstall, build, docs check, typecheck,
+  standards (77 tests), and the full suite (3,264 tests).
+- The first full-suite attempt was blocked by sandbox localhost binding (`listen EPERM`);
+  the same suite passed with localhost socket access.
+- Container build/runtime verification is delegated to the new non-publishing GitHub CI job.
+
 ## OPA policy multi-scope (this session)
 - [x] Add `supportedScopes: ["account", "org", "project"]` + description hints for `policy` and `policy_set`
 - [x] Extend governance tests for supportedScopes and `resource_scope` query-param dispatch

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -6,7 +6,7 @@
 - [x] Make HTTP mode reachable through the container network while retaining the auth requirement
 - [x] Align the health check with the configurable runtime port and non-root user
 - [x] Add a CI image build and health smoke test so Dockerfile drift fails pull requests
-- [ ] Run repository validation, push the branch, open a PR, and verify its checks
+- [x] Run repository validation, push the branch, open a PR, and verify its checks
 
 ### Plan
 - Preserve the existing multi-stage build, frozen pnpm lockfile, and preloaded local-search model.
@@ -20,7 +20,9 @@
   standards (77 tests), and the full suite (3,264 tests).
 - The first full-suite attempt was blocked by sandbox localhost binding (`listen EPERM`);
   the same suite passed with localhost socket access.
-- Container build/runtime verification is delegated to the new non-publishing GitHub CI job.
+- GitHub's non-publishing container job built the Linux image and passed the external
+  health-reachability and bearer-auth smoke tests.
+- Branch `fix/dockerfile-build-runtime` was pushed and PR #907 opened against `main`.
 
 ## OPA policy multi-scope (this session)
 - [x] Add `supportedScopes: ["account", "org", "project"]` + description hints for `policy` and `policy_set`


### PR DESCRIPTION
## Summary
- copy the required adm-zip security scripts before dependency installation in both image stages
- use a Debian slim Node base with the native ONNX runtime dependency
- bind HTTP mode to the container interface while retaining bearer-token protection
- run as the fixed non-root Node user and make the health check honor `PORT`
- add a non-publishing CI image build plus health/auth smoke test
- align Docker and Kubernetes documentation with the transport auth requirement

## Why
The existing Dockerfile predates the package postinstall script and cannot complete `pnpm install`. It also leaves the HTTP server bound to container loopback, so published ports and Kubernetes probes cannot reach it.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm docs:check`
- `pnpm typecheck`
- `pnpm standards:check` (77 tests)
- `pnpm test` (3,264 tests)
- YAML syntax validation for the CI workflow and Kubernetes secret

The new GitHub Actions container job builds and smoke-tests the image without publishing it.