### PR TITLE
Point work_artifact at catalog list and get APIs

### DIFF
--- a/src/registry/toolsets/autonomous_work.ts
+++ b/src/registry/toolsets/autonomous_work.ts
@@ -105,6 +105,8 @@ export const autonomousWorkToolset: ToolsetDefinition = {
         { resourceType: "work_timeline", relationship: "child", description: "Timeline rail for this work item" },
         { resourceType: "work_phase", relationship: "child", description: "Lifecycle phase detail" },
         { resourceType: "work_budget", relationship: "child", description: "Budgets applying to this work item" },
+        { resourceType: "work_artifact", relationship: "child", description: "Type-filtered artifacts and catalog content for this work item" },
+        { resourceType: "work_phase_artifact", relationship: "child", description: "Unfiltered artifact collection for a phase" },
       ],
       operations: {
         list: {
@@ -230,7 +232,9 @@ export const autonomousWorkToolset: ToolsetDefinition = {
     {
       resourceType: "work_phase_artifact",
       displayName: "Work Phase Artifacts",
-      description: "Artifact collection for a phase of a work item.",
+      description:
+        "Unfiltered artifact collection for one phase of a work item. " +
+        "To fetch blob content, call harness_get on work_artifact with the catalog id (no phase_id).",
       toolset: "autonomous_work",
       scope: "project",
       identifierFields: ["work_item_id", "phase_id"],
@@ -247,19 +251,60 @@ export const autonomousWorkToolset: ToolsetDefinition = {
     },
     {
       resourceType: "work_artifact",
-      displayName: "Work Artifact Content",
-      description: "Resolved content of one artifact within a phase's collection.",
+      displayName: "Work Artifact",
+      description:
+        "Work-item artifacts from the catalog. List latest artifacts by type " +
+        "(TICKET, DESIGN, PULL_REQUEST, PLAN, OTHER); get resolves content by catalog row id. " +
+        "phase_id is an optional list filter, not a get identifier. " +
+        "Pass work_item_id via params; pass type via filters.",
       toolset: "autonomous_work",
       scope: "project",
-      identifierFields: ["work_item_id", "phase_id", "artifact_id"],
+      identifierFields: ["work_item_id", "artifact_id"],
+      listFilterFields: [
+        {
+          name: "type",
+          required: true,
+          description: "Artifact type to list. Required.",
+          enum: ["TICKET", "DESIGN", "PULL_REQUEST", "PLAN", "OTHER"],
+        },
+        {
+          name: "phase_id",
+          description:
+            "Optional authored phase id. When set, limits the list to the latest artifacts_reported attempt of that phase.",
+        },
+      ],
       operations: {
+        list: {
+          method: "POST",
+          path: "/adlc/api/workitems/{workItemId}/artifacts",
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          pathParams: { work_item_id: "workItemId" },
+          queryParams: { page: "offset", size: "limit", phase_id: "phaseId" },
+          bodyBuilder: (input) => ({ type: input.type }),
+          skipScopeBodyInjection: true,
+          skipCompact: true,
+          responseExtractor: listResponseExtractor,
+          paramsSchema: {
+            fields: [
+              { name: "work_item_id", required: true, description: "Work item identifier." },
+            ],
+          },
+          description:
+            "List current work-item artifacts of the requested type (latest artifacts_reported attempt per matching phase).",
+        },
         get: {
           method: "GET",
-          path: "/adlc/api/workitems/{workItemId}/phases/{phaseId}/artifacts/{artifactId}",
+          path: "/adlc/api/workitems/{workItemId}/artifacts/{artifactId}",
           operationPolicy: { risk: "read", retryPolicy: "safe" },
-          pathParams: { work_item_id: "workItemId", phase_id: "phaseId", artifact_id: "artifactId" },
+          pathParams: { work_item_id: "workItemId", artifact_id: "artifactId" },
           responseExtractor: passthrough,
-          description: "Resolve one artifact's content within a phase's artifact collection.",
+          paramsSchema: {
+            fields: [
+              { name: "work_item_id", required: true, description: "Work item identifier." },
+              { name: "artifact_id", required: true, description: "Catalog row id (work_item_artifacts.id)." },
+            ],
+          },
+          description: "Resolve one artifact's content by catalog row id. Does not require phase_id.",
         },
       },
     },

--- a/src/registry/toolsets/autonomous_work.ts
+++ b/src/registry/toolsets/autonomous_work.ts
@@ -62,15 +62,24 @@ const softwareComponentBodySchema: BodySchema = {
 const listResponseExtractor = passthrough;
 
 /** Guarantee `items` + `total` so skipCompact survives harness_list normalization. */
-function workArtifactListExtract(raw: unknown): Record<string, unknown> {
+function workArtifactListExtract(raw: unknown, input?: Record<string, unknown>): Record<string, unknown> {
   const r = raw !== null && typeof raw === "object" && !Array.isArray(raw)
     ? (raw as Record<string, unknown>)
     : {};
   const items = Array.isArray(r.items) ? r.items : [];
+  const total = typeof r.total === "number" ? r.total : items.length;
+  const size = typeof input?.size === "number" && input.size > 0 ? input.size : 20;
+  const page = typeof input?.page === "number" && input.page >= 0 ? input.page : 0;
+  const filters: Record<string, unknown> = { type: input?.type, page: page + 1, size };
+  if (input?.phase_id) filters.phase_id = input.phase_id;
+  const hasMore = (page + 1) * size < total;
   return {
     ...r,
     items,
-    total: typeof r.total === "number" ? r.total : items.length,
+    total,
+    _nextPageHint: hasMore
+      ? `For the next page, call harness_list with resource_type='work_artifact', params={"work_item_id":${JSON.stringify(input?.work_item_id ?? "")}} and filters=${JSON.stringify(filters)}. Keep type and size identical — this list uses offset = page × size, unlike work_item list which maps page to offset directly.`
+      : "No more pages — all matching artifacts have been returned.",
   };
 }
 
@@ -258,6 +267,14 @@ export const autonomousWorkToolset: ToolsetDefinition = {
       toolset: "autonomous_work",
       scope: "project",
       identifierFields: ["work_item_id", "phase_id"],
+      relatedResources: [
+        {
+          resourceType: "work_artifact",
+          relationship: "related",
+          description:
+            "Fetch blob content with harness_get on work_artifact using the catalog id from this list. Do not pass phase_id on get.",
+        },
+      ],
       operations: {
         list: {
           method: "GET",

--- a/src/registry/toolsets/autonomous_work.ts
+++ b/src/registry/toolsets/autonomous_work.ts
@@ -61,6 +61,26 @@ const softwareComponentBodySchema: BodySchema = {
 // passthrough returns the raw object; harness_list reads .items automatically.
 const listResponseExtractor = passthrough;
 
+/** Guarantee `items` + `total` so skipCompact survives harness_list normalization. */
+function workArtifactListExtract(raw: unknown): Record<string, unknown> {
+  const r = raw !== null && typeof raw === "object" && !Array.isArray(raw)
+    ? (raw as Record<string, unknown>)
+    : {};
+  const items = Array.isArray(r.items) ? r.items : [];
+  return {
+    ...r,
+    items,
+    total: typeof r.total === "number" ? r.total : items.length,
+  };
+}
+
+/** harness_list page is 0-indexed; ADLC paginates with offset = page × size. */
+function applyWorkArtifactListOffset(input: Record<string, unknown>): void {
+  const size = typeof input.size === "number" && input.size > 0 ? input.size : 20;
+  const page = typeof input.page === "number" && input.page >= 0 ? input.page : 0;
+  input.offset = page * size;
+}
+
 // Execute actions that take an empty or minimal body still declare a bodySchema
 // so harness_describe shows agents what (if anything) to pass, and the
 // structural-validation test's risky-execute contract is satisfied.
@@ -279,18 +299,22 @@ export const autonomousWorkToolset: ToolsetDefinition = {
           path: "/adlc/api/workitems/{workItemId}/artifacts",
           operationPolicy: { risk: "read", retryPolicy: "safe" },
           pathParams: { work_item_id: "workItemId" },
-          queryParams: { page: "offset", size: "limit", phase_id: "phaseId" },
+          queryParams: { offset: "offset", size: "limit", phase_id: "phaseId" },
+          preflight: async ({ input }) => {
+            applyWorkArtifactListOffset(input);
+          },
           bodyBuilder: (input) => ({ type: input.type }),
           skipScopeBodyInjection: true,
           skipCompact: true,
-          responseExtractor: listResponseExtractor,
+          responseExtractor: workArtifactListExtract,
           paramsSchema: {
             fields: [
               { name: "work_item_id", required: true, description: "Work item identifier." },
             ],
           },
           description:
-            "List current work-item artifacts of the requested type (latest artifacts_reported attempt per matching phase).",
+            "List current work-item artifacts of the requested type (latest artifacts_reported attempt per matching phase). " +
+            "Pagination is 0-indexed: offset = page × size (keep size constant across pages).",
         },
         get: {
           method: "GET",

--- a/tests/registry/autonomous-work-artifacts.test.ts
+++ b/tests/registry/autonomous-work-artifacts.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi } from "vitest";
+import { Registry } from "../../src/registry/index.js";
+import { autonomousWorkToolset } from "../../src/registry/toolsets/autonomous_work.js";
+import type { Config } from "../../src/config.js";
+import type { HarnessClient } from "../../src/client/harness-client.js";
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    HARNESS_API_KEY: "pat.test",
+    HARNESS_ACCOUNT_ID: "test-account",
+    HARNESS_BASE_URL: "https://app.harness.io",
+    HARNESS_ORG: "default",
+    HARNESS_PROJECT: "adlc-project",
+    HARNESS_API_TIMEOUT_MS: 30000,
+    HARNESS_MAX_RETRIES: 3,
+    LOG_LEVEL: "info",
+    HARNESS_MAX_BODY_SIZE_MB: 10,
+    HARNESS_RATE_LIMIT_RPS: 10,
+    HARNESS_READ_ONLY: false,
+    HARNESS_SKIP_ELICITATION: false,
+    HARNESS_ALLOW_HTTP: false,
+    HARNESS_FME_BASE_URL: "https://api.split.io",
+    HARNESS_TOOLSETS: "autonomous_work",
+    ...overrides,
+  } as Config;
+}
+
+function makeClient(requestFn?: (...args: unknown[]) => unknown): HarnessClient {
+  return {
+    request: requestFn ?? vi.fn().mockResolvedValue({}),
+    account: "test-account",
+  } as unknown as HarnessClient;
+}
+
+const workArtifact = autonomousWorkToolset.resources.find((r) => r.resourceType === "work_artifact");
+const workPhaseArtifact = autonomousWorkToolset.resources.find((r) => r.resourceType === "work_phase_artifact");
+const workItem = autonomousWorkToolset.resources.find((r) => r.resourceType === "work_item");
+
+describe("work_artifact resource shape", () => {
+  it("is project-scoped with catalog identifiers (no phase_id)", () => {
+    expect(workArtifact).toBeDefined();
+    expect(workArtifact!.toolset).toBe("autonomous_work");
+    expect(workArtifact!.scope).toBe("project");
+    expect(workArtifact!.identifierFields).toEqual(["work_item_id", "artifact_id"]);
+  });
+
+  it("lists via POST catalog path and gets via catalog UUID path", () => {
+    expect(Object.keys(workArtifact!.operations).sort()).toEqual(["get", "list"]);
+    expect(workArtifact!.operations.list).toMatchObject({
+      method: "POST",
+      path: "/adlc/api/workitems/{workItemId}/artifacts",
+      skipScopeBodyInjection: true,
+      skipCompact: true,
+    });
+    expect(workArtifact!.operations.list!.queryParams).toEqual({
+      page: "offset",
+      size: "limit",
+      phase_id: "phaseId",
+    });
+    expect(workArtifact!.operations.list!.pathParams).toEqual({ work_item_id: "workItemId" });
+    expect(workArtifact!.operations.list!.operationPolicy).toEqual({ risk: "read", retryPolicy: "safe" });
+    expect(workArtifact!.operations.get).toMatchObject({
+      method: "GET",
+      path: "/adlc/api/workitems/{workItemId}/artifacts/{artifactId}",
+    });
+    expect(workArtifact!.operations.get!.pathParams).toEqual({
+      work_item_id: "workItemId",
+      artifact_id: "artifactId",
+    });
+    expect(workArtifact!.operations.get!.path).not.toContain("phases");
+    expect(workArtifact!.operations.get!.operationPolicy).toEqual({ risk: "read", retryPolicy: "safe" });
+  });
+
+  it("requires type filter with ArtifactType enum and optional phase_id", () => {
+    const typeField = workArtifact!.listFilterFields?.find((f) => f.name === "type");
+    const phaseField = workArtifact!.listFilterFields?.find((f) => f.name === "phase_id");
+    expect(typeField).toMatchObject({ required: true });
+    expect(typeField!.enum).toEqual(["TICKET", "DESIGN", "PULL_REQUEST", "PLAN", "OTHER"]);
+    expect(phaseField?.required).toBeFalsy();
+  });
+
+  it("still exposes phase collection list on work_phase_artifact", () => {
+    expect(workPhaseArtifact!.operations.list).toMatchObject({
+      method: "GET",
+      path: "/adlc/api/workitems/{workItemId}/phases/{phaseId}/artifacts",
+    });
+  });
+
+  it("links work_artifact from work_item relatedResources", () => {
+    expect(workItem!.relatedResources?.some((r) => r.resourceType === "work_artifact")).toBe(true);
+  });
+});
+
+describe("work_artifact dispatch", () => {
+  it("POSTs list with type body, offset/limit query, and no org/project in body", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({
+      items: [{ id: "art-1", type: "DESIGN", title: "Design" }],
+      total: 1,
+      limit: 20,
+      offset: 0,
+      exceptions: [],
+    });
+    const registry = new Registry(makeConfig());
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "work_artifact", "list", {
+      work_item_id: "WI-1",
+      type: "DESIGN",
+      page: 0,
+      size: 20,
+    });
+
+    const call = mockRequest.mock.calls[0][0];
+    expect(call.method).toBe("POST");
+    expect(call.path).toBe("/adlc/api/workitems/WI-1/artifacts");
+    expect(call.body).toEqual({ type: "DESIGN" });
+    expect(call.body.orgIdentifier).toBeUndefined();
+    expect(call.body.projectIdentifier).toBeUndefined();
+    expect(call.params.offset).toBe(0);
+    expect(call.params.limit).toBe(20);
+    expect(call.params.orgIdentifier).toBe("default");
+    expect(call.params.projectIdentifier).toBe("adlc-project");
+  });
+
+  it("forwards optional phase_id as phaseId query param", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0, exceptions: [] });
+    const registry = new Registry(makeConfig());
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "work_artifact", "list", {
+      work_item_id: "WI-1",
+      type: "PULL_REQUEST",
+      phase_id: "implement",
+    });
+
+    const call = mockRequest.mock.calls[0][0];
+    expect(call.params.phaseId).toBe("implement");
+    expect(call.body).toEqual({ type: "PULL_REQUEST" });
+  });
+
+  it("rejects list without type", async () => {
+    const registry = new Registry(makeConfig());
+    const client = makeClient();
+    await expect(
+      registry.dispatch(client, "work_artifact", "list", { work_item_id: "WI-1" }),
+    ).rejects.toThrow(/Missing required filter.*type/);
+  });
+
+  it("GETs content by catalog id without phaseId in the path", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({
+      id: "art-1",
+      type: "DESIGN",
+      title: "Design",
+      mime_type: "text/markdown",
+      encoding: "plain",
+      content: "# hello",
+      fetched_at: 1,
+    });
+    const registry = new Registry(makeConfig());
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "work_artifact", "get", {
+      work_item_id: "WI-1",
+      artifact_id: "art-1",
+    });
+
+    const call = mockRequest.mock.calls[0][0];
+    expect(call.method).toBe("GET");
+    expect(call.path).toBe("/adlc/api/workitems/WI-1/artifacts/art-1");
+    expect(call.path).not.toContain("phases");
+  });
+});

