### PR TITLE
Bump version to 3.2.24

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "harness-mcp-server",
   "display_name": "Harness",
-  "version": "3.2.23",
+  "version": "3.2.24",
   "description": "Connect AI agents to Harness for CI/CD, code repositories, pull requests, services, environments, and feature flags.",
   "long_description": "The Harness MCP Server gives MCP-compatible clients access to Harness platform workflows through consolidated tools, resources, and prompts. It supports local stdio usage and can be bundled as a Node-based MCPB extension.",
   "author": {

--- a/mcp-directory/manifest.json
+++ b/mcp-directory/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "harness-mcp-server",
   "display_name": "Harness",
-  "version": "3.2.23",
+  "version": "3.2.24",
   "description": "Connect AI agents to Harness for CI/CD, code repositories, pull requests, services, environments, and feature flags.",
   "long_description": "The Harness MCP Server gives MCP-compatible clients access to Harness platform workflows through consolidated tools, resources, and prompts. It supports local stdio usage and can be bundled as a Node-based MCPB extension.",
   "author": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "harness-mcp-v2",
-  "version": "3.2.23",
+  "version": "3.2.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "harness-mcp-v2",
-      "version": "3.2.23",
+      "version": "3.2.24",
       "dependencies": {
         "@hono/node-server": "^2.0.10",
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-mcp-v2",
-  "version": "3.2.23",
+  "version": "3.2.24",
   "description": "Give AI agents full access to the Harness.io platform — manage pipelines, deployments, cloud costs, chaos engineering, feature flags, SEI, and 125+ resource types through 11 MCP tools",
   "type": "module",
   "main": "build/index.js",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,24 @@
 # Harness MCP Server — Task Tracking
 
+## Version bump 3.2.24 (2026-09-04)
+
+- [x] Update package, shrinkwrap, and MCP manifest versions to 3.2.24.
+- [x] Update release metadata and bundle filename expectations.
+- [x] Run release checks, typecheck, build, docs, standards, audit, and the full suite.
+- [ ] Commit, push, open a PR against current main, and verify its live checks.
+
+### Plan
+
+- Keep the change metadata-only and avoid dependency or generated-schema churn.
+- Synchronize both shrinkwrap root version fields with the package and bundle manifests.
+- Stage only the release metadata files and this task record.
+
+### Review
+
+- Updated `package.json`, both `npm-shrinkwrap.json` root version fields, `manifest.json`, and `mcp-directory/manifest.json` from 3.2.23 to 3.2.24.
+- Updated release metadata, MCPB asset naming, and legacy-manifest normalization expectations for 3.2.24.
+- Local verification passed: install/postinstall, seven release tests, shrinkwrap check, typecheck, build, sequential docs check, standards (77 tests), production audit (0 findings), full suite (144 files / 3,267 tests), and diff check.
+
 ## Container runtime vulnerability hardening (2026-09-04)
 
 - [x] Keep pnpm/Corepack and dependency installation out of the production image.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -5,7 +5,7 @@
 - [x] Update package, shrinkwrap, and MCP manifest versions to 3.2.24.
 - [x] Update release metadata and bundle filename expectations.
 - [x] Run release checks, typecheck, build, docs, standards, audit, and the full suite.
-- [ ] Commit, push, open a PR against current main, and verify its live checks.
+- [x] Commit, push, open a PR against current main, and verify its live checks.
 
 ### Plan
 
@@ -18,6 +18,7 @@
 - Updated `package.json`, both `npm-shrinkwrap.json` root version fields, `manifest.json`, and `mcp-directory/manifest.json` from 3.2.23 to 3.2.24.
 - Updated release metadata, MCPB asset naming, and legacy-manifest normalization expectations for 3.2.24.
 - Local verification passed: install/postinstall, seven release tests, shrinkwrap check, typecheck, build, sequential docs check, standards (77 tests), production audit (0 findings), full suite (144 files / 3,267 tests), and diff check.
+- Branch `chore/version-3.2.24` was pushed and PR #915 opened against current main; all repository, container, Trivy, and automation checks passed, with an approving review and no inline comments.
 
 ## Container runtime vulnerability hardening (2026-09-04)
 

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -32,7 +32,7 @@ describe("release metadata", () => {
     const rootManifest = readJson("manifest.json");
     const directoryManifest = readJson("mcp-directory/manifest.json");
 
-    expect(packageJson.version).toBe("3.2.23");
+    expect(packageJson.version).toBe("3.2.24");
     expect(rootManifest.version).toBe(packageJson.version);
     expect(directoryManifest.version).toBe(packageJson.version);
   });
@@ -52,9 +52,9 @@ describe("release metadata", () => {
     legacyManifest.server.entry_point = "build/index.js";
     legacyManifest.server.mcp_config.args[0] = "${__dirname}/build/index.js";
 
-    expect(assetNameForVersion("3.2.23")).toBe("harness-mcp-server-3.2.23.mcpb");
+    expect(assetNameForVersion("3.2.24")).toBe("harness-mcp-server-3.2.24.mcpb");
     expect(MCPB_CLI_PACKAGE).toBe("@anthropic-ai/mcpb@2.1.2");
-    expect(normalizeBundleManifest(legacyManifest, "3.2.23").server).toMatchObject({
+    expect(normalizeBundleManifest(legacyManifest, "3.2.24").server).toMatchObject({
       entry_point: "server/index.js",
       mcp_config: { args: ["${__dirname}/server/index.js", "stdio"] },
     });


### PR DESCRIPTION
## Summary
- bump the npm package version from 3.2.23 to 3.2.24
- synchronize both npm shrinkwrap root fields and the root/MCP directory manifests
- update release metadata and MCPB asset-name expectations

## Scope
Metadata-only patch release bump. No dependency, generated-schema, tool-contract, or runtime changes.

## Validation
- pnpm install --frozen-lockfile
- pnpm vitest run tests/release-metadata.test.ts (7 tests)
- pnpm npm-shrinkwrap:check
- pnpm typecheck
- pnpm build
- pnpm docs:check
- pnpm standards:check (77 tests)
- pnpm audit --prod (0 findings across 174 audited dependencies)
- pnpm test (144 files / 3,267 tests)
- git diff --check