### PR TITLE
fix: align agent openInHarness links with worker-agents detail route

### DIFF
--- a/src/registry/toolsets/agents.ts
+++ b/src/registry/toolsets/agents.ts
@@ -48,7 +48,7 @@ export const agentsToolset: ToolsetDefinition = {
       scope: "project",
       scopeOptional: false,
       identifierFields: ["agent_id"],
-      deepLinkTemplate: "/ng/account/{accountId}/all/ai-agents/orgs/{orgIdentifier}/projects/{projectIdentifier}/agents/{agentIdentifier}",
+      deepLinkTemplate: "/ng/account/{accountId}/all/ai-agents/orgs/{orgIdentifier}/projects/{projectIdentifier}/worker-agents/{agentIdentifier}",
       operations: {
         list: {
           method: "GET",

--- a/src/utils/url-parser.ts
+++ b/src/utils/url-parser.ts
@@ -223,32 +223,50 @@ export function parseHarnessUrl(urlStr: string): ParsedHarnessUrl {
   }
 
   // 7. AI Worker Agents (ai-agents module):
-  // .../all/ai-agents/orgs/{org}/projects/{project}/worker-agents[/{agentId}]
-  // Legacy detail (pre AIPLAT-1530): .../ai-agents/.../agents/{agentId}
+  // List:  .../all/ai-agents/orgs/{org}/projects/{project}/worker-agents
+  // Detail: .../worker-agents/{agentId}
+  // Legacy detail: .../ai-agents/.../agents/{agentId}
   const aiAgentsIdx = segments.indexOf("ai-agents");
   if (aiAgentsIdx >= 0) {
-    result.resource_type = "agent";
-    if (result.project_id) {
-      result.resource_scope = "project";
-    } else if (result.org_id) {
-      result.resource_scope = "org";
-    }
+    const readAiAgentId = (segmentIdx: number): string | undefined => {
+      if (segmentIdx < 0 || segmentIdx + 1 >= segments.length) return undefined;
+      const candidate = decodeURIComponent(segments[segmentIdx + 1]!);
+      if (!candidate || STRUCTURAL.has(candidate) || RESOURCE_SEGMENTS[candidate]) {
+        return undefined;
+      }
+      return candidate;
+    };
+
+    const applyAiAgentScope = (): void => {
+      if (result.project_id) {
+        result.resource_scope = "project";
+      } else if (result.org_id) {
+        result.resource_scope = "org";
+      }
+    };
 
     const workerAgentsIdx = segments.indexOf("worker-agents", aiAgentsIdx);
-    if (workerAgentsIdx >= 0 && workerAgentsIdx + 1 < segments.length) {
-      const agentId = decodeURIComponent(segments[workerAgentsIdx + 1]!);
-      if (agentId && !STRUCTURAL.has(agentId)) {
+    if (workerAgentsIdx >= 0) {
+      const agentId = readAiAgentId(workerAgentsIdx);
+      if (agentId) {
+        result.resource_type = "agent";
+        applyAiAgentScope();
         result.agent_id = agentId;
         result.resource_id = agentId;
+      } else if (workerAgentsIdx + 1 >= segments.length) {
+        // worker-agents with no following segment is the list page; do not fall
+        // through to legacy .../agents/{id} parsing below.
+        result.resource_type = "agent";
+        applyAiAgentScope();
       }
     } else {
       const legacyAgentsIdx = segments.indexOf("agents", aiAgentsIdx);
-      if (legacyAgentsIdx >= 0 && legacyAgentsIdx + 1 < segments.length) {
-        const agentId = decodeURIComponent(segments[legacyAgentsIdx + 1]!);
-        if (agentId && !STRUCTURAL.has(agentId)) {
-          result.agent_id = agentId;
-          result.resource_id = agentId;
-        }
+      const agentId = readAiAgentId(legacyAgentsIdx);
+      if (agentId) {
+        result.resource_type = "agent";
+        applyAiAgentScope();
+        result.agent_id = agentId;
+        result.resource_id = agentId;
       }
     }
   }

--- a/src/utils/url-parser.ts
+++ b/src/utils/url-parser.ts
@@ -222,7 +222,38 @@ export function parseHarnessUrl(urlStr: string): ParsedHarnessUrl {
     }
   }
 
-  // 7. RMG release-management URLs:
+  // 7. AI Worker Agents (ai-agents module):
+  // .../all/ai-agents/orgs/{org}/projects/{project}/worker-agents[/{agentId}]
+  // Legacy detail (pre AIPLAT-1530): .../ai-agents/.../agents/{agentId}
+  const aiAgentsIdx = segments.indexOf("ai-agents");
+  if (aiAgentsIdx >= 0) {
+    result.resource_type = "agent";
+    if (result.project_id) {
+      result.resource_scope = "project";
+    } else if (result.org_id) {
+      result.resource_scope = "org";
+    }
+
+    const workerAgentsIdx = segments.indexOf("worker-agents", aiAgentsIdx);
+    if (workerAgentsIdx >= 0 && workerAgentsIdx + 1 < segments.length) {
+      const agentId = decodeURIComponent(segments[workerAgentsIdx + 1]!);
+      if (agentId && !STRUCTURAL.has(agentId)) {
+        result.agent_id = agentId;
+        result.resource_id = agentId;
+      }
+    } else {
+      const legacyAgentsIdx = segments.indexOf("agents", aiAgentsIdx);
+      if (legacyAgentsIdx >= 0 && legacyAgentsIdx + 1 < segments.length) {
+        const agentId = decodeURIComponent(segments[legacyAgentsIdx + 1]!);
+        if (agentId && !STRUCTURAL.has(agentId)) {
+          result.agent_id = agentId;
+          result.resource_id = agentId;
+        }
+      }
+    }
+  }
+
+  // 8. RMG release-management URLs:
   // .../release-management/releases/{slug}/execution/phases|tasks|activities
   const rmgRootIdx = segments.indexOf("release-management");
   if (rmgRootIdx >= 0) {

--- a/tests/registry/agent-deep-links.test.ts
+++ b/tests/registry/agent-deep-links.test.ts
@@ -6,7 +6,7 @@
  * (".../agents/{agentIdentifier}/details"). Chat navigated to that URL as-is.
  *
  * Correct UI 2.0 path (same layout as the worker-agents list):
- * /ng/account/{accountId}/all/ai-agents/orgs/{org}/projects/{project}/agents/{id}
+ * /ng/account/{accountId}/all/ai-agents/orgs/{org}/projects/{project}/worker-agents/{id}
  *
  * Create with only `id`/`uid` (no `agent_id` on input) is what would have caught
  * the original bug. List also has no `agent_id`; items must not include `name`
@@ -39,7 +39,7 @@ function mockFetchResponse(body: unknown, status = 200): Response {
 }
 
 const EXPECTED_PATH =
-  "https://app.harness.io/ng/account/testaccount/all/ai-agents/orgs/default/projects/aiTeam/agents/pipeline_lister_agent";
+  "https://app.harness.io/ng/account/testaccount/all/ai-agents/orgs/default/projects/aiTeam/worker-agents/pipeline_lister_agent";
 const EXPECTED_CUSTOM_LINK = `${EXPECTED_PATH}?type=custom`;
 const EXPECTED_SYSTEM_LINK = `${EXPECTED_PATH}?type=system`;
 

--- a/tests/utils/deep-links.test.ts
+++ b/tests/utils/deep-links.test.ts
@@ -82,7 +82,7 @@ describe("buildDeepLink", () => {
 });
 
 describe("appendAgentTypeQuery", () => {
-  const link = "https://app.harness.io/ng/account/a/all/ai-agents/orgs/o/projects/p/agents/x";
+  const link = "https://app.harness.io/ng/account/a/all/ai-agents/orgs/o/projects/p/worker-agents/x";
 
   it("appends type=custom or type=system from role", () => {
     expect(appendAgentTypeQuery(link, { role: "custom" })).toBe(`${link}?type=custom`);

--- a/tests/utils/url-parser.test.ts
+++ b/tests/utils/url-parser.test.ts
@@ -213,10 +213,40 @@ describe("parseHarnessUrl", () => {
     const result = parseHarnessUrl(
       "https://qa.harness.io/ng/account/abc123/all/ai-agents/orgs/avitest/projects/avi/worker-agents/ca_testashish?type=custom",
     );
+    expect(result.account_id).toBe("abc123");
+    expect(result.org_id).toBe("avitest");
+    expect(result.project_id).toBe("avi");
     expect(result.resource_type).toBe("agent");
     expect(result.agent_id).toBe("ca_testashish");
     expect(result.resource_id).toBe("ca_testashish");
     expect(result.resource_scope).toBe("project");
+  });
+
+  it("does not treat ai-agents module home as resource_type agent", () => {
+    const result = parseHarnessUrl(
+      "https://app.harness.io/ng/account/abc123/all/ai-agents",
+    );
+    expect(result.account_id).toBe("abc123");
+    expect(result.resource_type).toBeUndefined();
+    expect(result.agent_id).toBeUndefined();
+  });
+
+  it("does not treat nested worker-agents path segment as agent", () => {
+    const result = parseHarnessUrl(
+      "https://app.harness.io/ng/account/abc123/all/ai-agents/orgs/avitest/projects/avi/worker-agents/applications/myApp",
+    );
+    expect(result.resource_type).toBe("gitops_application");
+    expect(result.agent_id).toBeUndefined();
+    expect(result.resource_id).toBe("myApp");
+  });
+
+  it("handles gitops agent URL without ai-agents segment as gitops_agent", () => {
+    const result = parseHarnessUrl(
+      "https://app.harness.io/ng/account/abc123/all/orgs/default/projects/myProject/gitops/agents/myAgent",
+    );
+    expect(result.resource_type).toBe("gitops_agent");
+    expect(result.agent_id).toBe("myAgent");
+    expect(result.resource_id).toBe("myAgent");
   });
 
   it("handles legacy ai-agents detail URL with /agents/ segment (not gitops_agent)", () => {

--- a/tests/utils/url-parser.test.ts
+++ b/tests/utils/url-parser.test.ts
@@ -196,6 +196,39 @@ describe("parseHarnessUrl", () => {
     expect(result.agent_id).toBe("myAgent");
   });
 
+  it("handles ai-agents worker-agents list URL", () => {
+    const result = parseHarnessUrl(
+      "https://app.harness.io/ng/account/abc123/all/ai-agents/orgs/avitest/projects/avi/worker-agents",
+    );
+    expect(result.account_id).toBe("abc123");
+    expect(result.org_id).toBe("avitest");
+    expect(result.project_id).toBe("avi");
+    expect(result.resource_type).toBe("agent");
+    expect(result.resource_id).toBeUndefined();
+    expect(result.agent_id).toBeUndefined();
+    expect(result.resource_scope).toBe("project");
+  });
+
+  it("handles ai-agents worker-agents detail URL", () => {
+    const result = parseHarnessUrl(
+      "https://qa.harness.io/ng/account/abc123/all/ai-agents/orgs/avitest/projects/avi/worker-agents/ca_testashish?type=custom",
+    );
+    expect(result.resource_type).toBe("agent");
+    expect(result.agent_id).toBe("ca_testashish");
+    expect(result.resource_id).toBe("ca_testashish");
+    expect(result.resource_scope).toBe("project");
+  });
+
+  it("handles legacy ai-agents detail URL with /agents/ segment (not gitops_agent)", () => {
+    const result = parseHarnessUrl(
+      "https://app.harness.io/ng/account/abc123/all/ai-agents/orgs/avitest/projects/avi/agents/ca_testashish?type=custom",
+    );
+    expect(result.resource_type).toBe("agent");
+    expect(result.agent_id).toBe("ca_testashish");
+    expect(result.resource_id).toBe("ca_testashish");
+    expect(result.resource_scope).toBe("project");
+  });
+
   it("handles feature flags URL", () => {
     const result = parseHarnessUrl(
       "https://app.harness.io/ng/account/abc123/cf/orgs/default/projects/myProject/feature-flags/my_flag",


### PR DESCRIPTION
Update deep links and URL parsing so AI agent detail paths use /worker-agents/{id} under ai-agents, matching platformUI AIPLAT-1530.

## Description
<!-- What does this PR do? -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [ ] `pnpm test` passes
- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` passes
- [ ] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [ ] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
If this PR adds or changes Harness API coverage:
- [ ] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [ ] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [ ] `operationPolicy` on every new/changed endpoint
- [ ] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [ ] `identifierFields` and `scope` declared on new resources
- [ ] No `console.log()` in `src/` (stdio JSON-RPC safety)
