### PR TITLE
fix: map commit content/text onto payload so file writes persist

### DIFF
--- a/src/registry/toolsets/repositories.ts
+++ b/src/registry/toolsets/repositories.ts
@@ -3,13 +3,33 @@ import { fileContentGetExtract, passthrough } from "../extractors.js";
 import { assertValidBase64 } from "../../utils/base64.js";
 import { isRecord } from "../../utils/type-guards.js";
 
+const COMMIT_ACTIONS_NEEDING_CONTENT = new Set(["CREATE", "UPDATE", "MOVE"]);
+
+function actionNeedsFileContent(actionType: unknown): boolean {
+  return typeof actionType === "string" && COMMIT_ACTIONS_NEEDING_CONTENT.has(actionType.toUpperCase());
+}
+
 /**
- * Validate base64-declared commit file payloads client-side, and normalize
- * away embedded whitespace. Harness Code's commit-files endpoint rejects
- * embedded whitespace/newlines in `encoding: "base64"` payloads outright,
- * with an opaque Internal (500-style) error rather than a clean 400 — so
- * payload whitespace must be stripped here too, or a payload that validates
- * fine client-side would still fail server-side.
+ * Agents often put file bytes on `content` / `text` because
+ * `file_content` GET returns `content.text`. Harness Code only persists
+ * `payload` — a missing payload writes Git's empty blob and wipes the file.
+ */
+function resolveCommitActionPayload(action: Record<string, unknown>): string | undefined {
+  if (typeof action.payload === "string") return action.payload;
+  if (typeof action.content === "string") return action.content;
+  if (typeof action.text === "string") return action.text;
+  const nested = isRecord(action.content) ? action.content : undefined;
+  if (!nested) return undefined;
+  if (typeof nested.text === "string") return nested.text;
+  if (typeof nested.data === "string") return nested.data;
+  return undefined;
+}
+
+/**
+ * Shape commit-file actions for Harness Code:
+ * - copy `content`/`text` onto `payload` when payload is omitted
+ * - reject CREATE/UPDATE/MOVE with empty payload (that would wipe the file)
+ * - validate and strip whitespace from `encoding: "base64"` payloads
  */
 function buildCommitFilesBody(input: Record<string, unknown>): unknown {
   const body = input.body;
@@ -18,11 +38,30 @@ function buildCommitFilesBody(input: Record<string, unknown>): unknown {
   if (!Array.isArray(actions)) return body;
 
   const normalizedActions = actions.map((action, index) => {
-    if (!isRecord(action) || action.encoding !== "base64" || typeof action.payload !== "string") {
-      return action;
+    if (!isRecord(action)) return action;
+
+    const field = `body.actions[${index}]`;
+    const payload = resolveCommitActionPayload(action);
+    const next: Record<string, unknown> = { ...action };
+    delete next.content;
+    delete next.text;
+
+    if (payload !== undefined) {
+      next.payload = payload;
     }
-    const normalizedPayload = assertValidBase64(action.payload, `body.actions[${index}].payload`);
-    return { ...action, payload: normalizedPayload };
+
+    if (actionNeedsFileContent(action.action) && (typeof next.payload !== "string" || next.payload.length === 0)) {
+      throw new Error(
+        `${field}.payload is required for ${String(action.action)} (file content). ` +
+          `Pass payload, or content/text (aliases). An omitted payload commits an empty file.`,
+      );
+    }
+
+    if (next.encoding !== "base64" || typeof next.payload !== "string") {
+      return next;
+    }
+    next.payload = assertValidBase64(next.payload, `${field}.payload`);
+    return next;
   });
 
   return { ...body, actions: normalizedActions };
@@ -240,7 +279,7 @@ export const repositoriesToolset: ToolsetDefinition = {
           bodyBuilder: buildCommitFilesBody,
           responseExtractor: passthrough,
           description:
-            "Commit file changes to a repository. Each action specifies a file operation (CREATE, UPDATE, DELETE, MOVE). Payload is the file content (utf8 or base64). For UPDATE, include the current blob sha. Returns the new commit_id and list of changed files.",
+            "Commit file changes to a repository. Each action specifies a file operation (CREATE, UPDATE, DELETE, MOVE). File bytes go in payload (utf8 or base64). content/text are accepted aliases — omitting payload on CREATE/UPDATE writes an empty file. For UPDATE, include the current blob sha. Returns the new commit_id and list of changed files.",
           bodySchema: {
             description:
               "Commit with one or more file actions. branch is the target branch, message is the commit message, actions is the list of file operations.",
@@ -249,7 +288,7 @@ export const repositoriesToolset: ToolsetDefinition = {
               { name: "message", type: "string", required: false, description: "Extended commit message body" },
               { name: "branch", type: "string", required: true, description: "Target branch to commit to (e.g. 'main')" },
               { name: "new_branch", type: "string", required: false, description: "If set, creates a new branch from 'branch' and commits there instead" },
-              { name: "actions", type: "array", required: true, description: "File operations. Each action: {action: 'CREATE'|'UPDATE'|'DELETE'|'MOVE', path: 'file/path', payload: 'content', encoding: 'utf8'|'base64' (default utf8 — set explicitly for binary content, payload must then be valid base64), sha: 'blob_sha (required for UPDATE)'}." },
+              { name: "actions", type: "array", required: true, description: "File operations. Each action: {action: 'CREATE'|'UPDATE'|'DELETE'|'MOVE', path: 'file/path', payload: 'file bytes (required for CREATE/UPDATE/MOVE; content or text aliases are copied onto payload)', encoding: 'utf8'|'base64' (default utf8 — set explicitly for binary content, payload must then be valid base64), sha: 'blob_sha (required for UPDATE)'}." },
               { name: "bypass_rules", type: "boolean", required: false, description: "Bypass branch protection rules (requires permission)" },
               { name: "dry_run_rules", type: "boolean", required: false, description: "Check rules without committing" },
             ],

--- a/src/registry/toolsets/repositories.ts
+++ b/src/registry/toolsets/repositories.ts
@@ -3,32 +3,57 @@ import { fileContentGetExtract, passthrough } from "../extractors.js";
 import { assertValidBase64 } from "../../utils/base64.js";
 import { isRecord } from "../../utils/type-guards.js";
 
-const COMMIT_ACTIONS_NEEDING_CONTENT = new Set(["CREATE", "UPDATE", "MOVE"]);
+const COMMIT_ACTIONS_NEEDING_FILE_BYTES = new Set(["CREATE", "UPDATE"]);
 
-function actionNeedsFileContent(actionType: unknown): boolean {
-  return typeof actionType === "string" && COMMIT_ACTIONS_NEEDING_CONTENT.has(actionType.toUpperCase());
+function commitActionType(actionType: unknown): string {
+  return typeof actionType === "string" ? actionType.toUpperCase() : "";
 }
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+type ResolvedCommitPayload = { payload: string; encoding?: string };
 
 /**
  * Agents often put file bytes on `content` / `text` because
- * `file_content` GET returns `content.text`. Harness Code only persists
- * `payload` — a missing payload writes Git's empty blob and wipes the file.
+ * `file_content` GET returns `content.text` / `content.data`. Harness Code
+ * only persists `payload` — a missing UPDATE payload writes Git's empty blob
+ * and wipes the file. Empty `payload` must not shadow those aliases.
+ *
+ * Not used for MOVE: Code treats MOVE payload as the destination path
+ * (new path, optionally followed by NUL and replacement bytes), not file bytes.
  */
-function resolveCommitActionPayload(action: Record<string, unknown>): string | undefined {
-  if (typeof action.payload === "string") return action.payload;
-  if (typeof action.content === "string") return action.content;
-  if (typeof action.text === "string") return action.text;
+function resolveCommitActionPayload(action: Record<string, unknown>): ResolvedCommitPayload | undefined {
+  const payload = nonEmptyString(action.payload);
+  if (payload !== undefined) return { payload };
+
+  const content = nonEmptyString(action.content);
+  if (content !== undefined) return { payload: content };
+
+  const text = nonEmptyString(action.text);
+  if (text !== undefined) return { payload: text };
+
   const nested = isRecord(action.content) ? action.content : undefined;
   if (!nested) return undefined;
-  if (typeof nested.text === "string") return nested.text;
-  if (typeof nested.data === "string") return nested.data;
+
+  const nestedText = nonEmptyString(nested.text);
+  if (nestedText !== undefined) {
+    return { payload: nestedText, encoding: nonEmptyString(nested.encoding) };
+  }
+
+  const nestedData = nonEmptyString(nested.data);
+  if (nestedData !== undefined) {
+    return { payload: nestedData, encoding: nonEmptyString(nested.encoding) ?? "base64" };
+  }
   return undefined;
 }
 
 /**
  * Shape commit-file actions for Harness Code:
- * - copy `content`/`text` onto `payload` when payload is omitted
- * - reject CREATE/UPDATE/MOVE with empty payload (that would wipe the file)
+ * - copy `content`/`text` onto payload for CREATE/UPDATE when payload is empty
+ * - reject omitted CREATE payload and empty UPDATE payload (that would wipe)
+ * - leave MOVE/DELETE payload alone (MOVE payload is the destination path)
  * - validate and strip whitespace from `encoding: "base64"` payloads
  */
 function buildCommitFilesBody(input: Record<string, unknown>): unknown {
@@ -41,20 +66,32 @@ function buildCommitFilesBody(input: Record<string, unknown>): unknown {
     if (!isRecord(action)) return action;
 
     const field = `body.actions[${index}]`;
-    const payload = resolveCommitActionPayload(action);
+    const actionType = commitActionType(action.action);
     const next: Record<string, unknown> = { ...action };
-    delete next.content;
-    delete next.text;
 
-    if (payload !== undefined) {
-      next.payload = payload;
-    }
+    if (COMMIT_ACTIONS_NEEDING_FILE_BYTES.has(actionType)) {
+      const resolved = resolveCommitActionPayload(action);
+      delete next.content;
+      delete next.text;
+      if (resolved) {
+        next.payload = resolved.payload;
+        if (resolved.encoding !== undefined && nonEmptyString(next.encoding) === undefined) {
+          next.encoding = resolved.encoding;
+        }
+      }
 
-    if (actionNeedsFileContent(action.action) && (typeof next.payload !== "string" || next.payload.length === 0)) {
-      throw new Error(
-        `${field}.payload is required for ${String(action.action)} (file content). ` +
-          `Pass payload, or content/text (aliases). An omitted payload commits an empty file.`,
-      );
+      if (actionType === "UPDATE" && (typeof next.payload !== "string" || next.payload.length === 0)) {
+        throw new Error(
+          `${field}.payload is required for UPDATE (file content). ` +
+            `Pass payload, or content/text (aliases). An omitted payload commits an empty file.`,
+        );
+      }
+      if (actionType === "CREATE" && typeof next.payload !== "string") {
+        throw new Error(
+          `${field}.payload is required for CREATE (file content). ` +
+            `Pass payload, or content/text (aliases). An omitted payload commits an empty file.`,
+        );
+      }
     }
 
     if (next.encoding !== "base64" || typeof next.payload !== "string") {
@@ -279,7 +316,7 @@ export const repositoriesToolset: ToolsetDefinition = {
           bodyBuilder: buildCommitFilesBody,
           responseExtractor: passthrough,
           description:
-            "Commit file changes to a repository. Each action specifies a file operation (CREATE, UPDATE, DELETE, MOVE). File bytes go in payload (utf8 or base64). content/text are accepted aliases — omitting payload on CREATE/UPDATE writes an empty file. For UPDATE, include the current blob sha. Returns the new commit_id and list of changed files.",
+            "Commit file changes to a repository. Each action is CREATE, UPDATE, DELETE, or MOVE. For CREATE/UPDATE, file bytes go in payload (utf8 or base64); content/text and file_content GET content.text/content.data are aliases. CREATE and UPDATE require payload (omitted UPDATE is rejected because Code would write an empty file; CREATE may pass payload: '' for an empty file). MOVE payload is the destination path, not file bytes. For UPDATE, include the current blob sha. Returns the new commit_id and list of changed files.",
           bodySchema: {
             description:
               "Commit with one or more file actions. branch is the target branch, message is the commit message, actions is the list of file operations.",
@@ -288,7 +325,7 @@ export const repositoriesToolset: ToolsetDefinition = {
               { name: "message", type: "string", required: false, description: "Extended commit message body" },
               { name: "branch", type: "string", required: true, description: "Target branch to commit to (e.g. 'main')" },
               { name: "new_branch", type: "string", required: false, description: "If set, creates a new branch from 'branch' and commits there instead" },
-              { name: "actions", type: "array", required: true, description: "File operations. Each action: {action: 'CREATE'|'UPDATE'|'DELETE'|'MOVE', path: 'file/path', payload: 'file bytes (required for CREATE/UPDATE/MOVE; content or text aliases are copied onto payload)', encoding: 'utf8'|'base64' (default utf8 — set explicitly for binary content, payload must then be valid base64), sha: 'blob_sha (required for UPDATE)'}." },
+              { name: "actions", type: "array", required: true, description: "File operations. Each action: {action: 'CREATE'|'UPDATE'|'DELETE'|'MOVE', path: 'file/path', payload: 'CREATE/UPDATE: file bytes (required; content or text aliases are copied onto payload; empty string allowed only for CREATE). MOVE: destination path. DELETE: omit.', encoding: 'utf8'|'base64' (default utf8 — set explicitly for binary content, payload must then be valid base64), sha: 'blob_sha (required for UPDATE)'}." },
               { name: "bypass_rules", type: "boolean", required: false, description: "Bypass branch protection rules (requires permission)" },
               { name: "dry_run_rules", type: "boolean", required: false, description: "Check rules without committing" },
             ],

--- a/tests/registry/repositories-file-content-encoding.test.ts
+++ b/tests/registry/repositories-file-content-encoding.test.ts
@@ -232,6 +232,111 @@ describe("commit create — client-side base64 validation", () => {
     expect(call.body.actions[0]!.payload).toBe(rawPayload);
   });
 
+  it("copies actions.content onto payload (file_content GET shape) and drops the alias", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "repositories" }));
+    const mockRequest = vi.fn().mockResolvedValue({ commit_id: "sha1", files: [] });
+    const client = makeClient(mockRequest);
+    const yaml = "apiVersion: apps/v1\nkind: Deployment\n";
+
+    await registry.dispatch(client, "commit", "create", {
+      repo_id: "my-repo",
+      body: {
+        title: "Update deployment",
+        branch: "main",
+        actions: [
+          { action: "UPDATE", path: "k8s/deployment.yaml", sha: "abc123", content: yaml },
+        ],
+      },
+    });
+
+    const call = mockRequest.mock.calls[0]![0] as {
+      body: { actions: Array<{ payload?: string; content?: unknown; text?: unknown }> };
+    };
+    expect(call.body.actions[0]!.payload).toBe(yaml);
+    expect(call.body.actions[0]!.content).toBeUndefined();
+    expect(call.body.actions[0]!.text).toBeUndefined();
+  });
+
+  it("copies nested content.text onto payload", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "repositories" }));
+    const mockRequest = vi.fn().mockResolvedValue({ commit_id: "sha1", files: [] });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "commit", "create", {
+      repo_id: "my-repo",
+      body: {
+        title: "Update file",
+        branch: "main",
+        actions: [
+          {
+            action: "UPDATE",
+            path: "README.md",
+            sha: "abc123",
+            content: { text: "# hello", encoding: "utf8" },
+          },
+        ],
+      },
+    });
+
+    const call = mockRequest.mock.calls[0]![0] as { body: { actions: Array<{ payload?: string }> } };
+    expect(call.body.actions[0]!.payload).toBe("# hello");
+  });
+
+  it("prefers payload over content when both are set", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "repositories" }));
+    const mockRequest = vi.fn().mockResolvedValue({ commit_id: "sha1", files: [] });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "commit", "create", {
+      repo_id: "my-repo",
+      body: {
+        title: "Update file",
+        branch: "main",
+        actions: [
+          { action: "UPDATE", path: "a.txt", sha: "abc", payload: "keep-me", content: "ignore-me" },
+        ],
+      },
+    });
+
+    const call = mockRequest.mock.calls[0]![0] as { body: { actions: Array<{ payload?: string }> } };
+    expect(call.body.actions[0]!.payload).toBe("keep-me");
+  });
+
+  it("rejects CREATE/UPDATE with an empty payload so the file is not wiped", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "repositories" }));
+    const mockRequest = vi.fn();
+    const client = makeClient(mockRequest);
+
+    await expect(
+      registry.dispatch(client, "commit", "create", {
+        repo_id: "my-repo",
+        body: {
+          title: "Wipe file",
+          branch: "main",
+          actions: [{ action: "UPDATE", path: "k8s/deployment.yaml", sha: "abc" }],
+        },
+      }),
+    ).rejects.toThrow(/payload is required/);
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it("allows DELETE without a payload", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "repositories" }));
+    const mockRequest = vi.fn().mockResolvedValue({ commit_id: "sha1", files: [] });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "commit", "create", {
+      repo_id: "my-repo",
+      body: {
+        title: "Delete file",
+        branch: "main",
+        actions: [{ action: "DELETE", path: "gone.txt" }],
+      },
+    });
+
+    expect(mockRequest).toHaveBeenCalled();
+  });
+
   it("does not validate utf8-encoded payloads as base64", async () => {
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "repositories" }));
     const mockRequest = vi.fn().mockResolvedValue({ commit_id: "sha1", files: [] });

