### PR TITLE
fix(chaos): auto-detect UUID vs. slug for is_identity on chaos_experiment.run and variable list

### DIFF
--- a/docs/testing/chaos_experiment/test_plan.md
+++ b/docs/testing/chaos_experiment/test_plan.md
@@ -33,6 +33,6 @@
 
 ## Notes
 - Chaos API uses `organizationIdentifier` instead of `orgIdentifier` (scopeParams override)
-- The run execute action sends POST to `/chaos/manager/api/rest/v2/experiments/{experimentId}/run` with `isIdentity=false` query param
+- The run execute action sends POST to `/chaos/manager/api/rest/v2/experiments/{experimentId}/run`. `isIdentity` is auto-detected from the shape of `experiment_id` when omitted (UUID → `isIdentity=false`; slug → `isIdentity=true`); pass `is_identity` explicitly to override
 - Runtime inputs structure: `{ experiment: [{name, value}], tasks: { taskName: [{name, value}] } }`
 - Use `chaos_experiment_variable` list to discover required variables before running

--- a/src/registry/toolsets/chaos-descriptions.ts
+++ b/src/registry/toolsets/chaos-descriptions.ts
@@ -323,7 +323,7 @@ export const descGetExperimentRun = `Get the full timeline of a chaos experiment
 Returns the execution pipeline: individual fault/probe/action nodes with status, timing, chaos data, and error details.
 Also returns experiment name, infraID, resiliency score, run phase, manifest version, and template details.
 Pass experiment_id via resource_id. Pass run_id or notify_id via params (not resource_id) to identify the specific run.
-To start a new run, use chaos_experiment execute action: run instead. By default, chaos_experiment.run accepts the human-readable identity slug as experiment_id (isIdentity=true). Pass is_identity=false in params if you have the internal UUID (experimentID, e.g. "ef9199b6-0248-4c0b-9d63-9176bf2b7123"). See descIsIdentity for details.`;
+To start a new run, use chaos_experiment execute action: run instead. is_identity is auto-detected from the shape of experiment_id when omitted (UUID vs. slug) — pass is_identity explicitly in params to override. See descIsIdentity for details.`;
 
 export const descListProbes = `List chaos probes with optional filtering.
 Supports filtering by name, tags, date range, probe IDs, infrastructure type, probe entity type, and sorting.
@@ -496,7 +496,7 @@ export const descDeleteExperimentTemplate = `Delete a chaos experiment template 
 Requires hub_identity to identify which chaos hub owns the template.
 Returns a success confirmation on completion.`;
 
-export const descListExperimentVariables = `List variables for a chaos experiment (experiment-level and task-level). By default treats experiment_id as a human-readable identity slug (e.g. "exp-without-runtime"); pass is_identity=false to use the internal UUID instead.`;
+export const descListExperimentVariables = `List variables for a chaos experiment (experiment-level and task-level). is_identity is auto-detected from the shape of experiment_id when omitted: a UUID (e.g. "ef9199b6-0248-4c0b-9d63-9176bf2b7123") defaults to is_identity=false; a human-readable slug (e.g. "exp-without-runtime") defaults to is_identity=true. Pass is_identity explicitly to override.`;
 
 export const descListLinuxInfra = `List chaos Linux infrastructures (load runners)`;
 
@@ -1600,7 +1600,9 @@ export const descInputSetSpec = `JSON string containing the input set variable o
 
 export const descInputSetId = `Input set ID. Use harness_list with resource_type=chaos_input_set to find input set IDs.`;
 
-export const descIsIdentity = `Controls how experiment_id is interpreted by the backend. Pass is_identity=true to use the human-readable identity slug (e.g. "exp-without-runtime" from the UI URL). Pass is_identity=false to use the internal UUID (e.g. "ef9199b6-0248-4c0b-9d63-9176bf2b7123"). Default varies by resource: chaos_input_set operations default to false (UUID); chaos_experiment_variable.list and chaos_experiment.run default to true (slug). Only applies where the backend honors the toggle: chaos_experiment.run, chaos_experiment_variable.list, and chaos_input_set.{list,get,create,update,delete}. If is_identity=true fails with "no documents in result", the experiment may predate the identity field — use harness_list(resource_type=chaos_experiment) to find the UUID and retry with is_identity=false.`;
+export const descIsIdentity = `Controls how experiment_id is interpreted by the backend. Pass is_identity=true to use the human-readable identity slug (e.g. "exp-without-runtime" from the UI URL). Pass is_identity=false to use the internal UUID (e.g. "ef9199b6-0248-4c0b-9d63-9176bf2b7123"). Only applies where the backend honors the toggle: chaos_experiment.run, chaos_experiment_variable.list, and chaos_input_set.{list,get,create,update,delete}.
+Auto-detected when omitted for chaos_experiment.run and chaos_experiment_variable.list: if experiment_id looks like a UUID, is_identity defaults to false; otherwise it defaults to true (slug). chaos_input_set operations always default to false (UUID) regardless of shape. Pass is_identity explicitly to override the auto-detected/default value.
+If the call still fails with "no documents in result", the experiment may predate the identity field, or the ID's shape may not match what was auto-detected — retry the same call with the opposite is_identity value, or use harness_list(resource_type=chaos_experiment) to find the correct UUID.`;
 
 // ── Chaos Component Variables (unified v3 endpoint) ─────────────────
 

