### PR TITLE
fix: point FME feature flag deep link at the flag detail route

### DIFF
--- a/src/registry/toolsets/feature-flags.ts
+++ b/src/registry/toolsets/feature-flags.ts
@@ -413,7 +413,7 @@ export const featureFlagsToolset: ToolsetDefinition = {
       scopeOptional: true,
       identifierFields: ["workspace_id", "feature_flag_name"],
       product: "fme",
-      deepLinkTemplate: "/ng/account/{accountId}/module/fme/orgs/{orgIdentifier}/projects/{projectIdentifier}/setup/resources/targets/{trafficTypeId}/splits/{id}",
+      deepLinkTemplate: "/ng/account/{accountId}/module/fme/orgs/{org}/projects/{project}/feature-flags/{id}",
       listFilterFields: [
         { name: "workspace_id", description: "FME workspace ID (get from harness_list resource_type=fme_workspace). Deprecated — omit and pass org_id+project_id instead for Harness-native scoping." },
         { name: "offset", description: "Pagination offset for FME feature flags", type: "number" },

--- a/tests/registry/feature-flags.test.ts
+++ b/tests/registry/feature-flags.test.ts
@@ -1842,3 +1842,72 @@ describe("fme_segment_definition", () => {
     expect(resource.executeActions).toBeUndefined();
   });
 });
+
+describe("fme_feature_flag deep link", () => {
+  // A v4 FeatureFlag response: `id` is the flag UUID the UI's :splitId param expects.
+  const flagPayload = {
+    type: "FEATURE_FLAG",
+    id: "0ab78cc0-5e72-11f1-a78d-62a1a48ed05e",
+    name: "my_flag",
+    trafficType: { id: "64bf1ba0-6e15-11f0-9751-56ca2eed5650", type: "TRAFFIC_TYPE", name: "user" },
+  };
+
+  const expectedLink =
+    "https://app.harness.io/ng/account/test-account/module/fme/orgs/anotherorg/projects/projectA" +
+    "/feature-flags/0ab78cc0-5e72-11f1-a78d-62a1a48ed05e";
+
+  it("get: builds the flag detail URL from the flag UUID and the request scope", async () => {
+    const registry = new Registry(makeConfig());
+    const client = makeClient(vi.fn().mockResolvedValue({ ...flagPayload }));
+
+    const result = (await registry.dispatch(client, "fme_feature_flag", "get", {
+      org_id: "anotherorg",
+      project_id: "projectA",
+      feature_flag_name: "my_flag",
+    })) as Record<string, unknown>;
+
+    expect(result.openInHarness).toBe(expectedLink);
+  });
+
+  it("get: never emits the old settings-bound route or unresolved placeholders", async () => {
+    const registry = new Registry(makeConfig());
+    const client = makeClient(vi.fn().mockResolvedValue({ ...flagPayload }));
+
+    const result = (await registry.dispatch(client, "fme_feature_flag", "get", {
+      org_id: "anotherorg",
+      project_id: "projectA",
+      feature_flag_name: "my_flag",
+    })) as Record<string, unknown>;
+
+    const link = result.openInHarness as string;
+    expect(link).not.toContain("setup/resources");
+    expect(link).not.toContain("/splits/");
+    expect(link).not.toMatch(/\{\w+\}/);
+    // Scope must survive: FME sends snake_case scope params, so {orgIdentifier} never resolved.
+    expect(link).not.toContain("/orgs//");
+    expect(link).toContain("/orgs/anotherorg/projects/projectA/");
+  });
+
+  it("list: builds a per-item flag detail URL from each item's UUID", async () => {
+    const registry = new Registry(makeConfig());
+    const client = makeClient(
+      vi.fn().mockResolvedValue({
+        data: [
+          { ...flagPayload },
+          { ...flagPayload, id: "aaaaaaaa-5e72-11f1-a78d-62a1a48ed05e", name: "other_flag" },
+        ],
+      }),
+    );
+
+    const result = (await registry.dispatch(client, "fme_feature_flag", "list", {
+      org_id: "anotherorg",
+      project_id: "projectA",
+    })) as { data: Record<string, unknown>[] };
+
+    expect(result.data[0]!.openInHarness).toBe(expectedLink);
+    expect(result.data[1]!.openInHarness).toBe(
+      "https://app.harness.io/ng/account/test-account/module/fme/orgs/anotherorg/projects/projectA" +
+        "/feature-flags/aaaaaaaa-5e72-11f1-a78d-62a1a48ed05e",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- The `fme_feature_flag` deep link pointed at `/setup/resources/targets/{trafficTypeId}/splits/{id}`, a route the FME UI doesn't have. Customers clicking an agent-generated flag link landed on FME settings instead of the flag (reported three times, easily reproduced).
- The template also used `{orgIdentifier}`/`{projectIdentifier}`, which never resolve for FME because its Harness-native scope params are snake_case (`organization_identifier`/`project_identifier`). Both collapsed to empty and were stripped by the empty-segment cleanup in `buildDeepLink`, so the link wasn't even scoped to the right project.
- New template: `/ng/account/{accountId}/module/fme/orgs/{org}/projects/{project}/feature-flags/{id}`.
  - `{org}`/`{project}` are the placeholders that actually get populated for FME.
  - `{id}` is the flag UUID, which is what the UI's `:splitId` route param expects (confirmed against `v4/FeatureFlag.java` and the legacy `SplitMetadataExternal`).
  - No `/env/:envId` or tab segment needed — the detail page redirects to the stored-or-first environment and default tab.
  - `/module` is deliberate: the new nav rewrites `/module` → `/all`, the old nav serves it directly, so one template covers both.

## Test plan
- [x] 3 new tests in `tests/registry/feature-flags.test.ts`: `get` builds the correct URL, `list` builds correct per-item URLs, and a guard asserting the output never contains `setup/resources`, `/splits/`, an unresolved `{placeholder}`, or `/orgs//`
- [x] Negative control — reverting the template makes all 3 fail
- [x] Verified locally against the real built server (see Verification)

## Verification
`pnpm test` (3232 passing), `pnpm standards:check` (77 passing), `pnpm typecheck` and `pnpm docs:check` clean.