### PR TITLE
chore: prepare 3.2.27 with dependency security updates

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "harness-mcp-server",
   "display_name": "Harness",
-  "version": "3.2.26",
+  "version": "3.2.27",
   "description": "Connect AI agents to Harness for CI/CD, code repositories, pull requests, services, environments, and feature flags.",
   "long_description": "The Harness MCP Server gives MCP-compatible clients access to Harness platform workflows through consolidated tools, resources, and prompts. It supports local stdio usage and can be bundled as a Node-based MCPB extension.",
   "author": {

--- a/mcp-directory/manifest.json
+++ b/mcp-directory/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "harness-mcp-server",
   "display_name": "Harness",
-  "version": "3.2.26",
+  "version": "3.2.27",
   "description": "Connect AI agents to Harness for CI/CD, code repositories, pull requests, services, environments, and feature flags.",
   "long_description": "The Harness MCP Server gives MCP-compatible clients access to Harness platform workflows through consolidated tools, resources, and prompts. It supports local stdio usage and can be bundled as a Node-based MCPB extension.",
   "author": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "harness-mcp-v2",
-  "version": "3.2.26",
+  "version": "3.2.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "harness-mcp-v2",
-      "version": "3.2.26",
+      "version": "3.2.27",
       "dependencies": {
         "@hono/node-server": "^2.0.10",
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@hono/node-server": "^2.0.10",
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "adm-zip": "^0.6.0",
+        "adm-zip": "^0.6.1",
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
         "hono": "^4.13.5",
@@ -630,9 +630,9 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
-      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.1.tgz",
+      "integrity": "sha512-Xwrja8nx9e5o2N1my4DsKCeKpdrnACyr1wtbPxBDgGzKzKyE9kRtBFA8mWldI+RVlD7CBZNWY/wQ2+ydwOR6kQ==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0"
@@ -1698,16 +1698,6 @@
         "adm-zip": "^0.5.16",
         "global-agent": "^3.0.0",
         "onnxruntime-common": "1.24.3"
-      }
-    },
-    "node_modules/onnxruntime-node/node_modules/adm-zip": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
-      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12.0"
       }
     },
     "node_modules/onnxruntime-web": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness-mcp-v2",
-  "version": "3.2.26",
+  "version": "3.2.27",
   "description": "Give AI agents full access to the Harness.io platform — manage pipelines, deployments, cloud costs, chaos engineering, feature flags, SEI, and 125+ resource types through 11 MCP tools",
   "type": "module",
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@hono/node-server": "^2.0.10",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "adm-zip": "^0.6.0",
+    "adm-zip": "^0.6.1",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "hono": "^4.13.5",
@@ -96,7 +96,12 @@
     "@types/node": "^22.13.5",
     "typescript": "^5.7.3",
     "vite": "^7.3.5",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.11"
+  },
+  "overrides": {
+    "onnxruntime-node": {
+      "adm-zip": "0.6.1"
+    }
   },
   "pnpm": {
     "overrides": {
@@ -107,13 +112,14 @@
       "express-rate-limit": ">=8.2.2",
       "ip-address": ">=10.3.1",
       "vite": "^7.3.5",
+      "nanoid": "^3.3.18",
       "esbuild": ">=0.28.1",
       "postcss": ">=8.5.18",
       "fast-uri": ">=4.1.3",
       "body-parser": ">=2.3.0",
       "sharp": ">=0.35.4",
       "protobufjs": ">=8.6.0",
-      "adm-zip": ">=0.6.0",
+      "adm-zip": ">=0.6.1",
       "@opentelemetry/core": ">=2.8.0",
       "qs": ">=6.16.0"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,13 +12,14 @@ overrides:
   express-rate-limit: '>=8.2.2'
   ip-address: '>=10.3.1'
   vite: ^7.3.5
+  nanoid: ^3.3.18
   esbuild: '>=0.28.1'
   postcss: '>=8.5.18'
   fast-uri: '>=4.1.3'
   body-parser: '>=2.3.0'
   sharp: '>=0.35.4'
   protobufjs: '>=8.6.0'
-  adm-zip: '>=0.6.0'
+  adm-zip: '>=0.6.1'
   '@opentelemetry/core': '>=2.8.0'
   qs: '>=6.16.0'
 
@@ -33,8 +34,8 @@ importers:
         specifier: ^1.27.1
         version: 1.27.1(zod@4.3.6)
       adm-zip:
-        specifier: '>=0.6.0'
-        version: 0.6.0
+        specifier: '>=0.6.1'
+        version: 0.6.1
       dotenv:
         specifier: ^17.3.1
         version: 17.3.1
@@ -82,8 +83,8 @@ importers:
         specifier: ^7.3.5
         version: 7.3.5(@types/node@22.19.12)(lightningcss@1.32.0)(yaml@2.8.3)
       vitest:
-        specifier: ^4.1.0
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.12)(vite@7.3.5(@types/node@22.19.12)(lightningcss@1.32.0)(yaml@2.8.3))
+        specifier: ^4.1.11
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@22.19.12)(vite@7.3.5(@types/node@22.19.12)(lightningcss@1.32.0)(yaml@2.8.3))
     optionalDependencies:
       '@huggingface/transformers':
         specifier: ^4.2.0
