### PR TITLE
feat: [AIPLAT-1436]: include `all` in account scope links

### DIFF
--- a/src/utils/deep-links.ts
+++ b/src/utils/deep-links.ts
@@ -12,14 +12,13 @@ export function buildDeepLink(
   for (const [key, value] of Object.entries(params)) {
     url = url.replace(`{${key}}`, encodeURIComponent(value));
   }
-  // Strip empty scope segments (e.g. "orgs//projects//" when listing at account level,
-  // or "projects//" when listing at org level). The Harness UI uses shorter URL patterns
-  // for higher scopes: /ng/account/{id}/settings/... (account) vs
-  // /ng/account/{id}/all/orgs/{org}/settings/... (org).
+  // Strip empty scope segments (e.g. "orgs//projects//" at account level,
+  // or "projects//" at org level). Keep the `/all` module segment — NG routes
+  // are `/ng/account/{id}/all/settings/...` (account),
+  // `/ng/account/{id}/all/orgs/{org}/settings/...` (org), and
+  // `/ng/account/{id}/all/orgs/{org}/projects/{project}/settings/...` (project).
   url = url.replace(/\/orgs\/\/projects\/\//, "/");
   url = url.replace(/\/projects\/\//, "/");
-  // Also strip the /all prefix when it immediately precedes /settings (account scope)
-  url = url.replace(/\/all\/settings\//, "/settings/");
   // Ensure base URL doesn't double-slash
   const base = baseUrl.replace(/\/$/, "");
   return `${base}${url}`;

--- a/tests/utils/deep-links.test.ts
+++ b/tests/utils/deep-links.test.ts
@@ -43,6 +43,42 @@ describe("buildDeepLink", () => {
     const url = buildDeepLink(baseUrl, accountId, "/ng/account/{accountId}/home", {});
     expect(url).toBe("https://app.harness.io/ng/account/abc123/home");
   });
+
+  const connectorTemplate =
+    "/ng/account/{accountId}/all/orgs/{orgIdentifier}/projects/{projectIdentifier}/settings/connectors/{connectorIdentifier}";
+
+  it("keeps /all at account scope after stripping empty org/project segments", () => {
+    const url = buildDeepLink(baseUrl, accountId, connectorTemplate, {
+      orgIdentifier: "",
+      projectIdentifier: "",
+      connectorIdentifier: "github_random_7x4k",
+    });
+    expect(url).toBe(
+      "https://app.harness.io/ng/account/abc123/all/settings/connectors/github_random_7x4k",
+    );
+  });
+
+  it("keeps /all at org scope after stripping empty project segment", () => {
+    const url = buildDeepLink(baseUrl, accountId, connectorTemplate, {
+      orgIdentifier: "default",
+      projectIdentifier: "",
+      connectorIdentifier: "github_random_7x4k",
+    });
+    expect(url).toBe(
+      "https://app.harness.io/ng/account/abc123/all/orgs/default/settings/connectors/github_random_7x4k",
+    );
+  });
+
+  it("keeps /all at project scope", () => {
+    const url = buildDeepLink(baseUrl, accountId, connectorTemplate, {
+      orgIdentifier: "default",
+      projectIdentifier: "GitX_Test",
+      connectorIdentifier: "github_random_7x4k",
+    });
+    expect(url).toBe(
+      "https://app.harness.io/ng/account/abc123/all/orgs/default/projects/GitX_Test/settings/connectors/github_random_7x4k",
+    );
+  });
 });
 
 describe("appendAgentTypeQuery", () => {


### PR DESCRIPTION
## Description
<!-- What does this PR do? -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [ ] `pnpm build` passes
- [ ] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [ ] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
If this PR adds or changes Harness API coverage:
- [ ] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [ ] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [ ] `operationPolicy` on every new/changed endpoint
- [ ] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [ ] `identifierFields` and `scope` declared on new resources
- [ ] No `console.log()` in `src/` (stdio JSON-RPC safety)