--- a/tests/registry/repositories-file-content-encoding.test.ts
+++ b/tests/registry/repositories-file-content-encoding.test.ts
@@ -302,7 +302,76 @@ describe("commit create — client-side base64 validation", () => {
     expect(call.body.actions[0]!.payload).toBe("keep-me");
   });
 
-  it("rejects CREATE/UPDATE with an empty payload so the file is not wiped", async () => {
+  it("copies actions.text onto payload", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "repositories" }));
+    const mockRequest = vi.fn().mockResolvedValue({ commit_id: "sha1", files: [] });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "commit", "create", {
+      repo_id: "my-repo",
+      body: {
+        title: "Update file",
+        branch: "main",
+        actions: [{ action: "UPDATE", path: "a.txt", sha: "abc", text: "from-text" }],
+      },
+    });
+
+    const call = mockRequest.mock.calls[0]![0] as {
+      body: { actions: Array<{ payload?: string; text?: unknown }> };
+    };
+    expect(call.body.actions[0]!.payload).toBe("from-text");
+    expect(call.body.actions[0]!.text).toBeUndefined();
+  });
+
+  it("uses content when payload is an empty string", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "repositories" }));
+    const mockRequest = vi.fn().mockResolvedValue({ commit_id: "sha1", files: [] });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "commit", "create", {
+      repo_id: "my-repo",
+      body: {
+        title: "Update file",
+        branch: "main",
+        actions: [{ action: "UPDATE", path: "a.txt", sha: "abc", payload: "", content: "from-content" }],
+      },
+    });
+
+    const call = mockRequest.mock.calls[0]![0] as { body: { actions: Array<{ payload?: string }> } };
+    expect(call.body.actions[0]!.payload).toBe("from-content");
+  });
+
+  it("copies nested content.data onto payload and sets encoding base64", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "repositories" }));
+    const mockRequest = vi.fn().mockResolvedValue({ commit_id: "sha1", files: [] });
+    const client = makeClient(mockRequest);
+    const data = Buffer.from([0, 1, 2, 255]).toString("base64");
+
+    await registry.dispatch(client, "commit", "create", {
+      repo_id: "my-repo",
+      body: {
+        title: "Update binary",
+        branch: "main",
+        actions: [
+          {
+            action: "UPDATE",
+            path: "blob.bin",
+            sha: "abc123",
+            content: { data },
+          },
+        ],
+      },
+    });
+
+    const call = mockRequest.mock.calls[0]![0] as {
+      body: { actions: Array<{ payload?: string; encoding?: string; content?: unknown }> };
+    };
+    expect(call.body.actions[0]!.payload).toBe(data);
+    expect(call.body.actions[0]!.encoding).toBe("base64");
+    expect(call.body.actions[0]!.content).toBeUndefined();
+  });
+
+  it("rejects UPDATE with an empty payload so the file is not wiped", async () => {
     const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "repositories" }));
     const mockRequest = vi.fn();
     const client = makeClient(mockRequest);