@@ -643,9 +644,6 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -679,11 +677,11 @@ packages:
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
-  '@vitest/expect@4.1.8':
-    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
 
-  '@vitest/mocker@4.1.8':
-    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^7.3.5
@@ -693,27 +691,27 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.8':
-    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
 
-  '@vitest/runner@4.1.8':
-    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
 
-  '@vitest/snapshot@4.1.8':
-    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
 
-  '@vitest/spy@4.1.8':
-    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
 
-  '@vitest/utils@4.1.8':
-    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
-  adm-zip@0.6.0:
-    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+  adm-zip@0.6.1:
+    resolution: {integrity: sha512-Xwrja8nx9e5o2N1my4DsKCeKpdrnACyr1wtbPxBDgGzKzKyE9kRtBFA8mWldI+RVlD7CBZNWY/wQ2+ydwOR6kQ==}
     engines: {node: '>=14.0'}
 
   ajv-formats@3.0.1:
@@ -1141,8 +1139,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.19:
+    resolution: {integrity: sha512-Y2tUNy4ouw6tq5oDSKeQYGOyhkUBhNOcGV/02KC+6kd9eDGqdZd++mjMiIDilrBYvjEnCYvVtsuHCuP+okSfug==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1348,10 +1346,6 @@ packages:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
-
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -1435,20 +1429,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.8:
-    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.8
-      '@vitest/browser-preview': 4.1.8
-      '@vitest/browser-webdriverio': 4.1.8
-      '@vitest/coverage-istanbul': 4.1.8
-      '@vitest/coverage-v8': 4.1.8
-      '@vitest/ui': 4.1.8
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
       happy-dom: '*'
       jsdom: '*'
       vite: ^7.3.5
@@ -1916,8 +1910,6 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
-  '@types/estree@1.0.8': {}
-
   '@types/estree@1.0.9': {}
 
   '@types/express-serve-static-core@5.1.1':
@@ -1959,44 +1951,44 @@ snapshots:
       '@types/http-errors': 2.0.5
       '@types/node': 22.19.12
 
-  '@vitest/expect@4.1.8':
+  '@vitest/expect@4.1.11':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@7.3.5(@types/node@22.19.12)(lightningcss@1.32.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.11(vite@7.3.5(@types/node@22.19.12)(lightningcss@1.32.0)(yaml@2.8.3))':
     dependencies:
-      '@vitest/spy': 4.1.8
+      '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.5(@types/node@22.19.12)(lightningcss@1.32.0)(yaml@2.8.3)
 
-  '@vitest/pretty-format@4.1.8':
+  '@vitest/pretty-format@4.1.11':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.8':
+  '@vitest/runner@4.1.11':
     dependencies:
-      '@vitest/utils': 4.1.8
+      '@vitest/utils': 4.1.11
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.8':
+  '@vitest/snapshot@4.1.11':
     dependencies:
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/utils': 4.1.8
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.8': {}
+  '@vitest/spy@4.1.11': {}
 
-  '@vitest/utils@4.1.8':
+  '@vitest/utils@4.1.11':
     dependencies:
-      '@vitest/pretty-format': 4.1.8
+      '@vitest/pretty-format': 4.1.11
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -2005,7 +1997,7 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  adm-zip@0.6.0: {}
+  adm-zip@0.6.1: {}
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
@@ -2167,7 +2159,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   etag@1.8.1: {}
 
@@ -2445,7 +2437,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.19: {}
 
   negotiator@1.0.0: {}
 
@@ -2474,7 +2466,7 @@ snapshots:
 
   onnxruntime-node@1.24.3:
     dependencies:
-      adm-zip: 0.6.0
+      adm-zip: 0.6.1
       global-agent: 3.0.0
       onnxruntime-common: 1.24.3
     optional: true
@@ -2508,7 +2500,7 @@ snapshots:
 
   postcss@8.5.24:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.19
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2718,11 +2710,6 @@ snapshots:
 
   tinyexec@1.2.4: {}
 
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -2772,15 +2759,15 @@ snapshots:
       lightningcss: 1.32.0
       yaml: 2.8.3
 
-  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.12)(vite@7.3.5(@types/node@22.19.12)(lightningcss@1.32.0)(yaml@2.8.3)):
+  vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@22.19.12)(vite@7.3.5(@types/node@22.19.12)(lightningcss@1.32.0)(yaml@2.8.3)):
     dependencies:
