### PR TITLE
feat: add Vibe app intake and lifecycle resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![MCP Toplist](https://mcptoplist.com/badge/glama%2Fharness%2Fmcp-server.svg)](https://mcptoplist.com/server/glama%2Fharness%2Fmcp-server)
 
-An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 243 resource types.
+An MCP (Model Context Protocol) server that gives AI agents full access to the Harness.io platform through 11 consolidated tools and 245 resource types.
 
 ## Why Use This MCP Server
 
@@ -10,8 +10,8 @@ Most MCP servers map one tool per API endpoint. For a platform as broad as Harne
 
 This server is built differently:
 
-- **11 tools, 243 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
-- **Full platform coverage.** 40 default toolsets spanning CI/CD, GitOps, Feature Flags, Cloud Cost Management, Security Testing, Chaos Engineering, Database DevOps, Internal Developer Portal, Software Supply Chain, Infrastructure as Code Management, Release Management, Governance, Service Overrides, Knowledge Graph, and more. Opt-in Ansible coverage is available when you need inventory and playbook data.
+- **11 tools, 245 resource types.** A registry-based dispatch system routes `harness_list`, `harness_get`, `harness_create`, etc. to any Harness resource — pipelines, services, environments, orgs, projects, feature flags, cost data, and more. The LLM picks from 11 tools instead of hundreds.
+- **Full platform coverage.** 41 default toolsets spanning CI/CD, GitOps, Feature Flags, Cloud Cost Management, Security Testing, Chaos Engineering, Database DevOps, Internal Developer Portal, Software Supply Chain, Infrastructure as Code Management, Release Management, Governance, Service Overrides, Knowledge Graph, and more. Opt-in Ansible coverage is available when you need inventory and playbook data.
 - **Multi-project workflows out of the box.** Agents discover organizations and projects dynamically — no hardcoded env vars needed. Ask "show failed executions across all projects" and the agent can navigate the full account hierarchy.
 - **35 prompt templates.** Pre-built prompts for common workflows: build & deploy apps end-to-end, debug failed pipelines, review DORA metrics, triage vulnerabilities, optimize cloud costs, audit access control, plan feature flag rollouts, review pull requests, approve pending pipelines, and more.
 - **Works everywhere.** Stdio transport for local clients (Claude Desktop, Cursor, Devin Desktop), HTTP transport for remote/shared deployments, Docker and Kubernetes ready.
@@ -1261,7 +1261,7 @@ Harness pipelines can be stored in three ways:
 
 ## Resource Types
 
-243 resource types organized across 40 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
+245 resource types organized across 41 toolsets. Each resource type supports a subset of CRUD operations and optional execute actions.
 
 ### Platform
 
@@ -1576,6 +1576,58 @@ Typical workflow:
 6. `harness_get` on `release_input`, `release_execution_phase_input`, `release_execution_phase_output`, `release_execution_activity_output`, or `release_execution_activity_input` using `release_id` plus `params.phase_identifier` / `params.activity_identifier` / `activity_execution_id` as documented on each resource.
 
 
+### Vibe
+
+The `vibe` toolset covers the [Vibe Orchestrator BFF contract](tests/fixtures/vibe-bff-openapi.yaml) under `${HARNESS_BASE_URL}/vibe/v1`. It uses the existing Harness connection and account header, without adding account/org/project query parameters or scope fields to request bodies. The contract documents bearer/session authentication; the server's OAuth mode forwards the current session's bearer token. PAT acceptance by the Vibe gateway is not specified in this contract.
+
+| Resource Type | List | Get | Create | Update | Delete | Execute Actions |
+| ------------- | ---- | --- | ------ | ------ | ------ | --------------- |
+| `vibe_project` |      |     | x      |        |        | `prepare`, `deploy` |
+| `vibe_app_lifecycle` | | x | | | | `events` |
+
+The API supports two intake paths. Keep these API-native request shapes:
+
+| Source available to the coding agent | API flow |
+| ----------------------------------- | -------- |
+| GitHub repository link/connector | `harness_create` with `resource_type="vibe_project"` and `body.mode` plus the mode-specific fields. The contract names `github_link` and `github_connector` but does not define their URL, branch, or connector field shapes; these fields are forwarded to the backend without inventing a mapping. |
+| ZIP file | Call `prepare` with the app name and file metadata, upload the bytes to the returned signed target, then call `deploy`. |
+| Local source directory | The coding agent archives the intended workspace source into a ZIP locally, then follows the ZIP flow. A local path or conversational context is not an API-supported source upload. |
+
+When packaging a directory, include the source, manifests, lockfiles, configuration, and intended uncommitted edits needed to build it. Exclude credentials, `.git`, installed dependencies, and generated artifacts. Packaging and the signed upload happen where the files are accessible; a hosted MCP server cannot read the coding agent's local directory.
+
+For an existing ZIP, prepare the upload:
+
+```json
+{
+  "resource_type": "vibe_project",
+  "action": "prepare",
+  "body": {
+    "name": "demo-app",
+    "file": {
+      "path": "app.zip",
+      "size_bytes": 12345,
+      "content_type": "application/zip"
+    }
+  }
+}
+```
+
+Pass this to `harness_execute`. The size must describe the actual ZIP; `size_bytes`, `content_type`, and `md5` are optional and nullable. Preparation returns `projectId`, `sourceId`, and `upload`, including each file's `uploadUrl`, `method`, `headers`, and `expiresAt`. Upload the file bytes directly using that signed URL, method, and headers; preserve the URL exactly and do not add Harness credentials to the storage request. The prepare action does not read or upload local files.
+
+After a successful upload, explicitly deploy:
+
+```json
+{
+  "resource_type": "vibe_project",
+  "action": "deploy",
+  "resource_id": "<projectId returned by prepare>"
+}
+```
+
+For JSON imports, use the returned `id` instead. Deployment also accepts `body: {"project_id": "<Vibe app id>"}` or `params.app_id`; the API wire field is snake_case `project_id` even though prepare returns camelCase `projectId`. The generic tool's top-level `project_id` is a Harness scope identifier and is never used as the Vibe app id. Import and prepare create the app/source; neither starts deployment. Writes are not automatically retried, and deployment uses the existing high-risk confirmation policy.
+
+Read progress with `harness_get(resource_type="vibe_app_lifecycle", resource_id="<Vibe app id>")`. It retains app URLs, execution stages, substeps, failures, log lines, and build-analyzer details. The `events` execute action consumes the SSE endpoint as a finite batch: up to 20 JSON events or five seconds after connection, with a 1 MiB response limit. It returns `events` and `stop_reason` (`end`, `event_limit`, or `duration_limit`), closes the stream, and does not reconnect. Events are transient diffs with no documented replay cursor; use lifecycle get for an authoritative snapshot. Both lifecycle reads are available in read-only mode.
+
 ### Feature Flags
 
 
@@ -1887,7 +1939,7 @@ Security exemption execute workflow:
 
 ## Toolset Filtering
 
-By default, 40 of 43 toolsets are enabled. Three toolsets are opt-in and excluded from the defaults:
+By default, 41 of 44 toolsets are enabled. Three toolsets are opt-in and excluded from the defaults:
 
 - **`ansible`** — Harness Ansible (inventories, playbooks, hosts, activity). Opt-in because it is project-scoped and adds concepts many users do not need.
 - **`autonomous_work`** — Development Harness (autonomous work). Opt-in; see toolset description for scope.
@@ -1971,6 +2023,7 @@ Available toolset names:
 | `ansible` *(opt-in)*    | ansible_inventory, ansible_playbook, ansible_host, ansible_host_activity, ansible_activity                                                                                                                                                                                                      |
 | `registries-v3` *(opt-in)* | package_v3, version_v3, file_v3, registry_metadata_v3, package_metadata_v3, version_metadata_v3, file_metadata_v3, metadata_key_v3, metadata_value_v3, artifact_scan_v3, bulk_scan_evaluation_v3, firewall_exception_v3, firewall_exception_version_v3                                       |
 | `release-management`  | release_process, release_activity, release, release_execution_phase, release_execution_task, release_execution_activity, release_input, release_execution_phase_input, release_execution_phase_output, release_execution_activity_input, release_execution_activity_output |
+| `vibe`                | vibe_project, vibe_app_lifecycle |
 
 
 ## Architecture
@@ -1988,8 +2041,8 @@ Available toolset names:
                           |
                  +--------v---------+
                 |    Registry       |  <-- Declarative resource definitions
-                |  40 Toolsets      |      (data files, not code)
-                |  243 Resource Types|
+                |  41 Toolsets      |      (data files, not code)
+                |  245 Resource Types|
                  +--------+---------+
                           |
                  +--------v---------+

--- a/README.md
+++ b/README.md
@@ -1578,7 +1578,7 @@ Typical workflow:
 
 ### Vibe
 
-The `vibe` toolset covers the [Vibe Orchestrator BFF contract](tests/fixtures/vibe-bff-openapi.yaml) under `${HARNESS_BASE_URL}/vibe/v1`. It uses the existing Harness connection and account header, without adding account/org/project query parameters or scope fields to request bodies. The contract documents bearer/session authentication; the server's OAuth mode forwards the current session's bearer token. PAT acceptance by the Vibe gateway is not specified in this contract.
+The default-enabled `vibe` toolset covers the [Vibe Orchestrator BFF contract](tests/fixtures/vibe-bff-openapi.yaml) under `${HARNESS_BASE_URL}/vibe/v1`. It uses the existing Harness connection and account header, without adding account/org/project query parameters or scope fields to request bodies. The team validated the Vibe flow using Harness API-key authentication (PAT/SAT), so no opt-in setting is required for default sessions. The curated OpenAPI documents bearer/session authentication; the server's OAuth mode forwards the current session's bearer token. Automated regressions verify both header paths; gateway authentication remains subject to the target environment's configuration.
 
 | Resource Type | List | Get | Create | Update | Delete | Execute Actions |
 | ------------- | ---- | --- | ------ | ------ | ------ | --------------- |
@@ -1612,7 +1612,7 @@ For an existing ZIP, prepare the upload:
 }
 ```
 
-Pass this to `harness_execute`. The size must describe the actual ZIP; `size_bytes`, `content_type`, and `md5` are optional and nullable. Preparation returns `projectId`, `sourceId`, and `upload`, including each file's `uploadUrl`, `method`, `headers`, and `expiresAt`. Upload the file bytes directly using that signed URL, method, and headers; preserve the URL exactly and do not add Harness credentials to the storage request. The prepare action does not read or upload local files.
+Pass this to `harness_execute`. The size must describe the actual ZIP; `size_bytes`, `content_type`, and `md5` are optional and nullable. Additional prepare fields are preserved for backend validation, as permitted by the OpenAPI. Preparation returns `projectId`, `sourceId`, and `upload`, including each file's `uploadUrl`, `method`, `headers`, and `expiresAt`. Upload the file bytes directly using that signed URL, method, and headers; preserve the URL exactly and do not add Harness credentials to the storage request. The prepare action does not read or upload local files.
 
 After a successful upload, explicitly deploy:
 
@@ -1626,7 +1626,7 @@ After a successful upload, explicitly deploy:
 
 For JSON imports, use the returned `id` instead. Deployment also accepts `body: {"project_id": "<Vibe app id>"}` or `params.app_id`; the API wire field is snake_case `project_id` even though prepare returns camelCase `projectId`. The generic tool's top-level `project_id` is a Harness scope identifier and is never used as the Vibe app id. Import and prepare create the app/source; neither starts deployment. Writes are not automatically retried, and deployment uses the existing high-risk confirmation policy.
 
-Read progress with `harness_get(resource_type="vibe_app_lifecycle", resource_id="<Vibe app id>")`. It retains app URLs, execution stages, substeps, failures, log lines, and build-analyzer details. The `events` execute action consumes the SSE endpoint as a finite batch: up to 20 JSON events or five seconds after connection, with a 1 MiB response limit. It returns `events` and `stop_reason` (`end`, `event_limit`, or `duration_limit`), closes the stream, and does not reconnect. Events are transient diffs with no documented replay cursor; use lifecycle get for an authoritative snapshot. Both lifecycle reads are available in read-only mode.
+Read progress with `harness_get(resource_type="vibe_app_lifecycle", resource_id="<Vibe app id>")`. It retains app URLs, execution stages, substeps, failures, log lines, and build-analyzer details. The `events` execute action accepts `resource_id` or `params.app_id` and consumes the SSE endpoint as a finite batch: up to 20 JSON events or five seconds after connection, with a 1 MiB response limit. These limits belong to the Vibe endpoint. The connection's `HARNESS_API_TIMEOUT_MS` also bounds connection and stream consumption together; expiration returns a timeout error. A completed batch returns `events` and `stop_reason` (`end`, `event_limit`, or `duration_limit`) and closes the stream. Neither initial connection failures nor broken streams are retried. Events are transient diffs with no documented replay cursor; use lifecycle get for an authoritative snapshot. Both lifecycle reads are available in read-only mode.
 
 ### Feature Flags
 

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -21,6 +21,7 @@ const README_COVERAGE_TOOLSETS = new Map([
   ["file_store", { sectionTitle: "File Store" }],
   ["chaos", { sectionTitle: "Chaos Engineering" }],
   ["release-management", { sectionTitle: "Release Management" }],
+  ["vibe", { sectionTitle: "Vibe" }],
 ]);
 const CRUD_OPERATIONS = ["list", "get", "create", "update", "delete"];
 const CRUD_COLUMN_INDEX = { list: 1, get: 2, create: 3, update: 4, delete: 5 };

--- a/src/client/harness-client.ts
+++ b/src/client/harness-client.ts
@@ -3,9 +3,9 @@ import type { RequestOptions } from "./types.js";
 import { HarnessApiError } from "../utils/errors.js";
 import { RateLimiter } from "../utils/rate-limiter.js";
 import { createLogger } from "../utils/logger.js";
-import { redactJsonString } from "../utils/redact.js";
+import { redactJsonString, redactSensitiveFields } from "../utils/redact.js";
 import { isFormDataBody, isRecord } from "../utils/type-guards.js";
-import { readJsonEventStream } from "./sse.js";
+import { assertJsonEventStreamLimits, readJsonEventStream } from "./sse.js";
 
 const log = createLogger("harness-client");
 
@@ -110,18 +110,19 @@ const ERROR_FIELD_ENRICHMENTS: Array<{ pathPrefix: string; field: string }> = [
 
 const MAX_ERROR_DETAIL_CHARS = 400;
 
-/** Accept standard Harness errors and BFF envelopes with nested error.code/message. */
-function parseApiError(body: string): Record<string, unknown> & { message?: string; code?: string; correlationId?: string } {
+/** Preserve standard Harness errors; adapt Vibe's nested BFF envelope only on Vibe paths. */
+function parseApiError(body: string, path: string): Record<string, unknown> & { message?: string; code?: string | number; correlationId?: string } {
   let raw: unknown;
   try { raw = JSON.parse(body); } catch { return {}; }
   if (!isRecord(raw)) return {};
-  const nested = isRecord(raw.error) ? raw.error : {};
+  const nested = path.startsWith("/vibe/v1/") && isRecord(raw.error) ? raw.error : {};
   const message = typeof raw.message === "string" ? raw.message : nested.message;
-  const code = typeof raw.code === "string" ? raw.code : nested.code;
+  const code = raw.code ?? nested.code;
   return {
     ...raw,
     message: typeof message === "string" ? message : undefined,
-    code: typeof code === "string" ? code : undefined,
+    code: typeof code === "string" || typeof code === "number" ? code : undefined,
+    details: raw.details ?? (isRecord(nested.details) ? JSON.stringify(redactSensitiveFields(nested.details)) : nested.details),
     correlationId: typeof raw.correlationId === "string" ? raw.correlationId : undefined,
   };
 }
@@ -353,6 +354,7 @@ export class HarnessClient {
   }
 
   async request<T>(options: RequestOptions): Promise<T> {
+    if (options.responseType === "sse") assertJsonEventStreamLimits(options.sseLimits);
     await this.rateLimiter.acquire();
 
     const method = options.method ?? "GET";
@@ -378,6 +380,7 @@ export class HarnessClient {
         await new Promise((r) => setTimeout(r, backoff));
       }
 
+      let timer: ReturnType<typeof setTimeout> | undefined;
       try {
         // Check if already aborted before starting the request
         if (options.signal?.aborted) {
@@ -386,7 +389,7 @@ export class HarnessClient {
 
         const timeoutController = new AbortController();
         const effectiveTimeout = options.timeoutMs ?? this.timeout;
-        const timer = setTimeout(() => timeoutController.abort(), effectiveTimeout);
+        timer = setTimeout(() => timeoutController.abort(), effectiveTimeout);
         // Merge external signal (client disconnect) with timeout signal
         const signal = options.signal
           ? AbortSignal.any([options.signal, timeoutController.signal])
@@ -412,11 +415,12 @@ export class HarnessClient {
           signal,
         });
 
-        clearTimeout(timer);
+        // JSON/binary behavior is unchanged; SSE keeps the HTTP deadline through consumption.
+        if (options.responseType !== "sse") clearTimeout(timer);
 
         if (!response.ok) {
           const body = await response.text();
-          const parsed = parseApiError(body);
+          const parsed = parseApiError(body, options.path);
 
           const rawMessage = isGarbageMessage(parsed.message)
               ? humanizeHttpError(response.status, body)
@@ -445,7 +449,15 @@ export class HarnessClient {
         }
 
         if (options.responseType === "sse") {
-          return await readJsonEventStream(response, options.signal) as T;
+          try {
+            return await readJsonEventStream(response, signal, options.sseLimits!) as T;
+          } catch (cause) {
+            // Never reconnect a consumed stream, including when the overall HTTP deadline expires.
+            if (timeoutController.signal.aborted && !options.signal?.aborted) {
+              throw new HarnessApiError("Request timed out", 408, undefined, undefined, cause);
+            }
+            throw cause;
+          }
         }
 
         // Binary response mode — return raw ArrayBuffer (used for ZIP downloads)
@@ -496,6 +508,8 @@ export class HarnessClient {
           undefined,
           err,
         );
+      } finally {
+        clearTimeout(timer);
       }
     }
 
@@ -557,7 +571,7 @@ export class HarnessClient {
 
         if (!response.ok) {
           const body = await response.text();
-          const parsed = parseApiError(body);
+          const parsed = parseApiError(body, options.path);
 
           const rawMessage = isGarbageMessage(parsed.message)
               ? humanizeHttpError(response.status, body)

--- a/src/client/harness-client.ts
+++ b/src/client/harness-client.ts
@@ -4,7 +4,8 @@ import { HarnessApiError } from "../utils/errors.js";
 import { RateLimiter } from "../utils/rate-limiter.js";
 import { createLogger } from "../utils/logger.js";
 import { redactJsonString } from "../utils/redact.js";
-import { isFormDataBody } from "../utils/type-guards.js";
+import { isFormDataBody, isRecord } from "../utils/type-guards.js";
+import { readJsonEventStream } from "./sse.js";
 
 const log = createLogger("harness-client");
 
@@ -108,6 +109,22 @@ const ERROR_FIELD_ENRICHMENTS: Array<{ pathPrefix: string; field: string }> = [
 ];
 
 const MAX_ERROR_DETAIL_CHARS = 400;
+
+/** Accept standard Harness errors and BFF envelopes with nested error.code/message. */
+function parseApiError(body: string): Record<string, unknown> & { message?: string; code?: string; correlationId?: string } {
+  let raw: unknown;
+  try { raw = JSON.parse(body); } catch { return {}; }
+  if (!isRecord(raw)) return {};
+  const nested = isRecord(raw.error) ? raw.error : {};
+  const message = typeof raw.message === "string" ? raw.message : nested.message;
+  const code = typeof raw.code === "string" ? raw.code : nested.code;
+  return {
+    ...raw,
+    message: typeof message === "string" ? message : undefined,
+    code: typeof code === "string" ? code : undefined,
+    correlationId: typeof raw.correlationId === "string" ? raw.correlationId : undefined,
+  };
+}
 
 /** Extra NG fields (`details`, `detailedMessage`, `responseMessages`) not already in `message`. */
 function collectErrorDetail(parsed: Record<string, unknown>, message: string): string | undefined {
@@ -399,13 +416,7 @@ export class HarnessClient {
 
         if (!response.ok) {
           const body = await response.text();
-          let parsed: { message?: string; code?: string; correlationId?: string } = {};
-          try {
-            parsed = JSON.parse(body);
-          } catch {
-            // Non-JSON error (HTML proxy page, WAF block, etc.)
-            // Provide actionable messages instead of leaking raw HTML to the LLM
-          }
+          const parsed = parseApiError(body);
 
           const rawMessage = isGarbageMessage(parsed.message)
               ? humanizeHttpError(response.status, body)
@@ -431,6 +442,10 @@ export class HarnessClient {
           }
 
           throw error;
+        }
+
+        if (options.responseType === "sse") {
+          return await readJsonEventStream(response, options.signal) as T;
         }
 
         // Binary response mode — return raw ArrayBuffer (used for ZIP downloads)
@@ -542,8 +557,7 @@ export class HarnessClient {
 
         if (!response.ok) {
           const body = await response.text();
-          let parsed: { message?: string; code?: string; correlationId?: string } = {};
-          try { parsed = JSON.parse(body); } catch { /* non-JSON */ }
+          const parsed = parseApiError(body);
 
           const rawMessage = isGarbageMessage(parsed.message)
               ? humanizeHttpError(response.status, body)

--- a/src/client/sse.ts
+++ b/src/client/sse.ts
@@ -1,4 +1,12 @@
 import { HarnessApiError } from "../utils/errors.js";
+import type { JsonEventStreamLimits } from "./types.js";
+
+export function assertJsonEventStreamLimits(limits: JsonEventStreamLimits | undefined): asserts limits is JsonEventStreamLimits {
+  if (!limits || ![limits.maxEvents, limits.durationMs, limits.maxBytes].every(value => Number.isSafeInteger(value) && value > 0)
+      || limits.durationMs > 2_147_483_647) {
+    throw new Error("SSE requires explicit positive integer maxEvents, durationMs, and maxBytes limits; durationMs must fit a timer.");
+  }
+}
 
 export interface JsonEventBatch {
   events: unknown[];
@@ -8,9 +16,10 @@ export interface JsonEventBatch {
 /** Read a finite batch of JSON data events; this is not a reconnecting EventSource. */
 export async function readJsonEventStream(
   response: Response,
-  signal?: AbortSignal,
-  limits = { maxEvents: 20, durationMs: 5000, maxBytes: 1_048_576 },
+  signal: AbortSignal | undefined,
+  limits: JsonEventStreamLimits,
 ): Promise<JsonEventBatch> {
+  assertJsonEventStreamLimits(limits);
   if (response.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase() !== "text/event-stream") {
     void response.body?.cancel().catch(() => {});
     throw new HarnessApiError("Expected a text/event-stream response", 502);
@@ -60,7 +69,7 @@ export async function readJsonEventStream(
       if (chunk === "duration_limit") return { events, stop_reason: chunk };
       if (!chunk.done) {
         bytes += chunk.value.byteLength;
-        if (bytes > limits.maxBytes) throw new HarnessApiError("Event stream exceeded the 1 MiB batch size limit", 502);
+        if (bytes > limits.maxBytes) throw new HarnessApiError(`Event stream exceeded the ${limits.maxBytes} byte batch size limit`, 502);
       }
       pending += decoder.decode(chunk.value, { stream: !chunk.done });
       while (true) {

--- a/src/client/sse.ts
+++ b/src/client/sse.ts
@@ -1,0 +1,91 @@
+import { HarnessApiError } from "../utils/errors.js";
+
+export interface JsonEventBatch {
+  events: unknown[];
+  stop_reason: "end" | "event_limit" | "duration_limit";
+}
+
+/** Read a finite batch of JSON data events; this is not a reconnecting EventSource. */
+export async function readJsonEventStream(
+  response: Response,
+  signal?: AbortSignal,
+  limits = { maxEvents: 20, durationMs: 5000, maxBytes: 1_048_576 },
+): Promise<JsonEventBatch> {
+  if (response.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase() !== "text/event-stream") {
+    void response.body?.cancel().catch(() => {});
+    throw new HarnessApiError("Expected a text/event-stream response", 502);
+  }
+  if (!response.body) throw new HarnessApiError("Event stream has no response body", 502);
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const events: unknown[] = [];
+  let pending = "";
+  let dataLines: string[] = [];
+  let bytes = 0;
+  let stop: (reason: "duration_limit" | "cancelled") => void = () => {};
+  const stopped = new Promise<"duration_limit" | "cancelled">((resolve) => { stop = resolve; });
+  const timer = setTimeout(() => stop("duration_limit"), limits.durationMs);
+  const onAbort = () => stop("cancelled");
+  signal?.addEventListener("abort", onAbort, { once: true });
+
+  function processLine(line: string): void {
+    if (line === "") {
+      if (dataLines.length > 0) {
+        const data = dataLines.join("\n");
+        dataLines = [];
+        if (data === "") return;
+        try {
+          events.push(JSON.parse(data));
+        } catch (cause) {
+          // Do not echo event contents: streams may contain logs or signed URLs.
+          throw new HarnessApiError("Event stream contains invalid JSON data", 502, undefined, undefined, cause);
+        }
+      }
+      return;
+    }
+    if (line.startsWith(":")) return;
+    const colon = line.indexOf(":");
+    const field = colon < 0 ? line : line.slice(0, colon);
+    let value = colon < 0 ? "" : line.slice(colon + 1);
+    if (value.startsWith(" ")) value = value.slice(1);
+    if (field === "data") dataLines.push(value);
+  }
+
+  try {
+    while (true) {
+      if (signal?.aborted) throw new HarnessApiError("Request cancelled", 499);
+      const chunk = await Promise.race([reader.read(), stopped]);
+      if (chunk === "cancelled" || signal?.aborted) throw new HarnessApiError("Request cancelled", 499);
+      if (chunk === "duration_limit") return { events, stop_reason: chunk };
+      if (!chunk.done) {
+        bytes += chunk.value.byteLength;
+        if (bytes > limits.maxBytes) throw new HarnessApiError("Event stream exceeded the 1 MiB batch size limit", 502);
+      }
+      pending += decoder.decode(chunk.value, { stream: !chunk.done });
+      while (true) {
+        const end = pending.search(/[\r\n]/);
+        if (end < 0) break;
+        // A CR at a chunk boundary may be the first half of CRLF.
+        if (!chunk.done && pending[end] === "\r" && end === pending.length - 1) break;
+        const line = pending.slice(0, end);
+        const width = pending[end] === "\r" && pending[end + 1] === "\n" ? 2 : 1;
+        pending = pending.slice(end + width);
+        processLine(line);
+        if (events.length >= limits.maxEvents) return { events, stop_reason: "event_limit" };
+      }
+      // SSE dispatch requires a blank line; an unterminated final event is discarded.
+      if (chunk.done) return { events, stop_reason: "end" };
+    }
+  } catch (cause) {
+    if (cause instanceof HarnessApiError) throw cause;
+    // A broken stream must not become a retried HTTP timeout: diffs have no replay cursor.
+    throw new HarnessApiError(signal?.aborted ? "Request cancelled" : "Event stream read failed", signal?.aborted ? 499 : 502, undefined, undefined, cause);
+  } finally {
+    clearTimeout(timer);
+    signal?.removeEventListener("abort", onAbort);
+    // Cancellation is best effort; slow source cleanup must not extend the batch deadline.
+    void reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
+}

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -37,6 +37,13 @@ export interface HarnessV1ListResponse<T> {
   totalPages?: number;
 }
 
+/** Endpoint-owned limits for a finite batch of JSON SSE data events. */
+export interface JsonEventStreamLimits {
+  maxEvents: number;
+  durationMs: number;
+  maxBytes: number;
+}
+
 export interface RequestOptions {
   method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
   path: string;
@@ -52,8 +59,10 @@ export interface RequestOptions {
   signal?: AbortSignal;
   /** Override default timeout for this request (milliseconds). */
   timeoutMs?: number;
-  /** JSON, binary download, or a bounded batch of JSON SSE data events (20 events / 5 seconds / 1 MiB). */
+  /** JSON, binary download, or a bounded batch of JSON SSE data events. */
   responseType?: "json" | "buffer" | "sse";
+  /** Required for responseType=sse. The caller owns the batch policy. */
+  sseLimits?: JsonEventStreamLimits;
   /** Product backend — when "fme", skips Harness-specific auth/headers/params. */
   product?: "harness" | "fme";
   /** When true, omit the automatic `accountIdentifier` query param.

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -52,8 +52,8 @@ export interface RequestOptions {
   signal?: AbortSignal;
   /** Override default timeout for this request (milliseconds). */
   timeoutMs?: number;
-  /** Return raw ArrayBuffer instead of parsing JSON. Used for binary endpoints (ZIP downloads). */
-  responseType?: "json" | "buffer";
+  /** JSON, binary download, or a bounded batch of JSON SSE data events (20 events / 5 seconds / 1 MiB). */
+  responseType?: "json" | "buffer" | "sse";
   /** Product backend — when "fme", skips Harness-specific auth/headers/params. */
   product?: "harness" | "fme";
   /** When true, omit the automatic `accountIdentifier` query param.

--- a/src/registry/extractors.ts
+++ b/src/registry/extractors.ts
@@ -10,6 +10,70 @@ import {
   buildStageMetadataMap,
 } from "../utils/runtime-input-metadata.js";
 import type { PreflightContext } from "./types.js";
+import { HarnessApiError } from "../utils/errors.js";
+
+/** Vibe returns unwrapped, mixed-case DTOs. Keep contract fields without forwarding internal metadata. */
+function pickVibeFields(value: unknown, fields: readonly string[]): Record<string, unknown> {
+  if (!isRecord(value)) throw new HarnessApiError("Unexpected Vibe response: expected an object", 502);
+  return Object.fromEntries(fields.filter((field) => value[field] !== undefined).map((field) => [field, value[field]]));
+}
+
+export function vibeProjectExtract(raw: unknown): unknown {
+  return pickVibeFields(raw, ["id", "name", "source_type", "source_path", "latest_execution_id", "created_at"]);
+}
+
+export function vibeExecutionExtract(raw: unknown): unknown {
+  return pickVibeFields(raw, ["id", "project_id", "status", "error_message", "created_at"]);
+}
+
+export function vibePrepareExtract(raw: unknown): unknown {
+  const result = pickVibeFields(raw, ["projectId", "sourceId", "upload"]);
+  const upload = pickVibeFields(result.upload, ["uploadId", "files", "expiresAt"]);
+  if (!Array.isArray(upload.files)) throw new HarnessApiError("Unexpected Vibe upload response: files must be an array", 502);
+  upload.files = upload.files.map((file) => pickVibeFields(file, ["path", "objectPath", "uploadUrl", "method", "headers", "expiresAt"]));
+  result.upload = upload;
+  return result;
+}
+
+function projectVibeFailure(value: unknown): unknown {
+  if (value === null) return null;
+  const failure = pickVibeFields(value, ["stageKey", "subStepKey", "summary", "file", "exitCode", "logLines", "suggestion", "patch", "attempt", "maxAttempts", "aiReason"]);
+  if (failure.aiReason !== undefined && failure.aiReason !== null) {
+    const reason = pickVibeFields(failure.aiReason, ["rootCause", "primaryError", "suggestedFix", "fixPrompt", "generatedInMs"]);
+    if (reason.primaryError !== undefined && reason.primaryError !== null) {
+      reason.primaryError = pickVibeFields(reason.primaryError, ["ref", "message"]);
+    }
+    failure.aiReason = reason;
+  }
+  return failure;
+}
+
+function projectVibeStage(value: unknown): unknown {
+  const stage = pickVibeFields(value, ["id", "executionId", "appId", "stageKey", "order", "status", "endUserMessage", "adminMessage", "detail", "subSteps", "failure", "startedAt", "finishedAt", "durationLabel", "harnessExecutionId", "harnessExecutionUrl", "artifactRefs", "logs", "origin"]);
+  if (Array.isArray(stage.subSteps)) {
+    stage.subSteps = stage.subSteps.map((step) => pickVibeFields(step, ["key", "label", "state", "durationLabel", "detail", "startedAt", "finishedAt", "href", "linkLabel", "kind"]));
+  }
+  if (stage.failure !== undefined) stage.failure = projectVibeFailure(stage.failure);
+  return stage;
+}
+
+export function vibeLifecycleExtract(raw: unknown): unknown {
+  const result = pickVibeFields(raw, ["app", "execution", "currentStageKey", "overallPercent", "elapsedSeconds", "phase", "failure", "harnessExecutionId", "harnessExecutionUrl"]);
+  result.app = pickVibeFields(result.app, ["id", "name", "status", "approvalStatus", "previewUrl", "productionUrl", "repoUrl", "latestExecutionId", "isOnboarded"]);
+  const execution = pickVibeFields(result.execution, ["id", "appId", "type", "status", "startedAt", "finishedAt", "triggeredBy", "stages", "origin"]);
+  if (Array.isArray(execution.stages)) execution.stages = execution.stages.map(projectVibeStage);
+  result.execution = execution;
+  if (result.failure !== undefined) result.failure = projectVibeFailure(result.failure);
+  return result;
+}
+
+export function vibeLifecycleEventsExtract(raw: unknown): unknown {
+  const result = pickVibeFields(raw, ["events", "stop_reason"]);
+  if (!Array.isArray(result.events)) throw new HarnessApiError("Unexpected Vibe event batch: events must be an array", 502);
+  // payload is deliberately open-ended in the OpenAPI; retain event-specific details.
+  result.events = result.events.map((event) => pickVibeFields(event, ["type", "payload", "at"]));
+  return result;
+}
 
 /** Extract `data` from standard NG API responses: `{ status, data, ... }` */
 export const ngExtract = (raw: unknown): unknown => {

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -56,6 +56,7 @@ import { incidentsToolset } from "./toolsets/incidents.js";
 import { alertsToolset } from "./toolsets/alerts.js";
 import { deploysToolset } from "./toolsets/deploys.js";
 import { releaseManagementToolset } from "./toolsets/release-management.js";
+import { vibeToolset } from "./toolsets/vibe.js";
 
 const log = createLogger("registry");
 
@@ -175,6 +176,7 @@ const ALL_TOOLSETS: ToolsetDefinition[] = [
   alertsToolset,
   deploysToolset,
   releaseManagementToolset,
+  vibeToolset,
 ];
 
 /** All available toolset names — used by docs generation to discover opt-in toolsets. */

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -839,6 +839,7 @@ export class Registry {
       ...(baseUrl ? { baseUrl } : {}),
       ...(Object.keys(productHeaders).length > 0 ? { headers: productHeaders } : {}),
       ...(spec.responseType ? { responseType: spec.responseType } : {}),
+      ...(spec.sseLimits ? { sseLimits: spec.sseLimits } : {}),
       ...(product !== "harness" ? { product } : {}),
       ...(spec.headerBasedScoping || def.headerBasedScoping ? { headerBasedScoping: true } : {}),
       ...(spec.operationPolicy?.retryPolicy ? { retryPolicy: spec.operationPolicy.retryPolicy } : {}),

--- a/src/registry/toolsets/vibe.ts
+++ b/src/registry/toolsets/vibe.ts
@@ -1,0 +1,167 @@
+import type { ToolsetDefinition } from "../types.js";
+import {
+  vibeProjectExtract,
+  vibePrepareExtract,
+  vibeExecutionExtract,
+  vibeLifecycleExtract,
+  vibeLifecycleEventsExtract,
+} from "../extractors.js";
+import { isRecord } from "../../utils/type-guards.js";
+
+function objectBody(input: Record<string, unknown>): Record<string, unknown> {
+  if (!isRecord(input.body)) throw new Error("body must be a JSON object. Use harness_describe for the Vibe request fields.");
+  return input.body;
+}
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim() === "") throw new Error(`${field} must be a non-empty string.`);
+  return value;
+}
+
+function importBody(input: Record<string, unknown>): Record<string, unknown> {
+  const body = objectBody(input);
+  requiredString(body.mode, "body.mode");
+  // The OpenAPI deliberately leaves mode-specific fields open for backend validation.
+  return { ...body };
+}
+
+function prepareBody(input: Record<string, unknown>): Record<string, unknown> {
+  const body = objectBody(input);
+  const name = requiredString(body.name, "body.name");
+  if (!isRecord(body.file)) throw new Error("body.file must be an object with a path.");
+  const file: Record<string, unknown> = { path: requiredString(body.file.path, "body.file.path") };
+  if (body.file.size_bytes !== undefined) {
+    const size = body.file.size_bytes;
+    if (size !== null && (typeof size !== "number" || !Number.isSafeInteger(size) || size < 0)) {
+      throw new Error("body.file.size_bytes must be a non-negative integer or null.");
+    }
+    file.size_bytes = size;
+  }
+  for (const field of ["content_type", "md5"] as const) {
+    const value = body.file[field];
+    if (value !== undefined) {
+      if (value !== null && typeof value !== "string") throw new Error(`body.file.${field} must be a string or null.`);
+      file[field] = value;
+    }
+  }
+  return { name, file };
+}
+
+function deployBody(input: Record<string, unknown>): Record<string, unknown> {
+  if (input.body !== undefined && !isRecord(input.body)) throw new Error("body must be a JSON object.");
+  const body = isRecord(input.body) ? input.body : {};
+  if (body.projectId !== undefined) throw new Error("Use body.project_id (snake_case) for deployment, or pass the Vibe app id as resource_id.");
+  const bodyId = body.project_id;
+  const targetId = input.app_id;
+  if (bodyId !== undefined) requiredString(bodyId, "body.project_id");
+  if (targetId !== undefined) requiredString(targetId, "app_id");
+  if (bodyId !== undefined && targetId !== undefined && bodyId !== targetId) {
+    throw new Error("body.project_id conflicts with the Vibe app id supplied via resource_id/app_id.");
+  }
+  // Top-level project_id is Harness scope, never the Vibe deployment target.
+  return { project_id: requiredString(bodyId ?? targetId, "Vibe app id (resource_id, params.app_id, or body.project_id)") };
+}
+
+export const vibeToolset: ToolsetDefinition = {
+  name: "vibe",
+  displayName: "Vibe",
+  description: "Vibe app import, signed upload preparation, deployment, and lifecycle progress under /vibe/v1.",
+  resources: [
+    {
+      resourceType: "vibe_project",
+      displayName: "Vibe Project",
+      description: "Create a Vibe Source + App from a registered JSON import mode, or prepare a direct upload. Import and prepare do not deploy; call the deploy action separately. These app IDs are not Harness project identifiers.",
+      toolset: "vibe",
+      scope: "account",
+      headerBasedScoping: true,
+      identifierFields: ["app_id"],
+      searchAliases: ["vibe app", "vibe import", "zip upload", "github import", "vibe deploy"],
+      relatedResources: [{ resourceType: "vibe_app_lifecycle", relationship: "deployment progress", description: "Read lifecycle progress using the app id returned by import (id) or prepare (projectId)." }],
+      executeHint: "JSON import: harness_create with mode and its backend-specific fields, then deploy using the returned id. ZIP upload: prepare, upload file bytes to the returned uploadUrl using its method and headers, then deploy using projectId. For a source directory, the coding agent first archives the intended local workspace files into a ZIP (including intended uncommitted edits, excluding credentials, .git, dependencies, and generated artifacts), then uses the ZIP flow. A directory path is not transferable source content, and the hosted MCP server cannot read the caller's filesystem. Preserve signed URLs exactly; upload is an external storage request without Harness authorization headers. Deploy is a separate write operation.",
+      diagnosticHint: "Use the Vibe app id, not a Harness project identifier. A 409 means no source is ready; a 422 may mean the prepared upload session is missing. Complete the signed upload before deploy. The supplied contract has no project list/get/update/delete endpoints; use vibe_app_lifecycle for status.",
+      operations: {
+        create: {
+          method: "POST",
+          path: "/vibe/v1/projects/import",
+          bodyBuilder: importBody,
+          responseExtractor: vibeProjectExtract,
+          operationPolicy: { risk: "medium_write", retryPolicy: "do_not_retry" },
+          description: "Import from a registered JSON mode, creating a Source + App without deploying it.",
+          bodySchema: {
+            description: "JSON import envelope. Additional mode-specific fields are passed through and validated by the backend; this OpenAPI does not define their shapes. ZIP uploads use prepare instead.",
+            fields: [{ name: "mode", type: "string", required: true, description: "Registered non-empty import mode, for example github_link or github_connector. Provide the extra fields required by that mode alongside mode." }],
+          },
+        },
+      },
+      executeActions: {
+        prepare: {
+          method: "POST",
+          path: "/vibe/v1/projects/prepare",
+          bodyBuilder: prepareBody,
+          responseExtractor: vibePrepareExtract,
+          operationPolicy: { risk: "medium_write", retryPolicy: "do_not_retry" },
+          actionDescription: "Create a Source + App and obtain signed file upload targets. Returns projectId, sourceId, and upload metadata; does not upload bytes or deploy.",
+          bodySchema: {
+            description: "Project name and metadata for the file to upload. After prepare, upload directly to object storage, then deploy separately.",
+            fields: [
+              { name: "name", type: "string", required: true, description: "Vibe app name." },
+              { name: "file", type: "object", required: true, description: "Upload file metadata (snake_case).", fields: [
+                { name: "path", type: "string", required: true, description: "File path/name for the upload, such as app.zip." },
+                { name: "size_bytes", type: "number", required: false, description: "Non-negative integer file size in bytes, or null. Zero is preserved." },
+                { name: "content_type", type: "string", required: false, description: "File MIME type, or null." },
+                { name: "md5", type: "string", required: false, description: "File checksum when available, or null." },
+              ] },
+            ],
+          },
+        },
+        deploy: {
+          method: "POST",
+          path: "/vibe/v1/projects/deploy",
+          bodyBuilder: deployBody,
+          responseExtractor: vibeExecutionExtract,
+          operationPolicy: { risk: "high_write", retryPolicy: "do_not_retry" },
+          actionDescription: "Trigger the ship flow for the app's latest source. Publishes a receiving source inline first. This starts deployment and must be requested separately after import or upload.",
+          paramsSchema: { fields: [{ name: "app_id", required: false, description: "Vibe app id, alternatively supplied as resource_id or body.project_id. Never use the top-level Harness project_id scope field for this id." }] },
+          bodySchema: {
+            description: "Deployment target. resource_id/params.app_id may supply the same id when body is omitted. The wire field is project_id, even though prepare returns projectId.",
+            fields: [{ name: "project_id", type: "string", required: true, description: "Vibe app id from import.id or prepare.projectId, alternatively resolved from resource_id/params.app_id." }],
+          },
+        },
+      },
+    },
+    {
+      resourceType: "vibe_app_lifecycle",
+      displayName: "Vibe App Lifecycle",
+      description: "Current Vibe app, latest deployment execution, stages, substeps, preview/production URLs, and failure details. Uses the Vibe app UUID, not a Harness project id.",
+      toolset: "vibe",
+      scope: "account",
+      headerBasedScoping: true,
+      identifierFields: ["app_id"],
+      searchAliases: ["vibe progress", "vibe preview", "vibe logs", "vibe lifecycle events"],
+      relatedResources: [{ resourceType: "vibe_project", relationship: "app", description: "Import/prepare an app and explicitly deploy it before monitoring lifecycle progress." }],
+      diagnosticHint: "A 404 means the app UUID does not resolve for this connection. Poll get for authoritative current progress; event batches are transient diffs, with no replay cursor documented by this API.",
+      operations: {
+        get: {
+          method: "GET",
+          path: "/vibe/v1/apps/{app_id}/lifecycle",
+          pathParams: { app_id: "app_id" },
+          responseExtractor: vibeLifecycleExtract,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          description: "Read the latest lifecycle snapshot including stages, failures, and preview readiness.",
+        },
+      },
+      executeActions: {
+        events: {
+          method: "GET",
+          path: "/vibe/v1/apps/{app_id}/lifecycle/events",
+          pathParams: { app_id: "app_id" },
+          headers: { Accept: "text/event-stream" },
+          responseType: "sse",
+          responseExtractor: vibeLifecycleEventsExtract,
+          operationPolicy: { risk: "read", retryPolicy: "safe" },
+          actionDescription: "Read a bounded SSE batch: up to 20 JSON events over 5 seconds after connection, capped at 1 MiB. Returns events and stop_reason; no automatic reconnect or replay. Use get for a complete snapshot.",
+        },
+      },
+    },
+  ],
+};

--- a/src/registry/toolsets/vibe.ts
+++ b/src/registry/toolsets/vibe.ts
@@ -29,7 +29,7 @@ function prepareBody(input: Record<string, unknown>): Record<string, unknown> {
   const body = objectBody(input);
   const name = requiredString(body.name, "body.name");
   if (!isRecord(body.file)) throw new Error("body.file must be an object with a path.");
-  const file: Record<string, unknown> = { path: requiredString(body.file.path, "body.file.path") };
+  const file: Record<string, unknown> = { ...body.file, path: requiredString(body.file.path, "body.file.path") };
   if (body.file.size_bytes !== undefined) {
     const size = body.file.size_bytes;
     if (size !== null && (typeof size !== "number" || !Number.isSafeInteger(size) || size < 0)) {
@@ -44,7 +44,8 @@ function prepareBody(input: Record<string, unknown>): Record<string, unknown> {
       file[field] = value;
     }
   }
-  return { name, file };
+  // The OpenAPI does not prohibit additional properties at either object level.
+  return { ...body, name, file };
 }
 
 function deployBody(input: Record<string, unknown>): Record<string, unknown> {
@@ -102,7 +103,7 @@ export const vibeToolset: ToolsetDefinition = {
           operationPolicy: { risk: "medium_write", retryPolicy: "do_not_retry" },
           actionDescription: "Create a Source + App and obtain signed file upload targets. Returns projectId, sourceId, and upload metadata; does not upload bytes or deploy.",
           bodySchema: {
-            description: "Project name and metadata for the file to upload. After prepare, upload directly to object storage, then deploy separately.",
+            description: "Project name and metadata for the file to upload. Additional fields are preserved for backend validation. After prepare, upload directly to object storage, then deploy separately.",
             fields: [
               { name: "name", type: "string", required: true, description: "Vibe app name." },
               { name: "file", type: "object", required: true, description: "Upload file metadata (snake_case).", fields: [
@@ -157,9 +158,11 @@ export const vibeToolset: ToolsetDefinition = {
           pathParams: { app_id: "app_id" },
           headers: { Accept: "text/event-stream" },
           responseType: "sse",
+          sseLimits: { maxEvents: 20, durationMs: 5000, maxBytes: 1_048_576 },
           responseExtractor: vibeLifecycleEventsExtract,
-          operationPolicy: { risk: "read", retryPolicy: "safe" },
-          actionDescription: "Read a bounded SSE batch: up to 20 JSON events over 5 seconds after connection, capped at 1 MiB. Returns events and stop_reason; no automatic reconnect or replay. Use get for a complete snapshot.",
+          operationPolicy: { risk: "read", retryPolicy: "do_not_retry" },
+          paramsSchema: { fields: [{ name: "app_id", required: true, description: "Vibe app UUID. Supply as resource_id or params.app_id; resource_id resolves this required path identifier." }] },
+          actionDescription: "Read a bounded SSE batch: up to 20 JSON events over 5 seconds after connection, capped at 1 MiB and subject to the connection's HTTP timeout. Returns events and stop_reason; no connection retries, automatic reconnect, or replay. Use get for a complete snapshot.",
         },
       },
     },

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -321,8 +321,10 @@ export interface EndpointSpec {
   headers?: Record<string, string>;
   /** For GET: extract the useful part from the raw response */
   responseExtractor?: (raw: unknown, input?: Record<string, unknown>) => unknown;
-  /** Request JSON, binary, or a bounded JSON SSE batch (20 events / 5 seconds / 1 MiB). */
+  /** Request JSON, binary, or a bounded JSON SSE batch. */
   responseType?: "json" | "buffer" | "sse";
+  /** Required with responseType=sse; explicitly declares this endpoint's batch policy. */
+  sseLimits?: RequestOptions["sseLimits"];
   /** Description shown in harness_describe output */
   description?: string;
   /** Optional body schema for write operations — exposed via harness_describe */

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -157,6 +157,7 @@ export type ToolsetName =
   | "alerts"
   | "deploys"
   | "release-management"
+  | "vibe"
   | "knowledge-graph"
   | "semantic-layer";
 
@@ -320,8 +321,8 @@ export interface EndpointSpec {
   headers?: Record<string, string>;
   /** For GET: extract the useful part from the raw response */
   responseExtractor?: (raw: unknown, input?: Record<string, unknown>) => unknown;
-  /** Request binary (ArrayBuffer) response instead of JSON. Used for ZIP download endpoints. */
-  responseType?: "json" | "buffer";
+  /** Request JSON, binary, or a bounded JSON SSE batch (20 events / 5 seconds / 1 MiB). */
+  responseType?: "json" | "buffer" | "sse";
   /** Description shown in harness_describe output */
   description?: string;
   /** Optional body schema for write operations — exposed via harness_describe */

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -25,7 +25,7 @@ export class HarnessApiError extends Error {
   constructor(
     message: string,
     public readonly statusCode: number,
-    public readonly harnessCode?: string,
+    public readonly harnessCode?: string | number,
     public readonly correlationId?: string,
     cause?: unknown,
   ) {

--- a/tests/client/harness-client.test.ts
+++ b/tests/client/harness-client.test.ts
@@ -32,6 +32,7 @@ describe("HarnessClient", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   describe("constructor and account getter", () => {
@@ -568,7 +569,106 @@ describe("HarnessClient", () => {
     });
   });
 
+  describe("request — bounded SSE transport", () => {
+    const sseLimits = { maxEvents: 1, durationMs: 1000, maxBytes: 1024 };
+
+    it("uses the caller's event limit for a non-Vibe endpoint", async () => {
+      const cancel = vi.fn();
+      const body = new ReadableStream<Uint8Array>({ start(controller) { controller.enqueue(new TextEncoder().encode('data: {"n":1}\n\ndata: {"n":2}\n\n')); }, cancel });
+      fetchSpy.mockResolvedValue(new Response(body, { headers: { "Content-Type": "text/event-stream" } }));
+      const client = new HarnessClient(makeConfig());
+      await expect(client.request({ path: "/other/events", responseType: "sse", sseLimits })).resolves.toEqual({ events: [{ n: 1 }], stop_reason: "event_limit" });
+      expect(cancel).toHaveBeenCalledOnce();
+    });
+
+    it("uses the caller's duration limit and clears the longer HTTP deadline", async () => {
+      vi.useFakeTimers();
+      const cancel = vi.fn();
+      const body = new ReadableStream<Uint8Array>({ cancel });
+      fetchSpy.mockResolvedValue(new Response(body, { headers: { "Content-Type": "text/event-stream" } }));
+      const client = new HarnessClient(makeConfig({ HARNESS_API_TIMEOUT_MS: 100 }));
+      const result = client.request({ path: "/other/events", responseType: "sse", sseLimits: { ...sseLimits, durationMs: 15 } });
+      await vi.advanceTimersByTimeAsync(15);
+      await expect(result).resolves.toEqual({ events: [], stop_reason: "duration_limit" });
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("uses the caller's byte limit", async () => {
+      fetchSpy.mockResolvedValue(new Response(': too many bytes\n', { headers: { "Content-Type": "text/event-stream" } }));
+      const client = new HarnessClient(makeConfig());
+      await expect(client.request({ path: "/other/events", responseType: "sse", sseLimits: { ...sseLimits, maxBytes: 4 } })).rejects.toThrow("4 byte batch size limit");
+    });
+
+    it.each([{ timeoutMs: undefined, deadline: 100 }, { timeoutMs: 50, deadline: 50 }])("keeps the HTTP deadline through SSE consumption ($deadline ms)", async ({ timeoutMs, deadline }) => {
+      vi.useFakeTimers();
+      const cancel = vi.fn();
+      const body = new ReadableStream<Uint8Array>({ cancel });
+      // Connection time counts against the same deadline as body consumption.
+      fetchSpy.mockImplementation(() => new Promise(resolve => setTimeout(() => resolve(new Response(body, { headers: { "Content-Type": "text/event-stream" } })), 20)));
+      const client = new HarnessClient(makeConfig({ HARNESS_API_TIMEOUT_MS: 100 }));
+      const failure = expect(client.request({ path: "/other/events", responseType: "sse", sseLimits, timeoutMs })).rejects.toMatchObject({ statusCode: 408, message: "Request timed out" });
+      await vi.advanceTimersByTimeAsync(deadline);
+      await failure;
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("distinguishes client cancellation from an HTTP timeout", async () => {
+      vi.useFakeTimers();
+      const controller = new AbortController();
+      const cancel = vi.fn();
+      fetchSpy.mockResolvedValue(new Response(new ReadableStream<Uint8Array>({ cancel }), { headers: { "Content-Type": "text/event-stream" } }));
+      const client = new HarnessClient(makeConfig());
+      const failure = expect(client.request({ path: "/other/events", responseType: "sse", sseLimits, signal: controller.signal })).rejects.toMatchObject({ statusCode: 499 });
+      await vi.advanceTimersByTimeAsync(0);
+      controller.abort();
+      await failure;
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it.each([
+      { limits: undefined },
+      { limits: { ...sseLimits, maxEvents: 0 } },
+      { limits: { ...sseLimits, maxBytes: Infinity } },
+      { limits: { ...sseLimits, durationMs: 2 ** 31 } },
+    ])("rejects missing or unbounded SSE policy before HTTP", async ({ limits }) => {
+      const client = new HarnessClient(makeConfig());
+      await expect(client.request({ path: "/other/events", responseType: "sse", sseLimits: limits })).rejects.toThrow("SSE requires explicit");
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe("request — error handling", () => {
+    it.each(["request", "requestStream"] as const)("preserves NG numeric codes and correlation IDs through %s", async method => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({ message: "Service unavailable", code: 503, correlationId: "ng-corr", error: { message: "Not an NG envelope", details: { field: "ignore" } } }), { status: 503 }));
+      const client = new HarnessClient(makeConfig({ HARNESS_MAX_RETRIES: 0 }));
+      await expect(client[method]({ path: "/ng/api/connectors" })).rejects.toMatchObject({
+        message: "Service unavailable", harnessCode: 503, correlationId: "ng-corr", statusCode: 503,
+      });
+      expect(fetchSpy).toHaveBeenCalledOnce();
+    });
+
+    it.each(["request", "requestStream"] as const)("includes nested Vibe validation details through %s", async method => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({ error: { code: "INVALID_IMPORT", message: "Invalid import", details: { field: "mode" } }, correlationId: "bff-corr" }), { status: 422 }));
+      const client = new HarnessClient(makeConfig());
+      await expect(client[method]({ path: "/vibe/v1/projects/import" })).rejects.toMatchObject({
+        message: 'Invalid import — {"field":"mode"}', harnessCode: "INVALID_IMPORT", correlationId: "bff-corr", statusCode: 422,
+      });
+    });
+
+    it("redacts credentials and bounds nested Vibe error details", async () => {
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({ error: { code: "INVALID_IMPORT", message: "Invalid import", details: { token: "private-token", field: "x".repeat(1000) } } }), { status: 422 }));
+      const client = new HarnessClient(makeConfig());
+      const error = await client.request({ path: "/vibe/v1/projects/import" }).then(() => { throw new Error("Expected failure"); }, err => err as HarnessApiError);
+      expect(error.message).toContain('"token":"[REDACTED]"');
+      expect(error.message).not.toContain("private-token");
+      expect(error.message.length).toBe("Invalid import — ".length + 401);
+    });
+
     it("throws HarnessApiError with parsed message on 400", async () => {
       fetchSpy.mockResolvedValue(new Response(
         JSON.stringify({ message: "Invalid input", code: "INVALID", correlationId: "corr-1" }),

--- a/tests/client/sse.test.ts
+++ b/tests/client/sse.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { readJsonEventStream } from "../../src/client/sse.js";
+
+const limits = { maxEvents: 2, durationMs: 50, maxBytes: 1024 };
+function stream(chunks: Uint8Array[], close = true) {
+  const cancel = vi.fn();
+  const body = new ReadableStream<Uint8Array>({ start(controller) { chunks.forEach(c => controller.enqueue(c)); if (close) controller.close(); }, cancel });
+  return { cancel, response: new Response(body, { headers: { "Content-Type": "text/event-stream; charset=utf-8" } }) };
+}
+const bytes = (value: string) => new TextEncoder().encode(value);
+afterEach(() => { vi.useRealTimers(); });
+
+describe("bounded JSON SSE consumption", () => {
+  it("handles UTF-8, BOM, CRLF split across chunks, comments, and multiline data", async () => {
+    const raw = bytes('\uFEFF: comment\r\nevent: stage_updated\r\ndata: {"type":"stage_updated",\r\ndata: "payload":{"label":"café"},"at":"now"}\r\n\r\n');
+    const { response } = stream(Array.from(raw, b => Uint8Array.of(b)));
+    await expect(readJsonEventStream(response, undefined, limits)).resolves.toEqual({ events: [{ type: "stage_updated", payload: { label: "café" }, at: "now" }], stop_reason: "end" });
+  });
+
+  it("supports CR and LF lines and discards an unterminated final event", async () => {
+    const { response } = stream([bytes('data: {"n":1}\r\rdata: {"n":2}\n')]);
+    await expect(readJsonEventStream(response, undefined, limits)).resolves.toEqual({ events: [{ n: 1 }], stop_reason: "end" });
+  });
+
+  it("stops at the event limit even if the stream remains open", async () => {
+    const { response, cancel } = stream([bytes('data: {"n":1}\n\ndata: {"n":2}\n\ndata: {"n":3}\n\n')], false);
+    await expect(readJsonEventStream(response, undefined, limits)).resolves.toEqual({ events: [{ n: 1 }, { n: 2 }], stop_reason: "event_limit" });
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([{ chunks: [] }, { chunks: [bytes('data: {"n":1}\n\n')] }])("returns a partial batch at the time limit and cancels the reader", async ({ chunks }) => {
+    vi.useFakeTimers();
+    const { response, cancel } = stream(chunks, false);
+    const result = readJsonEventStream(response, undefined, limits);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(await result).toEqual({ events: chunks.length ? [{ n: 1 }] : [], stop_reason: "duration_limit" });
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels promptly on client disconnect and does not report a successful partial batch", async () => {
+    const controller = new AbortController();
+    const { response, cancel } = stream([], false);
+    const result = readJsonEventStream(response, controller.signal, limits);
+    const rejection = expect(result).rejects.toMatchObject({ statusCode: 499 });
+    controller.abort();
+    await rejection;
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an already-aborted request", async () => {
+    const { response, cancel } = stream([], false);
+    await expect(readJsonEventStream(response, AbortSignal.abort(), limits)).rejects.toMatchObject({ statusCode: 499 });
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds bytes even when there are no complete events", async () => {
+    const { response, cancel } = stream([bytes(`: ${"x".repeat(1025)}`)], false);
+    await expect(readJsonEventStream(response, undefined, limits)).rejects.toThrow("batch size limit");
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects invalid JSON without including its contents in the error", async () => {
+    const { response, cancel } = stream([bytes('data: signed-url-secret\n\n')], false);
+    await expect(readJsonEventStream(response, undefined, limits)).rejects.toMatchObject({ message: "Event stream contains invalid JSON data", statusCode: 502 });
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an unexpected content type and cancels the body", async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({ cancel });
+    await expect(readJsonEventStream(new Response(body, { headers: { "Content-Type": "application/json" } }), undefined, limits)).rejects.toThrow("text/event-stream");
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not wait for slow stream cancellation after the batch deadline", async () => {
+    vi.useFakeTimers();
+    const cancel = vi.fn(() => new Promise<void>(() => {}));
+    const body = new ReadableStream<Uint8Array>({ cancel });
+    const result = readJsonEventStream(new Response(body, { headers: { "Content-Type": "text/event-stream" } }), undefined, limits);
+    await vi.advanceTimersByTimeAsync(50);
+    await expect(result).resolves.toEqual({ events: [], stop_reason: "duration_limit" });
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(body.locked).toBe(false);
+  });
+});

--- a/tests/fixtures/vibe-bff-openapi.yaml
+++ b/tests/fixtures/vibe-bff-openapi.yaml
@@ -1,0 +1,609 @@
+openapi: 3.0.3
+info:
+  title: Vibe Orchestrator BFF API
+  description: >
+    Hand-authored OpenAPI spec for the prepare, import, deploy, and
+    lifecycle endpoints of the BFF surface (mounted under /vibe/v1). The
+    full API is also auto-generated at runtime by FastAPI at /openapi.json;
+    this file covers a curated subset for external documentation/codegen
+    purposes.
+  version: "1.0.0"
+servers:
+  - url: /vibe/v1
+security:
+  - bearerAuth: []
+tags:
+  - name: bff-projects
+    description: Orchestrator-compat endpoints (legacy snake_case /projects surface)
+  - name: bff-lifecycle
+    description: App lifecycle progress and streaming
+
+paths:
+  /projects/import:
+    post:
+      tags: [bff-projects]
+      summary: Import a project from a JSON-based source
+      description: >
+        Dispatches to a registered JSON import mode (e.g. github_link,
+        github_connector) which creates a Source + App. Zip uploads do not
+        use this endpoint — they go through /projects/prepare followed by a
+        direct presigned PUT. This endpoint only creates the Source/App; it
+        does not trigger a deployment. Call POST /projects/deploy with the
+        returned `id` (as `projectId`) next to actually ship it.
+      operationId: importProject
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ImportRequest'
+      responses:
+        '201':
+          description: Project imported; App and Source were created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrchestratorProjectOut'
+        '415':
+          description: Content-Type was not application/json.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '422':
+          description: Body was not valid JSON, or `mode` was missing/invalid, or the mode-specific fields failed validation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+  /projects/prepare:
+    post:
+      tags: [bff-projects]
+      summary: Prepare a project for a direct file upload
+      description: >
+        Pre-signed URL intake: creates a Source + App and returns signed PUT
+        URL(s) for the client to upload file bytes directly to object
+        storage. After uploading, the client calls /projects/deploy to
+        trigger the ship flow.
+      operationId: prepareProject
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PrepareRequest'
+      responses:
+        '201':
+          description: Source and App created; signed upload targets issued.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrepareProjectOut'
+        '422':
+          description: Request body failed schema validation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+  /projects/deploy:
+    post:
+      tags: [bff-projects]
+      summary: Trigger a deployment for a project
+      description: >
+        Trigger the ship flow for the project's latest source. This is the
+        step that actually kicks off a deployment — both /projects/import
+        and /projects/prepare only create the Source + App and must be
+        followed by a call here to deploy. Handles two source states: a
+        source already published via the legacy multipart path deploys
+        directly; a source still "receiving" (the pre-signed URL flow) is
+        published inline first, then triggered.
+      operationId: deployProject
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeployRequest'
+      responses:
+        '201':
+          description: Deployment triggered.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrchestratorExecutionOut'
+        '404':
+          description: Project not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '409':
+          description: Project has no source ready to deploy.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+        '422':
+          description: No upload session found for the source (pre-signed URL flow).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+  /apps/{app_id}/lifecycle:
+    get:
+      tags: [bff-lifecycle]
+      summary: Get an app's current lifecycle progress
+      description: >
+        Snapshot of the app's latest deployment execution, its stages, and
+        overall progress. Poll this endpoint, or use
+        /apps/{app_id}/lifecycle/events for a live SSE stream of diffs.
+      operationId: getAppLifecycle
+      parameters:
+        - $ref: '#/components/parameters/AppId'
+      responses:
+        '200':
+          description: Current lifecycle progress for the app.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppLifecycleProgressOut'
+        '404':
+          description: App not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+  /apps/{app_id}/lifecycle/events:
+    get:
+      tags: [bff-lifecycle]
+      summary: Stream live lifecycle progress updates (SSE)
+      description: >
+        Server-Sent Events stream. Polls the derive-on-read lifecycle
+        projection roughly once a second and emits diff-based typed events
+        (stage_updated, substep_updated, preview_ready, failed, heartbeat).
+        Each `data:` frame is a JSON-encoded AppLifecycleEventOut.
+      operationId: streamAppLifecycleEvents
+      parameters:
+        - $ref: '#/components/parameters/AppId'
+      responses:
+        '200':
+          description: text/event-stream of lifecycle events.
+          content:
+            text/event-stream:
+              schema:
+                $ref: '#/components/schemas/AppLifecycleEventOut'
+        '404':
+          description: App not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: >
+        Auth is enforced globally by AuthMiddleware (not per-route
+        dependencies) via a bearer token or session cookie set by the
+        gateway; documented here as a bearer scheme for spec-completeness.
+  parameters:
+    AppId:
+      name: app_id
+      in: path
+      required: true
+      description: App UUID.
+      schema:
+        type: string
+        format: uuid
+
+  schemas:
+    ErrorEnvelope:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+            details:
+              type: object
+              additionalProperties: true
+          required: [code, message]
+      required: [error]
+
+    ImportRequest:
+      type: object
+      description: >
+        Envelope validation only — `mode` selects the registered import mode,
+        which then validates its own mode-specific extra fields (e.g.
+        github_link, github_connector). Additional properties are
+        mode-specific and passed through.
+      properties:
+        mode:
+          type: string
+          minLength: 1
+          description: Import mode identifier (e.g. "github_link", "github_connector").
+      required: [mode]
+      additionalProperties: true
+
+    OrchestratorProjectOut:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        source_type:
+          type: string
+          enum: [zip_upload, github]
+        source_path:
+          type: string
+        latest_execution_id:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+      required: [id, name, source_type, source_path, created_at]
+
+    DeployRequest:
+      type: object
+      properties:
+        project_id:
+          type: string
+          description: App id returned by /projects/import or /projects/prepare.
+      required: [project_id]
+
+    OrchestratorExecutionOut:
+      type: object
+      description: Response from POST /projects/deploy.
+      properties:
+        id:
+          type: string
+        project_id:
+          type: string
+        status:
+          type: string
+          enum: [pending, running, awaiting_approval, completed, failed]
+        error_message:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+      required: [id, project_id, status, created_at]
+
+    PrepareFileRequest:
+      type: object
+      properties:
+        path:
+          type: string
+        size_bytes:
+          type: integer
+          nullable: true
+        content_type:
+          type: string
+          nullable: true
+        md5:
+          type: string
+          nullable: true
+      required: [path]
+
+    PrepareRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        file:
+          $ref: '#/components/schemas/PrepareFileRequest'
+      required: [name, file]
+
+    SignedUploadFile:
+      type: object
+      properties:
+        path:
+          type: string
+        objectPath:
+          type: string
+        uploadUrl:
+          type: string
+        method:
+          type: string
+          default: PUT
+        headers:
+          type: object
+          additionalProperties:
+            type: string
+        expiresAt:
+          type: string
+          format: date-time
+      required: [path, objectPath, uploadUrl, method, expiresAt]
+
+    SignedUploadSession:
+      type: object
+      properties:
+        uploadId:
+          type: string
+          format: uuid
+        files:
+          type: array
+          items:
+            $ref: '#/components/schemas/SignedUploadFile'
+        expiresAt:
+          type: string
+          format: date-time
+      required: [uploadId, files, expiresAt]
+
+    PrepareProjectOut:
+      type: object
+      description: camelCase on the wire (ContractModel).
+      properties:
+        projectId:
+          type: string
+        sourceId:
+          type: string
+        upload:
+          $ref: '#/components/schemas/SignedUploadSession'
+      required: [projectId, sourceId, upload]
+
+    StageSubStepOut:
+      type: object
+      properties:
+        key:
+          type: string
+        label:
+          type: string
+        state:
+          type: string
+          enum: [pending, active, done, failed]
+        durationLabel:
+          type: string
+          nullable: true
+        detail:
+          type: string
+          nullable: true
+        startedAt:
+          type: string
+          nullable: true
+        finishedAt:
+          type: string
+          nullable: true
+        href:
+          type: string
+          nullable: true
+        linkLabel:
+          type: string
+          nullable: true
+        kind:
+          type: string
+          nullable: true
+          enum: [static, dynamic]
+      required: [key, label, state]
+
+    StageFailurePrimaryErrorOut:
+      type: object
+      properties:
+        ref:
+          type: string
+        message:
+          type: string
+      required: [ref, message]
+
+    StageFailureAiReasonOut:
+      type: object
+      description: Build-stage only — populated when the "Vibe Build Analyzer" agent step ran.
+      properties:
+        rootCause:
+          type: string
+        primaryError:
+          $ref: '#/components/schemas/StageFailurePrimaryErrorOut'
+        suggestedFix:
+          type: string
+          nullable: true
+        fixPrompt:
+          type: string
+          nullable: true
+          description: Clipboard text for pasting into a coding agent.
+        generatedInMs:
+          type: integer
+          nullable: true
+      required: [rootCause]
+
+    StageFailureOut:
+      type: object
+      properties:
+        stageKey:
+          type: string
+        subStepKey:
+          type: string
+          nullable: true
+        summary:
+          type: string
+        file:
+          type: string
+          nullable: true
+        exitCode:
+          type: integer
+          nullable: true
+        logLines:
+          type: array
+          items:
+            type: string
+        suggestion:
+          type: string
+          nullable: true
+        patch:
+          type: string
+          nullable: true
+        attempt:
+          type: integer
+          nullable: true
+        maxAttempts:
+          type: integer
+          nullable: true
+        aiReason:
+          $ref: '#/components/schemas/StageFailureAiReasonOut'
+      required: [stageKey, summary]
+
+    AppStageExecutionOut:
+      type: object
+      properties:
+        id:
+          type: string
+        executionId:
+          type: string
+        appId:
+          type: string
+        stageKey:
+          type: string
+        order:
+          type: integer
+        status:
+          type: string
+          enum: [pending, processing, completed, failed, paused, skipped]
+        endUserMessage:
+          type: string
+        adminMessage:
+          type: string
+        detail:
+          type: string
+          nullable: true
+        subSteps:
+          type: array
+          items:
+            $ref: '#/components/schemas/StageSubStepOut'
+        failure:
+          $ref: '#/components/schemas/StageFailureOut'
+        startedAt:
+          type: string
+          nullable: true
+        finishedAt:
+          type: string
+          nullable: true
+        durationLabel:
+          type: string
+          nullable: true
+        harnessExecutionId:
+          type: string
+          nullable: true
+        harnessExecutionUrl:
+          type: string
+          nullable: true
+        artifactRefs:
+          type: array
+          items:
+            type: string
+        logs:
+          type: array
+          items:
+            type: string
+        origin:
+          type: string
+          default: real
+      required: [id, executionId, appId, stageKey, order, status, endUserMessage, adminMessage]
+
+    AppExecutionOut:
+      type: object
+      properties:
+        id:
+          type: string
+        appId:
+          type: string
+        type:
+          type: string
+          enum: [import_and_preview, production_approval, production_deploy, rollback]
+        status:
+          type: string
+          enum: [queued, running, paused, succeeded, failed, canceled]
+        startedAt:
+          type: string
+        finishedAt:
+          type: string
+          nullable: true
+        triggeredBy:
+          type: string
+        stages:
+          type: array
+          items:
+            $ref: '#/components/schemas/AppStageExecutionOut'
+        origin:
+          type: string
+          default: real
+      required: [id, appId, type, status, startedAt, triggeredBy, stages]
+
+    LifecycleAppOut:
+      type: object
+      description: AppOut restricted to the nine fields the lifecycle view needs.
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        status:
+          type: string
+        approvalStatus:
+          type: string
+        previewUrl:
+          type: string
+          nullable: true
+        productionUrl:
+          type: string
+          nullable: true
+        repoUrl:
+          type: string
+          nullable: true
+        latestExecutionId:
+          type: string
+          nullable: true
+        isOnboarded:
+          type: boolean
+          default: false
+      required: [id, name, status, approvalStatus]
+
+    AppLifecycleProgressOut:
+      type: object
+      properties:
+        app:
+          $ref: '#/components/schemas/LifecycleAppOut'
+        execution:
+          $ref: '#/components/schemas/AppExecutionOut'
+        currentStageKey:
+          type: string
+          nullable: true
+        overallPercent:
+          type: number
+          format: float
+        elapsedSeconds:
+          type: integer
+          nullable: true
+        phase:
+          type: string
+          enum: [setting_up, live, failed]
+        failure:
+          $ref: '#/components/schemas/StageFailureOut'
+        harnessExecutionId:
+          type: string
+          nullable: true
+        harnessExecutionUrl:
+          type: string
+          nullable: true
+      required: [app, execution, overallPercent, phase]
+
+    AppLifecycleEventOut:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [stage_updated, substep_updated, preview_ready, failed, heartbeat]
+        payload:
+          type: object
+          additionalProperties: true
+        at:
+          type: string
+      required: [type, payload, at]

--- a/tests/registry/vibe.test.ts
+++ b/tests/registry/vibe.test.ts
@@ -1,0 +1,184 @@
+import { readFileSync } from "node:fs";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import YAML from "yaml";
+import type { Config } from "../../src/config.js";
+import { HarnessClient } from "../../src/client/harness-client.js";
+import { Registry } from "../../src/registry/index.js";
+import { vibeToolset } from "../../src/registry/toolsets/vibe.js";
+import { vibeLifecycleExtract, vibeLifecycleEventsExtract, vibePrepareExtract } from "../../src/registry/extractors.js";
+
+const appId = "08aff27b-6108-4589-bc39-eb32f94c8d5e";
+const imported = { id: appId, name: "demo", source_type: "github", source_path: "repo", latest_execution_id: null, created_at: "2026-09-09T00:00:00Z" };
+const upload = {
+  projectId: appId,
+  sourceId: "source-1",
+  upload: { uploadId: "upload-1", expiresAt: "2026-09-09T01:00:00Z", files: [
+    { path: "app.zip", objectPath: "sources/a.zip", uploadUrl: "https://storage.example/a.zip?sig=a%2Bb&expires=123", method: "PUT", headers: { "Content-Type": "application/zip", "x-custom": "signed-value" }, expiresAt: "2026-09-09T01:00:00Z" },
+  ] },
+};
+const execution = { id: "exec-1", project_id: appId, status: "pending", error_message: null, created_at: "2026-09-09T00:00:00Z" };
+const progress = {
+  app: { id: appId, name: "demo", status: "building", approvalStatus: "pending", previewUrl: null, productionUrl: null, isOnboarded: false },
+  execution: { id: "exec-1", appId, type: "import_and_preview", status: "running", startedAt: "2026-09-09T00:00:00Z", triggeredBy: "user", stages: [] },
+  currentStageKey: null, overallPercent: 0, elapsedSeconds: 0, phase: "setting_up",
+};
+const event = { type: "heartbeat", payload: { percent: 0 }, at: "2026-09-09T00:00:00Z" };
+
+function config(overrides: Partial<Config> = {}): Config {
+  return {
+    HARNESS_MCP_MODE: "single-user", HARNESS_API_KEY: "pat.account.id.secret", HARNESS_ACCOUNT_ID: "account",
+    HARNESS_BASE_URL: "https://app.harness.io", HARNESS_ORG: "ambient-org", HARNESS_PROJECT: "ambient-project",
+    HARNESS_API_TIMEOUT_MS: 5000, HARNESS_MAX_RETRIES: 2, HARNESS_RATE_LIMIT_RPS: 1000,
+    HARNESS_TOOLSETS: "vibe", HARNESS_READ_ONLY: false, HARNESS_AUTO_APPROVE_RISK: "all", LOG_LEVEL: "error",
+    ...overrides,
+  } as Config;
+}
+
+function response(value: unknown): Response { return new Response(JSON.stringify(value), { headers: { "Content-Type": "application/json" } }); }
+
+describe("Vibe OpenAPI coverage", () => {
+  it("maps every operation from the supplied contract exactly once", () => {
+    const api = YAML.parse(readFileSync(new URL("../fixtures/vibe-bff-openapi.yaml", import.meta.url), "utf8"));
+    const expected = Object.entries(api.paths).flatMap(([path, methods]) => Object.keys(methods as object).map(method => `${method.toUpperCase()} ${api.servers[0].url}${path}`));
+    const specs = vibeToolset.resources.flatMap(r => [...Object.values(r.operations), ...Object.values(r.executeActions ?? {})]);
+    expect(specs.map(s => `${s.method} ${s.path}`).sort()).toEqual(expected.sort());
+    expect(specs).toHaveLength(5);
+    expect(new Registry(config()).getAllResourceTypes()).toEqual(["vibe_app_lifecycle", "vibe_project"]);
+  });
+
+  it("supports discovery and filtering without inventing additional CRUD endpoints", () => {
+    expect(new Registry(config({ HARNESS_TOOLSETS: undefined })).getAllResourceTypes()).toContain("vibe_project");
+    expect(new Registry(config({ HARNESS_TOOLSETS: "-vibe" })).getAllResourceTypes()).not.toContain("vibe_project");
+    const registry = new Registry(config());
+    expect(Object.keys(registry.getResource("vibe_project").operations)).toEqual(["create"]);
+    expect(Object.keys(registry.getResource("vibe_app_lifecycle").operations)).toEqual(["get"]);
+    expect(registry.searchResources("vibe").map(r => r.type)).toEqual(expect.arrayContaining(["vibe_project", "vibe_app_lifecycle"]));
+  });
+});
+
+describe("Vibe wire contracts through the registry and HTTP client", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => { fetchSpy = vi.spyOn(globalThis, "fetch"); });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  const cases = [
+    { resource: "vibe_project", operation: "create", path: "/projects/import", method: "POST", body: { mode: "github_connector", connector_ref: "org.github", repository: "demo", options: { branch: "main", enabled: false } }, out: imported },
+    { resource: "vibe_project", operation: "prepare", path: "/projects/prepare", method: "POST", body: { name: "demo", file: { path: "app.zip", size_bytes: 0, content_type: null, md5: null } }, out: upload },
+    { resource: "vibe_project", operation: "deploy", path: "/projects/deploy", method: "POST", body: { project_id: appId }, out: execution },
+    { resource: "vibe_app_lifecycle", operation: "get", path: `/apps/${appId}/lifecycle`, method: "GET", body: undefined, out: progress },
+    { resource: "vibe_app_lifecycle", operation: "events", path: `/apps/${appId}/lifecycle/events`, method: "GET", body: undefined, out: event },
+  ];
+  it.each(cases)("$operation sends the exact path/body with no ambient scope leakage", async ({ resource, operation, path, method, body, out }) => {
+    fetchSpy.mockResolvedValue(operation === "events" ? new Response(`data: ${JSON.stringify(out)}\n\n`, { headers: { "Content-Type": "text/event-stream; charset=utf-8" } }) : response(out));
+    const cfg = config();
+    const registry = new Registry(cfg);
+    const client = new HarnessClient(cfg);
+    const input = { app_id: appId, body, org_id: "explicit-org", project_id: "harness-project" };
+    const result = operation === "get" || operation === "create"
+      ? await registry.dispatch(client, resource, operation, input)
+      : await registry.dispatchExecute(client, resource, operation, input);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(String(url)).toBe(`https://app.harness.io/vibe/v1${path}`);
+    expect(init?.method).toBe(method);
+    expect(init?.body).toBe(body === undefined ? undefined : JSON.stringify(body));
+    expect(init?.headers).toMatchObject({ "Harness-Account": "account", "x-api-key": cfg.HARNESS_API_KEY });
+    if (operation === "events") {
+      expect(init?.headers).toMatchObject({ Accept: "text/event-stream" });
+      expect(result).toEqual({ events: [event], stop_reason: "end" });
+    } else expect(result).toEqual(out);
+  });
+
+  it("forwards per-session OAuth bearer auth on the same Harness connection", async () => {
+    fetchSpy.mockResolvedValue(response(progress));
+    const cfg = config({ HARNESS_MCP_MODE: "oauth", HARNESS_API_KEY: "" });
+    const client = new HarnessClient(cfg);
+    client.setBearerTokenResolver(() => "session-token");
+    await new Registry(cfg).dispatch(client, "vibe_app_lifecycle", "get", { app_id: appId });
+    const headers = fetchSpy.mock.calls[0]![1]?.headers;
+    expect(headers).toMatchObject({ Authorization: "Bearer session-token" });
+    expect(headers).not.toHaveProperty("x-api-key");
+  });
+
+  it("does not reconnect after a stream abort, even when HTTP retries are enabled", async () => {
+    const body = new ReadableStream<Uint8Array>({ start(controller) { controller.error(new DOMException("Connection lost", "AbortError")); } });
+    fetchSpy.mockResolvedValue(new Response(body, { headers: { "Content-Type": "text/event-stream" } }));
+    const cfg = config();
+    await expect(new Registry(cfg).dispatchExecute(new HarnessClient(cfg), "vibe_app_lifecycle", "events", { app_id: appId }))
+      .rejects.toMatchObject({ statusCode: 502, message: "Event stream read failed" });
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it.each(["create", "prepare", "deploy"])("does not retry %s on a server error", async operation => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ error: { code: "VIBE_FAILED", message: "Vibe rejected this operation" } }), { status: 503 }));
+    const cfg = config();
+    const registry = new Registry(cfg);
+    const client = new HarnessClient(cfg);
+    const body = operation === "create" ? { mode: "github_link" } : operation === "prepare" ? { name: "demo", file: { path: "a.zip" } } : { project_id: appId };
+    const call = operation === "create" ? registry.dispatch(client, "vibe_project", "create", { body }) : registry.dispatchExecute(client, "vibe_project", operation, { body });
+    await expect(call).rejects.toMatchObject({ message: "Vibe rejected this operation", harnessCode: "VIBE_FAILED", statusCode: 503 });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves nested BFF errors from the event endpoint", async () => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ error: { code: "APP_NOT_FOUND", message: "App was not found" } }), { status: 404 }));
+    const cfg = config();
+    await expect(new Registry(cfg).dispatchExecute(new HarnessClient(cfg), "vibe_app_lifecycle", "events", { app_id: appId })).rejects.toMatchObject({ harnessCode: "APP_NOT_FOUND", statusCode: 404, message: "App was not found" });
+  });
+
+  it("encodes app path identifiers and rejects unsupported resource scopes", async () => {
+    fetchSpy.mockResolvedValue(response(progress));
+    const cfg = config();
+    const registry = new Registry(cfg);
+    const client = new HarnessClient(cfg);
+    await registry.dispatch(client, "vibe_app_lifecycle", "get", { app_id: "app /?#" });
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain("/apps/app%20%2F%3F%23/lifecycle");
+    await expect(registry.dispatch(client, "vibe_app_lifecycle", "get", { app_id: appId, resource_scope: "project" })).rejects.toThrow("does not support project scope");
+  });
+});
+
+describe("Vibe validation and projection", () => {
+  const invalid = [
+    { action: "create", input: {}, error: "body must" },
+    { action: "create", input: { body: { mode: " " } }, error: "body.mode" },
+    { action: "create", input: { body: { mode: 1 } }, error: "body.mode" },
+    { action: "prepare", input: { body: { name: "demo" } }, error: "body.file" },
+    { action: "prepare", input: { body: { name: "demo", file: [] } }, error: "body.file" },
+    { action: "prepare", input: { body: { name: "demo", file: { path: "" } } }, error: "body.file.path" },
+    ...[-1, 1.5, "100", false].map(size => ({ action: "prepare", input: { body: { name: "demo", file: { path: "a.zip", size_bytes: size } } }, error: "size_bytes" })),
+    { action: "deploy", input: { project_id: "ambient-project" }, error: "Vibe app id" },
+    { action: "deploy", input: { body: { projectId: appId } }, error: "body.project_id" },
+    { action: "deploy", input: { app_id: "a", body: { project_id: "b" } }, error: "conflicts" },
+    { action: "deploy", input: { body: { project_id: null } }, error: "body.project_id" },
+  ];
+  it.each(invalid)("rejects invalid $action input before HTTP", async ({ action, input, error }) => {
+    const request = vi.fn();
+    const client = { request } as unknown as HarnessClient;
+    const registry = new Registry(config());
+    const call = action === "create" ? registry.dispatch(client, "vibe_project", "create", input) : registry.dispatchExecute(client, "vibe_project", action, input);
+    await expect(call).rejects.toThrow(error);
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("keeps signed upload URLs and headers byte-for-byte while removing internal fields", () => {
+    const raw = structuredClone(upload);
+    Object.assign(raw, { internal: "remove" });
+    Object.assign(raw.upload, { debug: true });
+    Object.assign(raw.upload.files[0]!, { secretInternal: "remove" });
+    expect(vibePrepareExtract(raw)).toEqual(upload);
+    expect(raw).toHaveProperty("internal");
+  });
+
+  it("preserves detailed lifecycle failures, empty arrays, zero values and nulls", () => {
+    const failure = { stageKey: "build", summary: "failed", exitCode: 0, logLines: [], attempt: 0, aiReason: { rootCause: "dependency", primaryError: { ref: "line:1", message: "compile" }, suggestedFix: null, fixPrompt: "Fix the compile error", generatedInMs: 0 } };
+    const stage = { id: "stage-1", executionId: "exec-1", appId, stageKey: "build", order: 0, status: "failed", endUserMessage: "failed", adminMessage: "compile", failure, subSteps: [{ key: "compile", label: "Compile", state: "failed", detail: null }], logs: [], artifactRefs: [] };
+    const expected = { ...progress, execution: { ...progress.execution, stages: [stage] }, failure };
+    const raw = structuredClone(expected);
+    Object.assign(raw, { debug: true });
+    Object.assign(raw.app, { internal: true });
+    Object.assign(raw.execution.stages[0]!, { internal: true });
+    Object.assign(raw.failure.aiReason.primaryError, { internal: true });
+    expect(vibeLifecycleExtract(raw)).toEqual(expected);
+    expect(vibeLifecycleEventsExtract({ events: [{ ...event, payload: { arbitrary: { values: [] } }, debug: true }], stop_reason: "duration_limit", internal: true })).toEqual({ events: [{ ...event, payload: { arbitrary: { values: [] } } }], stop_reason: "duration_limit" });
+  });
+});

--- a/tests/registry/vibe.test.ts
+++ b/tests/registry/vibe.test.ts
@@ -100,6 +100,28 @@ describe("Vibe wire contracts through the registry and HTTP client", () => {
     expect(headers).not.toHaveProperty("x-api-key");
   });
 
+  it("keeps the team-tested PAT connection available with default toolsets", async () => {
+    fetchSpy.mockResolvedValue(response(imported));
+    const cfg = config({ HARNESS_TOOLSETS: undefined });
+    await new Registry(cfg).dispatch(new HarnessClient(cfg), "vibe_project", "create", { body: { mode: "github_link" } });
+    expect(fetchSpy.mock.calls[0]![1]?.headers).toMatchObject({ "x-api-key": cfg.HARNESS_API_KEY, "Harness-Account": "account" });
+  });
+
+  it("preserves additional prepare properties allowed by the OpenAPI", async () => {
+    fetchSpy.mockResolvedValue(response(upload));
+    const cfg = config();
+    const body = { name: "demo", extra: { enabled: false }, file: { path: "app.zip", size_bytes: 0, content_type: null, extra: { value: 0 } } };
+    await new Registry(cfg).dispatchExecute(new HarnessClient(cfg), "vibe_project", "prepare", { body });
+    expect(JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string)).toEqual(body);
+  });
+
+  it.each([429, 500, 502, 503, 504])("does not retry the initial event connection on HTTP %s", async status => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ error: { code: "UNAVAILABLE", message: "Try later" } }), { status }));
+    const cfg = config();
+    await expect(new Registry(cfg).dispatchExecute(new HarnessClient(cfg), "vibe_app_lifecycle", "events", { app_id: appId })).rejects.toMatchObject({ statusCode: status });
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
   it("does not reconnect after a stream abort, even when HTTP retries are enabled", async () => {
     const body = new ReadableStream<Uint8Array>({ start(controller) { controller.error(new DOMException("Connection lost", "AbortError")); } });
     fetchSpy.mockResolvedValue(new Response(body, { headers: { "Content-Type": "text/event-stream" } }));

--- a/tests/tools/vibe.test.ts
+++ b/tests/tools/vibe.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import * as z from "zod/v4";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Config } from "../../src/config.js";
+import type { ToolResult } from "../../src/utils/response-formatter.js";
+import { HarnessClient } from "../../src/client/harness-client.js";
+import { Registry } from "../../src/registry/index.js";
+import { registerCreateTool } from "../../src/tools/harness-create.js";
+import { registerExecuteTool } from "../../src/tools/harness-execute.js";
+import { registerGetTool } from "../../src/tools/harness-get.js";
+import { registerDescribeTool } from "../../src/tools/harness-describe.js";
+
+const appId = "08aff27b-6108-4589-bc39-eb32f94c8d5e";
+function setup(overrides: Partial<Config> = {}) {
+  const config = {
+    HARNESS_MCP_MODE: "single-user", HARNESS_API_KEY: "pat.account.id.secret", HARNESS_ACCOUNT_ID: "account",
+    HARNESS_BASE_URL: "https://app.harness.io", HARNESS_ORG: "ambient-org", HARNESS_PROJECT: "ambient-project",
+    HARNESS_API_TIMEOUT_MS: 5000, HARNESS_MAX_RETRIES: 0, HARNESS_RATE_LIMIT_RPS: 1000,
+    HARNESS_TOOLSETS: "vibe", HARNESS_READ_ONLY: false, HARNESS_AUTO_APPROVE_RISK: "all", LOG_LEVEL: "error", ...overrides,
+  } as Config;
+  type Handler = (args: Record<string, unknown>, extra: { signal: AbortSignal; sendNotification: () => Promise<void>; _meta: object }) => Promise<ToolResult>;
+  const registrations = new Map<string, { schema: { inputSchema: z.ZodRawShape }; handler: Handler }>();
+  const stub = { server: { getClientCapabilities: () => ({}) }, registerTool: (name: string, schema: { inputSchema: z.ZodRawShape }, handler: Handler) => { registrations.set(name, { schema, handler }); } };
+  const server = stub as unknown as McpServer;
+  const registry = new Registry(config);
+  const client = new HarnessClient(config);
+  registerCreateTool(server, registry, client, config);
+  registerExecuteTool(server, registry, client, config);
+  registerGetTool(server, registry, client);
+  registerDescribeTool(server, registry);
+  return {
+    async call(name: string, args: Record<string, unknown>, signal = new AbortController().signal) {
+      const tool = registrations.get(name)!;
+      const parsed = z.object(tool.schema.inputSchema).parse(args);
+      return tool.handler(parsed, { signal, sendNotification: async () => {}, _meta: {} });
+    },
+  };
+}
+function json(value: unknown) { return new Response(JSON.stringify(value), { headers: { "Content-Type": "application/json" } }); }
+function data(result: ToolResult): Record<string, unknown> {
+  const content = result.content[0]!;
+  if (content.type !== "text") throw new Error("Expected text content");
+  return JSON.parse(content.text);
+}
+afterEach(() => { vi.restoreAllMocks(); });
+
+describe("Vibe generic MCP tool workflow", () => {
+  it("imports a project without automatically deploying", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(json({ id: appId, name: "demo", source_type: "github", source_path: "repo", created_at: "now" }));
+    const tools = setup();
+    const result = await tools.call("harness_create", { resource_type: "vibe_project", body: { mode: "custom-mode", customConfig: { repository: "demo" } } });
+    expect(result.isError).toBeUndefined();
+    expect(data(result).id).toBe(appId);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0]).endsWith("/projects/import")).toBe(true);
+  });
+
+  it("prepares an upload, then deploys the returned projectId and reads lifecycle by resource_id", async () => {
+    const prepared = { projectId: appId, sourceId: "source", upload: { uploadId: "upload", expiresAt: "later", files: [{ path: "app.zip", objectPath: "source/app.zip", uploadUrl: "https://storage.example/app.zip?sig=abc%2B123", method: "PUT", headers: { "Content-Type": "application/zip" }, expiresAt: "later" }] } };
+    const progress = { app: { id: appId, name: "demo", status: "building", approvalStatus: "pending" }, execution: { id: "exec", appId, type: "import_and_preview", status: "running", startedAt: "now", triggeredBy: "user", stages: [] }, overallPercent: 0, phase: "setting_up" };
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(json(prepared))
+      .mockResolvedValueOnce(json({ id: "exec", project_id: appId, status: "pending", created_at: "now" }))
+      .mockResolvedValueOnce(json(progress));
+    const tools = setup();
+    const prepare = await tools.call("harness_execute", { resource_type: "vibe_project", action: "prepare", body: { name: "demo", file: { path: "app.zip" } } });
+    expect(data(prepare)).toEqual(prepared);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const deploy = await tools.call("harness_execute", { resource_type: "vibe_project", action: "deploy", resource_id: data(prepare).projectId, project_id: "harness-scope" });
+    expect(deploy.isError).toBeUndefined();
+    expect(JSON.parse(fetchSpy.mock.calls[1]![1]!.body as string)).toEqual({ project_id: appId });
+    const lifecycle = await tools.call("harness_get", { resource_type: "vibe_app_lifecycle", resource_id: appId });
+    expect(data(lifecycle)).toEqual(progress);
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    expect(String(fetchSpy.mock.calls[2]![0]).endsWith(`/apps/${appId}/lifecycle`)).toBe(true);
+  });
+
+  it("accepts deployment params.app_id and rejects disagreement with body.project_id", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(json({ id: "exec", project_id: appId, status: "pending", created_at: "now" }));
+    const tools = setup();
+    expect((await tools.call("harness_execute", { resource_type: "vibe_project", action: "deploy", params: { app_id: appId } })).isError).toBeUndefined();
+    const conflicting = await tools.call("harness_execute", { resource_type: "vibe_project", action: "deploy", resource_id: appId, body: { project_id: "different-app" } });
+    expect(conflicting.isError).toBe(true);
+    expect(data(conflicting).error).toContain("conflicts");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("requires confirmation for deployment and respects read-only mode", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const tools = setup({ HARNESS_AUTO_APPROVE_RISK: "none" });
+    const blocked = await tools.call("harness_execute", { resource_type: "vibe_project", action: "deploy", resource_id: appId });
+    expect(blocked.isError).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const readOnly = setup({ HARNESS_READ_ONLY: true });
+    for (const action of ["prepare", "deploy"]) {
+      expect((await readOnly.call("harness_execute", { resource_type: "vibe_project", action, resource_id: appId, confirm: true })).isError).toBe(true);
+    }
+    expect((await readOnly.call("harness_create", { resource_type: "vibe_project", body: { mode: "github_link" }, confirm: true })).isError).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns lifecycle event batches in read-only mode through harness_execute", async () => {
+    const event = { type: "preview_ready", payload: { previewUrl: "https://preview.example" }, at: "now" };
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(`data: ${JSON.stringify(event)}\n\n`, { headers: { "Content-Type": "text/event-stream" } }));
+    const tools = setup({ HARNESS_READ_ONLY: true, HARNESS_AUTO_APPROVE_RISK: "none" });
+    const result = await tools.call("harness_execute", { resource_type: "vibe_app_lifecycle", action: "events", resource_id: appId });
+    expect(data(result)).toEqual({ events: [event], stop_reason: "end" });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("describes upload schemas, deployment identity, related resources, and stream limits", async () => {
+    const tools = setup();
+    const project = data(await tools.call("harness_describe", { resource_type: "vibe_project" }));
+    expect(project.identifierFields).toEqual(["app_id"]);
+    expect(project.operations).toEqual([expect.objectContaining({ operation: "create", bodySchema: expect.objectContaining({ fields: [expect.objectContaining({ name: "mode", required: true })] }) })]);
+    expect(project.executeActions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ action: "prepare", bodySchema: expect.objectContaining({ fields: expect.arrayContaining([expect.objectContaining({ name: "file", fields: expect.arrayContaining([expect.objectContaining({ name: "path", required: true })]) })]) }) }),
+      expect.objectContaining({ action: "deploy", bodySchema: expect.objectContaining({ fields: [expect.objectContaining({ name: "project_id" })] }) }),
+    ]));
+    const lifecycle = data(await tools.call("harness_describe", { resource_type: "vibe_app_lifecycle" }));
+    expect(lifecycle.executeActions).toEqual([expect.objectContaining({ action: "events", description: expect.stringContaining("5 seconds") })]);
+  });
+});