@@ -318,6 +387,100 @@ describe("commit create — client-side base64 validation", () => {
       }),
     ).rejects.toThrow(/payload is required/);
     expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects CREATE when payload is omitted", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "repositories" }));
+    const mockRequest = vi.fn();
+    const client = makeClient(mockRequest);
+
+    await expect(
+      registry.dispatch(client, "commit", "create", {
+        repo_id: "my-repo",
+        body: {
+          title: "Add file",
+          branch: "main",
+          actions: [{ action: "CREATE", path: "notes.txt" }],
+        },
+      }),
+    ).rejects.toThrow(/payload is required/);
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it("allows CREATE with an explicit empty payload", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "repositories" }));
+    const mockRequest = vi.fn().mockResolvedValue({ commit_id: "sha1", files: [] });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "commit", "create", {
+      repo_id: "my-repo",
+      body: {
+        title: "Add empty file",
+        branch: "main",
+        actions: [{ action: "CREATE", path: ".gitkeep", payload: "" }],
+      },
+    });
+
+    const call = mockRequest.mock.calls[0]![0] as { body: { actions: Array<{ payload?: string }> } };
+    expect(call.body.actions[0]!.payload).toBe("");
+  });
+
+  it("allows MOVE without file bytes (payload is the destination path)", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "repositories" }));
+    const mockRequest = vi.fn().mockResolvedValue({ commit_id: "sha1", files: [] });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "commit", "create", {
+      repo_id: "my-repo",
+      body: {
+        title: "Rename file",
+        branch: "main",
+        actions: [{ action: "MOVE", path: "old.txt", payload: "new.txt", sha: "abc" }],
+      },
+    });
+
+    const call = mockRequest.mock.calls[0]![0] as {
+      body: { actions: Array<{ payload?: string; content?: unknown }> };
+    };
+    expect(call.body.actions[0]!.payload).toBe("new.txt");
+    expect(mockRequest).toHaveBeenCalled();
+  });
+
+  it("does not reject MOVE when payload is omitted", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "repositories" }));
+    const mockRequest = vi.fn().mockResolvedValue({ commit_id: "sha1", files: [] });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "commit", "create", {
+      repo_id: "my-repo",
+      body: {
+        title: "Rename file",
+        branch: "main",
+        actions: [{ action: "MOVE", path: "old.txt" }],
+      },
+    });
+
+    expect(mockRequest).toHaveBeenCalled();
+  });
+
+  it("does not copy file-content aliases onto MOVE payload", async () => {
+    const registry = new Registry(makeConfig({ HARNESS_TOOLSETS: "repositories" }));
+    const mockRequest = vi.fn().mockResolvedValue({ commit_id: "sha1", files: [] });
+    const client = makeClient(mockRequest);
+
+    await registry.dispatch(client, "commit", "create", {
+      repo_id: "my-repo",
+      body: {
+        title: "Rename file",
+        branch: "main",
+        actions: [
+          { action: "MOVE", path: "old.txt", payload: "new.txt", content: "file-bytes-must-not-replace-dest" },
+        ],
+      },
+    });
+
+    const call = mockRequest.mock.calls[0]![0] as { body: { actions: Array<{ payload?: string }> } };
+    expect(call.body.actions[0]!.payload).toBe("new.txt");
   });
 
   it("allows DELETE without a payload", async () => {


### PR DESCRIPTION
## Summary
- Agents often put file bytes on `actions[].content` or `text` because `file_content` GET returns `content.text`. Harness Code only persists `payload`, so an omitted payload wrote Git's empty blob and wiped the file.
- `buildCommitFilesBody` now copies those aliases onto `payload`, drops them from the request, and rejects CREATE/UPDATE/MOVE with an empty payload instead of committing a wipe.

## Validation
- `pnpm exec vitest run tests/registry/repositories-file-content-encoding.test.ts`
- Rebuild local `mcp-server-internal` against a Verdaccio `harness-mcp-v2` publish and retry a commit update that previously used `content` instead of `payload`.


Made with [Cursor](https://cursor.com)