### PR TITLE
Add HarnessID OAuth mode with per-user token forwarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,14 +14,15 @@ HARNESS_API_KEY=pat.xxxxx.xxxxx.xxxxx
 # multi-user mode when sessions provide or embed their own account ID.
 HARNESS_ACCOUNT_ID=your-account-id
 
-# Optional — defaults shown
+# Optional — defaults to https://app.harness.io, or https://mcp.harness.io/cli
+# when HARNESS_MCP_MODE=oauth.
 HARNESS_BASE_URL=https://app.harness.io
-# HarnessID OAuth resource-server settings. Required only in oauth mode.
-# Issuer must exactly match the access token iss claim. QA HarnessID realm:
-# https://id.harness-test.com/idp/realms/HarnessIDP
-HARNESS_MCP_OAUTH_ISSUER=
-# Public, canonical MCP URL, e.g. https://mcp.harness-test.com/mcp.
-HARNESS_MCP_OAUTH_RESOURCE=https://mcp.example.com/mcp
+# HarnessID OAuth resource-server settings. Production defaults are shown;
+# override them for QA, local development, or another Harness environment.
+# Issuer must exactly match the access token iss claim.
+HARNESS_MCP_OAUTH_ISSUER=https://id.harness.io/idp/realms/HarnessIDP
+# Public, canonical MCP URL published through RFC 9728 metadata.
+HARNESS_MCP_OAUTH_RESOURCE=https://mcp.harness.io/mcp
 # Optional; defaults to ${HARNESS_MCP_OAUTH_ISSUER}/protocol/openid-connect/certs.
 HARNESS_MCP_OAUTH_JWKS_URI=
 # HarnessID client the tokens must be issued to, matched against the azp claim.

--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,14 @@
-# Deployment mode: single-user (default) or multi-user.
+# Deployment mode: single-user (default), multi-user, or oauth.
 # single-user — HARNESS_API_KEY required, used for all sessions.
 # multi-user  — HTTP only; sessions provide credentials via x-harness-api-key
 #               and, when not embedded in the key, x-harness-account-id headers.
 #               HARNESS_API_KEY must NOT be set.
+# oauth       — HTTP only; clients log in through HarnessID OAuth 2.1 and the
+#               session's own access token is forwarded to Harness APIs as
+#               Authorization: Bearer. HARNESS_API_KEY must NOT be set.
 HARNESS_MCP_MODE=single-user
 
-# Required in single-user mode. Must NOT be set in multi-user mode.
+# Required in single-user mode. Must NOT be set in multi-user or oauth mode.
 HARNESS_API_KEY=pat.xxxxx.xxxxx.xxxxx
 # Required in single-user mode unless auto-extracted from PAT/SAT. Optional in
 # multi-user mode when sessions provide or embed their own account ID.
@@ -13,6 +16,21 @@ HARNESS_ACCOUNT_ID=your-account-id
 
 # Optional — defaults shown
 HARNESS_BASE_URL=https://app.harness.io
+# HarnessID OAuth resource-server settings. Required only in oauth mode.
+# Issuer must exactly match the access token iss claim. QA HarnessID realm:
+# https://id.harness-test.com/idp/realms/HarnessIDP
+HARNESS_MCP_OAUTH_ISSUER=
+# Public, canonical MCP URL, e.g. https://mcp.harness-test.com/mcp.
+HARNESS_MCP_OAUTH_RESOURCE=https://mcp.example.com/mcp
+# Optional; defaults to ${HARNESS_MCP_OAUTH_ISSUER}/protocol/openid-connect/certs.
+HARNESS_MCP_OAUTH_JWKS_URI=
+# HarnessID client the tokens must be issued to, matched against the azp claim.
+HARNESS_MCP_OAUTH_CLIENT_ID=mcp-client
+# Token claim holding the Harness account ID. The HarnessID organization scope
+# populates it.
+HARNESS_MCP_OAUTH_ACCOUNT_CLAIM=account_id
+# Space-separated scopes advertised in protected-resource metadata.
+HARNESS_MCP_OAUTH_SCOPES=openid profile email organization
 # Optional FME/Split Admin credential. This can be a legacy Split admin key or
 # an FME-entitled Harness PAT/SAT. FME calls go directly to api.split.io, so
 # hosted OAuth/service-routing credentials for Harness platform APIs do not
@@ -40,6 +58,7 @@ PORT=3000
 # between prompts) are not evicted mid-conversation.
 MCP_SESSION_TTL_MS=1800000
 # Require Authorization: Bearer <token> on /mcp routes when set.
+# Must be unset in oauth mode, where the Bearer value is a HarnessID access token.
 HARNESS_MCP_AUTH_TOKEN=
 # Non-loopback HTTP binds require HARNESS_MCP_AUTH_TOKEN unless this is true.
 HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP=false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ pnpm build && pnpm docs:generate   # always pair them
 
 Single-user mode: `HARNESS_API_KEY` required, used for every session.
 Multi-user mode (`HARNESS_MCP_MODE=multi-user`): `HARNESS_API_KEY` must NOT be set; sessions supply credentials via `x-harness-api-key` header.
+OAuth mode (`HARNESS_MCP_MODE=oauth`): `HARNESS_API_KEY` must NOT be set; HTTP clients authenticate with HarnessID access tokens, and each session's token is forwarded to the Harness API as `Authorization: Bearer`.
 
 PAT/SAT tokens embed the account ID (`pat.<accountId>.<tokenId>.<secret>`), so `HARNESS_ACCOUNT_ID` is only needed when the key lacks an embedded segment.
 
@@ -116,7 +117,7 @@ See `.env.example` for the full list. Non-obvious ones:
 
 | Var | Purpose |
 |-----|---------|
-| `HARNESS_MCP_MODE` | `single-user` (default) or `multi-user` |
+| `HARNESS_MCP_MODE` | `single-user` (default), `multi-user`, or HTTP-only `oauth` |
 | `HARNESS_TOOLSETS` | Comma-separated toolset names to restrict exposed tools |
 | `HARNESS_READ_ONLY` | Block all write operations (`true`/`false`) |
 | `HARNESS_AUTO_APPROVE_RISK` | Auto-approve operations at or below this risk level (`none` \| `read` \| `low_write` \| `medium_write` \| `high_write` \| `destructive` \| `all`; default `none`) |

--- a/README.md
+++ b/README.md
@@ -154,8 +154,9 @@ HARNESS_MCP_OAUTH_RESOURCE=https://mcp.harness-test.com/mcp
 HARNESS_MCP_OAUTH_CLIENT_ID=mcp-client
 HARNESS_MCP_OAUTH_SCOPES="openid profile email organization"
 
-# Harness API host the server calls on behalf of the logged-in user.
-HARNESS_BASE_URL=https://qa.harness.io
+# Harness API base the server calls on behalf of the logged-in user. On the QA
+# MCP host, the platform APIs sit behind the /cli prefix.
+HARNESS_BASE_URL=https://mcp.harness-test.com/cli
 ```
 
 `HARNESS_API_KEY` must not be set in this mode. `HARNESS_MCP_OAUTH_JWKS_URI` defaults to `<issuer>/protocol/openid-connect/certs`, and `HARNESS_ACCOUNT_ID` is unnecessary because the account comes from the token.

--- a/README.md
+++ b/README.md
@@ -145,19 +145,13 @@ Operational constraints in HTTP mode:
 
 #### HarnessID OAuth Mode
 
-Set `HARNESS_MCP_MODE=oauth` to let remote MCP clients discover HarnessID and complete OAuth 2.1 Authorization Code with PKCE. OAuth mode is available only with HTTP transport.
+Set `HARNESS_MCP_MODE=oauth` to let remote MCP clients discover HarnessID and complete OAuth 2.1 Authorization Code with PKCE. OAuth mode is available only with HTTP transport. Production HarnessID, MCP resource, and API routing defaults are built in:
 
 ```bash
 HARNESS_MCP_MODE=oauth
-HARNESS_MCP_OAUTH_ISSUER=https://id.harness-test.com/idp/realms/HarnessIDP
-HARNESS_MCP_OAUTH_RESOURCE=https://mcp.harness-test.com/mcp
-HARNESS_MCP_OAUTH_CLIENT_ID=mcp-client
-HARNESS_MCP_OAUTH_SCOPES="openid profile email organization"
-
-# Harness API base the server calls on behalf of the logged-in user. On the QA
-# MCP host, the platform APIs sit behind the /cli prefix.
-HARNESS_BASE_URL=https://mcp.harness-test.com/cli
 ```
+
+This defaults to the issuer `https://id.harness.io/idp/realms/HarnessIDP`, resource `https://mcp.harness.io/mcp`, OAuth client `mcp-client`, and Harness API base `https://mcp.harness.io/cli`. Override them only for QA, local development, or another Harness environment.
 
 `HARNESS_API_KEY` must not be set in this mode. `HARNESS_MCP_OAUTH_JWKS_URI` defaults to `<issuer>/protocol/openid-connect/certs`, and `HARNESS_ACCOUNT_ID` is unnecessary because the account comes from the token.
 
@@ -165,10 +159,10 @@ The server publishes RFC 9728 protected-resource metadata and returns this chall
 
 ```http
 HTTP/1.1 401 Unauthorized
-WWW-Authenticate: Bearer resource_metadata="https://mcp.harness-test.com/.well-known/oauth-protected-resource/mcp"
+WWW-Authenticate: Bearer resource_metadata="https://mcp.harness.io/.well-known/oauth-protected-resource/mcp"
 ```
 
-It validates the HarnessID access token's RS256 signature, `iss`, expiry, and `sub` using the configured JWKS endpoint, and checks that the token was issued to `HARNESS_MCP_OAUTH_CLIENT_ID` (the `azp` claim) for the resource in `HARNESS_MCP_OAUTH_RESOURCE`.
+It validates the HarnessID access token's RS256 signature, `iss`, expiry, and `sub` using the configured JWKS endpoint, and checks that the token was issued to `HARNESS_MCP_OAUTH_CLIENT_ID` through the `azp` claim. `HARNESS_MCP_OAUTH_RESOURCE` is the RFC 9728 protected-resource identifier used for discovery and challenges. Current HarnessID access tokens use `aud: account` rather than the MCP URL, so the resource is not compared with `aud`.
 
 The account ID comes from the token's `HARNESS_MCP_OAUTH_ACCOUNT_CLAIM` claim (`account_id` by default), which the HarnessID `organization` scope populates. Each session stores the caller's access token and forwards it to the Harness API as `Authorization: Bearer`, so Harness RBAC and audit records reflect the logged-in user rather than a shared PAT. The session is bound to the `sub` and account it was created with: a later request may carry a refreshed token, but one for a different user or account is rejected.
 
@@ -177,14 +171,14 @@ Clients normally need only the MCP resource URL:
 ```json
 {
   "mcpServers": {
-    "harness-qa": {
-      "url": "https://mcp.harness-test.com/mcp"
+    "harness": {
+      "url": "https://mcp.harness.io/mcp"
     }
   }
 }
 ```
 
-The client reads the protected-resource metadata, discovers `HARNESS_MCP_OAUTH_ISSUER`, and then uses that authorization server's RFC 8414 metadata. If the client does not support dynamic client registration, pre-register its client ID and redirect URI in QA Keycloak.
+The client reads the protected-resource metadata, discovers `HARNESS_MCP_OAUTH_ISSUER`, and then uses that authorization server's RFC 8414 metadata. If the client does not support dynamic client registration, use the pre-registered `mcp-client` client ID.
 
 See [HarnessID OAuth for a self-hosted MCP server](docs/harnessid-oauth.md) for the QA Keycloak checklist and validation commands.
 
@@ -586,14 +580,14 @@ The server automatically loads environment variables from a `.env` file in the p
 | `HARNESS_MCP_MODE`          | No       | `single-user`               | Deployment mode: `single-user` (shared API key), `multi-user` (HTTP with per-session API keys), or `oauth` (HTTP with HarnessID access-token validation)                                                                                              |
 | `HARNESS_API_KEY`           | Yes*     | --                          | Harness personal access token or service account token. Required in `single-user` mode. Must NOT be set in `multi-user` or `oauth` mode, where each session brings its own credential                                                                 |
 | `HARNESS_ACCOUNT_ID`        | No       | *(from PAT/SAT)*            | Harness account identifier. Auto-extracted from PAT/SAT tokens in single-user mode; multi-user sessions can provide their own via `x-harness-account-id` when the API key does not embed one                                                          |
-| `HARNESS_BASE_URL`          | No       | `https://app.harness.io`    | Harness API/UI base URL for local stdio or self-hosted HTTP deployments. Set this to environments such as `https://harness0.harness.io` when running the server yourself. It does not affect the managed `https://mcp.harness.io/mcp` hosted endpoint |
-| `HARNESS_MCP_OAUTH_ISSUER`  | OAuth    | --                          | HarnessID issuer. Required in `oauth` mode and matched exactly against the access token `iss` claim                                                                                                                                                  |
-| `HARNESS_MCP_OAUTH_RESOURCE` | OAuth   | --                          | Public canonical MCP URL, such as `https://mcp.harness-test.com/mcp`. Required in `oauth` mode and published as the RFC 9728 resource identifier                                                                                                     |
+| `HARNESS_BASE_URL`          | No       | `https://app.harness.io` (`https://mcp.harness.io/cli` in OAuth mode) | Harness API/UI base URL. OAuth mode routes through the hosted MCP `/cli` proxy by default; other modes use the Harness SaaS API directly |
+| `HARNESS_MCP_OAUTH_ISSUER`  | No       | `https://id.harness.io/idp/realms/HarnessIDP` | HarnessID issuer matched exactly against the access token `iss` claim                                                                                                                                                  |
+| `HARNESS_MCP_OAUTH_RESOURCE` | No      | `https://mcp.harness.io/mcp` | Public canonical MCP URL published as the RFC 9728 resource identifier                                                                                                     |
 | `HARNESS_MCP_OAUTH_JWKS_URI` | No      | `<issuer>/protocol/openid-connect/certs` | HarnessID JWKS endpoint used to validate RS256 access-token signatures                                                                                                                                                  |
 | `HARNESS_MCP_OAUTH_CLIENT_ID` | No     | `mcp-client`                | HarnessID client the access token must be issued to, checked against the token's `azp` claim                                                                                                                                                        |
 | `HARNESS_MCP_OAUTH_ACCOUNT_CLAIM` | No | `account_id`                | Access-token claim carrying the Harness account ID, populated by the HarnessID `organization` scope                                                                                                                                                 |
 | `HARNESS_MCP_OAUTH_SCOPES`  | No       | `openid profile email organization` | Space-separated scopes advertised in RFC 9728 protected-resource metadata                                                                                                                                                    |