--- a/tests/tools/vibe.test.ts
+++ b/tests/tools/vibe.test.ts
@@ -99,11 +99,11 @@ describe("Vibe generic MCP tool workflow", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("returns lifecycle event batches in read-only mode through harness_execute", async () => {
+  it.each([{ resource_id: appId }, { params: { app_id: appId } }])("returns lifecycle event batches in read-only mode through either identifier form", async identifier => {
     const event = { type: "preview_ready", payload: { previewUrl: "https://preview.example" }, at: "now" };
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(`data: ${JSON.stringify(event)}\n\n`, { headers: { "Content-Type": "text/event-stream" } }));
     const tools = setup({ HARNESS_READ_ONLY: true, HARNESS_AUTO_APPROVE_RISK: "none" });
-    const result = await tools.call("harness_execute", { resource_type: "vibe_app_lifecycle", action: "events", resource_id: appId });
+    const result = await tools.call("harness_execute", { resource_type: "vibe_app_lifecycle", action: "events", ...identifier });
     expect(data(result)).toEqual({ events: [event], stop_reason: "end" });
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
@@ -118,6 +118,6 @@ describe("Vibe generic MCP tool workflow", () => {
       expect.objectContaining({ action: "deploy", bodySchema: expect.objectContaining({ fields: [expect.objectContaining({ name: "project_id" })] }) }),
     ]));
     const lifecycle = data(await tools.call("harness_describe", { resource_type: "vibe_app_lifecycle" }));
-    expect(lifecycle.executeActions).toEqual([expect.objectContaining({ action: "events", description: expect.stringContaining("5 seconds") })]);
+    expect(lifecycle.executeActions).toEqual([expect.objectContaining({ action: "events", description: expect.stringContaining("5 seconds"), paramsSchema: { fields: [{ name: "app_id", required: true, description: expect.stringContaining("resource_id or params.app_id") }] } })]);
   });
 });