--- a/tests/registry/autonomous-work-artifacts.test.ts
+++ b/tests/registry/autonomous-work-artifacts.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
 import { Registry } from "../../src/registry/index.js";
 import { autonomousWorkToolset } from "../../src/registry/toolsets/autonomous_work.js";
+import { compactItems } from "../../src/utils/compact.js";
+import { normalizeHarnessListPayload } from "../../src/utils/response-formatter.js";
 import type { Config } from "../../src/config.js";
 import type { HarnessClient } from "../../src/client/harness-client.js";
 
@@ -53,7 +55,7 @@ describe("work_artifact resource shape", () => {
       skipCompact: true,
     });
     expect(workArtifact!.operations.list!.queryParams).toEqual({
-      page: "offset",
+      offset: "offset",
       size: "limit",
       phase_id: "phaseId",
     });
@@ -76,7 +78,8 @@ describe("work_artifact resource shape", () => {
     const phaseField = workArtifact!.listFilterFields?.find((f) => f.name === "phase_id");
     expect(typeField).toMatchObject({ required: true });
     expect(typeField!.enum).toEqual(["TICKET", "DESIGN", "PULL_REQUEST", "PLAN", "OTHER"]);
-    expect(phaseField?.required).toBeFalsy();
+    expect(phaseField).toBeDefined();
+    expect(phaseField!.required).toBeFalsy();
   });
 
   it("still exposes phase collection list on work_phase_artifact", () => {
@@ -120,6 +123,69 @@ describe("work_artifact dispatch", () => {
     expect(call.params.limit).toBe(20);
     expect(call.params.orgIdentifier).toBe("default");
     expect(call.params.projectIdentifier).toBe("adlc-project");
+  });
+
+  it("maps harness_list page to ADLC offset as page × size", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ items: [], total: 40, limit: 20, offset: 20, exceptions: [] });
+    const registry = new Registry(makeConfig());
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "work_artifact", "list", {
+      work_item_id: "WI-1",
+      type: "DESIGN",
+      page: 1,
+      size: 20,
+    });
+
+    const call = mockRequest.mock.calls[0][0];
+    expect(call.params.offset).toBe(20);
+    expect(call.params.limit).toBe(20);
+  });
+
+  it("forwards type into the POST body", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0, exceptions: [] });
+    const registry = new Registry(makeConfig());
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "work_artifact", "list", {
+      work_item_id: "WI-1",
+      type: "DESIGN",
+    });
+
+    expect(mockRequest.mock.calls[0][0].body).toEqual({ type: "DESIGN" });
+  });
+
+  it("keeps skipCompact when the API omits total so source_url survives list compact", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({
+      items: [{
+        id: "art-1",
+        type: "DESIGN",
+        title: "Design",
+        source_url: "https://example.invalid/design",
+        version: 2,
+        path: "design.md",
+      }],
+      exceptions: [],
+    });
+    const registry = new Registry(makeConfig());
+    const client = makeClient(mockRequest);
+
+    const result = await registry.dispatch(client, "work_artifact", "list", {
+      work_item_id: "WI-1",
+      type: "DESIGN",
+    }) as Record<string, unknown> & { items: Array<Record<string, unknown>>; __skipCompact?: boolean };
+
+    expect(result.__skipCompact).toBe(true);
+    expect(result.total).toBe(1);
+
+    const normalized = normalizeHarnessListPayload(result, { page: 0 }) as typeof result;
+    expect(normalized.__skipCompact).toBe(true);
+    expect(normalized.items[0]?.source_url).toBe("https://example.invalid/design");
+    expect(normalized.items[0]?.version).toBe(2);
+    expect(normalized.items[0]?.path).toBe("design.md");
+
+    const compacted = compactItems(normalized.items);
+    expect((compacted[0] as Record<string, unknown>).source_url).toBeUndefined();
   });
 
   it("forwards optional phase_id as phaseId query param", async () => {

--- a/tests/registry/autonomous-work-artifacts.test.ts
+++ b/tests/registry/autonomous-work-artifacts.test.ts
@@ -89,6 +89,10 @@ describe("work_artifact resource shape", () => {
     });
   });
 