-| `HARNESS_FME_API_KEY`       | No       | --                          | Optional single-user/self-hosted FME/Split Admin credential used for `fme_` resources in **legacy (`workspace_id`) mode only**. This can be a legacy Split admin key or an FME-entitled Harness PAT/SAT. FME calls go directly to `api.split.io`, so hosted OAuth/service-routing credentials for Harness platform APIs do not authenticate these requests. Must not be set in `multi-user` mode; FME must use each session's `x-harness-api-key` credential. If unset, FME falls back to a non-placeholder `HARNESS_API_KEY` for self-hosted sessions. Harness-native (`org_id`+`project_id`) mode ignores this and uses the standard `HARNESS_API_KEY`/`HARNESS_BASE_URL` instead |
+| `HARNESS_FME_API_KEY`       | No       | --                          | Optional single-user/self-hosted FME/Split Admin credential used for `fme_` resources in **legacy (`workspace_id`) mode only**. Legacy FME is unavailable in OAuth mode so HarnessID tokens are never sent to `api.split.io`; use Harness-native `org_id`+`project_id` scope instead. Must not be set in `multi-user` or `oauth` mode |
 | `HARNESS_FME_BASE_URL`      | No       | `https://api.split.io`      | Split/FME Admin API base URL used by `fme_` resources in **legacy (`workspace_id`) mode only**. HTTP URLs require `HARNESS_ALLOW_HTTP=true` for local development. Harness-native (`org_id`+`project_id`) mode ignores this and uses the standard `HARNESS_API_KEY`/`HARNESS_BASE_URL` instead |
 | `HARNESS_ORG`               | No       | --                          | Organization ID. Used when `org_id` is not specified per tool call. If omitted, `org_id` must be provided explicitly. Agents can also discover orgs dynamically via `harness_list(resource_type="organization")`                                      |
 | `HARNESS_PROJECT`           | No       | --                          | Project ID. Used when `project_id` is not specified per tool call. Agents can also discover projects dynamically via `harness_list(resource_type="project")`                                                                                          |

--- a/README.md
+++ b/README.md
@@ -123,14 +123,17 @@ When running in HTTP mode, the server exposes:
 | `/mcp`    | `DELETE`  | Terminate an active MCP session                                  |
 | `/mcp`    | `OPTIONS` | CORS preflight                                                   |
 | `/health` | `GET`     | Health check — returns `{ "status": "ok", "sessions": <count> }` |
+| `/.well-known/oauth-protected-resource` | `GET` | RFC 9728 metadata when `HARNESS_MCP_MODE=oauth` |
+| `/.well-known/oauth-protected-resource/mcp` | `GET` | Path-aware RFC 9728 metadata for the default `/mcp` resource |
 
 
 The HTTP transport runs in **session-based mode**. A new MCP session is created on `initialize`, the server returns an `mcp-session-id` header, and subsequent requests for that session must include the same header.
 
 Operational constraints in HTTP mode:
 
-- Set `HARNESS_MCP_AUTH_TOKEN` for any shared or remotely reachable deployment. When set, every `POST`, `GET`, and `DELETE` request to `/mcp` must include `Authorization: Bearer <token>`.
-- Non-loopback binds require `HARNESS_MCP_AUTH_TOKEN` by default. To run unauthenticated on a non-loopback interface anyway, set `HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP=true` explicitly.
+- Set `HARNESS_MCP_AUTH_TOKEN` for shared or remotely reachable single-user and multi-user deployments. When set, every `POST`, `GET`, and `DELETE` request to `/mcp` must include `Authorization: Bearer <token>`.
+- OAuth mode accepts HarnessID access tokens instead of `HARNESS_MCP_AUTH_TOKEN` and can bind to a non-loopback address without the unauthenticated opt-out.
+- Non-loopback single-user and multi-user binds require `HARNESS_MCP_AUTH_TOKEN` by default. To run unauthenticated on a non-loopback interface anyway, set `HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP=true` explicitly.
 - `POST /mcp` without `mcp-session-id` must be an `initialize` request.
 - `POST /mcp`, `GET /mcp`, and `DELETE /mcp` for existing sessions require the `mcp-session-id` header.
 - `GET /mcp` is used for SSE notifications (progress updates and elicitation prompts).
@@ -139,6 +142,50 @@ Operational constraints in HTTP mode:
 - Request body size is capped by `HARNESS_MAX_BODY_SIZE_MB` (default `10` MB).
 - Set `x-harness-pipeline-version: 0` or `1` on the `initialize` request to select V0 or V1 pipeline resources for that HTTP session.
 - Set `x-harness-auto-approve-risk: none|low_write|medium_write|high_write|all` on the `initialize` request to choose a stricter per-session auto-approval threshold. The server caps this value at the deployment-level `HARNESS_AUTO_APPROVE_RISK`, so a session can reduce but not expand the configured approval ceiling.
+
+#### HarnessID OAuth Mode
+
+Set `HARNESS_MCP_MODE=oauth` to let remote MCP clients discover HarnessID and complete OAuth 2.1 Authorization Code with PKCE. OAuth mode is available only with HTTP transport.
+
+```bash
+HARNESS_MCP_MODE=oauth
+HARNESS_MCP_OAUTH_ISSUER=https://id.harness-test.com/idp/realms/HarnessIDP
+HARNESS_MCP_OAUTH_RESOURCE=https://mcp.harness-test.com/mcp
+HARNESS_MCP_OAUTH_CLIENT_ID=mcp-client
+HARNESS_MCP_OAUTH_SCOPES="openid profile email organization"
+
+# Harness API host the server calls on behalf of the logged-in user.
+HARNESS_BASE_URL=https://qa.harness.io
+```
+
+`HARNESS_API_KEY` must not be set in this mode. `HARNESS_MCP_OAUTH_JWKS_URI` defaults to `<issuer>/protocol/openid-connect/certs`, and `HARNESS_ACCOUNT_ID` is unnecessary because the account comes from the token.
+
+The server publishes RFC 9728 protected-resource metadata and returns this challenge when a client has not authenticated:
+
+```http
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer resource_metadata="https://mcp.harness-test.com/.well-known/oauth-protected-resource/mcp"
+```
+
+It validates the HarnessID access token's RS256 signature, `iss`, expiry, and `sub` using the configured JWKS endpoint, and checks that the token was issued to `HARNESS_MCP_OAUTH_CLIENT_ID` (the `azp` claim) for the resource in `HARNESS_MCP_OAUTH_RESOURCE`.
+
+The account ID comes from the token's `HARNESS_MCP_OAUTH_ACCOUNT_CLAIM` claim (`account_id` by default), which the HarnessID `organization` scope populates. Each session stores the caller's access token and forwards it to the Harness API as `Authorization: Bearer`, so Harness RBAC and audit records reflect the logged-in user rather than a shared PAT. The session is bound to the `sub` and account it was created with: a later request may carry a refreshed token, but one for a different user or account is rejected.
+
+Clients normally need only the MCP resource URL:
+
+```json
+{
+  "mcpServers": {
+    "harness-qa": {
+      "url": "https://mcp.harness-test.com/mcp"
+    }
+  }
+}
+```
+
+The client reads the protected-resource metadata, discovers `HARNESS_MCP_OAUTH_ISSUER`, and then uses that authorization server's RFC 8414 metadata. If the client does not support dynamic client registration, pre-register its client ID and redirect URI in QA Keycloak.
+
+See [HarnessID OAuth for a self-hosted MCP server](docs/harnessid-oauth.md) for the QA Keycloak checklist and validation commands.
 
 #### Multi-User Mode
 
@@ -535,10 +582,16 @@ The server automatically loads environment variables from a `.env` file in the p
 
 | Variable                    | Required | Default                     | Description                                                                                                                                                                                                                                           |
 | --------------------------- | -------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `HARNESS_MCP_MODE`          | No       | `single-user`               | Deployment mode: `single-user` (API key in config, used for all sessions) or `multi-user` (HTTP only, per-session credentials via `x-harness-api-key` and optional `x-harness-account-id` headers)                                                   |
-| `HARNESS_API_KEY`           | Yes*     | --                          | Harness personal access token or service account token. Required in `single-user` mode. Must NOT be set in `multi-user` mode                                                                                                                          |
+| `HARNESS_MCP_MODE`          | No       | `single-user`               | Deployment mode: `single-user` (shared API key), `multi-user` (HTTP with per-session API keys), or `oauth` (HTTP with HarnessID access-token validation)                                                                                              |
+| `HARNESS_API_KEY`           | Yes*     | --                          | Harness personal access token or service account token. Required in `single-user` mode. Must NOT be set in `multi-user` or `oauth` mode, where each session brings its own credential                                                                 |
 | `HARNESS_ACCOUNT_ID`        | No       | *(from PAT/SAT)*            | Harness account identifier. Auto-extracted from PAT/SAT tokens in single-user mode; multi-user sessions can provide their own via `x-harness-account-id` when the API key does not embed one                                                          |
 | `HARNESS_BASE_URL`          | No       | `https://app.harness.io`    | Harness API/UI base URL for local stdio or self-hosted HTTP deployments. Set this to environments such as `https://harness0.harness.io` when running the server yourself. It does not affect the managed `https://mcp.harness.io/mcp` hosted endpoint |
+| `HARNESS_MCP_OAUTH_ISSUER`  | OAuth    | --                          | HarnessID issuer. Required in `oauth` mode and matched exactly against the access token `iss` claim                                                                                                                                                  |
+| `HARNESS_MCP_OAUTH_RESOURCE` | OAuth   | --                          | Public canonical MCP URL, such as `https://mcp.harness-test.com/mcp`. Required in `oauth` mode and published as the RFC 9728 resource identifier                                                                                                     |
+| `HARNESS_MCP_OAUTH_JWKS_URI` | No      | `<issuer>/protocol/openid-connect/certs` | HarnessID JWKS endpoint used to validate RS256 access-token signatures                                                                                                                                                  |
+| `HARNESS_MCP_OAUTH_CLIENT_ID` | No     | `mcp-client`                | HarnessID client the access token must be issued to, checked against the token's `azp` claim                                                                                                                                                        |
+| `HARNESS_MCP_OAUTH_ACCOUNT_CLAIM` | No | `account_id`                | Access-token claim carrying the Harness account ID, populated by the HarnessID `organization` scope                                                                                                                                                 |
+| `HARNESS_MCP_OAUTH_SCOPES`  | No       | `openid profile email organization` | Space-separated scopes advertised in RFC 9728 protected-resource metadata                                                                                                                                                    |
 | `HARNESS_FME_API_KEY`       | No       | --                          | Optional single-user/self-hosted FME/Split Admin credential used for `fme_` resources in **legacy (`workspace_id`) mode only**. This can be a legacy Split admin key or an FME-entitled Harness PAT/SAT. FME calls go directly to `api.split.io`, so hosted OAuth/service-routing credentials for Harness platform APIs do not authenticate these requests. Must not be set in `multi-user` mode; FME must use each session's `x-harness-api-key` credential. If unset, FME falls back to a non-placeholder `HARNESS_API_KEY` for self-hosted sessions. Harness-native (`org_id`+`project_id`) mode ignores this and uses the standard `HARNESS_API_KEY`/`HARNESS_BASE_URL` instead |
 | `HARNESS_FME_BASE_URL`      | No       | `https://api.split.io`      | Split/FME Admin API base URL used by `fme_` resources in **legacy (`workspace_id`) mode only**. HTTP URLs require `HARNESS_ALLOW_HTTP=true` for local development. Harness-native (`org_id`+`project_id`) mode ignores this and uses the standard `HARNESS_API_KEY`/`HARNESS_BASE_URL` instead |
 | `HARNESS_ORG`               | No       | --                          | Organization ID. Used when `org_id` is not specified per tool call. If omitted, `org_id` must be provided explicitly. Agents can also discover orgs dynamically via `harness_list(resource_type="organization")`                                      |
@@ -555,7 +608,7 @@ The server automatically loads environment variables from a `.env` file in the p
 | `HARNESS_ALLOW_HTTP`        | No       | `false`                     | Allow non-HTTPS `HARNESS_BASE_URL`. By default, the server enforces HTTPS for security. Set to `true` only for local development against a non-TLS Harness instance                                                                                   |
 | `HARNESS_PIPELINE_VERSION`  | No       | `0`                         | **(Alpha)** Pipeline YAML version. `0` loads the `pipeline` resource type and excludes `pipeline_v1`; `1` loads `pipeline_v1` and excludes `pipeline`. HTTP sessions can override this at initialize time with `x-harness-pipeline-version: 0` or `1` |
 | `HARNESS_MCP_ALLOWED_HOSTS` | No       | --                          | Comma-separated hostnames allowed by HTTP transport Host-header validation. `mcp.harness.io` is allowed by default for localhost binds; add proxy/custom domains here                                                                                 |
-| `HARNESS_MCP_AUTH_TOKEN`    | No       | --                          | Bearer token required on `/mcp` HTTP routes when set. Required by default when HTTP transport binds to a non-loopback host                                                                                                                             |
+| `HARNESS_MCP_AUTH_TOKEN`    | No       | --                          | Static Bearer token required on `/mcp` HTTP routes when set. Required by default for non-loopback single-user and multi-user binds. Must be unset in `oauth` mode                                                                                    |
 | `HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP` | No | `false`         | Explicitly allow unauthenticated HTTP transport on non-loopback binds. Use only behind another authenticated control                                                                                                                                    |
 | `HARNESS_MCP_TRUST_PROXY`   | No       | `0`                         | Number of reverse proxy / load balancer hops to trust for client IP resolution (Express `trust proxy`). Set to the proxy count in front of the server so per-IP rate limiting keys on the real client rather than the proxy socket peer                |
 | `HARNESS_MCP_LOG_FILE`      | No       | `~/.claude/harness-mcp.log` | File used for stdio disconnect/crash diagnostics when stderr may no longer be available                                                                                                                                                               |

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -150,6 +150,7 @@ All Zod schemas in tool handlers must:
 |------|--------|
 | `src/client/harness-client.ts` | Core HTTP transport |
 | `src/utils/log-resolver.ts` | Pre-signed CDN/S3 blob URLs must not receive API auth headers (would invalidate signatures) |
+| `src/utils/oauth-auth.ts` | Fetches HarnessID JWKS from the configured identity-provider host without attaching Harness API credentials |
 | `src/audit/sinks/webhook.ts` | Best-effort POST to a user-configured external audit webhook URL |
 | `src/search/remote-provider.ts` | Calls an external semantic-search service (not the Harness API) |
 