### PR DESCRIPTION
## Description

Adds Vibe app intake and deployment monitoring to the existing generic MCP tools, covering all five operations in the supplied Vibe Orchestrator BFF OpenAPI contract under `/vibe/v1`.

- `vibe_project`: JSON import through create, signed upload preparation through `prepare`, and explicit deployment through `deploy`.
- `vibe_app_lifecycle`: lifecycle snapshots through get and bounded SSE batches through `events` (20 events, five seconds after connection, 1 MiB). Batch limits are declared on the endpoint, the HTTP timeout bounds connection plus consumption, and neither initial connection failures nor broken streams are retried. Execute discovery documents both `resource_id` and `params.app_id`.
- Preserves API request casing, additional prepare fields, signed upload URLs/headers, and lifecycle failure details. Vibe app IDs remain separate from Harness project scope. Writes are not retried; deployment uses the existing high-risk confirmation policy, while lifecycle reads work in read-only mode. Vibe-specific error adaptation includes bounded, redacted validation details and preserves ordinary Harness numeric/string error codes and correlation IDs.
- Documents the coding-agent workflow: GitHub uses mode-specific import JSON; ZIPs use prepare, direct storage upload, then deploy; local directories must first be archived where their files are accessible.

The curated contract names `github_link` and `github_connector` but does not define their mode-specific fields. Those fields pass through for backend validation. Resources use the existing Harness connection, including per-session OAuth bearer forwarding. The team confirmed successful live validation using Harness API-key authentication (PAT/SAT); Vibe remains enabled in default sessions, with regressions covering default-session API-key forwarding and OAuth bearer forwarding.

The original OpenAPI is included unchanged as a test fixture. Tests cover exact HTTP paths, bodies, auth, scope isolation, validation, generic MCP workflows, write safety, response fields, stream limits/deadlines/cancellation, and non-Vibe error compatibility. Full validation passed: **150 files / 3,396 tests**; standards: **77 tests**. Review follow-up includes 23 additional regression cases; no additional live deployment was run as part of those fixes.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Other

## Checklist

- [x] `pnpm test --maxWorkers=1` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm standards:check` passes
- [x] Fresh build followed by `pnpm docs:generate` and `pnpm docs:check` passes

## Coding Standards (registry-driven MCP model)

- [x] No new `server.registerTool()` calls — API coverage uses toolset definitions in `src/registry/toolsets/`
- [x] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [x] `operationPolicy` on every new endpoint
- [x] Shared response extractors from `src/registry/extractors.ts`
- [x] `identifierFields` and `scope` declared on new resources
- [x] No `console.log()` in `src/`