-      '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@22.19.12)(lightningcss@1.32.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/runner': 4.1.8
-      '@vitest/snapshot': 4.1.8
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@7.3.5(@types/node@22.19.12)(lightningcss@1.32.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -2790,7 +2777,7 @@ snapshots:
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 7.3.5(@types/node@22.19.12)(lightningcss@1.32.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0

--- a/scripts/adm-zip-security-lib.mjs
+++ b/scripts/adm-zip-security-lib.mjs
@@ -4,8 +4,8 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 
-export const SECURE_ADM_ZIP_VERSION = "0.6.0";
-export const ADM_ZIP_CVE = "CVE-2026-39244";
+export const SECURE_ADM_ZIP_VERSION = "0.6.1";
+export const ADM_ZIP_ADVISORIES = "CVE-2026-39244 and CVE-2026-76845";
 
 /** @returns {string | null} */
 export function readAdmZipVersion(admZipDir) {
@@ -128,8 +128,8 @@ export function listInsecureAdmZipInstalls(
  * Upgrade adm-zip under packageRoot for npm consumers.
  * pnpm installs with pnpm.overrides should no-op when already secure.
  *
- * Nested adm-zip under onnxruntime-node is only upgraded when this runs (postinstall).
- * Consumers using `npm install --ignore-scripts` skip postinstall and remain exposed.
+ * The npm-native parent override protects normal packaged installs. This postinstall
+ * remains a fallback for consumers whose installer discards override or lock metadata.
  *
  * @param {string} packageRoot
  * @param {{ npmCommand?: string, target?: string, dryRun?: boolean, strict?: boolean }} [options]
@@ -209,7 +209,7 @@ export function ensureSecureAdmZip(
     const details = remaining
       .map(({ dir, version }) => `${dir}@${version ?? "missing"}`)
       .join(", ");
-    warnOrThrow(`insecure adm-zip remains after patch (${ADM_ZIP_CVE}): ${details}`);
+    warnOrThrow(`insecure adm-zip remains after patch (${ADM_ZIP_ADVISORIES}): ${details}`);
   }
 
   return { patched, skipped: false, warnings };

--- a/scripts/ensure-secure-adm-zip.mjs
+++ b/scripts/ensure-secure-adm-zip.mjs
@@ -3,17 +3,17 @@
 /**
  * Postinstall security patch for npm consumers.
  *
- * pnpm.overrides already pins adm-zip for pnpm installs, but `npm install -g`
- * ignores pnpm overrides and npm-shrinkwrap does not reliably override nested
- * optional adm-zip under onnxruntime-node. Upgrade in-place on install.
+ * pnpm.overrides pins adm-zip for pnpm installs, while the npm-native parent
+ * override and shrinkwrap pin the optional onnxruntime-node copy. Verify and
+ * repair any insecure copy left by an installer that discards that metadata.
  *
- * Requires install scripts to run — `npm install --ignore-scripts` skips this
- * patch and leaves nested adm-zip vulnerable to CVE-2026-39244.
+ * `npm install --ignore-scripts` skips this fallback, so the packaged overrides
+ * and shrinkwrap must remain independently secure.
  */
 
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { ensureSecureAdmZip, ADM_ZIP_CVE } from "./adm-zip-security-lib.mjs";
+import { ensureSecureAdmZip, ADM_ZIP_ADVISORIES } from "./adm-zip-security-lib.mjs";
 
 const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -25,7 +25,7 @@ const { patched, skipped, warnings } = ensureSecureAdmZip(packageRoot);
 
 if (!skipped && patched.length > 0) {
   console.error(
-    `[harness-mcp-v2] upgraded adm-zip to fix ${ADM_ZIP_CVE} (${patched.length} prefix(es))`,
+    `[harness-mcp-v2] upgraded adm-zip to fix ${ADM_ZIP_ADVISORIES} (${patched.length} prefix(es))`,
   );
 }
 

--- a/scripts/generate-npm-shrinkwrap.mjs
+++ b/scripts/generate-npm-shrinkwrap.mjs
@@ -4,7 +4,8 @@
  * Generate npm-shrinkwrap.json for npm consumers (harness-ai-agent global install).
  *
  * pnpm-lock.yaml remains the source of truth for repo development; this shrinkwrap
- * documents the npm production tree after the adm-zip postinstall policy is applied.
+ * documents an npm production tree whose overrides resolve every adm-zip copy
+ * to the secure release before postinstall fallback logic is needed.
  */
 
 import { copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -67,12 +68,18 @@ if (checkMode) {
     failCheck("root optionalDependencies do not match package.json");
   }
 
-  const hoistedAdmZipVersion = shrinkwrap.packages?.["node_modules/adm-zip"]?.version;
-  if (
-    !hoistedAdmZipVersion ||
-    !isSecureAdmZipVersion(hoistedAdmZipVersion, SECURE_ADM_ZIP_VERSION)
-  ) {
-    failCheck(`hoisted adm-zip is ${hoistedAdmZipVersion ?? "missing"}`);
+  const admZipInstalls = Object.entries(shrinkwrap.packages ?? {}).filter(([path]) =>
+    path.endsWith("node_modules/adm-zip"),
+  );
+  const insecureAdmZipInstalls = admZipInstalls.filter(
+    ([, metadata]) =>
+      !isSecureAdmZipVersion(metadata?.version, SECURE_ADM_ZIP_VERSION),
+  );
+  if (admZipInstalls.length === 0 || insecureAdmZipInstalls.length > 0) {
+    const details = insecureAdmZipInstalls
+      .map(([path, metadata]) => `${path}@${metadata?.version ?? "missing"}`)
+      .join(", ");
+    failCheck(details || "adm-zip is missing");
   }
 
   console.error("npm-shrinkwrap.json metadata is up to date");
@@ -105,7 +112,7 @@ const stagingManifest = {
   private: true,
   dependencies: pkg.dependencies,
   optionalDependencies: pkg.optionalDependencies,
-  overrides: transitiveOverrides,
+  overrides: { ...transitiveOverrides, ...(pkg.overrides ?? {}) },
 };
 
 writeFileSync(join(stagingRoot, "package.json"), `${JSON.stringify(stagingManifest, null, 2)}\n`);

--- a/scripts/prepare-mcpb.js
+++ b/scripts/prepare-mcpb.js
@@ -49,11 +49,12 @@ export function bundlePackageJson(packageJson) {
     ...Object.keys(packageJson.dependencies ?? {}),
     ...Object.keys(packageJson.optionalDependencies ?? {}),
   ]);
-  const overrides = Object.fromEntries(
+  const transitiveOverrides = Object.fromEntries(
     Object.entries(packageJson.pnpm?.overrides ?? {}).filter(
       ([name]) => !directDependencies.has(name),
     ),
   );
+  const overrides = { ...transitiveOverrides, ...(packageJson.overrides ?? {}) };
 
   return {
     name: packageJson.name,

--- a/scripts/verify-npm-adm-zip.mjs
+++ b/scripts/verify-npm-adm-zip.mjs
@@ -3,8 +3,8 @@
 /**
  * CI helper: simulate the supported global npm install and assert adm-zip is secure.
  *
- * Install scripts must run — do not pass `--ignore-scripts`; nested adm-zip under
- * onnxruntime-node is only upgraded by the package postinstall hook.
+ * This exercises the published install path, including the npm-native override
+ * and the postinstall fallback used when an installer leaves an insecure copy.
  */
 
 import { mkdtempSync, rmSync } from "node:fs";
@@ -14,7 +14,7 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname } from "node:path";
 import {
-  ADM_ZIP_CVE,
+  ADM_ZIP_ADVISORIES,
   listInsecureAdmZipInstalls,
   SECURE_ADM_ZIP_VERSION,
 } from "./adm-zip-security-lib.mjs";
@@ -59,7 +59,7 @@ try {
   const insecure = listInsecureAdmZipInstalls(packageRoot);
   if (insecure.length > 0) {
     console.error(
-      `insecure adm-zip after npm install (${ADM_ZIP_CVE}, expected >= ${SECURE_ADM_ZIP_VERSION}):`,
+      `insecure adm-zip after npm install (${ADM_ZIP_ADVISORIES}, expected >= ${SECURE_ADM_ZIP_VERSION}):`,
     );
     for (const { dir, version } of insecure) {
       console.error(`  ${dir} @ ${version ?? "missing"}`);

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -32,7 +32,7 @@ describe("release metadata", () => {
     const rootManifest = readJson("manifest.json");
     const directoryManifest = readJson("mcp-directory/manifest.json");
 
-    expect(packageJson.version).toBe("3.2.26");
+    expect(packageJson.version).toBe("3.2.27");
     expect(rootManifest.version).toBe(packageJson.version);
     expect(directoryManifest.version).toBe(packageJson.version);
   });
@@ -52,9 +52,9 @@ describe("release metadata", () => {
     legacyManifest.server.entry_point = "build/index.js";
     legacyManifest.server.mcp_config.args[0] = "${__dirname}/build/index.js";
 
-    expect(assetNameForVersion("3.2.26")).toBe("harness-mcp-server-3.2.26.mcpb");
+    expect(assetNameForVersion("3.2.27")).toBe("harness-mcp-server-3.2.27.mcpb");
     expect(MCPB_CLI_PACKAGE).toBe("@anthropic-ai/mcpb@2.1.2");
-    expect(normalizeBundleManifest(legacyManifest, "3.2.26").server).toMatchObject({
+    expect(normalizeBundleManifest(legacyManifest, "3.2.27").server).toMatchObject({
       entry_point: "server/index.js",
       mcp_config: { args: ["${__dirname}/server/index.js", "stdio"] },
     });

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -70,6 +70,9 @@ describe("release metadata", () => {
     expect(bundled.optionalDependencies).toEqual(packageJson.optionalDependencies);
     expect(bundled.overrides.sharp).toBe(packageJson.pnpm.overrides.sharp);
     expect(bundled.overrides).not.toHaveProperty("hono");
+    expect(bundled.overrides["onnxruntime-node"]).toEqual({
+      "adm-zip": "0.6.1",
+    });
   });
 
   it("ships matching 512×512 directory icons", () => {

--- a/tests/scripts/adm-zip-security-lib.test.ts
+++ b/tests/scripts/adm-zip-security-lib.test.ts
@@ -1,4 +1,12 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -10,6 +18,12 @@ import {
   listInsecureAdmZipInstalls,
   SECURE_ADM_ZIP_VERSION,
 } from "../../scripts/adm-zip-security-lib.mjs";
+
+const require = createRequire(import.meta.url);
+const AdmZip = require("adm-zip") as new () => {
+  addFile(name: string, content: Buffer): void;
+  extractAllTo(target: string, overwrite?: boolean): void;
+};
 
 function writePackage(root: string, name: string, version = "1.0.0") {
   mkdirSync(root, { recursive: true });
@@ -30,17 +44,37 @@ describe("adm-zip-security-lib", () => {
   });
 
   it("compares semver patch levels", () => {
-    expect(isSecureAdmZipVersion("0.6.0", SECURE_ADM_ZIP_VERSION)).toBe(true);
+    expect(isSecureAdmZipVersion("0.6.0", SECURE_ADM_ZIP_VERSION)).toBe(false);
     expect(isSecureAdmZipVersion("0.6.1", SECURE_ADM_ZIP_VERSION)).toBe(true);
     expect(isSecureAdmZipVersion("0.7.0", SECURE_ADM_ZIP_VERSION)).toBe(true);
     expect(isSecureAdmZipVersion("0.5.18", SECURE_ADM_ZIP_VERSION)).toBe(false);
-    expect(isSecureAdmZipVersion("0.6.0-beta.1", SECURE_ADM_ZIP_VERSION)).toBe(true);
+    expect(isSecureAdmZipVersion("0.6.0-beta.1", SECURE_ADM_ZIP_VERSION)).toBe(false);
   });
 
   it("treats missing or invalid versions as insecure", () => {
     expect(isSecureAdmZipVersion(null, SECURE_ADM_ZIP_VERSION)).toBe(false);
     expect(isSecureAdmZipVersion("", SECURE_ADM_ZIP_VERSION)).toBe(false);
     expect(isSecureAdmZipVersion("not-a-version", SECURE_ADM_ZIP_VERSION)).toBe(false);
+  });
+
+  it("blocks extraction through a destination symlink", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const root = mkdtempSync(join(tmpdir(), "adm-zip-symlink-"));
+    tempDirs.push(root);
+    const extractRoot = join(root, "extract");
+    const outsideRoot = join(root, "outside");
+    mkdirSync(extractRoot);
+    mkdirSync(outsideRoot);
+    symlinkSync(outsideRoot, join(extractRoot, "link"), "dir");
+
+    const zip = new AdmZip();
+    zip.addFile("link/payload.txt", Buffer.from("attacker content"));
+
+    expect(() => zip.extractAllTo(extractRoot, true)).toThrow();
+    expect(existsSync(join(outsideRoot, "payload.txt"))).toBe(false);
   });
 
   it("finds nested adm-zip installs", () => {


### PR DESCRIPTION
## Description

Prepares the Harness MCP Server 3.2.27 release and resolves the current dependency security alerts across both pnpm development installs and npm production consumers.

## Changes

- Synchronizes package, shrinkwrap, MCPB manifest, and release-test versions at 3.2.27.
- Upgrades `adm-zip` to 0.6.1 and adds an npm-native override so the optional `onnxruntime-node` path cannot retain a vulnerable nested copy.
- Upgrades Vitest and `@vitest/mocker` to 4.1.11.
- Pins Nano ID to the patched compatible 3.x line, resolving to 3.3.19 while preserving Node 20 support.
- Strengthens shrinkwrap validation to reject any vulnerable `adm-zip` installation path and adds a destination-symlink extraction regression.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Other: release metadata

## Validation

- [x] `pnpm audit` reports zero vulnerabilities
- [x] `npm audit --omit=dev` reports zero vulnerabilities
- [x] Simulated global npm consumer install contains only secure `adm-zip` copies
- [x] Focused security and release tests pass (17 tests)
- [x] `pnpm npm-shrinkwrap:check` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes
- [x] `pnpm standards:check` passes (10 files / 77 tests)
- [x] `pnpm docs:check` passes
- [x] Full suite passes with `pnpm test --maxWorkers=1 --testTimeout=15000` (154 files / 3,525 tests)
- [x] `git diff --check` passes

## Coding Standards (registry-driven MCP model)

Not applicable; this PR does not add or change Harness API coverage.