--- a/docs/harnessid-oauth.md
+++ b/docs/harnessid-oauth.md
@@ -1,0 +1,151 @@
+# HarnessID OAuth for a self-hosted MCP server
+
+This mode makes the HTTP MCP endpoint an OAuth 2.1 protected resource. MCP clients
+discover HarnessID through RFC 9728, complete Authorization Code with PKCE, and send
+the resulting access token as `Authorization: Bearer <token>`.
+
+## Authorization boundary
+
+HarnessID authenticates the user who connects to MCP, and the MCP server validates
+that user's access token before accepting any MCP request. The server then forwards
+the same access token to the Harness Platform API for every call made in that
+session, so Harness RBAC and audit records reflect the logged-in user. No
+deployment-level `HARNESS_API_KEY` is involved — it must not be set in this mode.
+
+The account ID is read from the access-token claim named by
+`HARNESS_MCP_OAUTH_ACCOUNT_CLAIM` (`account_id` by default), which the HarnessID
+`organization` scope populates. A session is bound to the `sub` and account of the
+token that created it. Later requests may carry a refreshed token for the same user,
+but a token for a different user or account is rejected.
+
+## QA HarnessID setup
+
+QA HarnessID realm: `https://id.harness-test.com/idp/realms/HarnessIDP`
+
+Configure a public OpenID Connect client in that realm:
+
+- Client ID: `mcp-client` (or allow RFC 7591 dynamic client registration)
+- Client authentication: off
+- Standard flow: on
+- PKCE method: `S256`
+- Redirect URIs: the callback URIs used by the MCP clients under test
+- Assigned scopes: `openid`, `profile`, `email`, and the `organization` scope that
+  emits the Harness account ID
+- Access-token signing algorithm: `RS256`
+
+The issuer in HarnessID's metadata and in the token `iss` claim must exactly match
+`HARNESS_MCP_OAUTH_ISSUER`, including the `/idp` path segment.
+
+Verify a token before pointing a client at the server:
+
+```bash
+curl -sS https://id.harness-test.com/idp/realms/HarnessIDP/.well-known/openid-configuration
+```
+
+A valid access token for this setup decodes to `iss` of
+`https://id.harness-test.com/idp/realms/HarnessIDP`, `azp` of `mcp-client`, a `scope`
+containing `organization:<accountId>`, and a top-level `account_id` claim.
+
+## Run the MCP server
+
+Build the server:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm build
+```
+
+Set these values for QA:
+
+```bash
+export HARNESS_MCP_MODE=oauth
+export HARNESS_MCP_OAUTH_ISSUER=https://id.harness-test.com/idp/realms/HarnessIDP
+export HARNESS_MCP_OAUTH_RESOURCE=https://mcp.harness-test.com/mcp
+export HARNESS_MCP_OAUTH_CLIENT_ID=mcp-client
+export HARNESS_MCP_OAUTH_SCOPES="openid profile email organization"
+
+export HARNESS_BASE_URL=https://qa.harness.io
+export HARNESS_MCP_ALLOWED_HOSTS=mcp.harness-test.com
+export HOST=0.0.0.0
+export PORT=3000
+
+pnpm start:http
+```
+
+`HARNESS_MCP_OAUTH_JWKS_URI` defaults to
+`https://id.harness-test.com/idp/realms/HarnessIDP/protocol/openid-connect/certs`;
+set it only when HarnessID publishes keys elsewhere.
+
+`HARNESS_BASE_URL` is the Harness Platform API host, which is a different host from
+the MCP endpoint — `mcp.harness-test.com` serves only `/mcp` and its
+`.well-known` metadata, and returns 404 for API paths.
+
+Terminate TLS at the ingress or reverse proxy. `HARNESS_MCP_OAUTH_RESOURCE` must be
+the external HTTPS URL used by clients, not the pod or cluster-local URL.
+
+Do not set `HARNESS_MCP_AUTH_TOKEN` or `HARNESS_API_KEY` in OAuth mode.
+
+## Check discovery and authentication
+
+Protected-resource metadata:
+
+```bash
+curl -sS https://mcp.harness-test.com/.well-known/oauth-protected-resource/mcp
+```
+
+Expected fields:
+
+```json
+{
+  "resource": "https://mcp.harness-test.com/mcp",
+  "authorization_servers": ["https://id.harness-test.com/idp/realms/HarnessIDP"],
+  "scopes_supported": ["openid", "profile", "email", "organization"],
+  "bearer_methods_supported": ["header"]
+}
+```
+
+An unauthenticated MCP request must return HTTP 401 with a discovery challenge:
+
+```bash
+curl -i https://mcp.harness-test.com/mcp
+```
+
+Expected header:
+
+```http
+WWW-Authenticate: Bearer resource_metadata="https://mcp.harness-test.com/.well-known/oauth-protected-resource/mcp"
+```
+
+Configure the MCP client with the resource URL:
+
+```json
+{
+  "mcpServers": {
+    "harness-qa": {
+      "url": "https://mcp.harness-test.com/mcp"
+    }
+  }
+}
+```
+
+If the client asks for a client ID, use `mcp-client`. After browser login, verify
+that the client can initialize a session and list tools.
+
+## Validation failures
+
+- `OAuth access token required`: the client did not send a Bearer token.
+- `Invalid OAuth access token` with an authorized-party error: the token was issued
+  to a client other than `HARNESS_MCP_OAUTH_CLIENT_ID`.
+- Issuer error: HarnessID metadata, the token `iss`, and `HARNESS_MCP_OAUTH_ISSUER`
+  differ — most often the `/idp` path segment is missing on one side.
+- `Jwt issuer is not configured` from the gateway rather than the MCP server: the
+  ingress in front of the deployment validates JWTs itself and has no provider
+  registered for the HarnessID issuer. This is fixed in the deployment's gateway
+  configuration, not in the MCP server.
+- Signing-key error: `kid` is absent from the configured JWKS or the key is not an
+  RS256 signing key.
+- Missing-account error: the token has no `account_id` claim, so the `organization`
+  scope was not granted or not requested.
+- Repeated login or HTTP 403 after initialization: a later request is using a token
+  for a different `sub` or account; OAuth sessions are bound to the user who
+  initialized them.

--- a/docs/harnessid-oauth.md
+++ b/docs/harnessid-oauth.md
@@ -64,7 +64,7 @@ export HARNESS_MCP_OAUTH_RESOURCE=https://mcp.harness-test.com/mcp
 export HARNESS_MCP_OAUTH_CLIENT_ID=mcp-client
 export HARNESS_MCP_OAUTH_SCOPES="openid profile email organization"
 
-export HARNESS_BASE_URL=https://qa.harness.io
+export HARNESS_BASE_URL=https://mcp.harness-test.com/cli
 export HARNESS_MCP_ALLOWED_HOSTS=mcp.harness-test.com
 export HOST=0.0.0.0
 export PORT=3000
@@ -76,9 +76,11 @@ pnpm start:http
 `https://id.harness-test.com/idp/realms/HarnessIDP/protocol/openid-connect/certs`;
 set it only when HarnessID publishes keys elsewhere.
 
-`HARNESS_BASE_URL` is the Harness Platform API host, which is a different host from
-the MCP endpoint — `mcp.harness-test.com` serves only `/mcp` and its
-`.well-known` metadata, and returns 404 for API paths.
+`HARNESS_BASE_URL` includes the `/cli` prefix: on the QA MCP host the Harness
+Platform APIs are routed under `/cli`, so a call to `/ng/api/organizations`
+resolves to `https://mcp.harness-test.com/cli/ng/api/organizations`. The same
+host serves `/mcp` and its `.well-known` metadata; unprefixed API paths return
+404.
 
 Terminate TLS at the ingress or reverse proxy. `HARNESS_MCP_OAUTH_RESOURCE` must be
 the external HTTPS URL used by clients, not the pod or cluster-local URL.

--- a/docs/harnessid-oauth.md
+++ b/docs/harnessid-oauth.md
@@ -18,6 +18,28 @@ The account ID is read from the access-token claim named by
 token that created it. Later requests may carry a refreshed token for the same user,
 but a token for a different user or account is rejected.
 
+Current HarnessID access tokens identify the OAuth client with `azp: mcp-client` and
+use `aud: account`; they do not emit the MCP resource URL as an audience. The server
+therefore validates `azp`, while `HARNESS_MCP_OAUTH_RESOURCE` identifies the protected
+resource in RFC 9728 metadata and authentication challenges.
+
+## Production defaults
+
+For the production Harness endpoint, OAuth mode needs only:
+
+```bash
+export HARNESS_MCP_MODE=oauth
+```
+
+The server defaults to:
+
+- HarnessID issuer: `https://id.harness.io/idp/realms/HarnessIDP`
+- MCP resource: `https://mcp.harness.io/mcp`
+- Harness API base: `https://mcp.harness.io/cli`
+- OAuth client: `mcp-client`
+
+Override these settings for QA, local development, or another Harness environment.
+
 ## QA HarnessID setup
 
 QA HarnessID realm: `https://id.harness-test.com/idp/realms/HarnessIDP`
@@ -86,6 +108,10 @@ Terminate TLS at the ingress or reverse proxy. `HARNESS_MCP_OAUTH_RESOURCE` must
 the external HTTPS URL used by clients, not the pod or cluster-local URL.
 
 Do not set `HARNESS_MCP_AUTH_TOKEN` or `HARNESS_API_KEY` in OAuth mode.
+Legacy FME calls that use `workspace_id` are unavailable because the server will
+not forward a HarnessID access token to `api.split.io`. Pass `org_id` and
+`project_id` to select the Harness-native FME API routed through
+`HARNESS_BASE_URL`.
 
 ## Check discovery and authentication
 