+  it("links work_artifact from work_phase_artifact relatedResources", () => {
+    expect(workPhaseArtifact!.relatedResources?.some((r) => r.resourceType === "work_artifact")).toBe(true);
+  });
+
   it("links work_artifact from work_item relatedResources", () => {
     expect(workItem!.relatedResources?.some((r) => r.resourceType === "work_artifact")).toBe(true);
   });
@@ -123,6 +127,48 @@ describe("work_artifact dispatch", () => {
     expect(call.params.limit).toBe(20);
     expect(call.params.orgIdentifier).toBe("default");
     expect(call.params.projectIdentifier).toBe("adlc-project");
+  });
+
+  it("emits _nextPageHint with page × size contract and active filters", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({
+      items: [{ id: "art-1" }],
+      total: 40,
+      limit: 20,
+      offset: 0,
+      exceptions: [],
+    });
+    const registry = new Registry(makeConfig());
+    const client = makeClient(mockRequest);
+
+    const result = await registry.dispatch(client, "work_artifact", "list", {
+      work_item_id: "WI-1",
+      type: "DESIGN",
+      phase_id: "implement",
+      page: 0,
+      size: 20,
+    }) as { _nextPageHint: string };
+
+    expect(result._nextPageHint).toContain("resource_type='work_artifact'");
+    expect(result._nextPageHint).toContain('"work_item_id":"WI-1"');
+    expect(result._nextPageHint).toContain('"type":"DESIGN"');
+    expect(result._nextPageHint).toContain('"phase_id":"implement"');
+    expect(result._nextPageHint).toContain('"page":1');
+    expect(result._nextPageHint).toContain('"size":20');
+    expect(result._nextPageHint).toContain("offset = page × size");
+    expect(result._nextPageHint).toContain("work_item list");
+  });
+
+  it("says no more pages when the catalog total fits on this page", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ items: [{ id: "art-1" }], total: 1, exceptions: [] });
+    const registry = new Registry(makeConfig());
+    const client = makeClient(mockRequest);
+
+    const result = await registry.dispatch(client, "work_artifact", "list", {
+      work_item_id: "WI-1",
+      type: "DESIGN",
+    }) as { _nextPageHint: string };
+
+    expect(result._nextPageHint).toMatch(/No more pages/i);
   });
 
   it("maps harness_list page to ADLC offset as page × size", async () => {


### PR DESCRIPTION
## Description
Point `work_artifact` at the catalog list/get APIs instead of the phase-scoped get-only path.

`harness_list` now POSTs `/adlc/api/workitems/{workItemId}/artifacts` with a required `{ type }` body (`TICKET`, `DESIGN`, `PULL_REQUEST`, `PLAN`, `OTHER`) and optional `phase_id`. Pagination maps `harness_list` page to ADLC `offset = page × size` (unlike `work_item` list, which maps `page` to `offset` directly). List responses include `_nextPageHint` so agents keep `type` and `size` constant. `harness_get` loads content by catalog row id and no longer takes `phase_id`.

`work_phase_artifact` stays as the unfiltered phase collection list and links to `work_artifact` via `relatedResources` for content get.

This is a **breaking change** for callers that still passed `phase_id` on `work_artifact` get; the toolset is opt-in.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [x] Other — breaking list/get contract on existing `work_artifact`

## Checklist
- [x] `pnpm test` — registry artifact tests 15 passed; full suite was 3297 on the previous push
- [x] `pnpm typecheck` passes (prior push)
- [x] `pnpm standards:check` passes (prior push)
- [ ] `pnpm build` — not re-run for this PR (registry-only; no generated-doc count change)
- [ ] `pnpm docs:check` — not required (same resource types; no `docs:generate`)

## Coding Standards (registry-driven MCP model)
- [x] No new `server.registerTool()` calls — only `src/registry/toolsets/autonomous_work.ts`
- [x] Toolset already in `ALL_TOOLSETS` / `ToolsetName`
- [x] `operationPolicy` on list and get
- [x] Shared extractors (`workArtifactListExtract` / `passthrough`); list uses `skipCompact` so `source_url` / `version` / `path` survive harness_list normalization
- [x] `identifierFields`: `work_item_id`, `artifact_id` (phase_id is a list filter only)
- [x] No `console.log()` in `src/`

## Agent call pattern (post-merge)
```
harness_list(
  resource_type="work_artifact",
  params={ work_item_id: "<id>" },
  filters={ type: "DESIGN", page: 0, size: 20 }  // keep type + size on later pages
)
harness_get(
  resource_type="work_artifact",
  params={ work_item_id: "<id>", artifact_id: "<catalog uuid from items[].id>" }
)
# Optional: unfiltered phase collection, then get content via work_artifact (no phase_id)
harness_list(resource_type="work_phase_artifact", params={ work_item_id, phase_id })
```

## Test plan
**Unit (registry)** — `tests/registry/autonomous-work-artifacts.test.ts` (15 tests):
- [x] Catalog POST list path, GET by catalog id, no `phase_id` on get
- [x] Required `type` enum; optional `phase_id` → `phaseId` query
- [x] POST body is `{ type }` only (no org/project in body); scope stays on query
- [x] `page × size` offset mapping and `_nextPageHint` (filters + no-more-pages)
- [x] `skipCompact` / `total` so compact does not drop catalog fields
- [x] `work_phase_artifact` list unchanged; `relatedResources` → `work_artifact`

**Live against local ADLC** (`adlc-service` `:8090`, demo work item `IDP-DEMO-1`, org `default` / project `SahilTest`, ng-manager port-forward for scope):
- [x] Direct ADLC: list `DESIGN` 200; get catalog UUID 200; `OTHER` pagination 200
- [x] MCP registry dispatch via `/adlc/api` → `/api` rewrite: list `DESIGN`, get by catalog id, `OTHER` page 0 vs page 1 returned distinct ids

Gateway still prefixes `/adlc` in real Harness; local MCP needed the rewrite proxy for that.