### PR TITLE
Harden the production container runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,28 @@ jobs:
           context: .
           load: true
           push: false
+          pull: true
           tags: harness-mcp-server:ci
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Block fixable critical and high vulnerabilities
+        uses: aquasecurity/trivy-action@0.36.0
+        with:
+          image-ref: harness-mcp-server:ci
+          format: table
+          exit-code: "1"
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: CRITICAL,HIGH
+      - name: Verify production image excludes package managers
+        run: |
+          set -euo pipefail
+          for command in npm npx corepack pnpm yarn yarnpkg; do
+            if docker run --rm --entrypoint "$command" harness-mcp-server:ci --version >/dev/null 2>&1; then
+              echo "Production image unexpectedly contains $command" >&2
+              exit 1
+            fi
+          done
       - name: Smoke test HTTP reachability and auth
         run: |
           container_id="$(docker run --detach \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Block fixable critical and high vulnerabilities
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           image-ref: harness-mcp-server:ci
           format: table

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,16 @@
 # syntax=docker/dockerfile:1
 
 ARG NODE_IMAGE=node:22-bookworm-slim
+ARG RUNTIME_IMAGE=debian:bookworm-slim
 
-# Shared runtime — ONNX Runtime's Node binding needs glibc and libgomp.
-FROM ${NODE_IMAGE} AS base
+# Build and dependency stages use the official Node image and pinned pnpm.
+FROM ${NODE_IMAGE} AS toolchain
 WORKDIR /app
 
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends ca-certificates libgomp1 \
-  && rm -rf /var/lib/apt/lists/*
-
-# Enable pnpm via corepack
 RUN corepack enable && corepack prepare pnpm@10.18.2 --activate
 
 # Stage 1 — build
-FROM base AS build
+FROM toolchain AS build
 
 # Install dependencies (layer cache: only re-run when lockfile changes)
 COPY package.json pnpm-lock.yaml ./
@@ -32,24 +28,40 @@ RUN pnpm build
 ENV HARNESS_HF_CACHE_DIR=/app/.cache/hf
 RUN node scripts/preload-hf-model.mjs /app/.cache/hf
 
-# Stage 2 — production
-FROM base AS production
+# Stage 2 — production dependencies
+FROM toolchain AS production-dependencies
+
+COPY package.json pnpm-lock.yaml ./
+COPY scripts/ensure-secure-adm-zip.mjs scripts/adm-zip-security-lib.mjs scripts/
+RUN pnpm install --frozen-lockfile --prod
+
+# Stage 3 — production runtime
+# ONNX Runtime's Node binding needs glibc and libgomp. Start from Debian and
+# copy only the Node executable so npm, npx, Corepack, pnpm, and Yarn never
+# enter the production image.
+FROM ${RUNTIME_IMAGE} AS production
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates libgomp1 libstdc++6 \
+  && rm -rf /var/lib/apt/lists/* \
+  && groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node \
+  && chown node:node /app
+
+COPY --from=toolchain /usr/local/bin/node /usr/local/bin/node
 
 ENV NODE_ENV=production \
     HOST=0.0.0.0 \
     PORT=3000 \
     HARNESS_HF_CACHE_DIR=/app/.cache/hf
 
-# Install production dependencies only
-COPY package.json pnpm-lock.yaml ./
-COPY scripts/ensure-secure-adm-zip.mjs scripts/adm-zip-security-lib.mjs scripts/
-RUN pnpm install --frozen-lockfile --prod
-
-# Copy compiled output and pre-downloaded model cache from build stage
+# Copy only runtime application artifacts into the package-manager-free image.
+COPY --chown=node:node package.json ./
+COPY --from=production-dependencies --chown=node:node /app/node_modules node_modules/
 COPY --from=build --chown=node:node /app/build build/
 COPY --from=build --chown=node:node /app/.cache/hf /app/.cache/hf
 
-# The official Node image provides a fixed non-root node user (uid/gid 1000).
 USER node
 
 EXPOSE 3000

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,10 @@
 # Lessons Learned
 
+## GitHub Action Tags Must Match the Published Ref Exactly
+- **Issue**: The Trivy release page labels the latest release `v0.36.0`, but the workflow initially referenced `0.36.0`; GitHub Actions failed during job setup because that ref does not exist.
+- **Fix**: Use the exact published action ref, including its `v` prefix, and verify the repository tag before pushing.
+- **Rule**: Treat marketplace display versions and Git refs as different inputs; resolve the exact action tag or commit SHA before adding a third-party action.
+
 ## HTTP Transport Tests Need Localhost Socket Access
 - **Issue**: Running the full suite in the restricted sandbox made HTTP transport tests fail with `listen EPERM: operation not permitted 127.0.0.1`, while all non-socket tests passed.
 - **Fix**: Rerun the same suite with localhost socket access before treating route, auth, host-validation, or rate-limit failures as product regressions.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,17 +2,26 @@
 
 ## Container runtime vulnerability hardening (2026-09-04)
 
-- [ ] Keep pnpm/Corepack and dependency installation out of the production image.
-- [ ] Assemble a minimal glibc runtime that preserves Node, CA certificates, `libgomp1`, production dependencies, and the preloaded model.
-- [ ] Add a CI vulnerability gate for fixable critical and high findings.
-- [ ] Run repository checks plus Linux container build, startup, auth, and vulnerability verification.
-- [ ] Commit, push, open the follow-up PR, and verify its live checks and review state.
+- [x] Keep pnpm/Corepack and dependency installation out of the production image.
+- [x] Assemble a minimal glibc runtime that preserves Node, CA certificates, `libgomp1`, production dependencies, and the preloaded model.
+- [x] Add a CI vulnerability gate for fixable critical and high findings.
+- [x] Run repository checks plus Linux container build, startup, auth, and vulnerability verification.
+- [x] Commit, push, open the follow-up PR, and verify its live checks and review state.
 
 ### Plan
 
 - Preserve the merged PR #907 HTTP behavior, non-root execution, deterministic dependency install, and ONNX native-runtime requirements.
 - Separate build tooling from runtime contents instead of treating every scanner finding as application reachability.
 - Keep the image unpublished in CI; the customer tag will be published only after the hardened image passes the new gate.
+
+### Review
+
+- Opened PR #910 because GitHub had already assigned #908 to an automated regression-test draft.
+- The production stage now starts from Debian 12, copies only the Node executable and runtime artifacts, and contains none of npm, npx, Corepack, pnpm, Yarn, or Yarnpkg.
+- The pinned Trivy v0.36.0 action runs Trivy v0.70.0 and reports zero fixable critical/high OS or library findings for the built image.
+- Linux container verification passed: fresh base pull, package-manager exclusion, HTTP startup, local-search model initialization, healthy `/health`, and unauthenticated `/mcp` rejection with `401`.
+- Repository verification passed: production audit (0 known findings across 174 audited dependencies), build, typecheck, standards (77 tests), docs check, full suite (144 files / 3,264 tests), workflow YAML parse, and diff check.
+- The initial action ref omitted the published `v` prefix and failed during runner setup; the corrected workflow pins the verified release commit SHA and the final CI run is green. Human review remains required by branch policy.
 
 ## Docker image build/runtime alignment (2026-09-04)
 - [x] Copy required postinstall security scripts before dependency installation in both stages

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,19 @@
 # Harness MCP Server — Task Tracking
 
+## Container runtime vulnerability hardening (2026-09-04)
+
+- [ ] Keep pnpm/Corepack and dependency installation out of the production image.
+- [ ] Assemble a minimal glibc runtime that preserves Node, CA certificates, `libgomp1`, production dependencies, and the preloaded model.
+- [ ] Add a CI vulnerability gate for fixable critical and high findings.
+- [ ] Run repository checks plus Linux container build, startup, auth, and vulnerability verification.
+- [ ] Commit, push, open the follow-up PR, and verify its live checks and review state.
+
+### Plan
+
+- Preserve the merged PR #907 HTTP behavior, non-root execution, deterministic dependency install, and ONNX native-runtime requirements.
+- Separate build tooling from runtime contents instead of treating every scanner finding as application reachability.
+- Keep the image unpublished in CI; the customer tag will be published only after the hardened image passes the new gate.
+
 ## Docker image build/runtime alignment (2026-09-04)
 - [x] Copy required postinstall security scripts before dependency installation in both stages
 - [x] Use a glibc-based Node image for the native ONNX search dependency


### PR DESCRIPTION
## Summary
- assemble the production image from Debian and copy only the Node executable, production dependencies, compiled server, and preloaded model
- keep npm, npx, Corepack, pnpm, and Yarn confined to build-only stages
- pull fresh base images and block fixable critical/high OS or library vulnerabilities with Trivy
- assert package managers are absent before the existing HTTP health and authentication smoke test

## Why
Docker Scout reported critical and high findings in the customer-requested image, including vulnerabilities from package-manager tooling that the running MCP server does not need. The smaller runtime preserves glibc, CA certificates, and libgomp for ONNX while reducing unnecessary production attack surface.

## Validation
- pnpm audit --prod (0 known vulnerabilities across 174 audited dependencies)
- pnpm build
- pnpm typecheck
- pnpm standards:check (77 tests)
- pnpm docs:check
- pnpm test (144 files / 3,264 tests)
- CI workflow YAML parse
- git diff --check

The Linux image build, package-manager exclusion check, Trivy gate, and HTTP/auth smoke test run in CI. This workflow does not publish the image.