--- a/src/registry/toolsets/chaos.ts
+++ b/src/registry/toolsets/chaos.ts
@@ -268,6 +268,19 @@ function coerceBody(input: Record<string, unknown>): Record<string, unknown> {
   return raw as Record<string, unknown>;
 }
 
+/**
+ * Detects whether a chaos experiment identifier looks like the internal UUID
+ * (e.g. "ef9199b6-0248-4c0b-9d63-9176bf2b7123") rather than a human-readable
+ * identity slug. Used to auto-default `is_identity` for chaos_experiment.run
+ * and chaos_experiment_variable.list so callers who only have the UUID
+ * (the only shape harness_list/harness_get ever return for chaos_experiment)
+ * don't need to know to pass is_identity=false explicitly.
+ */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+function looksLikeExperimentUuid(id: unknown): boolean {
+  return typeof id === "string" && UUID_RE.test(id);
+}
+
 // ── Load test helpers ────────────────────────────────────────────────
 // Since the loadTestManager variables migration, all tunables and custom env
 // vars live under toolConfig.<tool>.tunables / toolConfig.<tool>.variables. The
@@ -725,6 +738,7 @@ export const chaosToolset: ToolsetDefinition = {
       scopeParams: CHAOS_SCOPE,
       identifierFields: ["experiment_id"],
       deepLinkTemplate: "/ng/account/{accountId}/module/chaos/orgs/{orgIdentifier}/projects/{projectIdentifier}/experiments/{experimentId}/chaos-studio",
+      diagnosticHint: "If run fails with \"mongo: no documents in result\", the auto-detected is_identity value may not match this experiment_id's shape (UUID vs. human-readable slug). Retry the same call with the opposite is_identity value (params={is_identity: true|false}).",
       searchAliases: [
         "chaos test", "fault injection", "fault injection experiment",
         "blast radius experiment", "resilience test", "chaos engineering test",
@@ -871,6 +885,18 @@ export const chaosToolset: ToolsetDefinition = {
             // conflict; we only hoist when top-level is unset.
             if (input.is_identity === undefined && b.is_identity !== undefined) {
               (input as Record<string, unknown>).is_identity = b.is_identity;
+            }
+
+            // Auto-detect UUID vs slug when the caller didn't explicitly set
+            // is_identity (top-level or body-nested, handled above). harness_list/
+            // harness_get for chaos_experiment only ever return the internal UUID
+            // (no `identity` field in the ExperimentV2 response shape), so a caller
+            // that just listed/got an experiment and passes that ID straight into
+            // run would otherwise silently get isIdentity=true (slug lookup) and
+            // fail with "mongo: no documents in result". Explicit is_identity always
+            // wins; this only fills the gap when it's omitted entirely.
+            if (input.is_identity === undefined && looksLikeExperimentUuid(input.experiment_id)) {
+              (input as Record<string, unknown>).is_identity = false;
             }
 
             if (b.inputset_identity) {
@@ -1735,6 +1761,16 @@ export const chaosToolset: ToolsetDefinition = {
           pathParams: { experiment_id: "experimentId" },
           queryParams: { is_identity: "isIdentity" },
           defaultQueryParams: { isIdentity: "true" },
+          // No request body for this GET — bodyBuilder is used purely to auto-detect
+          // UUID vs slug (same rationale as chaos_experiment.run above) before
+          // queryParams resolves is_identity from input. Runs regardless of HTTP
+          // method, so this is safe here.
+          bodyBuilder: (input) => {
+            if (input.is_identity === undefined && looksLikeExperimentUuid(input.experiment_id)) {
+              (input as Record<string, unknown>).is_identity = false;
+            }
+            return undefined;
+          },
           responseExtractor: chaosRunTimeInputsExtract,
           description: descListExperimentVariables,
         },

--- a/tests/registry/chaos-experiment.test.ts
+++ b/tests/registry/chaos-experiment.test.ts
@@ -849,6 +849,36 @@ describe("chaos_experiment isIdentity routing", () => {
     expect(call.params.isIdentity).toBe(false);
   });
 
+  it("run: auto-detects a UUID-shaped experiment_id and defaults isIdentity=false when is_identity is omitted", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ experimentRunId: "run-1" });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatchExecute(client, "chaos_experiment", "run", {
+      experiment_id: "f8a2c4e6-1b3d-4f5a-9c7e-2d8b6a4f1e3c",
+      project_id: "templatescopetest",
+      org_id: "templatescopetest",
+    });
+
+    const call = mockRequest.mock.calls[0][0];
+    expect(call.path).toBe("/chaos/manager/api/rest/v2/experiments/f8a2c4e6-1b3d-4f5a-9c7e-2d8b6a4f1e3c/run");
+    expect(call.params.isIdentity).toBe(false);
+  });
+
+  it("run: explicit is_identity=true overrides auto-detection even for a UUID-shaped experiment_id", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ experimentRunId: "run-1" });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatchExecute(client, "chaos_experiment", "run", {
+      experiment_id: "f8a2c4e6-1b3d-4f5a-9c7e-2d8b6a4f1e3c",
+      is_identity: true,
+      project_id: "templatescopetest",
+      org_id: "templatescopetest",
+    });
+
+    const call = mockRequest.mock.calls[0][0];
+    expect(call.params.isIdentity).toBe(true);
+  });
+
   it("variables list: defaults isIdentity=true so a slug experiment_id works", async () => {
     const mockRequest = vi.fn().mockResolvedValue({ experiment: [], tasks: {} });
     const client = makeClient(mockRequest);
@@ -863,6 +893,36 @@ describe("chaos_experiment isIdentity routing", () => {
     expect(call.method).toBe("GET");
     expect(call.path).toBe("/chaos/manager/api/rest/v2/experiments/exp-without-runtime/variables");
     expect(call.params.isIdentity).toBe("true");
+  });
+
+  it("variables list: auto-detects a UUID-shaped experiment_id and defaults isIdentity=false when is_identity is omitted", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ experiment: [], tasks: {} });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "chaos_experiment_variable", "list", {
+      experiment_id: "f8a2c4e6-1b3d-4f5a-9c7e-2d8b6a4f1e3c",
+      project_id: "templatescopetest",
+      org_id: "templatescopetest",
+    });
+
+    const call = mockRequest.mock.calls[0][0];
+    expect(call.path).toBe("/chaos/manager/api/rest/v2/experiments/f8a2c4e6-1b3d-4f5a-9c7e-2d8b6a4f1e3c/variables");
+    expect(call.params.isIdentity).toBe(false);
+  });
+
+  it("variables list: explicit is_identity=true overrides auto-detection even for a UUID-shaped experiment_id", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({ experiment: [], tasks: {} });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "chaos_experiment_variable", "list", {
+      experiment_id: "f8a2c4e6-1b3d-4f5a-9c7e-2d8b6a4f1e3c",
+      is_identity: true,
+      project_id: "templatescopetest",
+      org_id: "templatescopetest",
+    });
+
+    const call = mockRequest.mock.calls[0][0];
+    expect(call.params.isIdentity).toBe(true);
   });
 
   it("variables list: null experiment/tasks returns empty items (no schema error)", async () => {


### PR DESCRIPTION
## Description
`chaos_experiment.run` and `chaos_experiment_variable.list` defaulted `isIdentity=true` (human-readable
identity slug lookup). However, `harness_list`/`harness_get` for `chaos_experiment` only ever return the
internal UUID (the `ExperimentV2` response shape has no `identity` field). An agent that lists/gets an
experiment and passes that UUID straight into `run` would silently get `isIdentity=true`, and the
chaos-manager backend would fail with `mongo: no documents in result` on a slug lookup against a UUID.

This adds a `looksLikeExperimentUuid()` check that auto-detects the shape of `experiment_id` and defaults
`is_identity` accordingly when the caller omits it:
- UUID-shaped `experiment_id` → `is_identity=false`
- Otherwise (slug) → `is_identity=true` (unchanged default)

An explicit `is_identity` (top-level or nested in `body`) always wins over auto-detection. A
`diagnosticHint` was also added to the `chaos_experiment` resource so that if a call still fails with
`"mongo: no documents in result"`, the LLM has a hint to retry with the opposite `is_identity` value
(surfaced via `harness_describe`).

Updated `descIsIdentity`, `descRunExperiment`/`descGetExperimentRun`, and `descListExperimentVariables` to
describe the new auto-detect behavior instead of the old static per-resource defaults, plus a matching note
in `docs/testing/chaos_experiment/test_plan.md`.

Scope note: this fix is intentionally limited to the `chaos` toolset (`src/registry/toolsets/chaos.ts`,
`chaos-descriptions.ts`). It does not touch the shared `src/utils/errors.ts` / `src/tools/harness-execute.ts`
error-handling paths.

Since `mcpServerInternal` (AskAI's backend) consumes the published `harness-mcp-v2` npm package built from
this repo, this fix resolves the failure for both AskAI and local Cursor MCP usage — the bug was not
AskAI-specific.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [ ] `pnpm build` passes
- [ ] `pnpm standards:check` passes (architecture guardrails — see [docs/coding-standards.md](docs/coding-standards.md))
- [ ] `pnpm docs:check` passes (if registry/tool counts changed)

## Coding Standards (registry-driven MCP model)
If this PR adds or changes Harness API coverage:
- [x] No new `server.registerTool()` calls — only toolset definitions in `src/registry/toolsets/`
- [x] Toolset registered in `ALL_TOOLSETS` and `ToolsetName` union
- [x] `operationPolicy` on every new/changed endpoint
- [x] Shared response extractors from `src/registry/extractors.ts` (no raw passthrough on real endpoints)
- [x] `identifierFields` and `scope` declared on new resources
- [x] No `console.log()` in `src/` (stdio JSON-RPC safety)