--- a/src/client/harness-client.ts
+++ b/src/client/harness-client.ts
@@ -234,6 +234,14 @@ export class HarnessClient {
   private applyDefaultAuth(headers: Record<string, string>, isFme: boolean): void {
     if (this.mcpMode === "oauth") {
       deleteHeaderValues(headers, "x-api-key");
+      if (isFme) {
+        throw new HarnessApiError(
+          "Legacy workspace-based FME calls are unavailable in oauth mode. " +
+          "Pass org_id and project_id to use the Harness-native FME API.",
+          401,
+          "FME_AUTH_MISSING",
+        );
+      }
       if (getHeaderValue(headers, "authorization")) return;
 
       const token = this.bearerTokenResolver?.();

--- a/src/client/harness-client.ts
+++ b/src/client/harness-client.ts
@@ -156,6 +156,7 @@ function enrichErrorMessage(
  * AsyncLocalStorage) instead of using the static config value.
  */
 export type AccountIdResolver = () => string | undefined;
+export type BearerTokenResolver = () => string | undefined;
 
 export class HarnessClient {
   private readonly baseUrl: string;
@@ -168,6 +169,7 @@ export class HarnessClient {
   private readonly fmeApiKey: string | undefined;
   private readonly mcpMode: Config["HARNESS_MCP_MODE"];
   private accountIdResolver?: AccountIdResolver;
+  private bearerTokenResolver?: BearerTokenResolver;
   private currentUserId?: string;
   private currentUserPromise?: Promise<string>;
 
@@ -189,6 +191,11 @@ export class HarnessClient {
    */
   setAccountIdResolver(resolver: AccountIdResolver): void {
     this.accountIdResolver = resolver;
+  }
+
+  /** Set the per-session OAuth access token used for downstream Harness calls. */
+  setBearerTokenResolver(resolver: BearerTokenResolver): void {
+    this.bearerTokenResolver = resolver;
   }
 
   /** Resolve the account ID: per-request override → static config fallback. */
@@ -225,6 +232,22 @@ export class HarnessClient {
   }
 
   private applyDefaultAuth(headers: Record<string, string>, isFme: boolean): void {
+    if (this.mcpMode === "oauth") {
+      deleteHeaderValues(headers, "x-api-key");
+      if (getHeaderValue(headers, "authorization")) return;
+
+      const token = this.bearerTokenResolver?.();
+      if (!token) {
+        throw new HarnessApiError(
+          "OAuth access token is unavailable for this MCP session.",
+          401,
+          "OAUTH_TOKEN_MISSING",
+        );
+      }
+      headers["Authorization"] = `Bearer ${token}`;
+      return;
+    }
+
     if (isFme) {
       // FME/Split Admin APIs expect Bearer auth. Drop x-api-key here so
       // placeholder credentials are never forwarded to api.split.io.

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,10 @@ const optionalStringFromEnv = z.preprocess(emptyStringAsUndefined, z.string().op
 const optionalUrlFromEnv = z.preprocess(emptyStringAsUndefined, z.string().url().optional());
 const urlFromEnv = (defaultValue: string) =>
   z.preprocess(emptyStringAsUndefined, z.string().url().default(defaultValue));
+const DEFAULT_HARNESS_BASE_URL = "https://app.harness.io";
+const DEFAULT_OAUTH_BASE_URL = "https://mcp.harness.io/cli";
+const DEFAULT_OAUTH_ISSUER = "https://id.harness.io/idp/realms/HarnessIDP";
+const DEFAULT_OAUTH_RESOURCE = "https://mcp.harness.io/mcp";
 
 function validateAllowedHosts(rawHosts: string | undefined): string | undefined {
   if (rawHosts === undefined) return undefined;
@@ -70,9 +74,9 @@ const RawConfigSchema = z.object({
   ),
   HARNESS_API_KEY: optionalStringFromEnv,
   HARNESS_ACCOUNT_ID: optionalStringFromEnv,
-  HARNESS_BASE_URL: urlFromEnv("https://app.harness.io"),
-  HARNESS_MCP_OAUTH_ISSUER: optionalUrlFromEnv,
-  HARNESS_MCP_OAUTH_RESOURCE: optionalUrlFromEnv,
+  HARNESS_BASE_URL: optionalUrlFromEnv,
+  HARNESS_MCP_OAUTH_ISSUER: urlFromEnv(DEFAULT_OAUTH_ISSUER),
+  HARNESS_MCP_OAUTH_RESOURCE: urlFromEnv(DEFAULT_OAUTH_RESOURCE),
   HARNESS_MCP_OAUTH_JWKS_URI: optionalUrlFromEnv,
   HARNESS_MCP_OAUTH_CLIENT_ID: z.preprocess(
     emptyStringAsUndefined,
@@ -164,6 +168,8 @@ const RawConfigSchema = z.object({
 export const ConfigSchema = RawConfigSchema.transform((data) => {
   const isMultiUser = data.HARNESS_MCP_MODE === "multi-user";
   const isOAuth = data.HARNESS_MCP_MODE === "oauth";
+  const harnessBaseUrl = data.HARNESS_BASE_URL
+    ?? (isOAuth ? DEFAULT_OAUTH_BASE_URL : DEFAULT_HARNESS_BASE_URL);
 
   if (isMultiUser && data.HARNESS_API_KEY) {
     throw new Error(
@@ -195,14 +201,6 @@ export const ConfigSchema = RawConfigSchema.transform((data) => {
 
   if (!isMultiUser && !isOAuth && !data.HARNESS_API_KEY) {
     throw new Error("HARNESS_API_KEY is required in single-user mode.");
-  }
-
-  if (isOAuth && !data.HARNESS_MCP_OAUTH_ISSUER) {
-    throw new Error("HARNESS_MCP_OAUTH_ISSUER is required in oauth mode.");
-  }
-
-  if (isOAuth && !data.HARNESS_MCP_OAUTH_RESOURCE) {
-    throw new Error("HARNESS_MCP_OAUTH_RESOURCE is required in oauth mode.");
   }
 
   if (
@@ -242,9 +240,9 @@ export const ConfigSchema = RawConfigSchema.transform((data) => {
     }
   }
 
-  if (!data.HARNESS_BASE_URL.startsWith("https://") && !data.HARNESS_ALLOW_HTTP) {
+  if (!harnessBaseUrl.startsWith("https://") && !data.HARNESS_ALLOW_HTTP) {
     throw new Error(
-      `HARNESS_BASE_URL must use HTTPS (got "${data.HARNESS_BASE_URL}"). ` +
+      `HARNESS_BASE_URL must use HTTPS (got "${harnessBaseUrl}"). ` +
       "If you need HTTP for local development, set HARNESS_ALLOW_HTTP=true.",
     );
   }
@@ -295,6 +293,7 @@ export const ConfigSchema = RawConfigSchema.transform((data) => {
     ...rest,
     HARNESS_API_KEY: data.HARNESS_API_KEY ?? "",
     HARNESS_ACCOUNT_ID: accountId,
+    HARNESS_BASE_URL: harnessBaseUrl,
     HARNESS_ORG,
     HARNESS_PROJECT,
     HARNESS_AUTO_APPROVE_RISK,

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ const booleanFromEnv = z
 
 const emptyStringAsUndefined = (val: unknown): unknown => val === "" ? undefined : val;
 const optionalStringFromEnv = z.preprocess(emptyStringAsUndefined, z.string().optional());
+const optionalUrlFromEnv = z.preprocess(emptyStringAsUndefined, z.string().url().optional());
 const urlFromEnv = (defaultValue: string) =>
   z.preprocess(emptyStringAsUndefined, z.string().url().default(defaultValue));
 
@@ -65,11 +66,26 @@ export function extractAccountIdFromToken(apiKey: string): string | undefined {
 const RawConfigSchema = z.object({
   HARNESS_MCP_MODE: z.preprocess(
     emptyStringAsUndefined,
-    z.enum(["single-user", "multi-user"]).default("single-user"),
+    z.enum(["single-user", "multi-user", "oauth"]).default("single-user"),
   ),
   HARNESS_API_KEY: optionalStringFromEnv,
   HARNESS_ACCOUNT_ID: optionalStringFromEnv,
   HARNESS_BASE_URL: urlFromEnv("https://app.harness.io"),
+  HARNESS_MCP_OAUTH_ISSUER: optionalUrlFromEnv,
+  HARNESS_MCP_OAUTH_RESOURCE: optionalUrlFromEnv,
+  HARNESS_MCP_OAUTH_JWKS_URI: optionalUrlFromEnv,
+  HARNESS_MCP_OAUTH_CLIENT_ID: z.preprocess(
+    emptyStringAsUndefined,
+    z.string().default("mcp-client"),
+  ),
+  HARNESS_MCP_OAUTH_ACCOUNT_CLAIM: z.preprocess(
+    emptyStringAsUndefined,
+    z.string().default("account_id"),
+  ),
+  HARNESS_MCP_OAUTH_SCOPES: z.preprocess(
+    emptyStringAsUndefined,
+    z.string().default("openid profile email organization"),
+  ),
   // New names (preferred)
   HARNESS_ORG: optionalStringFromEnv,
   HARNESS_PROJECT: optionalStringFromEnv,
@@ -147,6 +163,7 @@ const RawConfigSchema = z.object({
 
 export const ConfigSchema = RawConfigSchema.transform((data) => {
   const isMultiUser = data.HARNESS_MCP_MODE === "multi-user";
+  const isOAuth = data.HARNESS_MCP_MODE === "oauth";
 
   if (isMultiUser && data.HARNESS_API_KEY) {
     throw new Error(
@@ -162,14 +179,45 @@ export const ConfigSchema = RawConfigSchema.transform((data) => {
     );
   }
 
-  if (!isMultiUser && !data.HARNESS_API_KEY) {
+  if (!isMultiUser && !isOAuth && !data.HARNESS_API_KEY) {
+    throw new Error("HARNESS_API_KEY is required in single-user mode.");
+  }
+
+  if (isOAuth && !data.HARNESS_MCP_OAUTH_ISSUER) {
+    throw new Error("HARNESS_MCP_OAUTH_ISSUER is required in oauth mode.");
+  }
+
+  if (isOAuth && !data.HARNESS_MCP_OAUTH_RESOURCE) {
+    throw new Error("HARNESS_MCP_OAUTH_RESOURCE is required in oauth mode.");
+  }
+
+  if (
+    isOAuth
+    && !data.HARNESS_ALLOW_HTTP
+    && (
+      !data.HARNESS_MCP_OAUTH_ISSUER!.startsWith("https://")
+      || !data.HARNESS_MCP_OAUTH_RESOURCE!.startsWith("https://")
+      || (
+        data.HARNESS_MCP_OAUTH_JWKS_URI !== undefined
+        && !data.HARNESS_MCP_OAUTH_JWKS_URI.startsWith("https://")
+      )
+    )
+  ) {
     throw new Error(
-      "HARNESS_API_KEY is required in single-user mode.",
+      "HarnessID OAuth issuer, resource, and JWKS URLs must use HTTPS. " +
+      "Set HARNESS_ALLOW_HTTP=true only for local development.",
+    );
+  }
+
+  if (isOAuth && data.HARNESS_MCP_AUTH_TOKEN) {
+    throw new Error(
+      "HARNESS_MCP_AUTH_TOKEN must not be set in oauth mode. " +
+      "OAuth access tokens authenticate HTTP MCP requests.",
     );
   }
 
   let accountId: string | undefined;
-  if (isMultiUser) {
+  if (isMultiUser || isOAuth) {
     accountId = data.HARNESS_ACCOUNT_ID ?? "";
   } else {
     accountId = data.HARNESS_ACCOUNT_ID ?? extractAccountIdFromToken(data.HARNESS_API_KEY!);
@@ -223,8 +271,22 @@ export const ConfigSchema = RawConfigSchema.transform((data) => {
 
   // Remove deprecated keys from output, expose only the canonical names
   const { HARNESS_DEFAULT_ORG_ID: _oldOrg, HARNESS_DEFAULT_PROJECT_ID: _oldProject, ...rest } = data;
+  const oauthIssuer = data.HARNESS_MCP_OAUTH_ISSUER;
+  const oauthJwksUri = isOAuth
+    ? data.HARNESS_MCP_OAUTH_JWKS_URI
+      ?? `${oauthIssuer!.replace(/\/+$/, "")}/protocol/openid-connect/certs`
+    : data.HARNESS_MCP_OAUTH_JWKS_URI;
 
-  return { ...rest, HARNESS_API_KEY: data.HARNESS_API_KEY ?? "", HARNESS_ACCOUNT_ID: accountId, HARNESS_ORG, HARNESS_PROJECT, HARNESS_AUTO_APPROVE_RISK };
+  return {
+    ...rest,
+    HARNESS_API_KEY: data.HARNESS_API_KEY ?? "",
+    HARNESS_ACCOUNT_ID: accountId,
+    HARNESS_ORG,
+    HARNESS_PROJECT,
+    HARNESS_AUTO_APPROVE_RISK,
+    HARNESS_MCP_OAUTH_ISSUER: oauthIssuer,
+    HARNESS_MCP_OAUTH_JWKS_URI: oauthJwksUri,
+  };
 });
 
 export type Config = z.infer<typeof ConfigSchema>;

--- a/src/config.ts
+++ b/src/config.ts
@@ -179,6 +179,20 @@ export const ConfigSchema = RawConfigSchema.transform((data) => {
     );
   }
 
+  if (isOAuth && data.HARNESS_API_KEY) {
+    throw new Error(
+      "HARNESS_API_KEY must not be set in oauth mode. " +
+      "Each session must authenticate with a HarnessID access token.",
+    );
+  }
+
+  if (isOAuth && data.HARNESS_FME_API_KEY) {
+    throw new Error(
+      "HARNESS_FME_API_KEY must not be set in oauth mode. " +
+      "FME calls must use the session user's HarnessID access token.",
+    );
+  }
+
   if (!isMultiUser && !isOAuth && !data.HARNESS_API_KEY) {
     throw new Error("HARNESS_API_KEY is required in single-user mode.");
   }
@@ -309,14 +323,17 @@ export function isPlaceholderCredential(value: string | undefined): boolean {
 export function resolveFmeApiKey(
   config: Pick<Config, "HARNESS_MCP_MODE" | "HARNESS_FME_API_KEY" | "HARNESS_API_KEY">,
 ): string | undefined {
-  const explicitFmeKey = config.HARNESS_MCP_MODE === "multi-user"
-    ? undefined
-    : config.HARNESS_FME_API_KEY?.trim();
+  const explicitFmeKey =
+    config.HARNESS_MCP_MODE === "multi-user" || config.HARNESS_MCP_MODE === "oauth"
+      ? undefined
+      : config.HARNESS_FME_API_KEY?.trim();
   if (explicitFmeKey && !isPlaceholderCredential(explicitFmeKey)) {
     return explicitFmeKey;
   }
 
-  const fallbackHarnessKey = config.HARNESS_API_KEY?.trim();
+  const fallbackHarnessKey = config.HARNESS_MCP_MODE === "oauth"
+    ? undefined
+    : config.HARNESS_API_KEY?.trim();
   if (fallbackHarnessKey && !isPlaceholderCredential(fallbackHarnessKey)) {
     return fallbackHarnessKey;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import { configureElicitation } from "./utils/elicitation.js";
 import { resolveHttpHostValidationOptions } from "./utils/http-hosts.js";
 import { createMcpHttpAuthMiddleware, validateHttpAuthForBindHost } from "./utils/http-auth.js";
 import {
-  isOAuthSessionSubjectAuthorized,
+  refreshOAuthSessionCredential,
   registerOAuthProtectedResourceRoutes,
 } from "./utils/oauth-auth.js";
 import { loadEnvFile } from "./utils/env.js";
@@ -257,31 +257,6 @@ interface Session extends HttpSessionActivity {
 
 const REAP_INTERVAL_MS = 60_000; // check every minute
 
-function refreshOAuthSessionCredential(
-  session: Session,
-  locals: Record<string, unknown>,
-): boolean {
-  const requestSubject = locals.harnessOAuthClaims
-    && typeof locals.harnessOAuthClaims === "object"
-    ? (locals.harnessOAuthClaims as { sub?: unknown }).sub
-    : undefined;
-  if (!isOAuthSessionSubjectAuthorized(
-    session.oauthCredential?.subject,
-    requestSubject,
-  )) {
-    return false;
-  }
-  if (!session.oauthCredential) return true;
-  if (locals.harnessOAuthAccountId !== session.oauthCredential.accountId) {
-    return false;
-  }
-  if (typeof locals.harnessOAuthAccessToken !== "string") {
-    return false;
-  }
-  session.oauthCredential.accessToken = locals.harnessOAuthAccessToken;
-  return true;
-}
-
 /**
  * Start the server in HTTP mode — stateful, session-based.
  * Each `initialize` request creates a persistent session (server + transport).
@@ -415,7 +390,7 @@ async function startHttp(config: Config, port: number): Promise<void> {
         });
         return;
       }
-      if (!refreshOAuthSessionCredential(session, res.locals)) {
+      if (!refreshOAuthSessionCredential(session.oauthCredential, res.locals)) {
         res.status(403).json({
           jsonrpc: "2.0",
           error: { code: -32003, message: "This MCP session belongs to another OAuth subject." },
@@ -531,7 +506,7 @@ async function startHttp(config: Config, port: number): Promise<void> {
       });
       return;
     }
-    if (!refreshOAuthSessionCredential(session, res.locals)) {
+    if (!refreshOAuthSessionCredential(session.oauthCredential, res.locals)) {
       res.status(403).json({
         jsonrpc: "2.0",
         error: { code: -32003, message: "This MCP session belongs to another OAuth subject." },
@@ -588,7 +563,7 @@ async function startHttp(config: Config, port: number): Promise<void> {
       });
       return;
     }
-    if (!refreshOAuthSessionCredential(session, res.locals)) {
+    if (!refreshOAuthSessionCredential(session.oauthCredential, res.locals)) {
       res.status(403).json({
         jsonrpc: "2.0",
         error: { code: -32003, message: "This MCP session belongs to another OAuth subject." },

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,11 @@ import { registerAllPrompts } from "./prompts/index.js";
 import { parseArgs, resolvePort, getVersion } from "./utils/cli.js";
 import { configureElicitation } from "./utils/elicitation.js";
 import { resolveHttpHostValidationOptions } from "./utils/http-hosts.js";
-import { createHttpAuthMiddleware, validateHttpAuthForBindHost } from "./utils/http-auth.js";
+import { createMcpHttpAuthMiddleware, validateHttpAuthForBindHost } from "./utils/http-auth.js";
+import {
+  isOAuthSessionSubjectAuthorized,
+  registerOAuthProtectedResourceRoutes,
+} from "./utils/oauth-auth.js";
 import { loadEnvFile } from "./utils/env.js";
 import { createAuditManager, type AuditManager } from "./audit/index.js";
 import { SearchManager } from "./search/index.js";
@@ -34,13 +38,28 @@ interface HarnessServerResult {
   searchManager: SearchManager;
 }
 
+interface OAuthSessionCredential {
+  subject: string;
+  accountId: string;
+  accessToken: string;
+}
+
 /**
  * Create a fully-configured MCP server instance with all tools, resources, and prompts.
  * @param sharedAuditManager When set (HTTP mode), reuse this manager instead of creating one per session.
  */
-function createHarnessServer(config: Config, sharedAuditManager?: AuditManager, sharedSearchManager?: SearchManager): HarnessServerResult {
+function createHarnessServer(
+  config: Config,
+  sharedAuditManager?: AuditManager,
+  sharedSearchManager?: SearchManager,
+  oauthCredential?: OAuthSessionCredential,
+): HarnessServerResult {
   const auditManager = sharedAuditManager ?? createAuditManager(config);
   const client = new HarnessClient(config);
+  if (oauthCredential) {
+    client.setAccountIdResolver(() => oauthCredential.accountId);
+    client.setBearerTokenResolver(() => oauthCredential.accessToken);
+  }
   const registry = new Registry(config, { auditManager });
   const searchManager = sharedSearchManager ?? new SearchManager(config);
 
@@ -233,9 +252,35 @@ async function startStdio(config: Config): Promise<void> {
 interface Session extends HttpSessionActivity {
   server: McpServer;
   transport: StreamableHTTPServerTransport;
+  oauthCredential?: OAuthSessionCredential;
 }
 
 const REAP_INTERVAL_MS = 60_000; // check every minute
+
+function refreshOAuthSessionCredential(
+  session: Session,
+  locals: Record<string, unknown>,
+): boolean {
+  const requestSubject = locals.harnessOAuthClaims
+    && typeof locals.harnessOAuthClaims === "object"
+    ? (locals.harnessOAuthClaims as { sub?: unknown }).sub
+    : undefined;
+  if (!isOAuthSessionSubjectAuthorized(
+    session.oauthCredential?.subject,
+    requestSubject,
+  )) {
+    return false;
+  }
+  if (!session.oauthCredential) return true;
+  if (locals.harnessOAuthAccountId !== session.oauthCredential.accountId) {
+    return false;
+  }
+  if (typeof locals.harnessOAuthAccessToken !== "string") {
+    return false;
+  }
+  session.oauthCredential.accessToken = locals.harnessOAuthAccessToken;
+  return true;
+}
 
 /**
  * Start the server in HTTP mode — stateful, session-based.
@@ -270,8 +315,12 @@ async function startHttp(config: Config, port: number): Promise<void> {
     next();
   });
 
+  if (config.HARNESS_MCP_MODE === "oauth") {
+    registerOAuthProtectedResourceRoutes(app, config);
+  }
+
   // Auth gate before body parsing — reject unauthenticated requests without allocating body memory
-  app.use(createHttpAuthMiddleware(config.HARNESS_MCP_AUTH_TOKEN));
+  app.use(createMcpHttpAuthMiddleware(config));
 
   // Simple per-IP rate limiting: 60 requests per minute
   const ipHits = new Map<string, { count: number; resetAt: number }>();
@@ -366,6 +415,14 @@ async function startHttp(config: Config, port: number): Promise<void> {
         });
         return;
       }
+      if (!refreshOAuthSessionCredential(session, res.locals)) {
+        res.status(403).json({
+          jsonrpc: "2.0",
+          error: { code: -32003, message: "This MCP session belongs to another OAuth subject." },
+          id: null,
+        });
+        return;
+      }
       beginSessionRequest(session);
       try {
         await session.transport.handleRequest(req, res, req.body);
@@ -388,8 +445,23 @@ async function startHttp(config: Config, port: number): Promise<void> {
     let server: McpServer | undefined;
     let transport: StreamableHTTPServerTransport | undefined;
     try {
-      const sessionConfig = mergeConfigWithSessionHeaders(config, req.headers);
-      const result = createHarnessServer(sessionConfig, sharedAuditManager, sharedSearchManager);
+      const oauthCredential = config.HARNESS_MCP_MODE === "oauth"
+        ? {
+          subject: res.locals.harnessOAuthClaims.sub as string,
+          accountId: res.locals.harnessOAuthAccountId as string,
+          accessToken: res.locals.harnessOAuthAccessToken as string,
+        }
+        : undefined;
+      const headerConfig = mergeConfigWithSessionHeaders(config, req.headers);
+      const sessionConfig = oauthCredential
+        ? { ...headerConfig, HARNESS_ACCOUNT_ID: oauthCredential.accountId }
+        : headerConfig;
+      const result = createHarnessServer(
+        sessionConfig,
+        sharedAuditManager,
+        sharedSearchManager,
+        oauthCredential,
+      );
       server = result.server;
       transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: () => randomUUID(),
@@ -399,6 +471,7 @@ async function startHttp(config: Config, port: number): Promise<void> {
             transport: transport!,
             lastActivity: Date.now(),
             activeRequests: 0,
+            oauthCredential,
           });
           log.info("Session created", { sessionId: id, total: sessions.size });
         },
@@ -458,6 +531,14 @@ async function startHttp(config: Config, port: number): Promise<void> {
       });
       return;
     }
+    if (!refreshOAuthSessionCredential(session, res.locals)) {
+      res.status(403).json({
+        jsonrpc: "2.0",
+        error: { code: -32003, message: "This MCP session belongs to another OAuth subject." },
+        id: null,
+      });
+      return;
+    }
 
     beginSessionRequest(session);
     let streamClosed = false;
@@ -503,6 +584,14 @@ async function startHttp(config: Config, port: number): Promise<void> {
       res.status(404).json({
         jsonrpc: "2.0",
         error: { code: -32000, message: "Session not found." },
+        id: null,
+      });
+      return;
+    }
+    if (!refreshOAuthSessionCredential(session, res.locals)) {
+      res.status(403).json({
+        jsonrpc: "2.0",
+        error: { code: -32003, message: "This MCP session belongs to another OAuth subject." },
         id: null,
       });
       return;
@@ -612,9 +701,9 @@ async function main(): Promise<void> {
   const config = loadConfig();
   setLogLevel(config.LOG_LEVEL);
 
-  if (config.HARNESS_MCP_MODE === "multi-user" && transport === "stdio") {
+  if ((config.HARNESS_MCP_MODE === "multi-user" || config.HARNESS_MCP_MODE === "oauth") && transport === "stdio") {
     throw new Error(
-      "Multi-user mode is only supported with HTTP transport. " +
+      `${config.HARNESS_MCP_MODE} mode is only supported with HTTP transport. ` +
       "Use --transport http or set HARNESS_MCP_MODE=single-user for stdio.",
     );
   }

--- a/src/utils/http-auth.ts
+++ b/src/utils/http-auth.ts
@@ -3,10 +3,23 @@ import type { IncomingHttpHeaders } from "node:http";
 import type { RequestHandler } from "express";
 import type { Config } from "../config.js";
 import { createLogger } from "./logger.js";
+import { createOAuthHttpAuthMiddleware } from "./oauth-auth.js";
 
 const log = createLogger("http-auth");
 
-type HttpAuthConfig = Pick<Config, "HARNESS_MCP_AUTH_TOKEN" | "HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP" | "HARNESS_MCP_MODE" | "HARNESS_API_KEY">;
+type HttpAuthConfig = Pick<
+  Config,
+  | "HARNESS_MCP_AUTH_TOKEN"
+  | "HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP"
+  | "HARNESS_MCP_MODE"
+  | "HARNESS_API_KEY"
+> & Partial<Pick<
+  Config,
+  | "HARNESS_MCP_OAUTH_ISSUER"
+  | "HARNESS_MCP_OAUTH_RESOURCE"
+  | "HARNESS_MCP_OAUTH_JWKS_URI"
+  | "HARNESS_MCP_OAUTH_SCOPES"
+>>;
 
 export function isLoopbackBindHost(host: string): boolean {
   return host === "127.0.0.1" || host === "::1" || host === "localhost";
@@ -57,11 +70,18 @@ export function createHttpAuthMiddleware(token: string | undefined): RequestHand
   };
 }
 
+export function createMcpHttpAuthMiddleware(config: HttpAuthConfig): RequestHandler {
+  if (config.HARNESS_MCP_MODE === "oauth") {
+    return createOAuthHttpAuthMiddleware(config);
+  }
+  return createHttpAuthMiddleware(config.HARNESS_MCP_AUTH_TOKEN);
+}
+
 export function validateHttpAuthForBindHost(host: string, config: HttpAuthConfig): void {
   // Check 1: credentials at risk — single-user with an API key and no MCP auth token.
   // Bind address is irrelevant here: a loopback port exposed via reverse proxy or tunnel
   // is just as reachable as a public bind. Warn now; will become an error in next major.
-  const hasSingleUserCredentials = config.HARNESS_MCP_MODE !== "multi-user" && !!config.HARNESS_API_KEY;
+  const hasSingleUserCredentials = config.HARNESS_MCP_MODE === "single-user" && !!config.HARNESS_API_KEY;
   if (hasSingleUserCredentials && !config.HARNESS_MCP_AUTH_TOKEN && !config.HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP) {
     log.warn(
       "HTTP single-user mode has no HARNESS_MCP_AUTH_TOKEN set. " +
@@ -73,7 +93,13 @@ export function validateHttpAuthForBindHost(host: string, config: HttpAuthConfig
   }
 
   // Check 2: DNS-rebinding defense — non-loopback binds must be explicitly secured.
-  if (!isLoopbackBindHost(host) && !config.HARNESS_MCP_AUTH_TOKEN && !config.HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP) {
+  const hasOAuthAuthentication = config.HARNESS_MCP_MODE === "oauth";
+  if (
+    !isLoopbackBindHost(host)
+    && !config.HARNESS_MCP_AUTH_TOKEN
+    && !hasOAuthAuthentication
+    && !config.HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP
+  ) {
     throw new Error(
       "HARNESS_MCP_AUTH_TOKEN is required when HTTP transport binds to a non-loopback host. " +
       "Set HARNESS_MCP_AUTH_TOKEN or explicitly set HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP=true.",

--- a/src/utils/oauth-auth.ts
+++ b/src/utils/oauth-auth.ts
@@ -6,6 +6,7 @@ import { createLogger } from "./logger.js";
 
 const log = createLogger("oauth-auth");
 const JWKS_CACHE_TTL_MS = 5 * 60_000;
+const JWT_CLOCK_TOLERANCE_SECONDS = 30;
 
 type OAuthConfig = Partial<Pick<
   Config,
@@ -101,6 +102,28 @@ export function isOAuthSessionSubjectAuthorized(
   return sessionSubject === undefined || sessionSubject === requestSubject;
 }
 
+export function refreshOAuthSessionCredential(
+  credential: { subject: string; accountId: string; accessToken: string } | undefined,
+  locals: Record<string, unknown>,
+): boolean {
+  const requestSubject = locals.harnessOAuthClaims
+    && typeof locals.harnessOAuthClaims === "object"
+    ? (locals.harnessOAuthClaims as { sub?: unknown }).sub
+    : undefined;
+  if (!isOAuthSessionSubjectAuthorized(credential?.subject, requestSubject)) {
+    return false;
+  }
+  if (!credential) return true;
+  if (locals.harnessOAuthAccountId !== credential.accountId) {
+    return false;
+  }
+  if (typeof locals.harnessOAuthAccessToken !== "string") {
+    return false;
+  }
+  credential.accessToken = locals.harnessOAuthAccessToken;
+  return true;
+}
+
 export function registerOAuthProtectedResourceRoutes(app: Express, config: OAuthConfig): void {
   const { resource } = requiredOAuthConfig(config);
   const metadata = buildProtectedResourceMetadata(config);
@@ -130,7 +153,12 @@ class JwksResolver {
       await this.refresh();
     }
 
-    const key = this.cache?.keys.get(kid);
+    let key = this.cache?.keys.get(kid);
+    if (!key) {
+      // A new kid commonly appears before the cache TTL expires during key rotation.
+      await this.refresh();
+      key = this.cache?.keys.get(kid);
+    }
     if (!key) {
       throw new Error(`No OAuth signing key found for kid "${kid}".`);
     }
@@ -211,6 +239,7 @@ export function createOAuthHttpAuthMiddleware(
       const claims = jwt.verify(token, key, {
         algorithms: ["RS256"],
         issuer,
+        clockTolerance: JWT_CLOCK_TOLERANCE_SECONDS,
       }) as JwtPayload;
       if (typeof claims.sub !== "string" || claims.sub.length === 0) {
         throw new Error("Access token is missing sub.");

--- a/src/utils/oauth-auth.ts
+++ b/src/utils/oauth-auth.ts
@@ -1,0 +1,245 @@
+import { createPublicKey, type JsonWebKey as NodeJsonWebKey, type KeyObject } from "node:crypto";
+import type { Express, RequestHandler } from "express";
+import jwt, { type JwtPayload } from "jsonwebtoken";
+import type { Config } from "../config.js";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("oauth-auth");
+const JWKS_CACHE_TTL_MS = 5 * 60_000;
+
+type OAuthConfig = Partial<Pick<
+  Config,
+  | "HARNESS_MCP_OAUTH_ISSUER"
+  | "HARNESS_MCP_OAUTH_RESOURCE"
+  | "HARNESS_MCP_OAUTH_JWKS_URI"
+  | "HARNESS_MCP_OAUTH_CLIENT_ID"
+  | "HARNESS_MCP_OAUTH_ACCOUNT_CLAIM"
+  | "HARNESS_MCP_OAUTH_SCOPES"
+>>;
+
+interface OAuthJwk extends NodeJsonWebKey {
+  kid?: string;
+  alg?: string;
+  use?: string;
+}
+
+interface JwkSet {
+  keys: OAuthJwk[];
+}
+
+interface CachedJwkSet {
+  expiresAt: number;
+  keys: Map<string, KeyObject>;
+}
+
+function requiredOAuthConfig(config: OAuthConfig): {
+  issuer: string;
+  resource: string;
+  jwksUri: string;
+  clientId: string;
+  accountClaim: string;
+  scopes: string[];
+} {
+  const issuer = config.HARNESS_MCP_OAUTH_ISSUER;
+  const resource = config.HARNESS_MCP_OAUTH_RESOURCE;
+  const jwksUri = config.HARNESS_MCP_OAUTH_JWKS_URI;
+  if (!issuer || !resource || !jwksUri) {
+    throw new Error("HarnessID OAuth configuration is incomplete.");
+  }
+
+  return {
+    issuer,
+    resource,
+    jwksUri,
+    clientId: config.HARNESS_MCP_OAUTH_CLIENT_ID ?? "mcp-client",
+    accountClaim: config.HARNESS_MCP_OAUTH_ACCOUNT_CLAIM ?? "account_id",
+    scopes: (config.HARNESS_MCP_OAUTH_SCOPES ?? "openid profile email organization")
+      .split(/\s+/)
+      .filter(Boolean),
+  };
+}
+
+function isJwkSet(value: unknown): value is JwkSet {
+  if (!value || typeof value !== "object" || !("keys" in value)) return false;
+  return Array.isArray((value as { keys?: unknown }).keys);
+}
+
+function bearerToken(authorization: string | undefined): string | undefined {
+  if (!authorization) return undefined;
+  const match = /^Bearer\s+(.+)$/i.exec(authorization.trim());
+  return match?.[1];
+}
+
+function protectedResourceMetadataPath(resource: string): string {
+  const resourceUrl = new URL(resource);
+  const suffix = resourceUrl.pathname === "/" ? "" : resourceUrl.pathname.replace(/\/+$/, "");
+  return `/.well-known/oauth-protected-resource${suffix}`;
+}
+
+export function getProtectedResourceMetadataUrl(resource: string): string {
+  const resourceUrl = new URL(resource);
+  resourceUrl.pathname = protectedResourceMetadataPath(resource);
+  resourceUrl.search = "";
+  resourceUrl.hash = "";
+  return resourceUrl.toString();
+}
+
+export function buildProtectedResourceMetadata(config: OAuthConfig): Record<string, unknown> {
+  const { issuer, resource, scopes } = requiredOAuthConfig(config);
+  return {
+    resource,
+    authorization_servers: [issuer],
+    scopes_supported: scopes,
+    bearer_methods_supported: ["header"],
+  };
+}
+
+export function isOAuthSessionSubjectAuthorized(
+  sessionSubject: string | undefined,
+  requestSubject: unknown,
+): boolean {
+  return sessionSubject === undefined || sessionSubject === requestSubject;
+}
+
+export function registerOAuthProtectedResourceRoutes(app: Express, config: OAuthConfig): void {
+  const { resource } = requiredOAuthConfig(config);
+  const metadata = buildProtectedResourceMetadata(config);
+  const paths = new Set([
+    "/.well-known/oauth-protected-resource",
+    protectedResourceMetadataPath(resource),
+  ]);
+
+  for (const path of paths) {
+    app.get(path, (_req, res) => {
+      res.json(metadata);
+    });
+  }
+}
+
+class JwksResolver {
+  private cache?: CachedJwkSet;
+
+  constructor(
+    private readonly jwksUri: string,
+    private readonly fetchImpl: typeof fetch,
+  ) {}
+
+  async get(kid: string): Promise<KeyObject> {
+    const now = Date.now();
+    if (!this.cache || now >= this.cache.expiresAt) {
+      await this.refresh();
+    }
+
+    const key = this.cache?.keys.get(kid);
+    if (!key) {
+      throw new Error(`No OAuth signing key found for kid "${kid}".`);
+    }
+    return key;
+  }
+
+  private async refresh(): Promise<void> {
+    const response = await this.fetchImpl(this.jwksUri, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) {
+      throw new Error(`JWKS request failed with HTTP ${response.status}.`);
+    }
+
+    const body: unknown = await response.json();
+    if (!isJwkSet(body)) {
+      throw new Error("JWKS response does not contain a keys array.");
+    }
+
+    const keys = new Map<string, KeyObject>();
+    for (const jwk of body.keys) {
+      if (
+        typeof jwk.kid !== "string"
+        || jwk.kty !== "RSA"
+        || (jwk.use !== undefined && jwk.use !== "sig")
+        || (jwk.alg !== undefined && jwk.alg !== "RS256")
+      ) {
+        continue;
+      }
+      keys.set(jwk.kid, createPublicKey({ key: jwk, format: "jwk" }));
+    }
+
+    this.cache = {
+      expiresAt: Date.now() + JWKS_CACHE_TTL_MS,
+      keys,
+    };
+  }
+}
+
+export function createOAuthHttpAuthMiddleware(
+  config: OAuthConfig,
+  fetchImpl: typeof fetch = fetch,
+): RequestHandler {
+  const { issuer, resource, jwksUri, clientId, accountClaim } =
+    requiredOAuthConfig(config);
+  const metadataUrl = getProtectedResourceMetadataUrl(resource);
+  const resolver = new JwksResolver(jwksUri, fetchImpl);
+
+  return async (req, res, next) => {
+    if (req.path === "/health" || req.method === "OPTIONS") {
+      next();
+      return;
+    }
+
+    const token = bearerToken(req.headers.authorization);
+    if (!token) {
+      res.setHeader("WWW-Authenticate", `Bearer resource_metadata="${metadataUrl}"`);
+      res.status(401).json({
+        jsonrpc: "2.0",
+        error: { code: -32001, message: "OAuth access token required" },
+        id: null,
+      });
+      return;
+    }
+
+    try {
+      const decoded = jwt.decode(token, { complete: true });
+      if (
+        !decoded
+        || decoded.header.alg !== "RS256"
+        || typeof decoded.header.kid !== "string"
+      ) {
+        throw new Error("Access token has an unsupported JWT header.");
+      }
+
+      const key = await resolver.get(decoded.header.kid);
+      const claims = jwt.verify(token, key, {
+        algorithms: ["RS256"],
+        issuer,
+      }) as JwtPayload;
+      if (typeof claims.sub !== "string" || claims.sub.length === 0) {
+        throw new Error("Access token is missing sub.");
+      }
+      if (claims.azp !== clientId) {
+        throw new Error(`Access token was not issued to OAuth client "${clientId}".`);
+      }
+      const accountId = claims[accountClaim];
+      if (typeof accountId !== "string" || accountId.length === 0) {
+        throw new Error(`Access token is missing account claim "${accountClaim}".`);
+      }
+
+      res.locals.harnessOAuthClaims = claims;
+      res.locals.harnessOAuthAccessToken = token;
+      res.locals.harnessOAuthAccountId = accountId;
+      next();
+    } catch (error) {
+      log.warn("OAuth access token rejected", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      res.setHeader(
+        "WWW-Authenticate",
+        `Bearer error="invalid_token", resource_metadata="${metadataUrl}"`,
+      );
+      res.status(401).json({
+        jsonrpc: "2.0",
+        error: { code: -32001, message: "Invalid OAuth access token" },
+        id: null,
+      });
+    }
+  };
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -40,11 +40,13 @@
 - Verification passed: typecheck, build, and the full suite (147 files, 3,312 tests).
 - QA end-to-end against a real `mcp-client` token: local discovery matches the QA
   deployment's published metadata, `initialize` and `tools/list` succeed, and the token is
-  forwarded downstream with the account resolved from the token. Two QA-side gaps remain
-  outside this repo: the deployment gateway has no JWT provider registered for the
-  HarnessID issuer (`Jwt issuer is not configured`), and the QA Harness API returns
-  `500 UNKNOWN_ERROR` for a HarnessID token where an unknown token returns
-  `401 INVALID_TOKEN`.
+  forwarded downstream with the account resolved from the token.
+- QA `HARNESS_BASE_URL` is `https://mcp.harness-test.com/cli`; the platform APIs are routed
+  under `/cli` on the MCP host, and `buildUrl` preserves a base path prefix.
+- Open QA-side items outside this repo: the deployment gateway answered
+  `Jwt issuer is not configured` for the HarnessID issuer on both `/mcp` and `/cli` paths
+  during testing, and calling `qa.harness.io` directly with a HarnessID token returned
+  `500 UNKNOWN_ERROR` where an unknown token returns `401 INVALID_TOKEN`.
 
 ## Version bump 3.2.24 (2026-09-04)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,51 @@
 # Harness MCP Server — Task Tracking
 
+## HarnessID OAuth for self-hosted HTTP MCP (2026-09-07)
+
+- [x] Clone current `harness/mcp-server` main and inspect HTTP authentication/session paths.
+- [x] Add an opt-in OAuth deployment mode with RFC 9728 protected-resource discovery.
+- [x] Validate HarnessID JWT access tokens against issuer, audience, expiry, algorithm, and JWKS.
+- [x] Keep existing single-user and multi-user PAT behavior unchanged.
+- [x] Forward each session's HarnessID access token to the Harness API instead of a
+      shared deployment PAT.
+- [x] Add config, documentation, and focused HTTP/auth tests.
+- [x] Run build, typecheck, standards, docs, and test verification.
+
+### Plan
+
+- Publish protected-resource metadata from the MCP origin and challenge unauthenticated
+  requests with its URL so MCP clients can discover HarnessID and run authorization code
+  with PKCE.
+- Validate every HTTP MCP request, preserving `/health`, CORS preflight, and OAuth metadata
+  as public routes.
+- Carry the caller's own access token through to Harness API calls so RBAC and audit
+  records reflect the logged-in user, and take the account ID from the token rather than
+  from configuration.
+
+### Review
+
+- Added HTTP-only `oauth` mode, RFC 9728 root and path-aware metadata routes, HarnessID
+  JWKS caching, RS256/issuer/expiry/subject validation, `azp` client checking, and OAuth
+  subject binding for MCP sessions.
+- Sessions store the caller's access token and resolve it per request, so a refreshed token
+  is accepted while a token for a different subject or account is rejected. The client
+  sends it as `Authorization: Bearer` and no longer injects `x-api-key` in this mode;
+  `HARNESS_API_KEY` must not be set.
+- The account ID comes from the `account_id` claim populated by the HarnessID
+  `organization` scope, so `HARNESS_ACCOUNT_ID` is unnecessary in OAuth mode.
+- Kept static `HARNESS_MCP_AUTH_TOKEN`, single-user PAT/SAT, and multi-user session-PAT
+  paths unchanged.
+- Added QA HarnessID setup and validation guidance in `docs/harnessid-oauth.md`, plus
+  README and `.env.example` configuration.
+- Verification passed: typecheck, build, and the full suite (147 files, 3,312 tests).
+- QA end-to-end against a real `mcp-client` token: local discovery matches the QA
+  deployment's published metadata, `initialize` and `tools/list` succeed, and the token is
+  forwarded downstream with the account resolved from the token. Two QA-side gaps remain
+  outside this repo: the deployment gateway has no JWT provider registered for the
+  HarnessID issuer (`Jwt issuer is not configured`), and the QA Harness API returns
+  `500 UNKNOWN_ERROR` for a HarnessID token where an unknown token returns
+  `401 INVALID_TOKEN`.
+
 ## Version bump 3.2.24 (2026-09-04)
 
 - [x] Update package, shrinkwrap, and MCP manifest versions to 3.2.24.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,7 +4,9 @@
 
 - [x] Clone current `harness/mcp-server` main and inspect HTTP authentication/session paths.
 - [x] Add an opt-in OAuth deployment mode with RFC 9728 protected-resource discovery.
-- [x] Validate HarnessID JWT access tokens against issuer, audience, expiry, algorithm, and JWKS.
+- [x] Validate HarnessID JWT access tokens against issuer, expiry, algorithm, JWKS,
+      and the configured OAuth client (`azp`). HarnessID currently emits
+      `aud: account`, not the RFC 9728 MCP resource URL.
 - [x] Keep existing single-user and multi-user PAT behavior unchanged.
 - [x] Forward each session's HarnessID access token to the Harness API instead of a
       shared deployment PAT.

--- a/tests/client/harness-client.test.ts
+++ b/tests/client/harness-client.test.ts
@@ -413,6 +413,23 @@ describe("HarnessClient", () => {
       expect(url.searchParams.get("accountIdentifier")).toBe("account-from-token");
     });
 
+    it("does not forward a HarnessID token to the legacy Split API", async () => {
+      const client = new HarnessClient(makeConfig({
+        HARNESS_MCP_MODE: "oauth",
+        HARNESS_API_KEY: "",
+      }));
+      client.setBearerTokenResolver(() => "keycloak-access-token");
+
+      await expect(client.request({
+        path: "/internal/api/v2/splits/ws/workspace-1",
+        product: "fme",
+      })).rejects.toMatchObject({
+        statusCode: 401,
+        harnessCode: "FME_AUTH_MISSING",
+      });
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
     it("preserves caller-provided non-FME auth regardless of header casing", async () => {
       fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
       const client = new HarnessClient(makeConfig());

--- a/tests/client/harness-client.test.ts
+++ b/tests/client/harness-client.test.ts
@@ -367,6 +367,33 @@ describe("HarnessClient", () => {
       expect(headers["Harness-Account"]).toBe("test-account");
     });
 
+    it("forwards the current OAuth token as Bearer auth", async () => {
+      fetchSpy.mockImplementation(async () =>
+        new Response(JSON.stringify({}), { status: 200 })
+      );
+      const client = new HarnessClient(makeConfig({
+        HARNESS_MCP_MODE: "oauth",
+        HARNESS_API_KEY: "",
+      }));
+      let token = "keycloak-access-token-1";
+      client.setBearerTokenResolver(() => token);
+
+      await client.request({ path: "/ng/api/projects" });
+      token = "keycloak-access-token-2";
+      await client.request({ path: "/ng/api/projects" });
+
+      const firstHeaders = new Headers(fetchSpy.mock.calls[0][1]?.headers);
+      const secondHeaders = new Headers(fetchSpy.mock.calls[1][1]?.headers);
+      expect(firstHeaders.get("Authorization")).toBe(
+        "Bearer keycloak-access-token-1",
+      );
+      expect(secondHeaders.get("Authorization")).toBe(
+        "Bearer keycloak-access-token-2",
+      );
+      expect(firstHeaders.has("x-api-key")).toBe(false);
+      expect(secondHeaders.has("x-api-key")).toBe(false);
+    });
+
     it("preserves caller-provided non-FME auth regardless of header casing", async () => {
       fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
       const client = new HarnessClient(makeConfig());

--- a/tests/client/harness-client.test.ts
+++ b/tests/client/harness-client.test.ts
@@ -394,6 +394,25 @@ describe("HarnessClient", () => {
       expect(secondHeaders.has("x-api-key")).toBe(false);
     });
 
+    it("keeps the base URL path prefix on OAuth-mode requests", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      const client = new HarnessClient(makeConfig({
+        HARNESS_MCP_MODE: "oauth",
+        HARNESS_API_KEY: "",
+        HARNESS_BASE_URL: "https://mcp.harness-test.com/cli",
+      }));
+      client.setAccountIdResolver(() => "account-from-token");
+      client.setBearerTokenResolver(() => "keycloak-access-token");
+
+      await client.request({ path: "/ng/api/organizations" });
+
+      const url = new URL(fetchSpy.mock.calls[0][0] as string);
+      expect(url.origin + url.pathname).toBe(
+        "https://mcp.harness-test.com/cli/ng/api/organizations",
+      );
+      expect(url.searchParams.get("accountIdentifier")).toBe("account-from-token");
+    });
+
     it("preserves caller-provided non-FME auth regardless of header casing", async () => {
       fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
       const client = new HarnessClient(makeConfig());

--- a/tests/coding-standards/architecture.test.ts
+++ b/tests/coding-standards/architecture.test.ts
@@ -102,6 +102,7 @@ const SEARCH_DIR = join(SRC, "search");
 const ALLOWED_GLOBAL_FETCH_FILES = new Set([
   "src/client/harness-client.ts",
   "src/utils/log-resolver.ts",
+  "src/utils/oauth-auth.ts",
   "src/audit/sinks/webhook.ts",
   "src/search/remote-provider.ts",
 ]);
@@ -115,7 +116,7 @@ function zodV4RequiredFiles(): string[] {
 }
 
 /** Global fetch API calls — not method names like `async fetch(` or interface `fetch(...)`. */
-const GLOBAL_FETCH_PATTERN = /\bawait fetch\s*\(|\breturn fetch\s*\(|[^.\w]fetch\s*\(\s*["'`]|^fetch\s*\(/m;
+const GLOBAL_FETCH_PATTERN = /\bawait fetch\s*\(|\breturn fetch\s*\(|[^.\w]fetch\s*\(\s*["'`]|^fetch\s*\(|\bthis\.fetchImpl\s*\(/m;
 
 function walkTsFiles(dir: string): string[] {
   const results: string[] = [];

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -337,6 +337,84 @@ describe("ConfigSchema", () => {
     ).toThrow("HARNESS_API_KEY is required in single-user mode");
   });
 
+  it("accepts OAuth mode with HarnessID resource-server configuration", () => {
+    const result = ConfigSchema.safeParse({
+      HARNESS_MCP_MODE: "oauth",
+      HARNESS_MCP_OAUTH_ISSUER:
+        "https://id.harness-test.com/idp/realms/HarnessIDP/",
+      HARNESS_MCP_OAUTH_RESOURCE: "https://mcp.harness-test.com/mcp",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.HARNESS_API_KEY).toBe("");
+      expect(result.data.HARNESS_ACCOUNT_ID).toBe("");
+      expect(result.data.HARNESS_MCP_OAUTH_CLIENT_ID).toBe("mcp-client");
+      expect(result.data.HARNESS_MCP_OAUTH_ACCOUNT_CLAIM).toBe("account_id");
+      expect(result.data.HARNESS_MCP_OAUTH_JWKS_URI).toBe(
+        "https://id.harness-test.com/idp/realms/HarnessIDP/protocol/openid-connect/certs",
+      );
+      expect(result.data.HARNESS_MCP_OAUTH_SCOPES).toBe(
+        "openid profile email organization",
+      );
+    }
+  });
+
+  it("requires OAuth issuer and resource but not a shared Harness credential", () => {
+    expect(() =>
+      ConfigSchema.parse({
+        ...validConfig,
+        HARNESS_MCP_MODE: "oauth",
+        HARNESS_MCP_OAUTH_RESOURCE: "https://mcp.qa.example.com/mcp",
+      }),
+    ).toThrow("HARNESS_MCP_OAUTH_ISSUER is required");
+
+    expect(() =>
+      ConfigSchema.parse({
+        ...validConfig,
+        HARNESS_MCP_MODE: "oauth",
+        HARNESS_MCP_OAUTH_ISSUER: "https://harnessid.qa.example.com",
+      }),
+    ).toThrow("HARNESS_MCP_OAUTH_RESOURCE is required");
+
+    expect(() =>
+      ConfigSchema.parse({
+        HARNESS_MCP_MODE: "oauth",
+        HARNESS_MCP_OAUTH_ISSUER: "https://harnessid.qa.example.com",
+        HARNESS_MCP_OAUTH_RESOURCE: "https://mcp.qa.example.com/mcp",
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects a static HTTP auth token in OAuth mode", () => {
+    expect(() =>
+      ConfigSchema.parse({
+        ...validConfig,
+        HARNESS_MCP_MODE: "oauth",
+        HARNESS_MCP_OAUTH_ISSUER: "https://harnessid.qa.example.com",
+        HARNESS_MCP_OAUTH_RESOURCE: "https://mcp.qa.example.com/mcp",
+        HARNESS_MCP_AUTH_TOKEN: "ambiguous-shared-secret",
+      }),
+    ).toThrow("HARNESS_MCP_AUTH_TOKEN must not be set in oauth mode");
+  });
+
+  it("requires HTTPS for OAuth URLs unless local HTTP is explicitly allowed", () => {
+    const httpOAuthConfig = {
+      ...validConfig,
+      HARNESS_MCP_MODE: "oauth",
+      HARNESS_MCP_OAUTH_ISSUER: "http://127.0.0.1:8081",
+      HARNESS_MCP_OAUTH_RESOURCE: "http://127.0.0.1:3000/mcp",
+    };
+
+    expect(() => ConfigSchema.parse(httpOAuthConfig)).toThrow(
+      "HarnessID OAuth issuer, resource, and JWKS URLs must use HTTPS",
+    );
+    expect(ConfigSchema.safeParse({
+      ...httpOAuthConfig,
+      HARNESS_ALLOW_HTTP: "true",
+    }).success).toBe(true);
+  });
+
   it("parses HTTP MCP auth token and unauthenticated opt-out config", () => {
     const result = ConfigSchema.safeParse({
       ...validConfig,

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -366,22 +366,21 @@ describe("ConfigSchema", () => {
     }
   });
 
-  it("requires OAuth issuer and resource but not a shared Harness credential", () => {
-    expect(() =>
-      ConfigSchema.parse({
-        ...oauthConfig,
-        HARNESS_MCP_OAUTH_ISSUER: undefined,
-      }),
-    ).toThrow("HARNESS_MCP_OAUTH_ISSUER is required");
+  it("uses production HarnessID and MCP defaults in OAuth mode", () => {
+    const result = ConfigSchema.parse({ HARNESS_MCP_MODE: "oauth" });
 
-    expect(() =>
-      ConfigSchema.parse({
-        ...oauthConfig,
-        HARNESS_MCP_OAUTH_RESOURCE: undefined,
-      }),
-    ).toThrow("HARNESS_MCP_OAUTH_RESOURCE is required");
-
-    expect(() => ConfigSchema.parse(oauthConfig)).not.toThrow();
+    expect(result.HARNESS_BASE_URL).toBe("https://mcp.harness.io/cli");
+    expect(result.HARNESS_MCP_OAUTH_ISSUER).toBe(
+      "https://id.harness.io/idp/realms/HarnessIDP",
+    );
+    expect(result.HARNESS_MCP_OAUTH_RESOURCE).toBe(
+      "https://mcp.harness.io/mcp",
+    );
+    expect(result.HARNESS_MCP_OAUTH_JWKS_URI).toBe(
+      "https://id.harness.io/idp/realms/HarnessIDP/protocol/openid-connect/certs",
+    );
+    expect(result.HARNESS_API_KEY).toBe("");
+    expect(result.HARNESS_ACCOUNT_ID).toBe("");
   });
 
   it("rejects a static HTTP auth token in OAuth mode", () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -47,6 +47,12 @@ describe("ConfigSchema", () => {
     HARNESS_ACCOUNT_ID: "acct123",
   };
 
+  const oauthConfig = {
+    HARNESS_MCP_MODE: "oauth",
+    HARNESS_MCP_OAUTH_ISSUER: "https://harnessid.qa.example.com",
+    HARNESS_MCP_OAUTH_RESOURCE: "https://mcp.qa.example.com/mcp",
+  };
+
   it("parses valid full config", () => {
     const result = ConfigSchema.safeParse({
       ...validConfig,
@@ -363,45 +369,49 @@ describe("ConfigSchema", () => {
   it("requires OAuth issuer and resource but not a shared Harness credential", () => {
     expect(() =>
       ConfigSchema.parse({
-        ...validConfig,
-        HARNESS_MCP_MODE: "oauth",
-        HARNESS_MCP_OAUTH_RESOURCE: "https://mcp.qa.example.com/mcp",
+        ...oauthConfig,
+        HARNESS_MCP_OAUTH_ISSUER: undefined,
       }),
     ).toThrow("HARNESS_MCP_OAUTH_ISSUER is required");
 
     expect(() =>
       ConfigSchema.parse({
-        ...validConfig,
-        HARNESS_MCP_MODE: "oauth",
-        HARNESS_MCP_OAUTH_ISSUER: "https://harnessid.qa.example.com",
+        ...oauthConfig,
+        HARNESS_MCP_OAUTH_RESOURCE: undefined,
       }),
     ).toThrow("HARNESS_MCP_OAUTH_RESOURCE is required");
 
-    expect(() =>
-      ConfigSchema.parse({
-        HARNESS_MCP_MODE: "oauth",
-        HARNESS_MCP_OAUTH_ISSUER: "https://harnessid.qa.example.com",
-        HARNESS_MCP_OAUTH_RESOURCE: "https://mcp.qa.example.com/mcp",
-      }),
-    ).not.toThrow();
+    expect(() => ConfigSchema.parse(oauthConfig)).not.toThrow();
   });
 
   it("rejects a static HTTP auth token in OAuth mode", () => {
     expect(() =>
       ConfigSchema.parse({
-        ...validConfig,
-        HARNESS_MCP_MODE: "oauth",
-        HARNESS_MCP_OAUTH_ISSUER: "https://harnessid.qa.example.com",
-        HARNESS_MCP_OAUTH_RESOURCE: "https://mcp.qa.example.com/mcp",
+        ...oauthConfig,
         HARNESS_MCP_AUTH_TOKEN: "ambiguous-shared-secret",
       }),
     ).toThrow("HARNESS_MCP_AUTH_TOKEN must not be set in oauth mode");
   });
 
+  it("rejects shared Harness credentials in OAuth mode", () => {
+    expect(() =>
+      ConfigSchema.parse({
+        ...oauthConfig,
+        HARNESS_API_KEY: "pat.acct123.tokenId.secret",
+      }),
+    ).toThrow("HARNESS_API_KEY must not be set in oauth mode");
+
+    expect(() =>
+      ConfigSchema.parse({
+        ...oauthConfig,
+        HARNESS_FME_API_KEY: "shared-fme-key",
+      }),
+    ).toThrow("HARNESS_FME_API_KEY must not be set in oauth mode");
+  });
+
   it("requires HTTPS for OAuth URLs unless local HTTP is explicitly allowed", () => {
     const httpOAuthConfig = {
-      ...validConfig,
-      HARNESS_MCP_MODE: "oauth",
+      ...oauthConfig,
       HARNESS_MCP_OAUTH_ISSUER: "http://127.0.0.1:8081",
       HARNESS_MCP_OAUTH_RESOURCE: "http://127.0.0.1:3000/mcp",
     };
@@ -615,6 +625,14 @@ describe("ConfigSchema — HTTPS enforcement", () => {
       HARNESS_FME_API_KEY: "shared-fme-key",
       HARNESS_API_KEY: "pat.session-account.token.secret",
     })).toBe("pat.session-account.token.secret");
+  });
+
+  it("does not resolve deployment credentials for FME auth in oauth mode", () => {
+    expect(resolveFmeApiKey({
+      HARNESS_MCP_MODE: "oauth",
+      HARNESS_FME_API_KEY: "shared-fme-key",
+      HARNESS_API_KEY: "",
+    })).toBeUndefined();
   });
 });
 

--- a/tests/utils/http-auth.test.ts
+++ b/tests/utils/http-auth.test.ts
@@ -195,4 +195,24 @@ describe("HTTP MCP auth", () => {
     expect(warnSpy).not.toHaveBeenCalled();
     warnSpy.mockRestore();
   });
+
+  it("accepts non-loopback OAuth mode without a static auth token", () => {
+    const warnSpy = vi.spyOn(console, "error");
+
+    expect(() =>
+      validateHttpAuthForBindHost("0.0.0.0", {
+        HARNESS_MCP_AUTH_TOKEN: undefined,
+        HARNESS_MCP_ALLOW_UNAUTHENTICATED_HTTP: false,
+        HARNESS_MCP_MODE: "oauth",
+        HARNESS_API_KEY: "pat.test.abc.xyz",
+        HARNESS_MCP_OAUTH_ISSUER: "https://harnessid.qa.example.com",
+        HARNESS_MCP_OAUTH_RESOURCE: "https://mcp.qa.example.com/mcp",
+        HARNESS_MCP_OAUTH_JWKS_URI: "https://harnessid.qa.example.com/oauth/jwks",
+        HARNESS_MCP_OAUTH_SCOPES: "mcp:read mcp:execute",
+      }),
+    ).not.toThrow();
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
 });

--- a/tests/utils/oauth-auth.test.ts
+++ b/tests/utils/oauth-auth.test.ts
@@ -9,6 +9,7 @@ import {
   createOAuthHttpAuthMiddleware,
   getProtectedResourceMetadataUrl,
   isOAuthSessionSubjectAuthorized,
+  refreshOAuthSessionCredential,
   registerOAuthProtectedResourceRoutes,
 } from "../../src/utils/oauth-auth.js";
 
@@ -33,20 +34,31 @@ const publicJwk = {
   use: "sig",
 };
 
-function accessToken(clientId = "mcp-client"): string {
+interface AccessTokenOptions {
+  clientId?: string;
+  tokenIssuer?: string;
+  accountId?: string | null;
+  expiresIn?: jwt.SignOptions["expiresIn"];
+  signingKey?: typeof privateKey;
+  kid?: string;
+}
+
+function accessToken(options: AccessTokenOptions = {}): string {
+  const accountId = options.accountId === undefined ? "account-1" : options.accountId;
   return jwt.sign(
     {
-      azp: clientId,
+      azp: options.clientId ?? "mcp-client",
+      aud: "account",
       scope: "basic profile email organization:account-1",
-      account_id: "account-1",
+      ...(accountId === null ? {} : { account_id: accountId }),
     },
-    privateKey,
+    options.signingKey ?? privateKey,
     {
       algorithm: "RS256",
-      keyid: publicJwk.kid,
-      issuer,
+      keyid: options.kid ?? publicJwk.kid,
+      issuer: options.tokenIssuer ?? issuer,
       subject: "user-1",
-      expiresIn: "5m",
+      expiresIn: options.expiresIn ?? "5m",
     },
   );
 }
@@ -132,6 +144,32 @@ describe("HarnessID OAuth HTTP authentication", () => {
     expect(isOAuthSessionSubjectAuthorized(undefined, undefined)).toBe(true);
   });
 
+  it("refreshes only the token for the session's subject and account", () => {
+    const credential = {
+      subject: "user-1",
+      accountId: "account-1",
+      accessToken: "old-token",
+    };
+    expect(refreshOAuthSessionCredential(credential, {
+      harnessOAuthClaims: { sub: "user-1" },
+      harnessOAuthAccountId: "account-1",
+      harnessOAuthAccessToken: "refreshed-token",
+    })).toBe(true);
+    expect(credential.accessToken).toBe("refreshed-token");
+
+    expect(refreshOAuthSessionCredential(credential, {
+      harnessOAuthClaims: { sub: "user-2" },
+      harnessOAuthAccountId: "account-1",
+      harnessOAuthAccessToken: "stolen-token",
+    })).toBe(false);
+    expect(refreshOAuthSessionCredential(credential, {
+      harnessOAuthClaims: { sub: "user-1" },
+      harnessOAuthAccountId: "account-2",
+      harnessOAuthAccessToken: "other-account-token",
+    })).toBe(false);
+    expect(credential.accessToken).toBe("refreshed-token");
+  });
+
   it("serves root and path-aware protected-resource metadata without a token", async () => {
     const app = express();
     registerOAuthProtectedResourceRoutes(app, oauthConfig);
@@ -206,7 +244,7 @@ describe("HarnessID OAuth HTTP authentication", () => {
       const response = await get(
         baseUrl,
         "/mcp",
-        `Bearer ${accessToken("another-client")}`,
+        `Bearer ${accessToken({ clientId: "another-client" })}`,
       );
 
       expect(response.status).toBe(401);
@@ -214,6 +252,71 @@ describe("HarnessID OAuth HTTP authentication", () => {
       expect(response.body).toMatchObject({
         error: { code: -32001, message: "Invalid OAuth access token" },
       });
+    });
+  });
+
+  it.each([
+    ["issuer mismatch", accessToken({ tokenIssuer: "https://other.example.com" })],
+    ["expired token", accessToken({ expiresIn: "-1m" })],
+    ["missing account claim", accessToken({ accountId: null })],
+    ["empty account claim", accessToken({ accountId: "" })],
+  ])("rejects a token with %s", async (_case, token) => {
+    const app = express();
+    app.use(createOAuthHttpAuthMiddleware(oauthConfig, jwksFetch()));
+    app.get("/mcp", (_req, res) => res.json({ ok: true }));
+
+    await withListeningApp(app, async (baseUrl) => {
+      const response = await get(baseUrl, "/mcp", `Bearer ${token}`);
+      expect(response.status).toBe(401);
+      expect(response.authenticate).toContain('error="invalid_token"');
+    });
+  });
+
+  it("refreshes a warm JWKS cache when a token uses a rotated kid", async () => {
+    const rotated = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const rotatedJwk = {
+      ...rotated.publicKey.export({ format: "jwk" }),
+      kid: "rotated-signing-key",
+      alg: "RS256",
+      use: "sig",
+    };
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ keys: [publicJwk] })))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ keys: [publicJwk, rotatedJwk] })));
+    const app = express();
+    app.use(createOAuthHttpAuthMiddleware(oauthConfig, fetchImpl as unknown as typeof fetch));
+    app.get("/mcp", (_req, res) => res.json({ ok: true }));
+
+    await withListeningApp(app, async (baseUrl) => {
+      expect((await get(baseUrl, "/mcp", `Bearer ${accessToken()}`)).status).toBe(200);
+      const rotatedToken = accessToken({
+        signingKey: rotated.privateKey,
+        kid: rotatedJwk.kid,
+      });
+      expect((await get(baseUrl, "/mcp", `Bearer ${rotatedToken}`)).status).toBe(200);
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("rejects an unknown kid after refreshing a warm JWKS cache once", async () => {
+    const unknown = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const fetchImpl = jwksFetch();
+    const app = express();
+    app.use(createOAuthHttpAuthMiddleware(oauthConfig, fetchImpl));
+    app.get("/mcp", (_req, res) => res.json({ ok: true }));
+
+    await withListeningApp(app, async (baseUrl) => {
+      expect((await get(baseUrl, "/mcp", `Bearer ${accessToken()}`)).status).toBe(200);
+      const response = await get(
+        baseUrl,
+        "/mcp",
+        `Bearer ${accessToken({
+          signingKey: unknown.privateKey,
+          kid: "unknown-signing-key",
+        })}`,
+      );
+      expect(response.status).toBe(401);
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/tests/utils/oauth-auth.test.ts
+++ b/tests/utils/oauth-auth.test.ts
@@ -1,0 +1,219 @@
+import { generateKeyPairSync } from "node:crypto";
+import { request as httpRequest } from "node:http";
+import type { AddressInfo } from "node:net";
+import express from "express";
+import jwt from "jsonwebtoken";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildProtectedResourceMetadata,
+  createOAuthHttpAuthMiddleware,
+  getProtectedResourceMetadataUrl,
+  isOAuthSessionSubjectAuthorized,
+  registerOAuthProtectedResourceRoutes,
+} from "../../src/utils/oauth-auth.js";
+
+const issuer = "https://harnessid.qa.example.com";
+const resource = "https://mcp.qa.example.com/mcp";
+const oauthConfig = {
+  HARNESS_MCP_OAUTH_ISSUER: issuer,
+  HARNESS_MCP_OAUTH_RESOURCE: resource,
+  HARNESS_MCP_OAUTH_JWKS_URI: `${issuer}/oauth/jwks`,
+  HARNESS_MCP_OAUTH_CLIENT_ID: "mcp-client",
+  HARNESS_MCP_OAUTH_ACCOUNT_CLAIM: "account_id",
+  HARNESS_MCP_OAUTH_SCOPES: "openid profile email organization",
+};
+
+const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+});
+const publicJwk = {
+  ...publicKey.export({ format: "jwk" }),
+  kid: "qa-signing-key",
+  alg: "RS256",
+  use: "sig",
+};
+
+function accessToken(clientId = "mcp-client"): string {
+  return jwt.sign(
+    {
+      azp: clientId,
+      scope: "basic profile email organization:account-1",
+      account_id: "account-1",
+    },
+    privateKey,
+    {
+      algorithm: "RS256",
+      keyid: publicJwk.kid,
+      issuer,
+      subject: "user-1",
+      expiresIn: "5m",
+    },
+  );
+}
+
+function jwksFetch(): typeof fetch {
+  return vi.fn(async () =>
+    new Response(JSON.stringify({ keys: [publicJwk] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })) as unknown as typeof fetch;
+}
+
+async function withListeningApp(
+  app: express.Express,
+  fn: (baseUrl: string) => Promise<void>,
+): Promise<void> {
+  const server = app.listen(0, "127.0.0.1");
+  await new Promise<void>((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+
+  try {
+    const address = server.address() as AddressInfo;
+    await fn(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve());
+    });
+  }
+}
+
+async function get(
+  baseUrl: string,
+  path: string,
+  authorization?: string,
+): Promise<{ status: number; body: unknown; authenticate?: string }> {
+  const url = new URL(path, baseUrl);
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname,
+        method: "GET",
+        headers: authorization ? { Authorization: authorization } : undefined,
+      },
+      (res) => {
+        let rawBody = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => { rawBody += chunk; });
+        res.on("end", () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            body: rawBody ? JSON.parse(rawBody) : undefined,
+            authenticate: res.headers["www-authenticate"],
+          });
+        });
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("HarnessID OAuth HTTP authentication", () => {
+  it("builds RFC 9728 metadata and a path-aware metadata URL", () => {
+    expect(buildProtectedResourceMetadata(oauthConfig)).toEqual({
+      resource,
+      authorization_servers: [issuer],
+      scopes_supported: ["openid", "profile", "email", "organization"],
+      bearer_methods_supported: ["header"],
+    });
+    expect(getProtectedResourceMetadataUrl(resource)).toBe(
+      "https://mcp.qa.example.com/.well-known/oauth-protected-resource/mcp",
+    );
+  });
+
+  it("binds OAuth sessions to the subject that initialized them", () => {
+    expect(isOAuthSessionSubjectAuthorized("user-1", "user-1")).toBe(true);
+    expect(isOAuthSessionSubjectAuthorized("user-1", "user-2")).toBe(false);
+    expect(isOAuthSessionSubjectAuthorized("user-1", undefined)).toBe(false);
+    expect(isOAuthSessionSubjectAuthorized(undefined, undefined)).toBe(true);
+  });
+
+  it("serves root and path-aware protected-resource metadata without a token", async () => {
+    const app = express();
+    registerOAuthProtectedResourceRoutes(app, oauthConfig);
+    app.use(createOAuthHttpAuthMiddleware(oauthConfig, jwksFetch()));
+
+    await withListeningApp(app, async (baseUrl) => {
+      for (const path of [
+        "/.well-known/oauth-protected-resource",
+        "/.well-known/oauth-protected-resource/mcp",
+      ]) {
+        const response = await get(baseUrl, path);
+        expect(response.status).toBe(200);
+        expect(response.body).toMatchObject({
+          resource,
+          authorization_servers: [issuer],
+        });
+      }
+    });
+  });
+
+  it("challenges missing tokens with protected-resource metadata", async () => {
+    const app = express();
+    app.use(createOAuthHttpAuthMiddleware(oauthConfig, jwksFetch()));
+    app.get("/mcp", (_req, res) => res.json({ ok: true }));
+
+    await withListeningApp(app, async (baseUrl) => {
+      const response = await get(baseUrl, "/mcp");
+      expect(response.status).toBe(401);
+      expect(response.authenticate).toBe(
+        'Bearer resource_metadata="https://mcp.qa.example.com/.well-known/oauth-protected-resource/mcp"',
+      );
+      expect(response.body).toMatchObject({
+        error: { code: -32001, message: "OAuth access token required" },
+      });
+    });
+  });
+
+  it("accepts an mcp-client token and exposes its bearer credential", async () => {
+    const fetchImpl = jwksFetch();
+    const app = express();
+    app.use(createOAuthHttpAuthMiddleware(oauthConfig, fetchImpl));
+    app.get("/mcp", (_req, res) => {
+      res.json({
+        subject: res.locals.harnessOAuthClaims.sub,
+        accountId: res.locals.harnessOAuthAccountId,
+        accessToken: res.locals.harnessOAuthAccessToken,
+      });
+    });
+
+    await withListeningApp(app, async (baseUrl) => {
+      const token = accessToken();
+      const first = await get(baseUrl, "/mcp", `Bearer ${token}`);
+      const second = await get(baseUrl, "/mcp", `Bearer ${accessToken()}`);
+
+      expect(first.status).toBe(200);
+      expect(first.body).toEqual({
+        subject: "user-1",
+        accountId: "account-1",
+        accessToken: token,
+      });
+      expect(second.status).toBe(200);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("rejects tokens issued to another OAuth client", async () => {
+    const app = express();
+    app.use(createOAuthHttpAuthMiddleware(oauthConfig, jwksFetch()));
+    app.get("/mcp", (_req, res) => res.json({ ok: true }));
+
+    await withListeningApp(app, async (baseUrl) => {
+      const response = await get(
+        baseUrl,
+        "/mcp",
+        `Bearer ${accessToken("another-client")}`,
+      );
+
+      expect(response.status).toBe(401);
+      expect(response.authenticate).toContain('error="invalid_token"');
+      expect(response.body).toMatchObject({
+        error: { code: -32001, message: "Invalid OAuth access token" },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds an opt-in `HARNESS_MCP_MODE=oauth` for self-hosted HTTP deployments. The MCP endpoint becomes an OAuth 2.1 protected resource: remote clients discover HarnessID through RFC 9728, complete Authorization Code with PKCE, and send the resulting access token as `Authorization: Bearer`.

Each session keeps the caller's own access token and forwards it to the Harness API, so RBAC and audit records reflect the logged-in user instead of a shared deployment PAT. `HARNESS_API_KEY` and `HARNESS_FME_API_KEY` must not be set in this mode.

Single-user and multi-user credential paths are unchanged.

## How it works

- The server publishes protected-resource metadata at `/.well-known/oauth-protected-resource` and the path-aware variant for the configured resource, and answers unauthenticated requests with `401` plus a `WWW-Authenticate` challenge carrying the metadata URL.
- Access tokens are validated for issuer, expiry, and RS256 signature against the cached JWKS, and for the OAuth client they were issued to through the `azp` claim.
- Current HarnessID tokens use `aud: account` rather than the MCP resource URL. `HARNESS_MCP_OAUTH_RESOURCE` is therefore the RFC 9728 discovery/challenge identifier, not a JWT audience constraint.
- The account ID comes from the claim named by `HARNESS_MCP_OAUTH_ACCOUNT_CLAIM` (`account_id` by default), which the HarnessID `organization` scope populates, so `HARNESS_ACCOUNT_ID` is unnecessary.
- Sessions are bound to the subject and account that created them. A later request may carry a refreshed token for the same user; one for a different user or account is rejected.
- A warm-cache signing-key miss refreshes JWKS once, allowing normal HarnessID key rotation without waiting for cache expiry.
- Legacy workspace-based FME requests fail closed in OAuth mode so HarnessID tokens are never sent to `api.split.io`; Harness-native FME remains available with `org_id` and `project_id`.

## Zero-config production defaults

For production, only the mode is required:

```bash
HARNESS_MCP_MODE=oauth
```

Defaults:

- Issuer: `https://id.harness.io/idp/realms/HarnessIDP`
- Resource: `https://mcp.harness.io/mcp`
- Harness API base: `https://mcp.harness.io/cli`
- Client ID: `mcp-client`
- Scopes: `openid profile email organization`

All values remain overridable for local development and other Harness environments. `HARNESS_MCP_OAUTH_JWKS_URI` defaults to `<issuer>/protocol/openid-connect/certs`. OAuth-mode API routing defaults to `/cli`; single-user and multi-user still default to `https://app.harness.io`.

## Local Cursor test (2026-09-08)

Started the PR branch locally in OAuth HTTP mode:

```bash
HARNESS_MCP_MODE=oauth \
HARNESS_ALLOW_HTTP=true \
HARNESS_MCP_OAUTH_RESOURCE=http://127.0.0.1:3000/mcp \
HARNESS_MCP_OAUTH_ISSUER=https://id.harness.io/idp/realms/HarnessIDP \
HARNESS_BASE_URL=https://mcp.harness.io/cli \
HOST=127.0.0.1 \
PORT=3000 \
pnpm start:http
```

Startup:

```
Starting harness-mcp-server transport=http mode=oauth baseUrl=https://mcp.harness.io/cli accountId=(per-session)
Registry loaded: 243 resource types from 40 toolsets
harness-mcp-server listening on http://127.0.0.1:3000
Indexed 243 resource definitions
Session created sessionId=f495e8c9-89c4-44e2-ab7e-ea700bf0faa1 total=1
```

Health:

```json
{"status":"ok","sessions":0,"search":{"state":"ready","configured":"local","provider":"LocalSearchProvider"}}
```

RFC 9728 metadata at `GET /.well-known/oauth-protected-resource/mcp`:

```json
{
  "resource": "http://127.0.0.1:3000/mcp",
  "authorization_servers": ["https://id.harness.io/idp/realms/HarnessIDP"],
  "scopes_supported": ["openid", "profile", "email", "organization"],
  "bearer_methods_supported": ["header"]
}
```

Cursor MCP config used:

```json
{
  "mcpServers": {
    "harness-oauth-local": {
      "url": "http://127.0.0.1:3000/mcp",
      "auth": {
        "CLIENT_ID": "mcp-client"
      }
    }
  }
}
```

`harness_describe` from Cursor against that local session returned **243 resource types** across **40 toolsets**, matching the local registry load.

## Automated testing

- `pnpm build`, `pnpm typecheck`, `pnpm standards:check`, and `pnpm docs:check` pass.
- Full suite: 147 files, 3,323 tests passed.
- Added coverage for production defaults, issuer/expiry/account failures, `azp`, JWKS caching and rotation, Bearer refresh, session subject/account binding, `/cli` base-path preservation, and legacy FME fail-closed behavior.
- Verified end to end against production HarnessID and `https://mcp.harness.io/mcp` with a real `mcp-client` token across describe, list, get, schema, search, and status workflows.

## Docs

`docs/harnessid-oauth.md` covers production defaults, local HTTP setup, client configuration, discovery checks, validation behavior, and troubleshooting. README and `.env.example` are updated.